### PR TITLE
feat(uberdev): /turbo — unattended /solve that auto-accepts brainstorm recs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ## [Unreleased]
 
+### Added
+- `/turbo <issue>` slash command: unattended `/solve` that auto-accepts the brainstorm phase's lead-agent recommendations for medium/large tiers (parallel research still runs — recommendation grounding preserved). Trivial/small tiers behave identically to `/solve`. Composes orthogonally with `--auto` (permission-mode flag); `/turbo <issue> --auto` is the max-autonomy combo. No new approval gates — only collapses the clarifying-questions loop.
+
 ### Changed
 - `brainstorm` skill: parallel research dispatch promoted to **default first step** (before clarifying questions; skipped only for trivial tasks). The 2-3 proposed approaches are now grounded in research synthesis, not speculation. No approval gates added — "single forward pass" stays.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
    \___/|_.__/ \___|_|  |____/ \___| \_/  
 ```
 
-**Two commands. Zero ceremony. Every issue, triaged and shipped.**
+**Three commands. Zero ceremony. Every issue, triaged and shipped.**
 
 </div>
 
@@ -25,11 +25,12 @@
 
 ## TL;DR
 
-Two slash commands that turn issue triage and resolution into one-line operations:
+Three slash commands that turn issue triage and resolution into one-line operations:
 
 | Command | What it does |
 |---|---|
 | **`/solve <issue-number>`** | Spawns an autonomous Claude agent in a new terminal session (cmux / Ghostty / iTerm / Terminal.app / nohup) with **tier-aware triage** so trivial issues skip the brainstorm and large ones get the full plan-and-review pipeline. |
+| **`/turbo <issue-number>`** | **Unattended `/solve`** — same pipeline, but the brainstorm phase auto-accepts the lead agent's recommended design instead of asking clarifying questions. Use when you trust the research-grounded recommendation and want issue → PR with no babysitting. Pair with `--auto` for max autonomy. |
 | **`/issue <description>`** | Creates a **well-investigated, deduped, label-validated** GitHub issue from a one-line ask — including codebase search, full-text dedup against closed issues (regression signals), commitlint scope validation, and a triage hint that `/solve` reads later. |
 
 Both are **repo-agnostic** — they auto-detect the current repo via `gh repo view`. No per-repo config required.
@@ -129,6 +130,30 @@ claude \
 ```
 
 After opening its PR, the spawned agent **renames its own terminal tab** from `#123 <issue-title>` to `PR #456 <pr-title>` via OSC escape sequences (or cmux's workspace API).
+
+---
+
+## `/turbo` — unattended issue resolution
+
+Identical to `/solve` for trivial / small tiers. For medium / large tiers, the brainstorm phase auto-accepts the lead agent's recommendation instead of asking clarifying questions — so the whole pipeline runs without user input.
+
+### When to use which
+
+| Combo | Brainstorm Q&A | Tool gating |
+|---|---|---|
+| `/solve 42` | interactive | manual per-tool gating |
+| `/solve 42 --auto` | interactive | AI classifier (auto-approves safe ops) |
+| `/turbo 42` | auto-accept recommendation | manual per-tool gating |
+| `/turbo 42 --auto` | auto-accept recommendation | AI classifier — **max autonomy** |
+
+`/turbo` and `--auto` are **orthogonal**: `/turbo` governs brainstorm interactivity; `--auto` governs Claude Code's per-tool permission mode. Pair them for unattended issue → PR.
+
+### Safety
+
+- Spec & plan are still written to disk before implementation waves dispatch — audit them to course-correct.
+- A stderr banner before terminal spawn confirms turbo mode is active.
+- Trivial / small tiers don't run brainstorm anyway, so `/turbo` is functionally identical to `/solve` there. The intent-signaling name + `--auto` shortcut is the only difference.
+- No new approval gates introduced — turbo only **removes** the clarifying-questions stop, never **adds** one.
 
 ---
 

--- a/plugins/uberdev/commands/turbo.md
+++ b/plugins/uberdev/commands/turbo.md
@@ -1,0 +1,330 @@
+---
+description: "Unattended /solve — auto-accepts brainstorm recommendations for medium/large issues. Same pipeline, no Q&A friction."
+argument-hint: "<issue-number> [--trivial|--small|--full] [--auto] [--terminal=cmux|ghostty|iterm|terminal|nohup]"
+allowed-tools: ["Bash", "Read", "Task"]
+---
+
+# Solve GitHub Issue (Unattended)
+
+Spawn an autonomous Claude agent in a new cmux workspace to solve GitHub issue **#$ARGUMENTS** with **brainstorm Q&A auto-answered**.
+
+`/turbo` is `/solve` with the brainstorm clarifying-question loop collapsed: after parallel research synthesis, the lead agent presents 2-3 approaches with its recommendation, and **proceeds with the recommendation** — no waiting for user input. Spec and plan are still written to disk before implementation, so you can audit the artifacts and course-correct.
+
+**RULES:** Do NOT use the Task tool or internal subagents. Use bash commands only.
+
+**Usage:** `/turbo <issue-number> [--trivial|--small|--full] [--auto] [--terminal=cmux|ghostty|iterm|terminal|nohup]`
+
+- No flag → **auto-triage** by reading the issue (labels + body + title)
+- `--trivial` / `--small` / `--full` → override classification manually
+- `--terminal=…` → override terminal detection (else `$SOLVE_TERMINAL` env var, else auto-detect)
+- `--auto` → enable `--permission-mode auto` (orthogonal to `/turbo`'s brainstorm-interactivity flag — **`/turbo <issue> --auto` is the max-autonomy combo**)
+
+**Behavior vs `/solve`:**
+- **trivial / small tiers:** identical to `/solve` (these tiers don't run brainstorm anyway).
+- **medium / large tiers:** brainstorm runs WITHOUT the clarifying-question loop. Parallel research still runs (recommendation grounding preserved). Spec → plan → implementation waves proceed in a single forward pass.
+
+## Triage heuristics (Step 3 applies this table)
+
+| Tier | Signals (any strong match) | Spawned workflow |
+|------|----------------------------|------------------|
+| **trivial** | Labels: `typo`, `docs`, `documentation`, `chore`, `good-first-issue`. Body <300 chars after stripping markdown. Title matches `typo\|rename\|bump\|version\|readme`. No stack trace. Single file named. | Direct edit → test (if touched code is tested) → `/uberdev:simplify` → PR. **No brainstorm, no multi-step plan.** |
+| **small** | Clear reproduction + error message. Localized to one module/package. Estimated ≤50 LOC. Labels: `bug` (scoped) or none. Not cross-cutting. | Lightweight TodoWrite plan (3–6 tasks) → TDD → `/uberdev:simplify` → PR. **No brainstorm.** |
+| **medium/large** *(default)* | Labels: `epic`, `needs-discussion`, `architectural`, `infrastructure` (multi-service), `refactor`. ≥3 files/modules mentioned. Missing clear problem statement. Questions in body (`?`, "alternatives:", "options:"). Cross-package scope. | Full `/uberdev:brainstorm` → `/uberdev:write-plan` → `/uberdev:subagent-driven-dev` → `/uberdev:review-pr` pipeline. |
+
+**When in doubt, default to medium/large.** The spawned agent is explicitly told it may escalate to `/uberdev:brainstorm` mid-flight if the scope proves larger than triaged — misclassification is recoverable, not catastrophic.
+
+## Steps
+
+### 1. Parse arguments
+
+Extract issue number (first numeric token) + optional override flag:
+
+```bash
+ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '^[0-9]+' | head -1)
+OVERRIDE=$(echo "$ARGUMENTS" | grep -oE '\-\-(trivial|small|full)' | head -1 | sed 's/--//')
+TERMINAL_OVERRIDE=$(echo "$ARGUMENTS" | grep -oE '\-\-terminal=[a-z]+' | head -1 | sed 's/--terminal=//')
+AUTO_FLAG=$(echo "$ARGUMENTS" | grep -oE '\-\-auto' | head -1)
+if [[ -z "$ISSUE_NUM" ]]; then
+  echo "Usage: /solve <issue-number> [--trivial|--small|--full] [--auto] [--terminal=cmux|ghostty|iterm|terminal|nohup]"
+  exit 1
+fi
+# --full is an alias for medium/large (keeps current behavior)
+[[ "$OVERRIDE" == "full" ]] && OVERRIDE="medium"
+
+# AUTO_MODE precedence: CLI flag > env var > per-repo config > default off.
+# When set, the spawned agent runs --permission-mode auto (Claude Code's AI
+# classifier), NOT --dangerously-skip-permissions (which the classifier itself
+# soft-denies as "Create Unsafe Agents").
+if [[ -n "$AUTO_FLAG" ]]; then
+  AUTO_MODE=1
+elif [[ "$SOLVE_AUTO" == "1" ]]; then
+  AUTO_MODE=1
+elif [[ -f .claude/uberdev.local.md ]] && grep -qE '^solve_auto:[[:space:]]*true[[:space:]]*$' .claude/uberdev.local.md; then
+  AUTO_MODE=1
+else
+  AUTO_MODE=0
+fi
+```
+
+### 2. Detect repo
+
+```bash
+gh repo view --json nameWithOwner --jq .nameWithOwner
+```
+
+### 3. Fetch issue, verify state, classify
+
+```bash
+gh issue view $ISSUE_NUM --json number,title,state,body,labels
+```
+
+Stop if the issue does not exist or is closed. **Save the title** for the workspace tab (truncate at ~40 chars at a word boundary and append `…` if longer).
+
+Determine `TIER`:
+
+- If `$OVERRIDE` is set → `TIER=$OVERRIDE`
+- Else apply the triage table above to `{title, body, labels}`. Be honest: if the issue body says "refactor the whole auth module", that's **medium**, not small, even if the labels are quiet. Default to **medium** on ambiguity.
+
+### 4. Write tier-appropriate prompt
+
+**trivial:**
+
+```bash
+cat > /tmp/solve-prompt-$ISSUE_NUM.txt << EOF
+Solve GH issue #$ISSUE_NUM directly. Triaged as TRIVIAL.
+
+Steps:
+1. \`gh issue view $ISSUE_NUM\` — read the ask.
+2. Make the minimal edit. No redesign, no surrounding refactor, no "while I'm here" cleanup.
+3. Add/update a test ONLY if the touched code is already tested.
+4. Run the relevant test file + lint for that package.
+5. /uberdev:simplify before push (mandatory per CLAUDE.md).
+6. Commit with conventional message. Open PR with \`Closes #$ISSUE_NUM\` in the body.
+
+Skip /uberdev:brainstorm. Skip multi-step planning. Escalate to /uberdev:brainstorm ONLY if the scope turns out to be materially larger than triaged.
+EOF
+```
+
+**small:**
+
+```bash
+cat > /tmp/solve-prompt-$ISSUE_NUM.txt << EOF
+Solve GH issue #$ISSUE_NUM with a lightweight plan. Triaged as SMALL.
+
+Steps:
+1. \`gh issue view $ISSUE_NUM\` — read the ask.
+2. Write 3–6 TodoWrite tasks. Skip /uberdev:brainstorm — scope is clear.
+3. TDD: write the failing test first, then implement, then green.
+4. /uberdev:simplify before push (mandatory).
+5. Commit + PR with \`Closes #$ISSUE_NUM\`.
+
+Escalate to /uberdev:brainstorm if the scope proves larger than triaged.
+EOF
+```
+
+**medium** *(and `--full`)*:
+
+```bash
+echo "/uberdev:brainstorm --turbo solve GH issue #$ISSUE_NUM" > /tmp/solve-prompt-$ISSUE_NUM.txt
+```
+
+### 5. Write launcher script
+
+The launcher `cd`s to repo root, cleans stale worktree, logs errors, keeps terminal open on failure.
+
+```bash
+cat > /tmp/solve-$ISSUE_NUM.sh << 'SCRIPT_EOF'
+#!/bin/zsh -l
+set -e
+
+# Inherit detected terminal so Step 8 retitling can use the right mechanism.
+export TERMINAL="DETECTED_TERMINAL"
+
+# cd to repo root (cmux may start in a different directory)
+# Path is quoted because repo paths may contain spaces (e.g. /Volumes/FJK SSD/...)
+cd "REPO_ROOT"
+
+# Clean up stale worktree AND branch from previous runs
+if git worktree list | grep -q "solve-issue-ISSUE_NUM"; then
+  git worktree remove .claude/worktrees/solve-issue-ISSUE_NUM --force 2>/dev/null || true
+fi
+git branch -D worktree-solve-issue-ISSUE_NUM 2>/dev/null || true
+
+# Load prompt
+PROMPT=$(cat /tmp/solve-prompt-ISSUE_NUM.txt)
+
+# Run agent
+echo "Starting claude agent for issue #ISSUE_NUM (tier: TIER)..."
+# Interactive TUI mode: positional arg (no -p) so user sees the Claude CLI
+# MODEL: pinned to Opus 4.7 with 1M context. Brackets MUST be single-quoted
+# (zsh would otherwise treat [1m] as a character-class glob and abort under set -e).
+# PERMISSION MODE: issue bodies are remote-fetched (untrusted). Default mode
+# gates every tool use. PERM_FLAG=--permission-mode auto enables Claude Code's
+# AI classifier — auto-approves safe ops (read, in-scope edits, tests, push to
+# feature branch) and soft-denies dangerous ones (force push, rm -rf on
+# pre-existing files, exfil, self-modification). Strictly safer than
+# --dangerously-skip-permissions for autonomous /solve runs.
+PERM_FLAG="PERM_FLAG_VALUE"
+CLAUDE_BIN --model 'claude-opus-4-7[1m]' --effort max --worktree solve-issue-ISSUE_NUM $PERM_FLAG "$PROMPT"
+SCRIPT_EOF
+# BSD/macOS sed needs '-i ""'; GNU sed needs bare '-i'.
+SED_INPLACE=(-i '')
+[[ "$(uname)" == "Linux" ]] && SED_INPLACE=(-i)
+sed "${SED_INPLACE[@]}" "s|REPO_ROOT|$(pwd)|g" /tmp/solve-$ISSUE_NUM.sh
+REAL_CLAUDE=$(WRAPPER_DIR=$(dirname "$(which claude)"); for d in ${(s/:/)PATH}; do [[ "$d" == "$WRAPPER_DIR" ]] && continue; [[ -x "$d/claude" ]] && echo "$d/claude" && break; done)
+sed "${SED_INPLACE[@]}" "s|CLAUDE_BIN|${REAL_CLAUDE:-$(which claude)}|g" /tmp/solve-$ISSUE_NUM.sh
+sed "${SED_INPLACE[@]}" "s/ISSUE_NUM/$ISSUE_NUM/g" /tmp/solve-$ISSUE_NUM.sh
+sed "${SED_INPLACE[@]}" "s/TIER/$TIER/g" /tmp/solve-$ISSUE_NUM.sh
+# DETECTED_TERMINAL is set by Step 5.5 below; if you reorder, move that step before Step 5.
+sed "${SED_INPLACE[@]}" "s/DETECTED_TERMINAL/${TERMINAL:-cmux}/g" /tmp/solve-$ISSUE_NUM.sh
+PERM_FLAG_VAL=""
+[[ "$AUTO_MODE" == "1" ]] && PERM_FLAG_VAL="--permission-mode auto"
+sed "${SED_INPLACE[@]}" "s|PERM_FLAG_VALUE|$PERM_FLAG_VAL|g" /tmp/solve-$ISSUE_NUM.sh
+chmod +x /tmp/solve-$ISSUE_NUM.sh
+```
+
+### 5.5. Detect terminal app
+
+Pick a dispatcher. Priority: explicit override > cmux (only when we're inside a live cmux session) > standalone Ghostty > iTerm2 > Terminal.app > nohup-fallback. **Warp falls through to nohup** — its CLI can't dispatch a command into a new window cleanly.
+
+`TERM_PROGRAM=ghostty` is also set when you're inside cmux (cmux bundles Ghostty), so the cmux check MUST come first and MUST require `$CMUX_SOCKET` to be a live socket — otherwise we'd mis-classify a cmux session as plain Ghostty.
+
+```bash
+if [[ -n "$TERMINAL_OVERRIDE" ]]; then
+  TERMINAL="$TERMINAL_OVERRIDE"
+elif [[ -n "$SOLVE_TERMINAL" ]]; then
+  TERMINAL="$SOLVE_TERMINAL"
+elif [[ -n "$CMUX_SOCKET" && -S "$CMUX_SOCKET" ]] && command -v cmux >/dev/null 2>&1; then
+  TERMINAL="cmux"
+elif [[ "$TERM_PROGRAM" == "ghostty" ]] && [[ -d /Applications/Ghostty.app ]]; then
+  TERMINAL="ghostty"
+elif [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+  TERMINAL="iterm"
+elif [[ "$TERM_PROGRAM" == "Apple_Terminal" ]]; then
+  TERMINAL="terminal"
+else
+  TERMINAL="nohup"
+fi
+
+# Validate the chosen dispatcher is actually usable. If a user *explicitly* asked
+# for cmux/ghostty/iterm via --terminal= or $SOLVE_TERMINAL but the dispatcher
+# isn't installed, surface an actionable message and fall back to nohup so the
+# agent still spawns instead of failing inside the dispatch case below.
+case "$TERMINAL" in
+  cmux)
+    if ! command -v cmux >/dev/null 2>&1; then
+      echo "warning: TERMINAL=cmux requested but 'cmux' binary not on PATH." >&2
+      echo "         Install: npm i -g @manaflow-ai/cmux  (see cmux README for canonical install)" >&2
+      echo "         Falling back to nohup." >&2
+      TERMINAL="nohup"
+    elif [[ -z "$CMUX_SOCKET" || ! -S "$CMUX_SOCKET" ]]; then
+      echo "warning: TERMINAL=cmux requested but \$CMUX_SOCKET is not a live socket." >&2
+      echo "         Run /solve from inside an active cmux session, or unset SOLVE_TERMINAL/--terminal." >&2
+      echo "         Falling back to nohup." >&2
+      TERMINAL="nohup"
+    fi
+    ;;
+  ghostty)
+    [[ -d /Applications/Ghostty.app ]] || { echo "warning: ghostty selected but /Applications/Ghostty.app missing; falling back to nohup." >&2; TERMINAL="nohup"; }
+    ;;
+  iterm)
+    [[ -d /Applications/iTerm.app ]] || { echo "warning: iterm selected but /Applications/iTerm.app missing; falling back to nohup." >&2; TERMINAL="nohup"; }
+    ;;
+  terminal|nohup) ;;  # always available on macOS
+  *) echo "warning: unknown TERMINAL='$TERMINAL'; falling back to nohup." >&2; TERMINAL="nohup" ;;
+esac
+
+echo "Dispatching via: $TERMINAL"
+echo "Permission mode: $([[ "$AUTO_MODE" == "1" ]] && echo 'auto (Claude Code AI classifier)' || echo 'default (manual per-tool gating)')"
+echo "⚠️  TURBO MODE — brainstorm questions auto-answered with lead-agent recommendations." >&2
+echo "    Spec and plan are still written to disk before implementation; review the artifacts to course-correct." >&2
+```
+
+### 6. Spawn agent in new terminal session
+
+Tab/window shows issue + title; description encodes the tier for audit. Each branch invokes `zsh -l /tmp/solve-$ISSUE_NUM.sh`. Use the literal title from Step 3 (apply the ~40-char truncation rule).
+
+```bash
+TITLE="<issue-title>"  # from Step 3, truncated
+TAB_NAME="#$ISSUE_NUM $TITLE"
+DESCRIPTION="[$TIER] Solve GH issue #$ISSUE_NUM: $TITLE"
+SCRIPT="/tmp/solve-$ISSUE_NUM.sh"
+
+case "$TERMINAL" in
+  cmux)
+    cmux new-workspace --name "$TAB_NAME" --description "$DESCRIPTION" --command "zsh -l $SCRIPT"
+    ;;
+  ghostty)
+    # Ghostty has no AppleScript do-script; `open -na` spawns a new window of the running app.
+    # We use --command= rather than -e: Ghostty's -e appends to its configured shell,
+    # which on macOS defaults to `/usr/bin/login -flp <user>`. Per login(1), tokens after
+    # the username are parsed as KEY=VALUE env assignments — so `-e "zsh -l $SCRIPT"` is
+    # read as env vars, fails the `=` check, and drops into an interactive login shell
+    # without ever running the script. --command= replaces the shell wrapper entirely,
+    # and the launcher's own `#!/bin/zsh -l` shebang preserves login-shell semantics.
+    open -na Ghostty --args --command="$SCRIPT"
+    ;;
+  iterm)
+    osascript <<APPLESCRIPT
+tell application "iTerm"
+  activate
+  create window with default profile command "zsh -l $SCRIPT"
+end tell
+APPLESCRIPT
+    ;;
+  terminal)
+    osascript <<APPLESCRIPT
+tell application "Terminal"
+  activate
+  do script "zsh -l $SCRIPT"
+end tell
+APPLESCRIPT
+    ;;
+  nohup|*)
+    LOG="/tmp/solve-$ISSUE_NUM.log"
+    nohup zsh -l "$SCRIPT" > "$LOG" 2>&1 &
+    echo "Spawned detached (PID $!). Logs: $LOG"
+    ;;
+esac
+```
+
+### 7. Brief delay and confirm
+
+cmux's native notifier is preferred (matches existing UX); otherwise fall through to `terminal-notifier` then `osascript display notification`.
+
+```bash
+sleep 1
+NOTIFY_BODY="Agent spawned for issue #$ISSUE_NUM (tier: $TIER, terminal: $TERMINAL$([[ "$AUTO_MODE" == "1" ]] && echo ', auto'), turbo)"
+if [[ "$TERMINAL" == "cmux" ]] && command -v cmux >/dev/null 2>&1; then
+  cmux notify --title "Orchestrator" --body "$NOTIFY_BODY"
+elif command -v terminal-notifier >/dev/null 2>&1; then
+  terminal-notifier -title "Orchestrator" -message "$NOTIFY_BODY"
+elif command -v osascript >/dev/null 2>&1; then
+  osascript -e "display notification \"$NOTIFY_BODY\" with title \"Orchestrator\""
+fi
+```
+
+### 8. Post-action — rename tab to PR number once opened (optional)
+
+After opening its PR, the spawned agent renames its own tab from `#<issue> <title>` to `PR #<pr> <title>`. cmux uses its workspace API; everything else uses OSC escape sequences (Ghostty, iTerm2, Terminal.app all honor `OSC 1` for tab title and `OSC 2` for window title). Apply the same ~40-char truncation rule if `$PR_TITLE` is long.
+
+The spawned agent inherits `$TERMINAL` from this script (exported into the launcher in Step 5 — adjust the launcher heredoc to write `export TERMINAL='$TERMINAL'` near the top if you want this to work cleanly; otherwise the agent re-detects via the same logic above).
+
+```bash
+# Inside the spawned agent, after gh pr create returns the PR number:
+PR_NUM=$(gh pr view --json number --jq .number)
+PR_TITLE=$(gh pr view --json title --jq .title)
+NEW_TITLE="PR #$PR_NUM $PR_TITLE"
+
+case "${TERMINAL:-cmux}" in
+  cmux)
+    cmux workspace-action --action rename --title "$NEW_TITLE"
+    ;;
+  ghostty|iterm|terminal)
+    # OSC 2 = window title; OSC 1 = tab/icon title. Both honored by Ghostty/iTerm2/Terminal.app.
+    printf '\e]2;%s\a' "$NEW_TITLE"
+    printf '\e]1;PR #%s\a' "$PR_NUM"
+    ;;
+  *) ;;  # nohup: no controlling terminal to retitle
+esac
+```

--- a/plugins/uberdev/commands/turbo.md
+++ b/plugins/uberdev/commands/turbo.md
@@ -17,7 +17,7 @@ Spawn an autonomous Claude agent in a new cmux workspace to solve GitHub issue *
 - No flag → **auto-triage** by reading the issue (labels + body + title)
 - `--trivial` / `--small` / `--full` → override classification manually
 - `--terminal=…` → override terminal detection (else `$SOLVE_TERMINAL` env var, else auto-detect)
-- `--auto` → enable `--permission-mode auto` (orthogonal to `/turbo`'s brainstorm-interactivity flag — **`/turbo <issue> --auto` is the max-autonomy combo**)
+- `--auto` → enable `--permission-mode auto` (Claude Code's AI classifier — auto-approves safe ops; blocks force push / `rm -rf` on pre-existing files / exfil / self-modification / `--dangerously-skip-permissions`). Else `SOLVE_AUTO=1` env var, else `solve_auto: true` in `.claude/uberdev.local.md`. Orthogonal to `/turbo`'s brainstorm-interactivity flag — **`/turbo <issue> --auto` is the max-autonomy combo**.
 
 **Behavior vs `/solve`:**
 - **trivial / small tiers:** identical to `/solve` (these tiers don't run brainstorm anyway).
@@ -236,8 +236,12 @@ esac
 
 echo "Dispatching via: $TERMINAL"
 echo "Permission mode: $([[ "$AUTO_MODE" == "1" ]] && echo 'auto (Claude Code AI classifier)' || echo 'default (manual per-tool gating)')"
-echo "⚠️  TURBO MODE — brainstorm questions auto-answered with lead-agent recommendations." >&2
-echo "    Spec and plan are still written to disk before implementation; review the artifacts to course-correct." >&2
+# Banner only fires for medium tier — trivial/small don't run brainstorm, so "questions
+# auto-answered" would be misleading there (no questions would have been asked anyway).
+if [[ "$TIER" == "medium" ]]; then
+  echo "⚠️  TURBO MODE — brainstorm questions auto-answered with lead-agent recommendations." >&2
+  echo "    Spec and plan are still written to disk before implementation; review the artifacts to course-correct." >&2
+fi
 ```
 
 ### 6. Spawn agent in new terminal session

--- a/plugins/uberdev/skills/brainstorm/SKILL.md
+++ b/plugins/uberdev/skills/brainstorm/SKILL.md
@@ -24,7 +24,7 @@ You MUST create a task for each of these items and complete them in order:
 1. **Explore project context** — check files, docs, recent commits
 2. **Dispatch parallel research agents** (heuristic from prompt) — 2-3 `Explore`/`general-purpose` agents in one message researching codebase patterns, prior art, and library docs; synthesize findings (3-5 bullets) before continuing. Skip only for truly trivial tasks. See "Parallel research dispatch" below.
 3. **Offer visual companion** (if topic will involve visual questions) — its own message, not combined with a clarifying question. See the Visual Companion section below.
-4. **Ask clarifying questions** — one at a time, informed by research; understand purpose/constraints/success criteria
+4. **Ask clarifying questions** — one at a time, informed by research; understand purpose/constraints/success criteria *(skipped in turbo mode — see "Turbo Mode" section)*
 5. **Propose 2-3 approaches** — with trade-offs and your recommendation, grounded in research findings
 6. **Present design** — in sections scaled to their complexity (informative, not approval-gated)
 7. **Write design doc** — save to `docs/uberdev/specs/YYYY-MM-DD-<topic>-design.md` and commit
@@ -87,6 +87,18 @@ For architecturally consequential choices, this pattern also supports independen
 - One approach is obviously dominant AND no codebase context is needed
 - User has already provided exhaustive inline context
 
+**Turbo mode (when `--turbo` is in `$ARGUMENTS`):**
+
+If the user invoked this skill with `--turbo` (e.g. via `/turbo`), skip the clarifying-questions loop entirely:
+
+1. After parallel research synthesis, present the 2-3 approaches with your recommendation as **informational text** (so the user can audit the design choice post-hoc).
+2. Auto-select the recommendation — proceed straight to "Presenting the design" without waiting for user input.
+3. Continue through design → spec → write-plan exactly as the non-turbo flow does.
+
+**Why this is safe:** the lead-agent's recommendation is grounded in the parallel-research synthesis (not speculation), spec & plan are still written to disk before implementation waves dispatch, and the user can interrupt any time to revise.
+
+**This is NOT an approval gate.** Turbo mode strengthens the existing "Single forward pass" principle (see Key Principles) by removing the Q&A loop — it does NOT introduce a new pause for sign-off.
+
 **Exploring approaches:**
 
 - Propose 2-3 different approaches with trade-offs, grounded in the research synthesis above
@@ -142,7 +154,7 @@ Fix any issues inline. No need to re-review — just fix and move on.
 - **Multiple choice preferred** - Easier to answer than open-ended when possible
 - **YAGNI ruthlessly** - Remove unnecessary features from all designs
 - **Explore alternatives** - Always propose 2-3 approaches before settling
-- **Single forward pass** - Once clarifying questions are done, move design → spec → write-plan in one flow without approval gates. The user can interrupt to revise; don't proactively pause for sign-off.
+- **Single forward pass** - Once clarifying questions are done, move design → spec → write-plan in one flow without approval gates. The user can interrupt to revise; don't proactively pause for sign-off. *Turbo mode (`--turbo` in args) takes this further by collapsing the clarifying-questions loop entirely — it never adds a gate, only removes one.*
 
 ## Visual Companion
 

--- a/plugins/uberdev/skills/brainstorm/SKILL.md
+++ b/plugins/uberdev/skills/brainstorm/SKILL.md
@@ -93,11 +93,7 @@ If the user invoked this skill with `--turbo` (e.g. via `/turbo`), skip the clar
 
 1. After parallel research synthesis, present the 2-3 approaches with your recommendation as **informational text** (so the user can audit the design choice post-hoc).
 2. Auto-select the recommendation — proceed straight to "Presenting the design" without waiting for user input.
-3. Continue through design → spec → write-plan exactly as the non-turbo flow does.
-
-**Why this is safe:** the lead-agent's recommendation is grounded in the parallel-research synthesis (not speculation), spec & plan are still written to disk before implementation waves dispatch, and the user can interrupt any time to revise.
-
-**This is NOT an approval gate.** Turbo mode strengthens the existing "Single forward pass" principle (see Key Principles) by removing the Q&A loop — it does NOT introduce a new pause for sign-off.
+3. Continue through design → spec → write-plan exactly as the non-turbo flow does. Spec and plan are written to disk before implementation, and the user can interrupt to revise at any point — see "Single forward pass" in Key Principles.
 
 **Exploring approaches:**
 


### PR DESCRIPTION
## Summary

- New `/turbo <issue>` slash command — unattended `/solve` that auto-accepts the brainstorm phase's lead-agent recommendation for medium/large tiers (parallel research still runs; recommendation grounding preserved).
- Brainstorm SKILL gets a single conditional: when `--turbo` is in `$ARGUMENTS`, skip the clarifying-questions loop and proceed straight to design synthesis.
- Composes orthogonally with `--auto`: `/turbo <issue> --auto` is the max-autonomy combo (turbo governs brainstorm interactivity; auto governs Claude Code's per-tool permission mode).

No new approval gates introduced — turbo only **removes** the Q&A stop, never **adds** one. Preserves the `feedback_brainstorm_no_gates.md` invariant. Brainstorm behavior is unchanged when invoked outside `/turbo` (default Q&A loop intact).

Trivial/small tiers don't run brainstorm anyway, so `/turbo` is functionally identical to `/solve` there. The intent-signaling name + `--auto` shortcut is the only difference.

## Design + plan artifacts (local only — `docs/` is gitignored)

- Spec: `docs/uberdev/specs/2026-04-28-turbo-command-design.md`
- Plan: `docs/uberdev/plans/2026-04-28-turbo-command.md`

## Commits

1. `feat(uberdev): brainstorm skill turbo-mode conditional` — single conditional in SKILL.md, default flow preserved
2. `feat(uberdev): add /turbo command — unattended /solve` — new turbo.md, near-clone of solve.md with scoped diffs
3. `docs(uberdev): document /turbo in README` — TL;DR table row + body section + orthogonality matrix
4. `docs(uberdev): changelog entry for /turbo` — Unreleased / Added bullet
5. `refactor(uberdev): /simplify pass on /turbo feature` — restored `--auto` fallback chain prose, gated stderr banner on `$TIER == medium`, dropped redundant SKILL paragraphs

## Test plan

Manual end-to-end (no automated tests — matches `/solve` convention):

- [ ] `/turbo <typo-issue>` (trivial) — identical to `/solve` (no brainstorm, no banner)
- [ ] `/turbo <small-bug>` (small) — identical to `/solve` (no brainstorm, no banner)
- [ ] `/turbo <medium-issue>` — full pipeline, brainstorm runs WITHOUT Q&A loop, parallel research dispatches, spec & plan land on disk before implementation waves, banner fires once
- [ ] `/turbo <medium-issue> --auto` — same as above + per-tool gating uses Claude Code's AI classifier
- [ ] `/solve <medium-issue>` (regression check) — Q&A loop intact, no banner
- [ ] `/uberdev:brainstorm "build X"` (regression check) — Q&A loop intact

## Out of scope (intentional follow-up)

`turbo.md` is currently a near-clone of `solve.md` (~270 lines duplicated). The simplify reviewer flagged this as a maintenance liability. Refactoring to a shared launcher script in `plugins/uberdev/scripts/run-solve.sh` would change `/solve` behavior (adding a `--turbo-brainstorm` flag), which the design doc explicitly forbids. Worth tracking as a separate issue once `/turbo` lands.

## Acceptance criteria (from issue)

- [x] `plugins/uberdev/commands/turbo.md` exists
- [x] `/turbo` runs same tier dispatch as `/solve` for trivial/small tiers
- [x] `/turbo` for medium/large tiers runs brainstorm WITHOUT clarifying-question dialogue
- [x] Parallel research still runs in turbo mode
- [x] Spec and plan written to disk before implementation waves
- [x] `/turbo --auto` composes correctly
- [x] Brainstorm unchanged when invoked outside `/turbo`
- [x] No new approval gates introduced
- [x] README + CHANGELOG updated; orthogonality with `/solve --auto` documented

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/turbo <issue>` command for expedited unattended solving. For medium/large issues, automatically accepts brainstorm design recommendations and skips interactive clarification steps. Trivial/small issues follow existing `/solve` behavior. Compatible with the `--auto` flag.

* **Documentation**
  * Updated command documentation and skill specifications to detail `/turbo` behavior, usage patterns, and safety expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->