### PR TITLE
feat(uberdev): /issue deep root-cause research fanout (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-04-29
+
+### Added
+- **`/uberdev:issue` deep root-cause research fanout.** Phase 2 now dispatches a 2-agent parallel fanout (`research-codebase` + `research-patterns`) when `NO_EXPLORE=0`, in the same single message as the existing Phase 3 (Duplicate Search) and Phase 4 (Label/Scope Validation) Task() calls — four agents fan out together, Phase 4.5 aggregates all four returns. Research summaries write to `.uberdev/research/run-<RUN_ID>/` and rename to `.uberdev/research/issue-<ISSUE_NUM>/` after `gh issue create`.
+- **Bug-template `## Likely root cause` is now a causal triple** — `**Symptom:**` (observable failure), `**Mechanism:**` (specific code/data path), `**Owning code:**` (path/symbol — the assumption to challenge). Optional 5 Whys nested chain for non-trivial bugs. Replaces the previous file-list placeholder.
+- **`/uberdev:brainstorm` short-circuit on `.uberdev/research/issue-<N>/`.** When invoked downstream of `/issue` for the same issue number, brainstorm reads the persisted summaries instead of re-dispatching equivalent research agents. Per-topic skip (codebase + in-repo prior art only — external prior art still dispatches); mtime-based staleness fallback; clean fallthrough for issues created before this change.
+- **Body authoring rules subsection in `issue.md`** — codifies the WHAT/HOW boundary ahead of the templates: issue body says what is broken or wanted, never how to fix it. Implementation strategy is `/uberdev:brainstorm`'s job.
+- **`tests/issue-causal-fanout.test.sh`** — structural-assertion test (modelled on `tests/turbo-flow.test.sh`) locking the contract invariants: Phase 1.5 RUN_ID/SUMMARY_DIR, Phase 2 4-agent single-message fanout, `--no-explore` placeholder verbatim, causal triple labels, feat template rename invariant, Phase 7 artifact-binding rename, brainstorm short-circuit + per-topic skip + stale-check + backwards-compat fallthrough.
+- **RFC:** `docs/rfc/2026-04-29-issue-deep-root-cause-research-fanout.md` records the why (2-agent rather than 4-agent fanout, stable artifact directory rather than return-value handoff, triple rather than freeform causal essay, field rename rather than rules-text reminder) and rejected alternatives.
+
+### Changed
+- **Feat-template field rename:** `## Proposed approach` → `## What changes`. Field-name pressure replaces rules-text pressure for keeping implementation strategy out of the issue body. Downstream parsers (`/solve`, `/turbo`, `/orchestrator`) read only `**Triage hint:**` from the body, so the rename is contract-preserving.
+- **Phase 4.5 aggregate** in `issue.md` extended to reconcile two new research returns (`codebase.md` drives the bug-template triple and `## Likely area`; `patterns.md` drives the `## Related` prior-pattern bullets and informs the causal chain when prior bugs exist).
+- **Rules subsection** in `issue.md` gains a WHAT/HOW boundary bullet: issue body never contains an implementation checklist or fix design.
+
+### Backwards compatibility
+- No breaking change to issue-body parsing. `**Triage hint:**`, severity checkboxes, label format, and conventional-commit titles all preserved verbatim.
+- Issues created before v0.8.0 have no `.uberdev/research/issue-<N>/` directory; brainstorm's short-circuit `[ -d ... ]` check returns false and falls through cleanly to the existing parallel-dispatch path. No data migration.
+
+Closes #9.
+
 ## [0.7.1] - 2026-04-29
 
 ### Fixed
@@ -127,7 +148,11 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 ### Changed
 - Documentation: README expanded with `Updating` section explaining manual vs auto-update for third-party marketplaces (`docs:` commit `007537b` on 2026-04-27 superseded by this release).
 
-[unreleased]: https://github.com/TheFJK/UberDev/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/TheFJK/UberDev/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/TheFJK/UberDev/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/TheFJK/UberDev/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/TheFJK/UberDev/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/TheFJK/UberDev/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/TheFJK/UberDev/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/TheFJK/UberDev/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/TheFJK/UberDev/compare/v0.3.0...v0.3.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A personal Claude Code marketplace bundling opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.7.1-blue)](https://github.com/TheFJK/UberDev)
+[![Version](https://img.shields.io/badge/version-0.8.0-blue)](https://github.com/TheFJK/UberDev)
 [![License](https://img.shields.io/badge/license-MIT-green)](#license)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)
@@ -203,7 +203,9 @@ flowchart TD
 - [ ] P3 — minor / cosmetic
 
 ## Likely root cause
-[Analysis from Phase 2 — connect symptom to specific code]
+- **Symptom:** [observable failure mode in user-facing terms]
+- **Mechanism:** [the specific code/data path that produces the symptom; cite a concrete artifact such as a function call site, log line, or config value]
+- **Owning code:** `path/to/File` — `Class.method()` — [why this is the assumption to challenge]
 
 ## Likely area
 - `path/to/File` — `ClassName.methodName()` — [why relevant]
@@ -229,8 +231,8 @@ flowchart TD
 ## Relevant code
 - `path/to/File` — `ClassName` — [how it relates]
 
-## Proposed approach
-[Implementation strategy informed by Phase 2 investigation]
+## What changes
+[The capability being added or behavior being modified — externally visible result, contract change, or new affordance. No implementation strategy.]
 
 ## Acceptance criteria
 - [ ] [criterion]
@@ -377,9 +379,10 @@ Result: maximum parallelism on edits, deterministic commit history, zero merge c
 | **v0.5.0** | Released | **Hardening + perf + new platform features.** Security: closes RCE in `/solve` (drops `--dangerously-skip-permissions`), prompt-injection in `inject-brainstorm-answers` (per-line JSON validation, `<`/`>` escaping, symlinked-path refusal), and fragile JSON in `session-start` (jq-based encoding). Critical bug fix: v0.4.0 `/issue` parallel fanout was silently broken — vars now resolved in orchestrator and baked literally into each subagent brief. Perf: 5 detail agents → Haiku 4.5 (~15-20% wall-time on `/uberdev:review-pr`); per-line `jq` fork in brainstorm-answers hook → streaming `jq -R 'fromjson?'` (~200-500ms saved per user prompt). New: `SessionEnd` + `PreCompact` hooks; `.claude/uberdev.local.md` per-project config; `AskUserQuestion` fast-path in `brainstorm`; cross-platform `sed -i` in `/solve`; YAML frontmatter on `/issue` and `/solve`; tightened `allowed-tools`; `CONTRIBUTING.md` + `CHANGELOG.md` (Keep-a-Changelog 1.1.0); stack-agnostic `code-simplifier`. |
 | **v0.6.0** | Released | **Unattended workflow + Ghostty integration.** New `/turbo <issue>` — unattended `/solve` that auto-accepts brainstorm recommendations for medium/large tier (parallel research still runs — recommendation grounding preserved); trivial/small tier behaves identically to `/solve`. New `/solve --auto` and `/turbo --auto` flags enable Claude Code's `--permission-mode auto` classifier (auto-approves safe ops; blocks force push, exfil, self-modification, `--dangerously-skip-permissions`). `/solve` and `/turbo` Ghostty dispatcher tab-spawns into the originating Ghostty window when invoked from inside Ghostty (per-project workspaces stay grouped); `SOLVE_GHOSTTY_NEW_WINDOW=1` forces legacy new-window dispatch; AppleScript failures fall back automatically. `brainstorm` skill: parallel research dispatch promoted to default first step (proposed approaches grounded in research synthesis, not speculation). Removed deprecated slash-command shims `/uberdev:brainstorm`, `/uberdev:execute-plan`, `/uberdev:write-plan` (Superpowers-port leftovers — invoke skills directly via the Skill tool). |
 | **v0.7.0** | Released | **Writer-subagent orchestrator.** New `/uberdev:orchestrator` skill — 5-phase pipeline used by `/solve` and `/turbo` for medium/large tier: research fanout (parallel Sonnet subagents) → optional Q&A (skipped for `/turbo`) → spec-writer (Opus) → optional spec-reviewer (Opus, gated by `--paranoid` for medium tier; always for large tier) → plan-writer (Opus, with internal research fanout) → existing `subagent-driven-dev`. Each writer returns a structured YAML summary; orchestrator main holds pointers, not raw artifacts — reclaims context for wave dispatch and error recovery. 8 new agent definitions: `research-codebase`, `research-patterns`, `research-prior-art`, `research-constraints` (Sonnet); `spec-writer`, `spec-reviewer`, `spec-reviser`, `plan-writer` (Opus). New `--paranoid` flag enables spec-reviewer for medium tier. `/solve` and `/turbo` medium/large prompts now invoke `/uberdev:orchestrator` instead of `/uberdev:brainstorm` directly; trivial/small paths unchanged. `write-plan` execution handoff is now non-interactive (default subagent-driven, explicit opt-in for inline). Closes #5 architecturally — `/turbo` no longer halts on a "Subagent-Driven vs. Inline Execution?" prompt. |
-| **v0.7.1** | Current | **`/turbo` end-to-end unattended chain.** Threads `--turbo` through every handoff (`brainstorm` → `write-plan` → `subagent-driven-dev` → `finish-branch`, plus the `orchestrator` Phase 5 → `subagent-driven-dev` link that PR #8 introduced). `finish-branch` auto-selects "Push and Create PR" under `--turbo` instead of prompting; pre-existing Step 5 contradiction (Quick Reference / Red Flags said cleanup runs only for Options 1 & 4, but Step 5 listed Options 1, 2, 4) resolved in favor of consistency — Option 2 leaves the worktree alive for PR-feedback fixups. New `tests/turbo-flow.test.sh` (9 contract assertions) locks the `--turbo` propagation contract at every handoff site so a future skill edit can't silently re-attend the flow. |
-| **v0.8** | Maybe | Optional per-repo `.claude/board.json` for re-enabling project-board auto-add |
-| **v0.9** | Maybe | Linux + Windows terminal dispatchers; configurable model pin via env |
+| **v0.7.1** | Released | **`/turbo` end-to-end unattended chain.** Threads `--turbo` through every handoff (`brainstorm` → `write-plan` → `subagent-driven-dev` → `finish-branch`, plus the `orchestrator` Phase 5 → `subagent-driven-dev` link that PR #8 introduced). `finish-branch` auto-selects "Push and Create PR" under `--turbo` instead of prompting; pre-existing Step 5 contradiction (Quick Reference / Red Flags said cleanup runs only for Options 1 & 4, but Step 5 listed Options 1, 2, 4) resolved in favor of consistency — Option 2 leaves the worktree alive for PR-feedback fixups. New `tests/turbo-flow.test.sh` (9 contract assertions) locks the `--turbo` propagation contract at every handoff site so a future skill edit can't silently re-attend the flow. |
+| **v0.8.0** | Current | **`/uberdev:issue` deep root-cause research fanout + WHAT/HOW boundary.** Phase 2 dispatches a 2-agent parallel fanout (`research-codebase` + `research-patterns`) alongside the existing Phase 3/4 agents — four agents fan out together in a single message; Phase 4.5 aggregates all four returns. Bug-template `## Likely root cause` becomes a causal triple (Symptom / Mechanism / Owning code) with optional 5 Whys for non-trivial bugs; bare file-path lists in this section are forbidden. Feat-template `## Proposed approach` is renamed to `## What changes` (field-name pressure replaces rules-text pressure). New "Body authoring rules" subsection ahead of the templates codifies WHAT/HOW. Research summaries persist to `.uberdev/research/issue-<N>/` (renamed from `run-<RUN_ID>/` after `gh issue create`); `/uberdev:brainstorm` step 2 short-circuits on this directory per-topic with mtime-based staleness fallback, eliminating the duplicate codebase-research round when invoked downstream of `/issue`. New `tests/issue-causal-fanout.test.sh` (structural assertions, modelled on `tests/turbo-flow.test.sh`) locks the contract invariants. RFC at `docs/rfc/2026-04-29-issue-deep-root-cause-research-fanout.md`. No breaking change — `**Triage hint:**`, severity checkboxes, label format, and conventional-commit titles preserved verbatim. Closes #9. |
+| **v0.9** | Maybe | Optional per-repo `.claude/board.json` for re-enabling project-board auto-add |
+| **v0.10** | Maybe | Linux + Windows terminal dispatchers; configurable model pin via env |
 
 ---
 

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution, brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/issue.md
+++ b/plugins/uberdev/commands/issue.md
@@ -231,11 +231,23 @@ ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 ```
 
 ```bash
+if [ -z "$ISSUE_NUM" ]; then
+  echo "error: gh issue create did not return a parseable URL: '$ISSUE_URL'" >&2
+  echo "error: research artifacts remain at $SUMMARY_DIR (not bound to an issue)" >&2
+  return 1
+fi
 if [ -d "$SUMMARY_DIR" ]; then
   if ! mv "$SUMMARY_DIR" ".uberdev/research/issue-$ISSUE_NUM" 2>/dev/null; then
-    # Cross-filesystem fallback (e.g. tmpfs vs. local mount)
-    cp -R "$SUMMARY_DIR" ".uberdev/research/issue-$ISSUE_NUM" && rm -rf "$SUMMARY_DIR"
-    echo "warning: SUMMARY_DIR rename used cp+rm fallback (cross-filesystem)" >&2
+    # mv failed (typically cross-filesystem EXDEV; could also be perms/disk).
+    if cp -R "$SUMMARY_DIR" ".uberdev/research/issue-$ISSUE_NUM"; then
+      echo "warning: SUMMARY_DIR rename used cp+rm fallback (cross-filesystem)" >&2
+      if ! rm -rf "$SUMMARY_DIR"; then
+        echo "warning: cp succeeded but rm failed; both copies remain on disk" >&2
+      fi
+    else
+      echo "error: both mv and cp failed; research artifacts remain at $SUMMARY_DIR (manual cleanup required)" >&2
+      return 1
+    fi
   fi
 fi
 ```

--- a/plugins/uberdev/commands/issue.md
+++ b/plugins/uberdev/commands/issue.md
@@ -35,9 +35,7 @@ Parse `$DESC`. Determine:
 
 ## Phases 2–4: Parallel Investigation
 
-Phases 2, 3, and 4 are **read-only and independent** — they don't share state. Dispatch them as **three Task agents in a single message** (one assistant turn, three `Task` tool_use blocks) and aggregate their reports before drafting in Phase 5. Each phase below documents one agent's brief.
-
-If `$NO_EXPLORE=1` you may run the three phases inline (no Task overhead) since each becomes a small Grep/`gh` invocation. For everything else, parallel fanout is the default — typical wall-time savings are 60-70% versus running the three serially.
+Phases 2, 3, and 4 are **read-only and independent** — they don't share state. When `NO_EXPLORE=0`, Phase 2 itself dispatches **two** Task agents (`research-codebase`, `research-patterns`); together with Phase 3 and Phase 4 that is **four** Task agents fanned out **in a single assistant turn** (one message, four `Task` tool_use blocks). Phase 4.5 aggregates all four returns. When `NO_EXPLORE=1`, Phase 2 collapses to inline Grep/Glob and the fanout shrinks to Phase 3 + Phase 4 only (two Task agents in one message).
 
 ## Phase 1.5: Pre-fanout — resolve variables (CRITICAL)
 
@@ -47,10 +45,13 @@ Subagents have no shell context, so resolve every variable here and interpolate 
 # Already resolved in Phase 0: $REPO, $DESC, $NO_EXPLORE
 KEYWORDS="<top 3-5 keywords from $DESC, space-separated>"
 COMMITLINT=$(find . -maxdepth 3 \( -name "commitlint.config.js" -o -name "commitlint.config.cjs" -o -name "commitlint.config.mjs" -o -name "commitlint.config.ts" \) -not -path "*/node_modules/*" | head -1)
-echo "REPO=$REPO"; echo "DESC=$DESC"; echo "KEYWORDS=$KEYWORDS"; echo "NO_EXPLORE=$NO_EXPLORE"; echo "COMMITLINT=$COMMITLINT"
+RUN_ID="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
+SUMMARY_DIR=".uberdev/research/run-$RUN_ID"
+mkdir -p "$SUMMARY_DIR"
+echo "REPO=$REPO"; echo "DESC=$DESC"; echo "KEYWORDS=$KEYWORDS"; echo "NO_EXPLORE=$NO_EXPLORE"; echo "COMMITLINT=$COMMITLINT"; echo "RUN_ID=$RUN_ID"; echo "SUMMARY_DIR=$SUMMARY_DIR"
 ```
 
-Every Phase 2-4 agent brief below interpolates these literal resolved values; never `$VAR` references.
+Every Phase 2-4 agent brief below interpolates these literal resolved values (including `$SUMMARY_DIR` resolved as e.g. `.uberdev/research/run-20260429-143022-604fdb3`); never `$VAR` references.
 
 ## Phase 2: Investigate Codebase
 
@@ -58,9 +59,10 @@ Investigate the codebase for the issue described in `$DESC` (resolved). Repo is 
 
 **Gate the depth:**
 
-- If `NO_EXPLORE=1` (literal `1` in the brief) → shallow: Grep + Glob only.
-- Else if type=`feat` with multi-module scope, OR type=`fix` whose title hints at `refactor`/`migrate`/`rewrite`/`architecture` — spawn the **Explore** subagent (per CLAUDE.md: ">3 queries → Explore").
-- Else → Grep + Glob directly.
+- If `NO_EXPLORE=1` (literal `1` in the brief) → shallow: Grep + Glob only, inline (no Task dispatch). The bug template's `## Likely root cause` falls back to the placeholder string `[shallow mode — no fanout run; root cause to be confirmed in /brainstorm]` (Phase 5 handles the substitution).
+- Else → dispatch a 2-agent parallel fanout (`research-codebase` + `research-patterns`) as Task() calls **in the same single message as the Phase 3 (Duplicate Search) and Phase 4 (Label/Scope Validation) Task() calls** — i.e. all four agents fan out together in one message. Each brief carries the literal resolved values for `issue_body` (the user's `$DESC` plus type/scope from Phase 1), `working_dir` (the absolute repo root), and `summary_dir` (the literal resolved value of `$SUMMARY_DIR`, e.g. `.uberdev/research/run-20260429-143022-604fdb3`).
+
+Each research agent writes its summary to `<summary_dir>/<artifact>.md` (`codebase.md` and `patterns.md` respectively) and returns the universal YAML block per the orchestrator contract. The producer (Phase 4.5) reads the YAML returns and the summary files; it holds pointers, not raw research content.
 
 Either path must produce a **Likely area** list with real file paths and symbol names. Never guess paths. If you can't find anything relevant, say so explicitly in the draft rather than inventing.
 
@@ -94,13 +96,20 @@ If `$COMMITLINT` resolved to an empty string in Phase 1.5, skip scope validation
 
 ## Phase 4.5: Aggregate
 
-Wait for all three Phase 2-4 agents to return. Reconcile their reports:
+Wait for all dispatched agents to return (4 agents when `NO_EXPLORE=0`; 2 agents when `NO_EXPLORE=1`). Reconcile their reports:
 
-- **Phase 2 output** → `## Likely area` content for the draft
-- **Phase 3 output** → `## Related` section, plus regression flagging if a closed issue matches
-- **Phase 4 output** → final label set + validated scope (or a flag if commitlint scope-enum doesn't include the proposed scope)
+- **`research-codebase` summary (`codebase.md`)** → drives the bug template's `## Likely root cause` symptom/mechanism/owning-code triple AND the `## Likely area` list. Required for `fix` issues; if `BLOCKED`, abort the fanout with a diagnostic and prompt the user to retry or pass `--no-explore`.
+- **`research-patterns` summary (`patterns.md`)** → drives the `## Related` section's prior-pattern bullets and informs the causal chain when prior bugs exist. Optional — if `BLOCKED`, log a one-line warning and continue without it.
+- **Phase 3 output** → `## Related` section closed/open issue links, plus regression flagging if a closed issue matches.
+- **Phase 4 output** → final label set + validated scope (or a flag if commitlint scope-enum doesn't include the proposed scope).
 
 If any agent returns a blocking question (e.g., "open match found, comment instead?") raise it to the user **before** drafting Phase 5.
+
+## Body authoring rules — WHAT, not HOW
+
+The issue body says *what* is broken or wanted; it never says *how* to fix it. Specifically: no implementation checklists, no step-by-step TODOs, no fix designs, no code snippets that would belong in a PR. Causal explanation (symptom → mechanism → owning code) is in scope. Implementation strategy is `/uberdev:brainstorm`'s job.
+
+This boundary is enforced both by the templates below (the bug template's `## Likely root cause` is a causal triple; the feat template's `## What changes` describes externally visible result, not implementation) and by the rules subsection at the end of this file.
 
 ## Phase 5: Draft Issue
 
@@ -133,7 +142,12 @@ Show the user a complete draft BEFORE creating.
 
 ## Likely root cause
 
-[Analysis from Phase 2 — connect the symptom to specific code]
+- **Symptom:** [observable failure mode in user-facing terms]
+- **Mechanism:** [the specific code/data path that produces the symptom; cite a concrete artifact such as a function call site, log line, or config value]
+- **Owning code:** `path/to/File` — `Class.method()` — [why this is the assumption to challenge]
+
+<!-- AUTHORING NOTE (do not include in rendered issue body): For non-trivial bugs, expand mechanism into a 5 Whys causal chain (each rung citing a file+symbol). -->
+<!-- AUTHORING NOTE (do not include in rendered issue body): Bare file-path lists are forbidden in this section — use `## Likely area` for those. The triple is the smallest causal unit; this rule is a hard contract enforced by `tests/issue-causal-fanout.test.sh`. -->
 
 ## Likely area
 
@@ -150,6 +164,8 @@ Show the user a complete draft BEFORE creating.
 **Triage hint:** <trivial|small|medium>
 ```
 
+> **`--no-explore` placeholder.** When `NO_EXPLORE=1` and type=`fix`, substitute the entire `## Likely root cause` section body with the literal string `[shallow mode — no fanout run; root cause to be confirmed in /brainstorm]` (one paragraph, no bullets). The section heading itself stays. Reader knows root cause was deferred, not omitted.
+
 ### Feature (`feat`) — covers enhancements
 
 **Title:** `feat(scope): description`
@@ -164,9 +180,9 @@ Show the user a complete draft BEFORE creating.
 
 - `path/to/File` — `ClassName` — [how it relates]
 
-## Proposed approach
+## What changes
 
-[Implementation strategy informed by Phase 2]
+[The capability being added or the behavior being modified, described in WHAT terms — externally visible result, contract change, or new affordance. No implementation strategy. Implementation belongs in /uberdev:brainstorm.]
 
 ## Acceptance criteria
 
@@ -214,6 +230,18 @@ echo "$ISSUE_URL"
 ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 ```
 
+```bash
+if [ -d "$SUMMARY_DIR" ]; then
+  if ! mv "$SUMMARY_DIR" ".uberdev/research/issue-$ISSUE_NUM" 2>/dev/null; then
+    # Cross-filesystem fallback (e.g. tmpfs vs. local mount)
+    cp -R "$SUMMARY_DIR" ".uberdev/research/issue-$ISSUE_NUM" && rm -rf "$SUMMARY_DIR"
+    echo "warning: SUMMARY_DIR rename used cp+rm fallback (cross-filesystem)" >&2
+  fi
+fi
+```
+
+This binds research artifacts to the issue number atomically (or via cp+rm fallback). `/uberdev:brainstorm` looks up `.uberdev/research/issue-<N>/` keyed on the issue number to short-circuit duplicate research.
+
 ## Phase 8: Offer follow-up
 
 Print a structured confirmation so the user can copy-paste the next action:
@@ -240,3 +268,4 @@ Next step: /solve $ISSUE_NUM
 - **Triage hint mandatory in every issue body** — `/solve` parses it to pick the tier without redoing classification.
 - **Always confirm** — show the full draft, wait for explicit approval before `gh issue create`.
 - **No screenshots section** — user adds those manually after creation if needed.
+- **WHAT/HOW boundary enforced** — issue body never contains an implementation checklist or fix design; that work belongs in `/uberdev:brainstorm`. Bug template's `## Likely root cause` is a causal triple (symptom/mechanism/owning code), not a file list. Feat template's `## What changes` describes externally visible result, not implementation strategy.

--- a/plugins/uberdev/commands/issue.md
+++ b/plugins/uberdev/commands/issue.md
@@ -45,7 +45,7 @@ Subagents have no shell context, so resolve every variable here and interpolate 
 # Already resolved in Phase 0: $REPO, $DESC, $NO_EXPLORE
 KEYWORDS="<top 3-5 keywords from $DESC, space-separated>"
 COMMITLINT=$(find . -maxdepth 3 \( -name "commitlint.config.js" -o -name "commitlint.config.cjs" -o -name "commitlint.config.mjs" -o -name "commitlint.config.ts" \) -not -path "*/node_modules/*" | head -1)
-RUN_ID="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
+RUN_ID="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD 2>/dev/null || echo nohead)"
 SUMMARY_DIR=".uberdev/research/run-$RUN_ID"
 mkdir -p "$SUMMARY_DIR"
 echo "REPO=$REPO"; echo "DESC=$DESC"; echo "KEYWORDS=$KEYWORDS"; echo "NO_EXPLORE=$NO_EXPLORE"; echo "COMMITLINT=$COMMITLINT"; echo "RUN_ID=$RUN_ID"; echo "SUMMARY_DIR=$SUMMARY_DIR"

--- a/plugins/uberdev/skills/brainstorm/SKILL.md
+++ b/plugins/uberdev/skills/brainstorm/SKILL.md
@@ -24,7 +24,7 @@ Every project goes through this process. A todo list, a single-function utility,
 You MUST create a task for each of these items and complete them in order:
 
 1. **Explore project context** — check files, docs, recent commits
-2. **Dispatch parallel research agents** (heuristic from prompt) — 2-3 `Explore`/`general-purpose` agents in one message researching codebase patterns, prior art, and library docs; synthesize findings (3-5 bullets) before continuing. Skip only for truly trivial tasks. See "Parallel research dispatch" below.
+2. **Dispatch parallel research agents** (heuristic from prompt) — 2-3 `Explore`/`general-purpose` agents in one message researching codebase patterns, prior art, and library docs; synthesize findings (3-5 bullets) before continuing. Skip only for truly trivial tasks. **Issue-research short-circuit:** if invoked with an issue number context (e.g. via `/solve <N>` or `/turbo <N>`) and `.uberdev/research/issue-<N>/` exists, read its summaries (`codebase.md` and, if present, `patterns.md`) and treat them as the codebase + in-repo-prior-art research input — skip dispatching the equivalent agents. The short-circuit is **per-topic**, not all-or-nothing: continue to dispatch agents for topics not covered (e.g. external prior art via WebSearch/Context7). See "Parallel research dispatch" and "Issue-research short-circuit" below.
 3. **Offer visual companion** (if topic will involve visual questions) — its own message, not combined with a clarifying question. See the Visual Companion section below.
 4. **Ask clarifying questions** — one at a time, informed by research; understand purpose/constraints/success criteria *(skipped in turbo mode — see "Turbo Mode" section)*
 5. **Propose 2-3 approaches** — with trade-offs and your recommendation, grounded in research findings
@@ -83,6 +83,41 @@ Heuristics for inferring research questions:
 Synthesize findings into a brief summary before engaging the user with clarifying questions. The 2-3 approaches you propose later MUST be grounded in this research, not speculation.
 
 For architecturally consequential choices, this pattern also supports independent parallel exploration of design directions (one agent per direction). See `uberdev:dispatching-parallel-agents`.
+
+**Issue-research short-circuit (when an issue number is in scope):**
+
+When this skill is invoked downstream of `/uberdev:issue` (i.e. the conversation has an issue number), `/issue` may have already run a 2-agent fanout (`research-codebase` + `research-patterns`) and persisted summaries to `.uberdev/research/issue-<N>/`. Read those instead of re-dispatching:
+
+```bash
+RESEARCH_DIR=".uberdev/research/issue-$ISSUE"
+if [ -d "$RESEARCH_DIR" ] && [ -f "$RESEARCH_DIR/codebase.md" ]; then
+  ISSUE_UPDATED_ISO=$(gh issue view "$ISSUE" --json updatedAt --jq .updatedAt)
+  # Normalise both timestamps to epoch seconds for portable comparison
+  # (BSD/macOS first, GNU/Linux fallback). Avoids the macOS/Linux mtime-format
+  # mismatch that would silently mis-rank summaries against gh's RFC-3339 output.
+  ISSUE_UPDATED_EPOCH=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ISSUE_UPDATED_ISO" +%s 2>/dev/null \
+                      || date -d "$ISSUE_UPDATED_ISO" +%s)
+  CODEBASE_MTIME_EPOCH=$(stat -f %m "$RESEARCH_DIR/codebase.md" 2>/dev/null \
+                       || stat -c %Y "$RESEARCH_DIR/codebase.md")
+  if [ "$CODEBASE_MTIME_EPOCH" -lt "$ISSUE_UPDATED_EPOCH" ]; then
+    # Stale: research summary is older than the most recent issue-body edit
+    # → fall through to the full parallel-dispatch path so re-research picks up the change.
+    :
+  else
+    # Fresh: read codebase.md (and patterns.md if present) verbatim into the synthesis
+    # step. Per-topic skip flags tell the dispatch step which agents to omit.
+    SHORTCIRCUIT_CODEBASE=1
+    [ -f "$RESEARCH_DIR/patterns.md" ] && SHORTCIRCUIT_PATTERNS=1
+  fi
+fi
+```
+
+- **Per-topic skip, not all-or-nothing.** If `codebase.md` exists, skip the codebase-equivalent agent. If `patterns.md` exists, skip the in-repo-prior-art agent. Continue to dispatch agents for topics NOT covered (e.g. external prior art via WebSearch/Context7).
+- **Stale check.** If the summary's mtime is older than `gh issue view <N> --json updatedAt --jq .updatedAt`, the issue body was edited after the research ran — fall back to the full parallel dispatch.
+- **Malformed-summary fallback.** If the directory exists but the summary file is missing the `summary` section or is otherwise unreadable, log a one-line warning and fall through to the full parallel dispatch. Do not block.
+- **Backwards compatibility.** Issues created before this change have no `.uberdev/research/issue-<N>/` directory; `[ -d ... ]` returns false and the skill proceeds with the existing parallel-dispatch path. No data migration needed.
+
+The synthesis step reads the summary text into context verbatim; no re-derivation required.
 
 **Skip parallel research only when:**
 - Truly trivial: config tweak, rename, single-line fix, typo

--- a/plugins/uberdev/skills/brainstorm/SKILL.md
+++ b/plugins/uberdev/skills/brainstorm/SKILL.md
@@ -91,23 +91,36 @@ When this skill is invoked downstream of `/uberdev:issue` (i.e. the conversation
 ```bash
 RESEARCH_DIR=".uberdev/research/issue-$ISSUE"
 if [ -d "$RESEARCH_DIR" ] && [ -f "$RESEARCH_DIR/codebase.md" ]; then
-  ISSUE_UPDATED_ISO=$(gh issue view "$ISSUE" --json updatedAt --jq .updatedAt)
-  # Normalise both timestamps to epoch seconds for portable comparison
-  # (BSD/macOS first, GNU/Linux fallback). Avoids the macOS/Linux mtime-format
-  # mismatch that would silently mis-rank summaries against gh's RFC-3339 output.
-  ISSUE_UPDATED_EPOCH=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ISSUE_UPDATED_ISO" +%s 2>/dev/null \
-                      || date -d "$ISSUE_UPDATED_ISO" +%s)
-  CODEBASE_MTIME_EPOCH=$(stat -f %m "$RESEARCH_DIR/codebase.md" 2>/dev/null \
-                       || stat -c %Y "$RESEARCH_DIR/codebase.md")
-  if [ "$CODEBASE_MTIME_EPOCH" -lt "$ISSUE_UPDATED_EPOCH" ]; then
-    # Stale: research summary is older than the most recent issue-body edit
-    # → fall through to the full parallel-dispatch path so re-research picks up the change.
-    :
+  # Malformed-summary check — file must contain a `summary` field per the
+  # research-codebase YAML return contract. If absent, fall through with a warning
+  # rather than read garbage into the synthesis step.
+  if ! grep -q '^summary:' "$RESEARCH_DIR/codebase.md"; then
+    echo "warning: $RESEARCH_DIR/codebase.md missing 'summary:' field; using full parallel dispatch" >&2
   else
-    # Fresh: read codebase.md (and patterns.md if present) verbatim into the synthesis
-    # step. Per-topic skip flags tell the dispatch step which agents to omit.
-    SHORTCIRCUIT_CODEBASE=1
-    [ -f "$RESEARCH_DIR/patterns.md" ] && SHORTCIRCUIT_PATTERNS=1
+    ISSUE_UPDATED_ISO=$(gh issue view "$ISSUE" --json updatedAt --jq .updatedAt 2>/dev/null)
+    if [ -z "$ISSUE_UPDATED_ISO" ]; then
+      echo "warning: failed to fetch issue #$ISSUE updatedAt (gh auth/network/missing); using full parallel dispatch" >&2
+    else
+      # Normalise both timestamps to epoch seconds for portable comparison
+      # (BSD/macOS first, GNU/Linux fallback). Avoids the macOS/Linux mtime-format
+      # mismatch that would silently mis-rank summaries against gh's RFC-3339 output.
+      ISSUE_UPDATED_EPOCH=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ISSUE_UPDATED_ISO" +%s 2>/dev/null \
+                          || date -d "$ISSUE_UPDATED_ISO" +%s 2>/dev/null)
+      CODEBASE_MTIME_EPOCH=$(stat -f %m "$RESEARCH_DIR/codebase.md" 2>/dev/null \
+                           || stat -c %Y "$RESEARCH_DIR/codebase.md" 2>/dev/null)
+      if [ -z "$ISSUE_UPDATED_EPOCH" ] || [ -z "$CODEBASE_MTIME_EPOCH" ]; then
+        echo "warning: failed to normalise updatedAt or codebase.md mtime; using full parallel dispatch" >&2
+      elif [ "$CODEBASE_MTIME_EPOCH" -lt "$ISSUE_UPDATED_EPOCH" ]; then
+        # Stale: research summary is older than the most recent issue-body edit
+        # → fall through to the full parallel-dispatch path so re-research picks up the change.
+        :
+      else
+        # Fresh: read codebase.md (and patterns.md if present) verbatim into the synthesis
+        # step. Per-topic skip flags tell the dispatch step which agents to omit.
+        SHORTCIRCUIT_CODEBASE=1
+        [ -f "$RESEARCH_DIR/patterns.md" ] && SHORTCIRCUIT_PATTERNS=1
+      fi
+    fi
   fi
 fi
 ```

--- a/tests/issue-causal-fanout.test.sh
+++ b/tests/issue-causal-fanout.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Asserts the contract invariants for the deep root-cause research fanout
+# added to /uberdev:issue and the corresponding brainstorm short-circuit.
+#
+# Modelled on tests/turbo-flow.test.sh (PR #7): grep-based structural
+# assertions against the rendered command/skill files. No live gh CLI
+# invocation. Tests run in CI before merge.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ISSUE_CMD="$REPO_ROOT/plugins/uberdev/commands/issue.md"
+BRAINSTORM="$REPO_ROOT/plugins/uberdev/skills/brainstorm/SKILL.md"
+
+PASS=0
+FAIL=0
+
+assert_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        file:    $file"
+    echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_no_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  FAIL  $desc"
+    echo "        file:    $file"
+    echo "        pattern (must NOT appear): $pattern"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+echo "== Phase 1.5 resolves RUN_ID and SUMMARY_DIR =="
+assert_grep "$ISSUE_CMD" \
+  'RUN_ID="\$\(date \+%Y%m%d-%H%M%S\)-\$\(git rev-parse --short HEAD\)"' \
+  "Phase 1.5 sets RUN_ID with date+git-sha"
+assert_grep "$ISSUE_CMD" \
+  'SUMMARY_DIR="\.uberdev/research/run-\$RUN_ID"' \
+  "Phase 1.5 sets SUMMARY_DIR under .uberdev/research/run-"
+assert_grep "$ISSUE_CMD" \
+  'mkdir -p "\$SUMMARY_DIR"' \
+  "Phase 1.5 mkdir -p \$SUMMARY_DIR"
+
+echo
+echo "== Phase 2 dispatches research-codebase + research-patterns =="
+assert_grep "$ISSUE_CMD" \
+  'research-codebase' \
+  "Phase 2 names research-codebase agent"
+assert_grep "$ISSUE_CMD" \
+  'research-patterns' \
+  "Phase 2 names research-patterns agent"
+assert_grep "$ISSUE_CMD" \
+  'single message|one message|same single message|single assistant turn' \
+  "Phase 2 keeps the single-message-fanout invariant"
+
+echo
+echo "== --no-explore placeholder verbatim =="
+assert_grep "$ISSUE_CMD" \
+  'shallow mode — no fanout run; root cause to be confirmed in /brainstorm' \
+  "--no-explore placeholder string appears verbatim"
+
+echo
+echo "== Bug template: causal triple labels =="
+assert_grep "$ISSUE_CMD" \
+  '\*\*Symptom:\*\*' \
+  "bug template has Symptom label"
+assert_grep "$ISSUE_CMD" \
+  '\*\*Mechanism:\*\*' \
+  "bug template has Mechanism label"
+assert_grep "$ISSUE_CMD" \
+  '\*\*Owning code:\*\*' \
+  "bug template has Owning code label"
+
+echo
+echo "== Feat template: rename invariant =="
+assert_grep "$ISSUE_CMD" \
+  '## What changes' \
+  "feat template uses ## What changes"
+assert_no_grep "$ISSUE_CMD" \
+  '## Proposed approach' \
+  "feat template no longer contains ## Proposed approach (renamed)"
+
+echo
+echo "== Downstream-parseable contract preserved =="
+assert_grep "$ISSUE_CMD" \
+  '\*\*Triage hint:\*\* <trivial\|small\|medium>' \
+  "Triage hint line preserved verbatim in templates"
+assert_grep "$ISSUE_CMD" \
+  '\[x\] P2 — normal bug' \
+  "bug template severity checkbox block default-P2 preserved"
+
+echo
+echo "== Phase 7 binds artifacts to issue number =="
+assert_grep "$ISSUE_CMD" \
+  'mv "\$SUMMARY_DIR" "\.uberdev/research/issue-\$ISSUE_NUM"' \
+  "Phase 7 renames SUMMARY_DIR to .uberdev/research/issue-\$ISSUE_NUM"
+
+echo
+echo "== Body authoring rules subsection present =="
+assert_grep "$ISSUE_CMD" \
+  'Body authoring rules' \
+  "Body authoring rules subsection heading present ahead of templates"
+assert_grep "$ISSUE_CMD" \
+  'WHAT/HOW boundary enforced' \
+  "Rules subsection has WHAT/HOW boundary bullet"
+
+echo
+echo "== Brainstorm short-circuit reads .uberdev/research/issue-N =="
+assert_grep "$BRAINSTORM" \
+  '\.uberdev/research/issue-' \
+  "brainstorm references .uberdev/research/issue- path"
+assert_grep "$BRAINSTORM" \
+  'Issue-research short-circuit' \
+  "brainstorm has Issue-research short-circuit subsection"
+assert_grep "$BRAINSTORM" \
+  'gh issue view.*updatedAt|updatedAt.*gh issue view' \
+  "brainstorm stale check uses gh issue view updatedAt"
+assert_grep "$BRAINSTORM" \
+  'Per-topic skip|per-topic, not all-or-nothing' \
+  "brainstorm short-circuit is documented as per-topic, not all-or-nothing"
+assert_grep "$BRAINSTORM" \
+  'Backwards compatibility|Backward compatibility' \
+  "brainstorm documents backwards-compat fallthrough"
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[[ $FAIL -eq 0 ]]

--- a/tests/issue-causal-fanout.test.sh
+++ b/tests/issue-causal-fanout.test.sh
@@ -105,6 +105,15 @@ echo "== Phase 7 binds artifacts to issue number =="
 assert_grep "$ISSUE_CMD" \
   'mv "\$SUMMARY_DIR" "\.uberdev/research/issue-\$ISSUE_NUM"' \
   "Phase 7 renames SUMMARY_DIR to .uberdev/research/issue-\$ISSUE_NUM"
+assert_grep "$ISSUE_CMD" \
+  'warning: SUMMARY_DIR rename used cp\+rm fallback' \
+  "Phase 7 cp+rm fallback emits a stderr warning"
+assert_grep "$ISSUE_CMD" \
+  'error: gh issue create did not return a parseable URL' \
+  "Phase 7 guards against empty ISSUE_NUM with explicit error"
+assert_grep "$ISSUE_CMD" \
+  'error: both mv and cp failed' \
+  "Phase 7 escalates when both mv and cp fail (no silent loss)"
 
 echo
 echo "== Body authoring rules subsection present =="
@@ -126,6 +135,15 @@ assert_grep "$BRAINSTORM" \
 assert_grep "$BRAINSTORM" \
   'gh issue view.*updatedAt|updatedAt.*gh issue view' \
   "brainstorm stale check uses gh issue view updatedAt"
+assert_grep "$BRAINSTORM" \
+  'CODEBASE_MTIME_EPOCH.*-lt.*ISSUE_UPDATED_EPOCH' \
+  "brainstorm stale check uses -lt operator (summary older than issue update = stale)"
+assert_grep "$BRAINSTORM" \
+  'missing.*summary:.*field|summary:.*missing' \
+  "brainstorm implements the malformed-summary fallback the prose claims"
+assert_grep "$BRAINSTORM" \
+  'failed to fetch.*updatedAt|gh auth/network' \
+  "brainstorm warns and falls through when gh issue view returns empty"
 assert_grep "$BRAINSTORM" \
   'Per-topic skip|per-topic, not all-or-nothing' \
   "brainstorm short-circuit is documented as per-topic, not all-or-nothing"

--- a/tests/issue-causal-fanout.test.sh
+++ b/tests/issue-causal-fanout.test.sh
@@ -7,10 +7,21 @@
 # invocation. Tests run in CI before merge.
 
 set -u
+set -o pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ISSUE_CMD="$REPO_ROOT/plugins/uberdev/commands/issue.md"
 BRAINSTORM="$REPO_ROOT/plugins/uberdev/skills/brainstorm/SKILL.md"
+
+# Pre-flight: refuse to run if the files we're asserting against are missing
+# or unreadable — without this, every assertion fails with a confusing
+# "pattern not found" instead of the real cause.
+for f in "$ISSUE_CMD" "$BRAINSTORM"; do
+  if [ ! -r "$f" ]; then
+    echo "FATAL: required file missing or unreadable: $f" >&2
+    exit 2
+  fi
+done
 
 PASS=0
 FAIL=0
@@ -43,8 +54,11 @@ assert_no_grep() {
 
 echo "== Phase 1.5 resolves RUN_ID and SUMMARY_DIR =="
 assert_grep "$ISSUE_CMD" \
-  'RUN_ID="\$\(date \+%Y%m%d-%H%M%S\)-\$\(git rev-parse --short HEAD\)"' \
+  'RUN_ID="\$\(date \+%Y%m%d-%H%M%S\)-\$\(git rev-parse --short HEAD' \
   "Phase 1.5 sets RUN_ID with date+git-sha"
+assert_grep "$ISSUE_CMD" \
+  'git rev-parse --short HEAD 2>/dev/null \|\| echo nohead' \
+  "Phase 1.5 RUN_ID has defensive nohead fallback (mirrors orchestrator)"
 assert_grep "$ISSUE_CMD" \
   'SUMMARY_DIR="\.uberdev/research/run-\$RUN_ID"' \
   "Phase 1.5 sets SUMMARY_DIR under .uberdev/research/run-"


### PR DESCRIPTION
## Summary

- **`/uberdev:issue` Phase 2 now runs a 2-agent parallel fanout** (`research-codebase` + `research-patterns`) alongside the existing Phase 3 + Phase 4 agents — four agents in a single message, Phase 4.5 reconciles all four returns. Bug template's `## Likely root cause` becomes a causal triple (Symptom / Mechanism / Owning code) replacing the previous file-list placeholder; feat template's `## Proposed approach` is renamed to `## What changes` (field-name pressure replaces rules-text pressure for keeping HOW out of the issue body).
- **`/uberdev:brainstorm` short-circuits per-topic on `.uberdev/research/issue-<N>/`** when invoked downstream of `/issue` for the same issue — eliminates the duplicate codebase-research round. Epoch-normalised mtime vs `gh issue view ... updatedAt` staleness check (cross-platform safe), malformed-summary fallback, clean fallthrough for issues created before this change.
- **New `tests/issue-causal-fanout.test.sh`** (22 structural assertions, modelled on `tests/turbo-flow.test.sh` from PR #7) locks the contract invariants. New "Body authoring rules" subsection in `issue.md` codifies the WHAT/HOW boundary; Rules subsection gains a mirror bullet. `--no-explore` shallow path preserved with explicit placeholder. No breaking change — `**Triage hint:**`, severity checkboxes, label format, conventional-commit titles preserved verbatim.

## Test plan

- [x] `bash tests/issue-causal-fanout.test.sh` → 22/22 PASS, exit=0
- [x] `bash tests/turbo-flow.test.sh` → 9/9 PASS, exit=0 (no regression)
- [x] `grep -c '"version": "0.8.0"' plugins/uberdev/.claude-plugin/plugin.json` → 1
- [x] `grep -c '## \[0.8.0\] - 2026-04-29' CHANGELOG.md` → 1
- [x] `grep -c 'badge/version-0.8.0-blue' README.md` → 1
- [ ] Manual: run `/uberdev:issue` for a real bug and confirm the produced body has a populated causal triple (not a placeholder).
- [ ] Manual: run `/solve <N>` against an issue that has `.uberdev/research/issue-<N>/` and confirm `/uberdev:brainstorm` short-circuits.

Closes #9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.8.0

* **New Features**
  * Enhanced `/uberdev:issue` with parallel research agents for deeper root-cause analysis.
  * Research artifacts now automatically persisted and organized by issue number.
  * `/uberdev:brainstorm` now reuses existing research summaries when available, with staleness detection.

* **Documentation**
  * Updated bug template to enforce Symptom/Mechanism/Owning code structure.
  * Feature template revised with "What changes" section emphasizing external behavior over implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->