### PR TITLE
feat(uberdev): /solve tab-spawns into originating Ghostty window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ## [Unreleased]
 
+### Added
+- `/solve` Ghostty dispatcher tab-spawns into the originating Ghostty window when invoked from inside Ghostty (`TERM_PROGRAM=ghostty`), keeping per-project workspaces visually grouped instead of cluttering the desktop with new top-level windows. `SOLVE_GHOSTTY_NEW_WINDOW=1` forces the legacy new-window behavior; AppleScript failures (e.g. Accessibility permission denied) fall back to it automatically with a stderr warning.
+
 ### Changed
 - `brainstorm` skill: parallel research dispatch promoted to **default first step** (before clarifying questions; skipped only for trivial tasks). The 2-3 proposed approaches are now grounded in research synthesis, not speculation. No approval gates added — "single forward pass" stays.
 

--- a/plugins/uberdev/commands/solve.md
+++ b/plugins/uberdev/commands/solve.md
@@ -16,6 +16,7 @@ Spawn an autonomous Claude agent in a new cmux workspace to solve GitHub issue *
 - `--trivial` / `--small` / `--full` → override classification manually
 - `--terminal=…` → override terminal detection (else `$SOLVE_TERMINAL` env var, else auto-detect)
 - `--auto` → enable `--permission-mode auto` (Claude Code's AI classifier — auto-approves safe ops; blocks force push / `rm -rf` on pre-existing files / exfil / self-modification / `--dangerously-skip-permissions`). Else `SOLVE_AUTO=1` env var, else `solve_auto: true` in `.claude/uberdev.local.md`.
+- `SOLVE_GHOSTTY_NEW_WINDOW=1` env var → force the legacy *new window* dispatch instead of tab-spawning into the originating Ghostty window (Ghostty terminal only).
 
 ## Triage heuristics (Step 3 applies this table)
 
@@ -247,14 +248,41 @@ case "$TERMINAL" in
     cmux new-workspace --name "$TAB_NAME" --description "$DESCRIPTION" --command "zsh -l $SCRIPT"
     ;;
   ghostty)
-    # Ghostty has no AppleScript do-script; `open -na` spawns a new window of the running app.
-    # We use --command= rather than -e: Ghostty's -e appends to its configured shell,
-    # which on macOS defaults to `/usr/bin/login -flp <user>`. Per login(1), tokens after
-    # the username are parsed as KEY=VALUE env assignments — so `-e "zsh -l $SCRIPT"` is
-    # read as env vars, fails the `=` check, and drops into an interactive login shell
-    # without ever running the script. --command= replaces the shell wrapper entirely,
-    # and the launcher's own `#!/bin/zsh -l` shebang preserves login-shell semantics.
-    open -na Ghostty --args --command="$SCRIPT"
+    # Tab-spawn into the originating Ghostty window when /solve was invoked from
+    # inside Ghostty (TERM_PROGRAM=ghostty). Ghostty's macOS CLI rejects
+    # `+new-window` ("not supported on this platform") and its AppleScript
+    # dictionary doesn't expose `make new tab` cleanly, so we drive the
+    # default Cmd+T keybind via System Events and type the launcher path.
+    # Fall through to legacy new-window dispatch when:
+    #   - SOLVE_GHOSTTY_NEW_WINDOW=1 (explicit opt-out),
+    #   - TERM_PROGRAM != ghostty (no originating window — e.g. SOLVE_TERMINAL=ghostty
+    #     forced from another terminal),
+    #   - or the AppleScript fails (Accessibility permission denied, custom keybind, etc.).
+    TAB_SPAWNED=0
+    if [[ "$SOLVE_GHOSTTY_NEW_WINDOW" != "1" ]] && [[ "$TERM_PROGRAM" == "ghostty" ]]; then
+      if osascript >/dev/null 2>&1 <<APPLESCRIPT
+tell application "Ghostty" to activate
+delay 0.15
+tell application "System Events"
+  keystroke "t" using command down
+  delay 0.25
+  keystroke "zsh -l $SCRIPT"
+  keystroke return
+end tell
+APPLESCRIPT
+      then
+        TAB_SPAWNED=1
+      else
+        echo "warning: ghostty tab-spawn failed (Accessibility permission or non-default keybind?); falling back to new window." >&2
+      fi
+    fi
+    if [[ "$TAB_SPAWNED" != "1" ]]; then
+      # Legacy new-window dispatch. --command= rather than -e: Ghostty's -e appends to
+      # its login shell, which on macOS parses post-username tokens as KEY=VALUE env
+      # assignments — `-e "zsh -l $SCRIPT"` would never run the script. The launcher's
+      # `#!/bin/zsh -l` shebang preserves login-shell semantics inside `--command=`.
+      open -na Ghostty --args --command="$SCRIPT"
+    fi
     ;;
   iterm)
     osascript <<APPLESCRIPT


### PR DESCRIPTION
## Summary

- When `/solve` is invoked from inside Ghostty, the spawned agent now opens as a **new tab** in the originating window instead of cluttering the desktop with a new top-level window.
- Falls back to the legacy `open -na Ghostty --args --command="$SCRIPT"` new-window dispatch when `SOLVE_GHOSTTY_NEW_WINDOW=1`, when `TERM_PROGRAM != ghostty` (no originating window), or when the AppleScript fails (Accessibility denied / custom keybind).
- iTerm and Terminal.app dispatch paths are unchanged.

## How

- Drove the default Cmd+T keybind via `osascript` + System Events keystroke, then typed `zsh -l $SCRIPT` + Return into the new tab. Ghostty's macOS CLI `+new-window` is "not supported on this platform" and the AppleScript dictionary rejects `make new tab`, so this is the only currently-working tab-spawn path.
- Activate-then-keystroke needs ~150ms for window focus to settle and ~250ms for the new tab's PTY/shell to become writable on macOS — both delays sit inside the AppleScript.
- New env var `SOLVE_GHOSTTY_NEW_WINDOW=1` documented in the flags block and CHANGELOG.

## Test plan

Verification script at `/tmp/test-solve-ghostty.sh` extracts the `ghostty)` case branch from `solve.md` via `awk`, runs it under mocked `osascript`/`open`, and asserts:

- [x] **A:** `TERM_PROGRAM=ghostty` + osascript success → osascript called, `open -na` not called.
- [x] **B:** `TERM_PROGRAM=ghostty` + osascript fail → osascript attempted, fallback to `open -na Ghostty`, stderr warning emitted.
- [x] **C:** `SOLVE_GHOSTTY_NEW_WINDOW=1` → osascript skipped, legacy `open -na Ghostty` used directly.
- [x] **D:** `TERM_PROGRAM=iTerm.app` (forced via `SOLVE_TERMINAL=ghostty` from elsewhere) → osascript skipped, legacy dispatch.

Confirmed red against current code, then green after the change. Manual smoke-test on the spawned agent to follow.

Closes #1