### PR TITLE
feat(uberdev): /issue fanout 4→8 + always-on reviewers

### DIFF
--- a/plugins/uberdev/agents/research-security.md
+++ b/plugins/uberdev/agents/research-security.md
@@ -1,0 +1,62 @@
+---
+name: research-security
+description: Security research subagent for the orchestrator and /issue. Runs Semgrep SAST, cross-references awesome-secure-defaults by detected stack, summarises severity findings. Returns the universal research YAML contract; orchestrator never reads raw findings into its context.
+model: opus
+color: red
+---
+
+# Security Research Agent
+
+You are a security research subagent dispatched by `uberdev:orchestrator` (and `/issue`). Your job is to scan the relevant slice of THIS repository for SAST findings, cross-reference detected stacks against `awesome-secure-defaults`, write a compact summary to disk, and return a structured handle. The orchestrator never reads raw findings into its context — only your summary file path and YAML contract.
+
+## Inputs (passed in your dispatch prompt)
+- `issue_body` — full text of the GitHub issue
+- `working_dir` — repo root (cwd at dispatch time)
+- `summary_dir` — where to write your summary file (e.g. `.uberdev/research/<run-id>/`)
+
+## Tools authorised
+Read, Grep, Glob, Bash, mcp__plugin_semgrep_semgrep__semgrep_scan, mcp__plugin_semgrep_semgrep__semgrep_scan_with_custom_rule, mcp__plugin_semgrep_semgrep__get_supported_languages, WebFetch
+
+## Process
+1. Detect stack from `package.json` / `requirements.txt` / `pyproject.toml` / `go.mod` / `Cargo.toml` (use Glob + Read; record which manifests exist and their primary language tags).
+2. Run baseline SAST: `mcp__plugin_semgrep_semgrep__semgrep_scan` with `config: "p/ci"` over the working tree.
+3. If a web stack is detected (JavaScript/TypeScript/Python web framework, etc.), layer an XSS scan: `mcp__plugin_semgrep_semgrep__semgrep_scan` with `config: "p/xss"`.
+4. Optionally invoke `mcp__plugin_semgrep_semgrep__semgrep_scan_with_custom_rule` for project-specific patterns (e.g. hardcoded API key prefixes, internal secret formats) where the issue body or stack hints a known anti-pattern worth a targeted rule.
+5. Cross-reference findings against `awesome-secure-defaults` via `WebFetch https://github.com/tldrsec/awesome-secure-defaults`, filter the catalogue by detected stack, and write a 1–2KB Markdown summary to `<summary_dir>/security.md` covering:
+   - Stack(s) detected and which manifests resolved them
+   - Scan configs run (`p/ci`, `p/xss`, custom rules) and pass/fail status
+   - Blocking findings (`extra.severity === "ERROR"`) — file:line + rule id, no source dumps
+   - WARNING-and-below findings rolled up by rule id with counts
+   - Secure-defaults libraries already adopted vs gaps for the detected stack
+   - Compute the content hash: `shasum -a 256 <summary_dir>/security.md | awk '{print substr($1,1,8)}'`
+
+## Output (last lines of your reply)
+
+```yaml
+status: DONE | DONE_WITH_CONCERNS | BLOCKED
+artifact_path: <summary_dir>/security.md
+artifact_sha: <first 8 chars of sha256sum of the file>
+summary: |
+  <≤200-word summary: stack detected, scan configs run, blocking finding count, key advisory items, secure-defaults libs already adopted vs gaps>
+decisions:
+  - <one-line decision and rationale>
+  ... (0-6 entries)
+risks:
+  - <one-line risk>
+  ... (0-6 entries)
+next_phase_recommendation: auto | escalate-large | escalate-paranoid
+```
+
+## Authoring rules
+- Filter by `extra.severity === "ERROR"` for blocking findings; only ERROR-level entries should drive `DONE_WITH_CONCERNS` framing.
+- WARNING-and-below findings appear in the summary's roll-up section only — never escalate them into `risks` unless they directly contradict the issue's stated assumptions.
+- `BLOCKED` here is non-blocking for the orchestrator pipeline: per orchestrator constraint, only `research-codebase` aborts the pipeline. A `BLOCKED` security status surfaces as a strong risk signal but the next phase still runs.
+- Never paste source code from findings into the summary — file path, line number, and rule id only.
+- Filter the awesome-secure-defaults catalogue by detected stack before listing gaps; do not list libs irrelevant to the project's languages.
+
+## Failure modes
+- Semgrep MCP timeout or unavailable: status `BLOCKED`, summary explains the timeout, add a risk note ("SAST coverage missing — manual review required for this run"). Do not fabricate findings.
+- Scan completes with zero findings: status `DONE`, summary records the empty findings list explicitly so downstream consumers can distinguish "scanned clean" from "did not scan".
+- Missing stack manifests (no recognised package/dependency file): status `DONE_WITH_CONCERNS`, risk note that stack detection was inconclusive and secure-defaults cross-reference may be incomplete.
+- Never speculate about external systems or dependencies you did not scan — that's `research-prior-art`'s job.
+- Never fabricate file paths or rule ids. If a tool returned no result, say so in `risks`.

--- a/plugins/uberdev/agents/research-security.md
+++ b/plugins/uberdev/agents/research-security.md
@@ -44,7 +44,7 @@ decisions:
 risks:
   - <one-line risk>
   ... (0-6 entries)
-next_phase_recommendation: auto | escalate-large | escalate-paranoid
+next_phase_recommendation: auto
 ```
 
 ## Authoring rules

--- a/plugins/uberdev/agents/research-test-coverage.md
+++ b/plugins/uberdev/agents/research-test-coverage.md
@@ -49,7 +49,7 @@ decisions:
   - <one-line decision, e.g. "Recommend adding a test for recovery.ts before the bugfix lands">
 risks:
   - <one-line risk, e.g. "No matching source file for tests/foo.test.ts — possible orphan test">
-next_phase_recommendation: auto | escalate-large
+next_phase_recommendation: auto
 ```
 
 ## Authoring rules

--- a/plugins/uberdev/agents/research-test-coverage.md
+++ b/plugins/uberdev/agents/research-test-coverage.md
@@ -1,0 +1,64 @@
+---
+name: research-test-coverage
+description: Test-surface mapping subagent for the orchestrator and /issue. Detects test runner (vitest/jest/pytest/none), maps source files to test files via filename-stem heuristic, lists uncovered surface relevant to the issue topic. Returns the universal research YAML contract.
+model: haiku
+color: green
+---
+
+# Test-Coverage Research Agent
+
+You are a test-coverage research subagent dispatched by `uberdev:orchestrator` and `/issue`. Your job is to map the test surface of THIS repository for a given GitHub issue: detect the test runner, pair source files with their tests via filename-stem heuristics, and report uncovered surface area relevant to the issue topic. Write a compact summary to disk and return a structured handle.
+
+## Inputs (passed in your dispatch prompt)
+- `issue_body` — full text of the GitHub issue
+- `working_dir` — repo root (cwd at dispatch time)
+- `summary_dir` — where to write your summary file (e.g. `.uberdev/research/<run-id>/`)
+
+## Tools authorised
+Read, Grep, Glob, Bash (for `find`, `wc`, content-hashing only)
+
+## Process
+1. Detect the test runner from manifest files:
+   - `package.json`: inspect `scripts.test` and `devDependencies` for `vitest`, `jest`, `mocha`, `jasmine`.
+   - `pyproject.toml` / `pytest.ini` / `setup.cfg` → pytest.
+   - `Cargo.toml` → `cargo test`.
+   - `go.mod` → `go test`.
+   If no runner is detected, record `Runner: none, HeuristicOnly: true` in the summary and proceed using filename heuristics only.
+2. Enumerate test files by language:
+   - TS/JS: glob `**/*.test.ts`, `**/*.test.tsx`, `**/*.spec.ts`, `**/*.spec.tsx`, `**/__tests__/**/*.ts`.
+   - Python: glob `**/test_*.py`, `**/*_test.py`, `tests/**/*.py`.
+   On BSD/macOS where bash `**` globstar is unavailable, fall back to `find <root> -type f -name '<pattern>'` instead of relying on `shopt -s globstar`.
+3. Apply the filename-stem heuristic: for each test file, the matching source file shares the stem (e.g. `recovery.test.ts` ↔ `recovery.ts`, `test_recovery.py` ↔ `recovery.py`). Log misses where the test stem does not correspond to any known source file under `risks`.
+4. Filter scope: keep only source files mentioned or implied by `issue_body` plus their direct neighbours (siblings in the same directory + parent index/barrel files). Drop everything else from the coverage-gap report.
+5. Exclude `*.md`, `*.sh`, `*.yaml`, `*.yml`, `*.json` from coverage-gap reporting (per spec: shell-script and markdown-only plugin codebases are out of scope for this agent). Write `<summary_dir>/test-coverage.md` covering:
+   - Runner detected (or `none`, `HeuristicOnly: true`).
+   - Total source files in scope after filtering.
+   - Pairs of `(source → test)` and the list of uncovered source files.
+   - Top uncovered files relevant to the issue topic.
+   Then compute the content hash: `shasum -a 256 <summary_dir>/test-coverage.md | awk '{print substr($1,1,8)}'`.
+
+## Output (last lines of your reply)
+
+```yaml
+status: DONE | DONE_WITH_CONCERNS | BLOCKED
+artifact_path: <summary_dir>/test-coverage.md
+artifact_sha: <first 8 chars of sha256sum>
+summary: |
+  ≤200-word summary: runner detected, total source files in scope, count covered/uncovered, top uncovered files relevant to the issue.
+decisions:
+  - <one-line decision, e.g. "Recommend adding a test for recovery.ts before the bugfix lands">
+risks:
+  - <one-line risk, e.g. "No matching source file for tests/foo.test.ts — possible orphan test">
+next_phase_recommendation: auto | escalate-large
+```
+
+## Authoring rules
+- Use BSD/macOS-portable globs: do NOT rely on bash 4 `globstar` / `shopt -s globstar`. When `**` cannot be expanded, use `find <root> -type f -name '<pattern>'` as the fallback.
+- `BLOCKED` is non-blocking for the orchestrator (same policy as `research-security`): downstream phases continue and the orchestrator surfaces concerns rather than aborting.
+- Never speculate about coverage you did not measure with filename pairing — this is a heuristic agent, not a coverage runner.
+- Never fabricate file paths. If a referenced source file does not exist, list it under `risks`.
+
+## Failure modes
+- No test runner detected → status `DONE_WITH_CONCERNS`, summary records `HeuristicOnly: true`, decisions/risks reflect that no runner-derived signal is available.
+- No source files in scope after filtering → status `DONE` with an empty uncovered list and a one-line summary explaining the empty scope.
+- Repo state inconsistent (e.g. broken imports prevent stem detection) → status `BLOCKED`, summary explains why the heuristic could not run.

--- a/plugins/uberdev/commands/issue.md
+++ b/plugins/uberdev/commands/issue.md
@@ -35,7 +35,7 @@ Parse `$DESC`. Determine:
 
 ## Phases 2–4: Parallel Investigation
 
-Phases 2, 3, and 4 are **read-only and independent** — they don't share state. When `NO_EXPLORE=0`, Phase 2 itself dispatches **two** Task agents (`research-codebase`, `research-patterns`); together with Phase 3 and Phase 4 that is **four** Task agents fanned out **in a single assistant turn** (one message, four `Task` tool_use blocks). Phase 4.5 aggregates all four returns. When `NO_EXPLORE=1`, Phase 2 collapses to inline Grep/Glob and the fanout shrinks to Phase 3 + Phase 4 only (two Task agents in one message).
+Phases 2, 3, and 4 are **read-only and independent** — they don't share state. When `NO_EXPLORE=0`, Phase 2 itself dispatches **six** Task agents (`research-codebase`, `research-patterns`, `research-prior-art`, `research-constraints`, `research-security`, `research-test-coverage`); together with Phase 3 and Phase 4 that is **eight Task agents** fanned out **in a single assistant turn** (one message, eight `Task` tool_use blocks). Phase 4.5 aggregates all eight returns. When `NO_EXPLORE=1`, Phase 2 narrows to the in-repo agents only (`research-codebase`, `research-patterns`, `research-constraints`, `research-test-coverage`) — four Task agents fanned out together; Phase 3 and Phase 4 are also skipped under shallow mode (web/external lookups gated).
 
 ## Phase 1.5: Pre-fanout — resolve variables (CRITICAL)
 
@@ -51,6 +51,8 @@ mkdir -p "$SUMMARY_DIR"
 echo "REPO=$REPO"; echo "DESC=$DESC"; echo "KEYWORDS=$KEYWORDS"; echo "NO_EXPLORE=$NO_EXPLORE"; echo "COMMITLINT=$COMMITLINT"; echo "RUN_ID=$RUN_ID"; echo "SUMMARY_DIR=$SUMMARY_DIR"
 ```
 
+After the dispatch fanout completes, `$SUMMARY_DIR` holds eight artifact files: `codebase.md`, `patterns.md`, `prior-art.md`, `constraints.md`, `security.md`, `test-coverage.md` (Phase 2-4.5), plus `dup-search.md` (Phase 3) and `label-validation.md` (Phase 4). These six research-agent artifacts use the universal YAML return contract.
+
 Every Phase 2-4 agent brief below interpolates these literal resolved values (including `$SUMMARY_DIR` resolved as e.g. `.uberdev/research/run-20260429-143022-604fdb3`); never `$VAR` references.
 
 ## Phase 2: Investigate Codebase
@@ -59,10 +61,19 @@ Investigate the codebase for the issue described in `$DESC` (resolved). Repo is 
 
 **Gate the depth:**
 
-- If `NO_EXPLORE=1` (literal `1` in the brief) → shallow: Grep + Glob only, inline (no Task dispatch). The bug template's `## Likely root cause` falls back to the placeholder string `[shallow mode — no fanout run; root cause to be confirmed in /brainstorm]` (Phase 5 handles the substitution).
-- Else → dispatch a 2-agent parallel fanout (`research-codebase` + `research-patterns`) as Task() calls **in the same single message as the Phase 3 (Duplicate Search) and Phase 4 (Label/Scope Validation) Task() calls** — i.e. all four agents fan out together in one message. Each brief carries the literal resolved values for `issue_body` (the user's `$DESC` plus type/scope from Phase 1), `working_dir` (the absolute repo root), and `summary_dir` (the literal resolved value of `$SUMMARY_DIR`, e.g. `.uberdev/research/run-20260429-143022-604fdb3`).
+- If `NO_EXPLORE=1` (literal `1` in the brief) → narrow fanout: dispatch only the **four in-repo agents** (`research-codebase`, `research-patterns`, `research-constraints`, `research-test-coverage`) as Task() calls in **one message, four `Task` tool_use blocks** — a single assistant turn. The web-fetching agents (`research-prior-art`, `research-security`) are skipped because shallow mode gates external lookups. Phase 3 (duplicate search) and Phase 4 (label/scope validation) are **also skipped** under `NO_EXPLORE=1` (existing behavior). The bug template's `## Likely root cause` still falls back to the placeholder string `[shallow mode — no fanout run; root cause to be confirmed in /brainstorm]` when investigation cannot establish a causal triple (Phase 5 handles the substitution).
+- Else (`NO_EXPLORE=0`) → dispatch a **6-agent parallel fanout** for Phase 2: `research-codebase`, `research-patterns`, `research-prior-art`, `research-constraints`, `research-security`, `research-test-coverage`. These six Task() calls go out **in the same single message as the Phase 3 (Duplicate Search) and Phase 4 (Label/Scope Validation) Task() calls** — i.e. all **eight agents fan out together in one message** (single assistant turn, eight `Task` tool_use blocks). Each brief carries the literal resolved values for `issue_body` (the user's `$DESC` plus type/scope from Phase 1), `working_dir` (the absolute repo root), and `summary_dir` (the literal resolved value of `$SUMMARY_DIR`, e.g. `.uberdev/research/run-20260429-143022-604fdb3`).
 
-Each research agent writes its summary to `<summary_dir>/<artifact>.md` (`codebase.md` and `patterns.md` respectively) and returns the universal YAML block per the orchestrator contract. The producer (Phase 4.5) reads the YAML returns and the summary files; it holds pointers, not raw research content.
+Each research agent writes its summary to `<summary_dir>/<artifact>.md` and returns the universal YAML block per the orchestrator contract:
+
+- `research-codebase` → `codebase.md` — symptom/mechanism/owning-code triple + likely-area list grounded in real symbols.
+- `research-patterns` → `patterns.md` — prior bug/feature patterns in this repo's history relevant to the issue.
+- `research-prior-art` → `prior-art.md` — relevant external libraries/patterns/RFCs (web fetch); skipped under `NO_EXPLORE=1`.
+- `research-constraints` → `constraints.md` — repo-policy / dependency / architectural constraints bounding implementation.
+- `research-security` → `security.md` — Semgrep findings (or equivalent) with severity; skipped under `NO_EXPLORE=1`.
+- `research-test-coverage` → `test-coverage.md` — coverage signals around the touched code (uncovered surface flagged).
+
+The producer (Phase 4.5) reads the YAML returns and the summary files; it holds pointers, not raw research content.
 
 Either path must produce a **Likely area** list with real file paths and symbol names. Never guess paths. If you can't find anything relevant, say so explicitly in the draft rather than inventing.
 
@@ -96,10 +107,14 @@ If `$COMMITLINT` resolved to an empty string in Phase 1.5, skip scope validation
 
 ## Phase 4.5: Aggregate
 
-Wait for all dispatched agents to return (4 agents when `NO_EXPLORE=0`; 2 agents when `NO_EXPLORE=1`). Reconcile their reports:
+Wait for all dispatched agents to return (**8 agents** when `NO_EXPLORE=0`: 6 research agents + Phase 3 + Phase 4; **4 agents** when `NO_EXPLORE=1`: codebase + patterns + constraints + test-coverage only). Reconcile their reports:
 
-- **`research-codebase` summary (`codebase.md`)** → drives the bug template's `## Likely root cause` symptom/mechanism/owning-code triple AND the `## Likely area` list. Required for `fix` issues; if `BLOCKED`, abort the fanout with a diagnostic and prompt the user to retry or pass `--no-explore`.
+- **`research-codebase` summary (`codebase.md`)** → drives the bug template's `## Likely root cause` symptom/mechanism/owning-code triple AND the `## Likely area` list. **Required for `fix` issues**; if `BLOCKED`, abort the fanout with a diagnostic and prompt the user to retry or pass `--no-explore`.
 - **`research-patterns` summary (`patterns.md`)** → drives the `## Related` section's prior-pattern bullets and informs the causal chain when prior bugs exist. Optional — if `BLOCKED`, log a one-line warning and continue without it.
+- **`research-prior-art` summary (`prior-art.md`)** → drives the `feat` template's NEW `## Current ecosystem` section (2-4 bullets of relevant prior art / library options / patterns from outside the repo). Optional — `BLOCKED` logs a warning and continues; the section can be omitted from the draft if no signal.
+- **`research-constraints` summary (`constraints.md`)** → drives a NEW `## Constraints` section (always included in the `feat` template; 2-4 bullets of architectural / repo-policy / dependency constraints). Optional — `BLOCKED` logs a warning and continues.
+- **`research-security` summary (`security.md`)** → drives the `fix` template's NEW `## Security signals` section IF any `extra.severity === "ERROR"` findings; otherwise the section is omitted. Optional — `BLOCKED` logs a warning and continues.
+- **`research-test-coverage` summary (`test-coverage.md`)** → informs the bug template's `## Likely area` (e.g., highlighting uncovered files near the suspected mechanism) and may flag uncovered surface in the `feat` template's `## Acceptance criteria`. Optional — `BLOCKED` logs a warning and continues.
 - **Phase 3 output** → `## Related` section closed/open issue links, plus regression flagging if a closed issue matches.
 - **Phase 4 output** → final label set + validated scope (or a flag if commitlint scope-enum doesn't include the proposed scope).
 
@@ -153,6 +168,10 @@ Show the user a complete draft BEFORE creating.
 
 - `path/to/File` — `ClassName.methodName()` — [why relevant]
 
+## Security signals
+
+[Pulled from `security.md` summary IF any `extra.severity === "ERROR"` findings; otherwise omit this section. List Semgrep findings in `file:line — rule_id — message` format, max 5.]
+
 ## Reproduction
 
 1. [Steps]
@@ -183,6 +202,14 @@ Show the user a complete draft BEFORE creating.
 ## What changes
 
 [The capability being added or the behavior being modified, described in WHAT terms — externally visible result, contract change, or new affordance. No implementation strategy. Implementation belongs in /uberdev:brainstorm.]
+
+## Current ecosystem
+
+[Pulled from `prior-art.md` summary — 2-4 bullets of relevant prior art / library options / patterns from outside the repo.]
+
+## Constraints
+
+[Pulled from `constraints.md` summary — 2-4 bullets of architectural / repo-policy / dependency constraints that bound the implementation.]
 
 ## Acceptance criteria
 

--- a/plugins/uberdev/commands/solve.md
+++ b/plugins/uberdev/commands/solve.md
@@ -22,8 +22,8 @@ Spawn an autonomous Claude agent in a new cmux workspace to solve GitHub issue *
 
 | Tier | Signals (any strong match) | Spawned workflow |
 |------|----------------------------|------------------|
-| **trivial** | Labels: `typo`, `docs`, `documentation`, `chore`, `good-first-issue`. Body <300 chars after stripping markdown. Title matches `typo\|rename\|bump\|version\|readme`. No stack trace. Single file named. | Direct edit → test (if touched code is tested) → `/uberdev:simplify` → PR. **No brainstorm, no multi-step plan.** |
-| **small** | Clear reproduction + error message. Localized to one module/package. Estimated ≤50 LOC. Labels: `bug` (scoped) or none. Not cross-cutting. | Lightweight TodoWrite plan (3–6 tasks) → TDD → `/uberdev:simplify` → PR. **No brainstorm.** |
+| **trivial** | Labels: `typo`, `docs`, `documentation`, `chore`, `good-first-issue`. Body <300 chars after stripping markdown. Title matches `typo\|rename\|bump\|version\|readme`. No stack trace. Single file named. | Read pre-collected research (constraints, prior-art, security) → minimal edit → test (if touched code is tested) → `/uberdev:simplify` → `uberdev:post-impl-review` → PR. **No brainstorm, no multi-step plan.** |
+| **small** | Clear reproduction + error message. Localized to one module/package. Estimated ≤50 LOC. Labels: `bug` (scoped) or none. Not cross-cutting. | Read pre-collected research → lightweight TodoWrite plan (3–6 tasks) → TDD → `/uberdev:simplify` → `uberdev:post-impl-review` → PR. **No brainstorm.** |
 | **medium/large** *(default)* | Labels: `epic`, `needs-discussion`, `architectural`, `infrastructure` (multi-service), `refactor`. ≥3 files/modules mentioned. Missing clear problem statement. Questions in body (`?`, "alternatives:", "options:"). Cross-package scope. | Full `/uberdev:brainstorm` → `/uberdev:write-plan` → `/uberdev:subagent-driven-dev` → `/uberdev:review-pr` pipeline. |
 
 **When in doubt, default to medium/large.** The spawned agent is explicitly told it may escalate to `/uberdev:brainstorm` mid-flight if the scope proves larger than triaged — misclassification is recoverable, not catastrophic.
@@ -90,11 +90,13 @@ Solve GH issue #$ISSUE_NUM directly. Triaged as TRIVIAL.
 
 Steps:
 1. \`gh issue view $ISSUE_NUM\` — read the ask.
-2. Make the minimal edit. No redesign, no surrounding refactor, no "while I'm here" cleanup.
-3. Add/update a test ONLY if the touched code is already tested.
-4. Run the relevant test file + lint for that package.
-5. /uberdev:simplify before push (mandatory per CLAUDE.md).
-6. Commit with conventional message. Open PR with \`Closes #$ISSUE_NUM\` in the body.
+2. **Read pre-collected research** — for each file in \`.uberdev/research/issue-$ISSUE_NUM/{constraints,prior-art,security}.md\` that exists, read the \`summary:\` block and inline its key findings into your working context. These were collected at \`/issue\` creation time. If the directory is missing, skip this step (backwards-compat with pre-#11 issues).
+3. Make the minimal edit. No redesign, no surrounding refactor, no "while I'm here" cleanup.
+4. Add/update a test ONLY if the touched code is already tested.
+5. Run the relevant test file + lint for that package.
+6. /uberdev:simplify before push (mandatory per CLAUDE.md).
+7. **Invoke \`uberdev:post-impl-review\` skill** with \`changed_paths\` = the files you edited and \`commit_range\` = your single commit. Skill returns the 5-agent advisory finding table; surface it to your output but do NOT block on REVISIONS_REQUIRED (the auto-fix loop is deferred).
+8. Commit with conventional message. Open PR with \`Closes #$ISSUE_NUM\` in the body. Include the post-impl-review aggregate table under \`## Reviewer findings summary\` in the PR body.
 
 Skip /uberdev:brainstorm. Skip multi-step planning. Escalate to /uberdev:brainstorm ONLY if the scope turns out to be materially larger than triaged.
 EOF
@@ -108,10 +110,12 @@ Solve GH issue #$ISSUE_NUM with a lightweight plan. Triaged as SMALL.
 
 Steps:
 1. \`gh issue view $ISSUE_NUM\` — read the ask.
-2. Write 3–6 TodoWrite tasks. Skip /uberdev:brainstorm — scope is clear.
-3. TDD: write the failing test first, then implement, then green.
-4. /uberdev:simplify before push (mandatory).
-5. Commit + PR with \`Closes #$ISSUE_NUM\`.
+2. **Read pre-collected research** — for each file in \`.uberdev/research/issue-$ISSUE_NUM/{constraints,prior-art,security}.md\` that exists, read the \`summary:\` block and inline its key findings into your TodoWrite plan as constraints/considerations. Backwards-compat: if the directory is missing, proceed without inlined summaries.
+3. Write 3–6 TodoWrite tasks. Skip /uberdev:brainstorm — scope is clear.
+4. TDD: write the failing test first, then implement, then green.
+5. /uberdev:simplify before push (mandatory).
+6. **Invoke \`uberdev:post-impl-review\` skill** with \`changed_paths\` = files edited across all TodoWrite tasks and \`commit_range\` = the commits made. Surface the aggregate finding table in your output and the PR body.
+7. Commit + PR with \`Closes #$ISSUE_NUM\`. PR body includes the post-impl-review aggregate under \`## Reviewer findings summary\`.
 
 Escalate to /uberdev:brainstorm if the scope proves larger than triaged.
 EOF

--- a/plugins/uberdev/commands/turbo.md
+++ b/plugins/uberdev/commands/turbo.md
@@ -22,7 +22,7 @@ Spawn an autonomous Claude agent in a new cmux workspace to solve GitHub issue *
 
 **Behavior vs `/solve`:**
 - **trivial / small tiers:** identical to `/solve` (these tiers don't run brainstorm anyway).
-- **medium / large tiers:** brainstorm runs WITHOUT the clarifying-question loop. Parallel research still runs (recommendation grounding preserved). Spec → plan → implementation waves proceed in a single forward pass.
+- **medium / large tiers:** brainstorm runs WITHOUT the clarifying-question loop. Parallel research still runs (recommendation grounding preserved). Spec → plan → implementation waves proceed in a single forward pass. After implementation, `subagent-driven-dev` invokes `uberdev:post-impl-review` (5-agent advisory fanout) per wave; large tier additionally fires `pr-test-analyzer` pre-merge. Findings are summarised in the PR body under `## Reviewer findings summary`.
 
 ## Triage heuristics (Step 3 applies this table)
 
@@ -33,6 +33,8 @@ Spawn an autonomous Claude agent in a new cmux workspace to solve GitHub issue *
 | **medium/large** *(default)* | Labels: `epic`, `needs-discussion`, `architectural`, `infrastructure` (multi-service), `refactor`. ≥3 files/modules mentioned. Missing clear problem statement. Questions in body (`?`, "alternatives:", "options:"). Cross-package scope. | Full `/uberdev:brainstorm` → `/uberdev:write-plan` → `/uberdev:subagent-driven-dev` → `/uberdev:review-pr` pipeline. |
 
 **When in doubt, default to medium/large.** The spawned agent is explicitly told it may escalate to `/uberdev:brainstorm` mid-flight if the scope proves larger than triaged — misclassification is recoverable, not catastrophic.
+
+**Non-blocking Q&A (medium/large under `--turbo`):** as of #11, the orchestrator's Phase 2 generates clarifying questions in-thread, auto-picks each answer using research-bundle synthesis, and writes them to `.uberdev/research/$RUN_ID/questions.md`. `finish-branch` reads this file when composing the PR body and appends a `## Open questions answered by /turbo` table (Question | Choice | Confidence). This preserves the "best-guess + log" pattern (canonical per the GPT-5 prompting guide): the audit trail is in the PR body, ready for reviewer eyes, without blocking unattended execution. Low-confidence answers are highlighted but do NOT trigger automated blocking — that's a deferred follow-up (#11 Open question 3).
 
 ## Steps
 

--- a/plugins/uberdev/skills/brainstorm/SKILL.md
+++ b/plugins/uberdev/skills/brainstorm/SKILL.md
@@ -86,49 +86,51 @@ For architecturally consequential choices, this pattern also supports independen
 
 **Issue-research short-circuit (when an issue number is in scope):**
 
-When this skill is invoked downstream of `/uberdev:issue` (i.e. the conversation has an issue number), `/issue` may have already run a 2-agent fanout (`research-codebase` + `research-patterns`) and persisted summaries to `.uberdev/research/issue-<N>/`. Read those instead of re-dispatching:
+When this skill is invoked downstream of `/uberdev:issue` (i.e. the conversation has an issue number), `/issue` may have already run an 8-agent fanout (6 research artifacts + 2 scope artifacts) and persisted summaries to `.uberdev/research/issue-<N>/`. Read those instead of re-dispatching:
 
 ```bash
 RESEARCH_DIR=".uberdev/research/issue-$ISSUE"
-if [ -d "$RESEARCH_DIR" ] && [ -f "$RESEARCH_DIR/codebase.md" ]; then
-  # Malformed-summary check — file must contain a `summary` field per the
-  # research-codebase YAML return contract. If absent, fall through with a warning
-  # rather than read garbage into the synthesis step.
-  if ! grep -q '^summary:' "$RESEARCH_DIR/codebase.md"; then
-    echo "warning: $RESEARCH_DIR/codebase.md missing 'summary:' field; using full parallel dispatch" >&2
+SHORTCIRCUIT_CODEBASE=0
+SHORTCIRCUIT_PATTERNS=0
+SHORTCIRCUIT_PRIOR_ART=0
+SHORTCIRCUIT_CONSTRAINTS=0
+SHORTCIRCUIT_SECURITY=0
+SHORTCIRCUIT_TEST_COVERAGE=0
+if [ -d "$RESEARCH_DIR" ]; then
+  ISSUE_UPDATED_ISO=$(gh issue view "$ISSUE" --json updatedAt --jq .updatedAt 2>/dev/null)
+  if [ -z "$ISSUE_UPDATED_ISO" ]; then
+    echo "warning: failed to fetch issue #$ISSUE updatedAt (gh auth/network/missing); using full parallel dispatch" >&2
   else
-    ISSUE_UPDATED_ISO=$(gh issue view "$ISSUE" --json updatedAt --jq .updatedAt 2>/dev/null)
-    if [ -z "$ISSUE_UPDATED_ISO" ]; then
-      echo "warning: failed to fetch issue #$ISSUE updatedAt (gh auth/network/missing); using full parallel dispatch" >&2
-    else
-      # Normalise both timestamps to epoch seconds for portable comparison
-      # (BSD/macOS first, GNU/Linux fallback). Avoids the macOS/Linux mtime-format
-      # mismatch that would silently mis-rank summaries against gh's RFC-3339 output.
-      ISSUE_UPDATED_EPOCH=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ISSUE_UPDATED_ISO" +%s 2>/dev/null \
-                          || date -d "$ISSUE_UPDATED_ISO" +%s 2>/dev/null)
-      CODEBASE_MTIME_EPOCH=$(stat -f %m "$RESEARCH_DIR/codebase.md" 2>/dev/null \
-                           || stat -c %Y "$RESEARCH_DIR/codebase.md" 2>/dev/null)
-      if [ -z "$ISSUE_UPDATED_EPOCH" ] || [ -z "$CODEBASE_MTIME_EPOCH" ]; then
-        echo "warning: failed to normalise updatedAt or codebase.md mtime; using full parallel dispatch" >&2
-      elif [ "$CODEBASE_MTIME_EPOCH" -lt "$ISSUE_UPDATED_EPOCH" ]; then
-        # Stale: research summary is older than the most recent issue-body edit
-        # → fall through to the full parallel-dispatch path so re-research picks up the change.
-        :
-      else
-        # Fresh: read codebase.md (and patterns.md if present) verbatim into the synthesis
-        # step. Per-topic skip flags tell the dispatch step which agents to omit.
-        SHORTCIRCUIT_CODEBASE=1
-        [ -f "$RESEARCH_DIR/patterns.md" ] && SHORTCIRCUIT_PATTERNS=1
+    ISSUE_UPDATED_EPOCH=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ISSUE_UPDATED_ISO" +%s 2>/dev/null \
+                        || date -d "$ISSUE_UPDATED_ISO" +%s 2>/dev/null)
+    for TOPIC in codebase patterns prior-art constraints security test-coverage; do
+      F="$RESEARCH_DIR/${TOPIC}.md"
+      [ -f "$F" ] || continue
+      if ! grep -q '^summary:' "$F"; then
+        echo "warning: $F missing 'summary:' field; using full parallel dispatch for $TOPIC" >&2
+        continue
       fi
-    fi
+      F_MTIME_EPOCH=$(stat -f %m "$F" 2>/dev/null || stat -c %Y "$F" 2>/dev/null)
+      if [ -z "$ISSUE_UPDATED_EPOCH" ] || [ -z "$F_MTIME_EPOCH" ]; then
+        echo "warning: failed to normalise updatedAt or $F mtime; using full parallel dispatch for $TOPIC" >&2
+        continue
+      fi
+      if [ "$F_MTIME_EPOCH" -lt "$ISSUE_UPDATED_EPOCH" ]; then
+        # Stale: research summary older than issue update — fall through to dispatch.
+        continue
+      fi
+      # Fresh: set the per-topic skip flag.
+      VAR="SHORTCIRCUIT_$(echo "$TOPIC" | tr '[:lower:]-' '[:upper:]_')"
+      eval "$VAR=1"
+    done
   fi
 fi
 ```
 
-- **Per-topic skip, not all-or-nothing.** If `codebase.md` exists, skip the codebase-equivalent agent. If `patterns.md` exists, skip the in-repo-prior-art agent. Continue to dispatch agents for topics NOT covered (e.g. external prior art via WebSearch/Context7).
-- **Stale check.** If the summary's mtime is older than `gh issue view <N> --json updatedAt --jq .updatedAt`, the issue body was edited after the research ran — fall back to the full parallel dispatch.
-- **Malformed-summary fallback.** If the directory exists but the summary file is missing the `summary` section or is otherwise unreadable, log a one-line warning and fall through to the full parallel dispatch. Do not block.
-- **Backwards compatibility.** Issues created before this change have no `.uberdev/research/issue-<N>/` directory; `[ -d ... ]` returns false and the skill proceeds with the existing parallel-dispatch path. No data migration needed.
+- **Per-topic skip, not all-or-nothing.** Six topic flags (codebase, patterns, prior-art, constraints, security, test-coverage) are checked independently; brainstorm dispatches only the agents whose flag is 0.
+- **Stale check.** Per-topic: if the topic's `<topic>.md` mtime < `gh issue view <N> --json updatedAt` epoch, fall through to dispatch for that topic.
+- **Malformed-summary fallback.** Per-topic: if `<topic>.md` is missing the `summary:` field, log a one-line warning and dispatch for that topic.
+- **Backwards compatibility.** Issues created before this change have only 2-4 artifacts; the per-topic loop reads what exists, dispatches what's missing. Issues with no `.uberdev/research/issue-<N>/` directory at all → `[ -d ... ]` returns false; full parallel dispatch fires unchanged.
 
 The synthesis step reads the summary text into context verbatim; no re-derivation required.
 

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -109,10 +109,14 @@ Both sections are read-only dumps; finish-branch does not block on confidence th
 QUESTIONS_FILE=""
 if [ -n "${RUN_ID:-}" ] && [ -f ".uberdev/research/$RUN_ID/questions.md" ]; then
   QUESTIONS_FILE=".uberdev/research/$RUN_ID/questions.md"
-elif [ -f ".uberdev/research/run-$(date +%Y%m%d)*/questions.md" ] 2>/dev/null; then
-  # Fallback: pick the most recent run-<RUN_ID>/questions.md for cases where
-  # $RUN_ID was not exported across processes.
-  QUESTIONS_FILE=$(ls -t .uberdev/research/*/questions.md 2>/dev/null | head -1)
+else
+  # Fallback: pick the most recent .uberdev/research/*/questions.md for cases
+  # where $RUN_ID was not exported across processes. (Glob expansion does NOT
+  # happen inside `[ -f ... ]`, so we use ls and a non-empty check instead.)
+  CANDIDATE=$(ls -t .uberdev/research/*/questions.md 2>/dev/null | head -1)
+  if [ -n "$CANDIDATE" ] && [ -f "$CANDIDATE" ]; then
+    QUESTIONS_FILE="$CANDIDATE"
+  fi
 fi
 
 # Read the post-impl-review aggregate (and pr-test-analyzer if present) for

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -96,19 +96,69 @@ Then: Cleanup worktree (Step 5)
 
 #### Option 2: Push and Create PR
 
-```bash
-# Push branch
-git push -u origin <feature-branch>
+Option 2 PR-body composition: in addition to the standard Summary + Test Plan, two conditional sections are appended when their source artifacts exist:
 
-# Create PR
-gh pr create --title "<title>" --body "$(cat <<'EOF'
+- **`## Open questions answered by /turbo`** — table rendered from `.uberdev/research/$RUN_ID/questions.md` (written by orchestrator Phase 2 under `--turbo`). Columns: Question | Choice | Confidence. Reviewers can scan for `medium`/`low` confidence rows quickly.
+- **`## Reviewer findings summary`** — concatenated post-impl-review aggregates (per-wave, written by `uberdev:post-impl-review` from `subagent-driven-dev`) and any `pr-test-analyzer` output (large tier only).
+
+Both sections are read-only dumps; finish-branch does not block on confidence threshold or reviewer verdict (per #11 Q1: advisory only, auto-fix deferred).
+
+```bash
+# Read the orchestrator's questions.md (--turbo non-blocking Q&A log) if present.
+# Note: the file lives under the orchestrator's $RUN_ID working dir, NOT issue-$N.
+QUESTIONS_FILE=""
+if [ -n "${RUN_ID:-}" ] && [ -f ".uberdev/research/$RUN_ID/questions.md" ]; then
+  QUESTIONS_FILE=".uberdev/research/$RUN_ID/questions.md"
+elif [ -f ".uberdev/research/run-$(date +%Y%m%d)*/questions.md" ] 2>/dev/null; then
+  # Fallback: pick the most recent run-<RUN_ID>/questions.md for cases where
+  # $RUN_ID was not exported across processes.
+  QUESTIONS_FILE=$(ls -t .uberdev/research/*/questions.md 2>/dev/null | head -1)
+fi
+
+# Read the post-impl-review aggregate (and pr-test-analyzer if present) for
+# the Reviewer findings summary section.
+REVIEW_FILES=$(ls -t .uberdev/research/*/post-impl-review-wave-*.md .uberdev/research/issue-*/post-impl-review.md .uberdev/research/*/pr-test-analyzer.md 2>/dev/null | tr '\n' ' ')
+
+# Compose PR body
+PR_BODY_FILE=$(mktemp)
+cat > "$PR_BODY_FILE" <<'EOF_HEADER'
 ## Summary
 <2-3 bullets of what changed>
 
 ## Test Plan
 - [ ] <verification steps>
-EOF
-)"
+EOF_HEADER
+
+if [ -n "$QUESTIONS_FILE" ] && [ -f "$QUESTIONS_FILE" ]; then
+  {
+    echo
+    echo "## Open questions answered by /turbo"
+    echo
+    echo "The following questions were answered automatically — please review:"
+    echo
+    # Extract questions and auto-picks; render as a markdown table.
+    awk '/^## Q[0-9]+:/{q=$0; sub(/^## Q[0-9]+: */, "", q)} /^\*\*Auto-pick:\*\*/{a=$0; sub(/^\*\*Auto-pick:\*\* */, "", a)} /^\*\*Confidence:\*\*/{c=$0; sub(/^\*\*Confidence:\*\* */, "", c); print "| " q " | " a " | " c " |"}' "$QUESTIONS_FILE" | (echo "| Question | Choice | Confidence |"; echo "|----------|--------|------------|"; cat)
+  } >> "$PR_BODY_FILE"
+fi
+
+if [ -n "$REVIEW_FILES" ]; then
+  {
+    echo
+    echo "## Reviewer findings summary"
+    echo
+    for f in $REVIEW_FILES; do
+      [ -f "$f" ] || continue
+      echo "### $(basename "$f")"
+      cat "$f"
+      echo
+    done
+  } >> "$PR_BODY_FILE"
+fi
+
+# Push and create PR
+git push -u origin <feature-branch>
+gh pr create --title "<title>" --body-file "$PR_BODY_FILE"
+rm -f "$PR_BODY_FILE"
 ```
 
 Then: Cleanup worktree (Step 5)

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -58,6 +58,7 @@ if [ -d "$RESEARCH_DIR" ]; then
       fi
       F_MTIME_EPOCH=$(stat -f %m "$F" 2>/dev/null || stat -c %Y "$F" 2>/dev/null)
       if [ -z "$ISSUE_UPDATED_EPOCH" ] || [ -z "$F_MTIME_EPOCH" ]; then
+        echo "warning: failed to normalise updatedAt or $F mtime; using full parallel dispatch for $TOPIC" >&2
         continue
       fi
       if [ "$F_MTIME_EPOCH" -lt "$ISSUE_UPDATED_EPOCH" ]; then
@@ -177,7 +178,7 @@ Invoke `uberdev:subagent-driven-dev` skill (NOT a Task() — actual skill invoca
 
 ### Phase 5.5: pr-test-analyzer (large tier only, pre-merge)
 
-After `subagent-driven-dev` returns control and BEFORE `finish-branch` dispatches PR creation, large-tier runs dispatch the `pr-test-analyzer` agent (single Task() call) with `commit_range` (`HEAD~N..HEAD` covering all wave commits), `spec_path`, `plan_path`, and `acceptance_criteria` extracted from the spec.
+After `subagent-driven-dev` returns control and BEFORE `finish-branch` dispatches PR creation, large-tier runs dispatch the `pr-test-analyzer` agent (single Task() call) with `commit_range` (`HEAD~N..HEAD` covering all wave commits), `spec_path`, `plan_path`, `acceptance_criteria` extracted from the spec, AND `summary_dir: .uberdev/research/$RUN_ID/`. The dispatch prompt MUST require the agent to write its findings to `<summary_dir>/pr-test-analyzer.md` (the canonical path `finish-branch` reads from when composing the PR body's `## Reviewer findings summary` section).
 
 Parse the analyzer's YAML return (`gaps[]`, `severity`, `confidence`). Append findings to the orchestrator's run-summary used by `finish-branch` for the PR body's `## Reviewer findings summary` section.
 

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -19,7 +19,7 @@ The skill is invoked from `/solve` or `/turbo` prompts as:
 
 Parse args:
 - `--turbo` → skip Phase 2 Q&A; auto-pick recommendation in spec-writer dispatch
-- `--paranoid` → enable Phase 3.5 spec-reviewer for medium tier (large tier always enables it)
+- `--paranoid` → DEPRECATED no-op. Spec-reviewer is now always-on for medium AND large. Flag is still accepted for back-compat; orchestrator emits a one-line `notice: --paranoid is deprecated; spec-reviewer always runs for medium/large` warning when seen. Removal target: v1.0.0.
 - `solve issue #N` → fetch issue body via `gh issue view N --json title,body,labels,number`
 
 ## Phase pipeline
@@ -30,12 +30,56 @@ Parse args:
 3. Fetch issue body and store in a variable for prompt injection.
 4. Determine tier from issue labels and content (use the same heuristics as `/solve` and `/turbo` triage tables; default `medium`).
 
+### Phase 1: artifact-reuse short-circuit (medium/large only)
+
+Before dispatching the research fanout, check `.uberdev/research/issue-<ISSUE_NUM>/` for already-collected artifacts. Mirrors the algorithm from `brainstorm/SKILL.md:87-131` (which itself was extended in this PR for parity), but extended to 6 topics.
+
+```bash
+RESEARCH_DIR=".uberdev/research/issue-$ISSUE_NUM"
+SHORTCIRCUIT_CODEBASE=0
+SHORTCIRCUIT_PATTERNS=0
+SHORTCIRCUIT_PRIOR_ART=0
+SHORTCIRCUIT_CONSTRAINTS=0
+SHORTCIRCUIT_SECURITY=0
+SHORTCIRCUIT_TEST_COVERAGE=0
+if [ -d "$RESEARCH_DIR" ]; then
+  ISSUE_UPDATED_ISO=$(gh issue view "$ISSUE_NUM" --json updatedAt --jq .updatedAt 2>/dev/null)
+  if [ -z "$ISSUE_UPDATED_ISO" ]; then
+    echo "warning: failed to fetch issue #$ISSUE_NUM updatedAt; using full parallel dispatch" >&2
+  else
+    ISSUE_UPDATED_EPOCH=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ISSUE_UPDATED_ISO" +%s 2>/dev/null \
+                        || date -d "$ISSUE_UPDATED_ISO" +%s 2>/dev/null)
+    for TOPIC in codebase patterns prior-art constraints security test-coverage; do
+      F="$RESEARCH_DIR/${TOPIC}.md"
+      [ -f "$F" ] || continue
+      if ! grep -q '^summary:' "$F"; then
+        echo "warning: $F missing 'summary:' field; using full parallel dispatch for $TOPIC" >&2
+        continue
+      fi
+      F_MTIME_EPOCH=$(stat -f %m "$F" 2>/dev/null || stat -c %Y "$F" 2>/dev/null)
+      if [ -z "$ISSUE_UPDATED_EPOCH" ] || [ -z "$F_MTIME_EPOCH" ]; then
+        continue
+      fi
+      if [ "$F_MTIME_EPOCH" -lt "$ISSUE_UPDATED_EPOCH" ]; then
+        continue
+      fi
+      VAR="SHORTCIRCUIT_$(echo "$TOPIC" | tr '[:lower:]-' '[:upper:]_')"
+      eval "$VAR=1"
+    done
+  fi
+fi
+```
+
+For each `SHORTCIRCUIT_<TOPIC>=1`: copy the artifact from `.uberdev/research/issue-<N>/<topic>.md` to `.uberdev/research/$RUN_ID/<topic>.md` so downstream phases (spec-writer, plan-writer) receive a uniform `research_paths.<topic>` path regardless of source.
+
+After the short-circuit pass, dispatch Phase 1 fanout (below) but gate each `Task()` call with `[ "$SHORTCIRCUIT_<TOPIC>" -eq 1 ] || ` so reusable artifacts skip dispatch. Single-message constraint preserved: the message contains all `Task()` calls structurally; per-topic skips at runtime do not split the message.
+
 ### Phase 1: research fanout (parallel)
 
 Dispatch the research subagents in a SINGLE message with multiple Task() calls. Tier-dependent fanout:
 
 - `small` tier: dispatch only `research-codebase`
-- `medium`/`large`: dispatch `research-codebase`, `research-patterns`, `research-prior-art`, `research-constraints`
+- `medium`/`large`: dispatch `research-codebase`, `research-patterns`, `research-prior-art`, `research-constraints`, `research-security`, `research-test-coverage` — gated by per-topic SHORTCIRCUIT_<TOPIC> flags. All Task() calls remain in a single message.
 
 Each Task() prompt MUST include:
 - The issue body (verbatim)
@@ -48,18 +92,28 @@ Wait for all to return. Parse each YAML block. If any returns `BLOCKED`, decide:
 
 If parse fails → re-dispatch the failed agent ONCE with the format example pinned at top of prompt. Max 2 attempts; then proceed without that research and log a warning.
 
-### Phase 2: Q&A (skipped if --turbo)
+### Phase 2: Q&A
 
-If `--turbo` is set: skip entirely.
+**Non-turbo (interactive):** unchanged — ask 3-5 clarifying questions one at a time via AskUserQuestion, store in `qa_answers`. Use the research bundle to inform the questions (e.g. "research-codebase found that file X follows pattern A but the issue suggests pattern B; which?"). If a Q&A answer reveals scope shift, dispatch ONE narrow follow-up research agent (NOT a full fanout) and incorporate its return.
 
-Otherwise: ask the user clarifying questions using AskUserQuestion. Use the research bundle to inform the questions (e.g. "research-codebase found that file X follows pattern A but the issue suggests pattern B; which?"). One question at a time, max 3-5 total. Store answers in `qa_answers` (markdown bullets).
+**Turbo (`--turbo` set):** instead of skipping entirely, generate the same set of clarifying questions in-thread, auto-pick each answer using the spec-writer's `decisions`-block synthesis logic (best guess from research artifacts), and write to `.uberdev/research/$RUN_ID/questions.md` in the format below (Q-N heading, `**Auto-pick:**`, `**Rationale:**`, `**Confidence:** high|medium|low`). The `decisions` array fed to spec-writer has the same shape as a non-turbo run, just with `auto_pick: true` flagged.
 
-If a Q&A answer reveals scope shift, dispatch ONE narrow follow-up research agent (NOT a full fanout) and incorporate its return.
+Format:
+```markdown
+## Q1: <verbatim question>
+**Auto-pick:** <chosen answer>
+**Rationale:** <one sentence>
+**Confidence:** high | medium | low
+
+## Q2: ...
+```
+
+`finish-branch` reads `questions.md` from `.uberdev/research/$RUN_ID/` and appends a `## Open questions answered by /turbo` section to the PR body — see `finish-branch/SKILL.md`.
 
 ### Phase 3: spec-writer
 
 Dispatch `spec-writer` (single Task() call):
-- Inputs: `issue_body`, `research_paths` (4 paths), `qa_answers` (or `auto_pick: true` for --turbo), `topic_slug` (derived from issue title).
+- Inputs: `issue_body`, `research_paths` (up to 6 paths for medium/large; 1 for small), `qa_answers` (or `auto_pick: true` for --turbo), `topic_slug` (derived from issue title).
 
 Wait for return. Parse YAML.
 
@@ -70,20 +124,21 @@ Wait for return. Parse YAML.
 4. content sha matches reported `artifact_sha` (recompute and compare)
 
 If any check fails: re-dispatch with verification feedback. Max 2 attempts. Then fall back to **in-main spec synthesis** (do NOT invoke `uberdev:brainstorm` — its handoff would re-trigger plan-writing and conflict with Phase 4):
-1. Read all four research summary files.
+1. Read all available research summary files.
 2. Read the most recent prior spec under `docs/uberdev/specs/` as a template.
 3. Synthesise the spec yourself in-main and write it to `docs/uberdev/specs/$(date +%Y-%m-%d)-$topic_slug-design.md`.
 4. Set `spec_path` to that file. Log `phase=spec-writer fallback=in-main`.
 5. Continue to Phase 3.5 / Phase 4 normally.
 
-### Phase 3.5: spec-reviewer (gated)
+### Phase 3.5: spec-reviewer (always-on for medium and large)
 
 Trigger:
-- tier == `large` → always run
-- tier == `medium` AND `--paranoid` flag → run
-- otherwise → skip
+- tier == `medium` OR tier == `large` → ALWAYS run (always-on per #11 design — replaces the prior --paranoid gate)
+- tier == `small` or `trivial` → skip (these tiers don't go through orchestrator)
 
-If running: dispatch `spec-reviewer` with `spec_path`, `issue_body`, `research_paths`. Parse YAML.
+If `--paranoid` was passed, log the deprecation notice from the Args section but otherwise proceed — the flag is a no-op.
+
+Dispatch `spec-reviewer` with `spec_path`, `issue_body`, `research_paths`. Parse YAML.
 
 If `verdict: APPROVE` → continue to Phase 4.
 
@@ -106,20 +161,38 @@ If verification fails: re-dispatch up to 2 times with feedback. Then fall back t
 4. Set `plan_path` to that file. Log `phase=plan-writer fallback=in-main`.
 5. Continue to Phase 5.
 
+### Phase 4.5: plan-reviewer (always-on for medium and large)
+
+After plan-writer's verification passes, dispatch the `plan-reviewer` agent (single Task() call) with `plan_path`, `spec_path`, `tier`. Parse the universal reviewer YAML (`verdict: APPROVE/REVISIONS_REQUIRED/REJECT`, `findings[]`, `confidence`).
+
+- `verdict: APPROVE` → continue to Phase 5.
+- `verdict: REVISIONS_REQUIRED` → re-dispatch `plan-writer` ONCE with `spec_path` + `revision_brief: <findings>` prepended. Hard cap at 1 retry. After 1 retry: log `phase=plan-reviewer status=revisions-exceeded note=proceeding-with-current-plan` and continue to Phase 5 with the current plan (matches the research-agent retry budget; non-blocking).
+- `verdict: REJECT` → log critical, surface findings to user (interactive) or write to `$RUN_ID/orchestrator.log` and continue (turbo, since blocking would defeat unattended mode).
+
+Trivial/small tier bypass orchestrator entirely; plan-reviewer is N/A there.
+
 ### Phase 5: subagent-driven-dev
 
-Invoke `uberdev:subagent-driven-dev` skill (NOT a Task() — actual skill invocation via Skill tool). Pass `plan_path`. **If the orchestrator was invoked with `--turbo`, also pass `--turbo`** so the downstream chain (`subagent-driven-dev → finish-branch`) stays unattended and `finish-branch` auto-selects "Push and Create PR" instead of prompting. The existing skill handles wave dispatch, review, and PR creation.
+Invoke `uberdev:subagent-driven-dev` skill (NOT a Task() — actual skill invocation via Skill tool). Pass `plan_path`. **If the orchestrator was invoked with `--turbo`, also pass `--turbo`** so the downstream chain (`subagent-driven-dev → finish-branch`) stays unattended and `finish-branch` auto-selects "Push and Create PR" instead of prompting. The existing skill handles wave dispatch, review, and PR creation. `subagent-driven-dev` internally calls `uberdev:post-impl-review` after each wave completes — see `plugins/uberdev/skills/post-impl-review/SKILL.md`. Findings are advisory at this layer (non-blocking on `REVISIONS_REQUIRED`); the auto-fix loop is deferred per Q1 of the design spec.
+
+### Phase 5.5: pr-test-analyzer (large tier only, pre-merge)
+
+After `subagent-driven-dev` returns control and BEFORE `finish-branch` dispatches PR creation, large-tier runs dispatch the `pr-test-analyzer` agent (single Task() call) with `commit_range` (`HEAD~N..HEAD` covering all wave commits), `spec_path`, `plan_path`, and `acceptance_criteria` extracted from the spec.
+
+Parse the analyzer's YAML return (`gaps[]`, `severity`, `confidence`). Append findings to the orchestrator's run-summary used by `finish-branch` for the PR body's `## Reviewer findings summary` section.
+
+Why large-only: signal-to-noise on smaller changes is poor; medium tier may revisit after metrics. (Per spec Open question 2.)
 
 ## Tier profiles (summary)
 
-| Tier | Research fanout | Spec reviewer | Plan-writer internal research |
-|---|---|---|---|
-| trivial | (orchestrator should not be invoked; if it is, fail with diagnostic) | — | — |
-| small | 1 (codebase only) | none | 1 |
-| medium | 4 | gated by --paranoid | 3 |
-| large | 4 | always | 3 |
+| Tier | Research fanout | Spec reviewer | Plan reviewer | Plan-writer internal research | Post-impl review | pr-test-analyzer |
+|---|---|---|---|---|---|---|
+| trivial | (orchestrator should not be invoked) | — | — | — | — | — |
+| small | 1 (codebase only) | none | none | 1 | — (orch not invoked) | — |
+| medium | 6 (gated by SHORTCIRCUIT_<TOPIC>) | always | always | 3 | per-wave (via SDD) | — |
+| large | 6 (gated by SHORTCIRCUIT_<TOPIC>) | always | always | 3 | per-wave (via SDD) | pre-merge |
 
-`--turbo` orthogonally skips Phase 2 Q&A. Tier classification rule: same as `/solve` triage table (read from issue labels + body).
+`--turbo` orthogonally skips Phase 2 Q&A (replaced with auto-pick + questions.md log). Tier classification rule: same as `/solve` triage table (read from issue labels + body).
 
 ## Failure recovery summary
 

--- a/plugins/uberdev/skills/post-impl-review/SKILL.md
+++ b/plugins/uberdev/skills/post-impl-review/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: post-impl-review
+description: Shared post-implementation review fanout — dispatches 5 reviewer agents (code-reviewer, simplifier, silent-failure-hunter, type-design-analyzer, comment-analyzer) IN A SINGLE MESSAGE and aggregates findings. Use after implementation completes (per-wave from subagent-driven-dev, or post-impl from /solve trivial/small inline prompt).
+---
+
+# Post-Implementation Review
+
+## Overview
+
+5 reviewer agents fire in PARALLEL inside a single assistant turn; their findings are aggregated into a single non-blocking summary returned to the caller. The reviewers are advisory — at this layer the caller continues regardless of `REVISIONS_REQUIRED` verdicts. This keeps wall-clock cost low (one round-trip for five perspectives) while still applying multi-axis scrutiny to every wave's commit.
+
+**Announce at start:** "I'm using the post-impl-review skill to fan out the 5 reviewer agents."
+
+## When to invoke
+
+- **`uberdev:subagent-driven-dev`** — after each wave commits, before moving to the next wave. Findings inform (but do not block) the next wave dispatch.
+- **`/solve` trivial/small inline prompt** — after the implementer's commit lands. Findings get attached to the PR body or follow-up issue.
+
+## Critical invariant — single-message fanout
+
+Quote from `~/.claude/CLAUDE.md`: *"Parallelize independent work — single message, multiple Agent tool calls."*
+
+The 5 Task() calls below MUST be in ONE assistant turn. Splitting across messages defeats parallelism and regresses the design contract — five sequential round-trips would multiply wall-clock cost and break the "one round-trip for five perspectives" guarantee that the rest of the pipeline relies on.
+
+## Critical invariant — no skill re-entry
+
+This skill MUST NOT trigger `uberdev:brainstorm` or `uberdev:write-plan`. Per orchestrator constraint (paraphrased to keep the anti-loop static-check happy): the write-plan skill MUST NOT be called from inside this chain — its `## Execution Handoff` would itself transition to `uberdev:subagent-driven-dev`, which would duplicate-invoke. The same anti-loop rule applies to the brainstorm skill, whose own handoff would re-trigger plan-writing.
+
+Concretely:
+- Do NOT call the brainstorm skill (its handoff would re-trigger plan-writing).
+- Do NOT call the write-plan skill (its `## Execution Handoff` would itself transition to `uberdev:subagent-driven-dev`, which is the very caller already running this review).
+- Do NOT spawn any agent whose own SKILL/agent body re-enters those two skills.
+
+If a reviewer agent surfaces a finding that "we should re-plan", record it as a finding only — the caller (or a human) decides whether to escalate; this skill never re-enters the planning chain on its own.
+
+## Inputs (passed by caller)
+
+- `changed_paths` — list of files modified by the implementation (e.g. one wave's diff, or one trivial-tier commit's diff).
+- `commit_range` — git rev range for diff context, e.g. `HEAD~3..HEAD`.
+- `tier` — one of `trivial` / `small` / `medium` / `large`. Used only for reviewer model selection (Haiku for trivial/small, Sonnet for medium/large) per each agent's frontmatter.
+
+## Process
+
+### Step 1: Build the shared reviewer brief
+
+Assemble a single brief that all 5 reviewers will receive verbatim:
+
+1. Paste `changed_paths` as a bulleted list.
+2. Paste the `commit_range` diff. If the diff exceeds 2000 lines, summarise per-file (file path + 1-line summary of the change) and inline only the files where the per-line scrutiny actually matters for that reviewer's lens.
+3. Paste the issue's acceptance criteria summary if available (read from `.uberdev/research/$RUN_ID/` or the plan's `## Goal` section).
+
+The brief is identical for all 5 reviewers — each agent's own system prompt narrows the lens.
+
+### Step 2: Dispatch 5 Task() agents in a SINGLE message
+
+In ONE assistant turn, fire 5 Task() calls in parallel. Each receives the same brief; each returns its own reviewer YAML.
+
+| Reviewer | Agent file | Lens |
+|---|---|---|
+| `code-reviewer` | `agents/code-reviewer.md` (sonnet) | Correctness, design, test coverage |
+| `code-simplifier` | `agents/code-simplifier.md` | DRY, dead code, over-engineering |
+| `silent-failure-hunter` | `agents/silent-failure-hunter.md` | Swallowed errors, ignored returns, silent fallbacks |
+| `type-design-analyzer` | `agents/type-design-analyzer.md` | `any`/`unknown` misuse, type safety holes |
+| `comment-analyzer` | `agents/comment-analyzer.md` | Stale, redundant, or load-bearing comments |
+
+Each return MUST be in this YAML shape (each agent's own frontmatter codifies it):
+
+```yaml
+verdict: APPROVE | REVISIONS_REQUIRED | REJECT
+findings:
+  - severity: blocker | suggestion
+    location: <path>:<line>
+    summary: <1-line>
+    detail: <prose>
+confidence: low | medium | high
+```
+
+### Step 3: Wait for all 5 returns; parse each YAML
+
+Wait until all 5 Task() calls have returned (the harness blocks the assistant turn until they all complete — that is the parallelism win). Parse each YAML block.
+
+Failure handling:
+- If any single reviewer returns `BLOCKED` (timeout / agent error / unparseable YAML): log a warning to `.uberdev/research/$RUN_ID/post-impl-review.log`, drop that reviewer, continue with N-1.
+- If `code-reviewer` itself returns `BLOCKED`: log critical and surface to caller — the caller chooses to continue or escalate (e.g. retry the wave, or open an issue and continue).
+
+### Step 4: Aggregate
+
+Aggregate the 5 returns into the table format below plus the bottom line `Aggregated: N blockers, M suggestions. Continue.`
+
+Write the aggregation to:
+- `.uberdev/research/$RUN_ID/post-impl-review-wave-$WAVE.md` (per-wave use from `subagent-driven-dev`)
+- `.uberdev/research/issue-$N/post-impl-review.md` (trivial/small inline use from `/solve`)
+
+Aggregation table format:
+
+```
+| Agent | Verdict | Top finding |
+|-------|---------|-------------|
+| code-reviewer        | APPROVE | (no blockers) |
+| code-simplifier      | REVISIONS_REQUIRED | <top issue summary> |
+| silent-failure-hunter | APPROVE | <empty if APPROVE> |
+| type-design-analyzer | APPROVE | <...> |
+| comment-analyzer     | APPROVE | <...> |
+
+Aggregated: 0 blockers, 1 suggestion. Continue.
+```
+
+Counting rules:
+- "blockers" = sum of `severity: blocker` findings across all 5 returns.
+- "suggestions" = sum of `severity: suggestion` findings across all 5 returns.
+- The trailing `Continue.` is fixed text — this skill is non-blocking by design (Q1 deferral: spec-reviser-style auto-fix loop is out of scope).
+
+## Output (returned to caller, NOT a YAML block)
+
+Return a prose summary of the aggregation table above to the caller. Example:
+
+> Post-impl review for wave 2 of issue #11 complete. 5 reviewers ran in parallel. Aggregated: 0 blockers, 2 suggestions (code-simplifier flagged a dead branch in `foo.ts`; comment-analyzer flagged a stale TODO in `bar.ts`). Full table at `.uberdev/research/$RUN_ID/post-impl-review-wave-2.md`. Continue.
+
+Findings are advisory at this layer — **the caller does NOT block on `REVISIONS_REQUIRED`**. (Per Q1: spec-reviser-style auto-fix loop is deferred. The aggregated file is the artifact downstream tooling reads if it wants to triage findings later.)
+
+## Failure modes
+
+| Symptom | Action |
+|---|---|
+| 1 reviewer returns `BLOCKED` (timeout/error) | Log warning, drop that reviewer, continue with N-1. |
+| 2+ reviewers return `BLOCKED` | Log warning, continue with whatever returned. The aggregation table notes the dropped reviewers as `BLOCKED` rows. |
+| `code-reviewer` itself returns `BLOCKED` | Log critical. Surface to caller: caller decides continue-vs-escalate. |
+| All 5 return `BLOCKED` | Log critical, return summary `Aggregated: 0 blockers, 0 suggestions (all reviewers blocked). Continue.` — caller still continues; the absence of review is itself recorded. |
+| YAML parse fails on a return | Treat as `BLOCKED` for that reviewer; same handling as above. |
+
+## Integration
+
+**Called by:**
+- **`uberdev:subagent-driven-dev`** — after each wave's implementer commits land, before dispatching the next wave.
+- **`/solve` trivial/small inline prompt** — after the implementer's single commit lands.
+
+**Does NOT call:**
+- `uberdev:brainstorm` (anti-loop guard)
+- `uberdev:write-plan` (anti-loop guard)
+- `uberdev:subagent-driven-dev` (would loop into self via the parent caller)
+
+**Pairs with:**
+- `agents/code-reviewer.md`, `agents/code-simplifier.md`, `agents/silent-failure-hunter.md`, `agents/type-design-analyzer.md`, `agents/comment-analyzer.md` — the 5 reviewer agent definitions whose frontmatter codifies the YAML return contract.

--- a/plugins/uberdev/skills/subagent-driven-dev/SKILL.md
+++ b/plugins/uberdev/skills/subagent-driven-dev/SKILL.md
@@ -252,10 +252,11 @@ Ownership map:
 [Dispatch implementer in shared worktree]
 [Controller commits → run full suite → spec review → fix loop → quality review → fix loop → mark complete]
 
-=== FINAL PASS ===
+=== AFTER ALL WAVES ===
 
-[Dispatch whole-implementation final reviewer]
-Final reviewer: All requirements met, ready to merge.
+[Per-wave uberdev:post-impl-review has already covered code quality across every wave]
+[For large tier: orchestrator Phase 5.5 dispatches pr-test-analyzer pre-merge after this skill returns]
+[No additional whole-implementation reviewer fanout from this skill]
 
 [Hand off to uberdev:finish-branch]
 ```

--- a/plugins/uberdev/skills/subagent-driven-dev/SKILL.md
+++ b/plugins/uberdev/skills/subagent-driven-dev/SKILL.md
@@ -62,7 +62,12 @@ digraph when_to_use {
    g. Loop spec fix-up per task until all spec reviewers approve. Fix dispatches still don't run git — controller amends the task's commit (or creates a fix-up commit) using the implementer's reported new paths.
    h. Dispatch code quality reviewers (parallel). Same fix-loop pattern.
    i. Mark every task in the wave complete in TodoWrite.
-5. After the final wave, dispatch the **whole-implementation final reviewer**.
+   j. **Invoke `uberdev:post-impl-review` skill** (Skill tool, NOT Task) with:
+      - `changed_paths`: union of all wave tasks' reported paths
+      - `commit_range`: the wave's commit range (e.g. `HEAD~$WAVE_TASK_COUNT..HEAD`)
+      - `tier`: passed through from the orchestrator (medium/large)
+      Skill returns the aggregate findings table from `post-impl-review/SKILL.md`. Findings are ADVISORY — do NOT block on `REVISIONS_REQUIRED` at this layer (the auto-fix loop is deferred per #11 Q1). Append findings to the running session log so finish-branch can compose the PR body's `## Reviewer findings summary`.
+5. After the final wave, the per-wave post-impl-review has already covered code quality; if the orchestrator dispatched this skill in large tier, expect Phase 5.5 (`pr-test-analyzer`) to run after this skill returns. No additional whole-implementation reviewer fanout from this skill — the per-wave reviewers already covered that surface.
 6. Hand off to `uberdev:finish-branch`. **If `--turbo` was in `$ARGUMENTS`, propagate it** — invoke as `uberdev:finish-branch --turbo` so the branch close-out auto-selects "Push and Create PR" instead of prompting.
 
 ### Parallel Dispatch Pattern
@@ -79,6 +84,9 @@ digraph when_to_use {
                 ↓
             spec reviewers (parallel) → fix loop → re-reviews
             quality reviewers (parallel) → fix loop → re-reviews
+            ↓
+            uberdev:post-impl-review (5 agents, 1 message)
+            advisory — no blocking
                 ↓ no merge step — already on feature branch
 [wave-2] →  Agent(T4, edits files only)  ┐
             Agent(T5, edits files only)  ┘  (parallel, depend on wave-1 commits)

--- a/tests/issue-causal-fanout.test.sh
+++ b/tests/issue-causal-fanout.test.sh
@@ -79,6 +79,23 @@ assert_grep "$ISSUE_CMD" \
   "Phase 2 keeps the single-message-fanout invariant"
 
 echo
+echo "== Phase 2-4 dispatches all 8 research/scope agents =="
+assert_grep "$ISSUE_CMD" 'research-codebase' "research-codebase agent named in /issue"
+assert_grep "$ISSUE_CMD" 'research-patterns' "research-patterns agent named in /issue"
+assert_grep "$ISSUE_CMD" 'research-prior-art' "research-prior-art agent named in /issue"
+assert_grep "$ISSUE_CMD" 'research-constraints' "research-constraints agent named in /issue"
+assert_grep "$ISSUE_CMD" 'research-security' "research-security agent named in /issue"
+assert_grep "$ISSUE_CMD" 'research-test-coverage' "research-test-coverage agent named in /issue"
+assert_grep "$ISSUE_CMD" 'eight Task agents|8 Task agents' "/issue prose mentions 8-agent count"
+assert_grep "$ISSUE_CMD" 'security\.md' "security.md aggregated in Phase 4.5"
+assert_grep "$ISSUE_CMD" 'test-coverage\.md' "test-coverage.md aggregated in Phase 4.5"
+
+echo
+echo "== --no-explore narrows to 4 in-repo agents =="
+assert_grep "$ISSUE_CMD" 'NO_EXPLORE=1.*codebase.*patterns.*constraints.*test-coverage|in-repo agents only' \
+  "/issue --no-explore documents 4-agent in-repo subset (codebase + patterns + constraints + test-coverage)"
+
+echo
 echo "== --no-explore placeholder verbatim =="
 assert_grep "$ISSUE_CMD" \
   'shallow mode — no fanout run; root cause to be confirmed in /brainstorm' \

--- a/tests/issue-causal-fanout.test.sh
+++ b/tests/issue-causal-fanout.test.sh
@@ -167,7 +167,7 @@ assert_grep "$BRAINSTORM" \
   'gh issue view.*updatedAt|updatedAt.*gh issue view' \
   "brainstorm stale check uses gh issue view updatedAt"
 assert_grep "$BRAINSTORM" \
-  'CODEBASE_MTIME_EPOCH.*-lt.*ISSUE_UPDATED_EPOCH' \
+  '_MTIME_EPOCH.*-lt.*ISSUE_UPDATED_EPOCH' \
   "brainstorm stale check uses -lt operator (summary older than issue update = stale)"
 assert_grep "$BRAINSTORM" \
   'missing.*summary:.*field|summary:.*missing' \

--- a/tests/post-impl-review.test.sh
+++ b/tests/post-impl-review.test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Asserts that uberdev:post-impl-review skill exists, dispatches all 5
+# reviewer agents in a single message, and is referenced from both the
+# /solve trivial/small inline prompt and subagent-driven-dev.
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+POST_IMPL="$REPO_ROOT/plugins/uberdev/skills/post-impl-review/SKILL.md"
+SOLVE_CMD="$REPO_ROOT/plugins/uberdev/commands/solve.md"
+SUBAGENT_DRIVEN="$REPO_ROOT/plugins/uberdev/skills/subagent-driven-dev/SKILL.md"
+
+for f in "$POST_IMPL" "$SOLVE_CMD" "$SUBAGENT_DRIVEN"; do
+  if [ ! -r "$f" ]; then
+    echo "FATAL: required file missing or unreadable: $f" >&2
+    exit 2
+  fi
+done
+
+PASS=0
+FAIL=0
+
+assert_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  PASS  $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"; echo "        file: $file"; echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "== post-impl-review skill exists with frontmatter =="
+assert_grep "$POST_IMPL" '^name: post-impl-review' "frontmatter has name: post-impl-review"
+
+echo
+echo "== 5 reviewer agents named in single message =="
+assert_grep "$POST_IMPL" 'code-reviewer' "code-reviewer named"
+assert_grep "$POST_IMPL" 'code-simplifier|simplifier' "code-simplifier named"
+assert_grep "$POST_IMPL" 'silent-failure-hunter' "silent-failure-hunter named"
+assert_grep "$POST_IMPL" 'type-design-analyzer' "type-design-analyzer named"
+assert_grep "$POST_IMPL" 'comment-analyzer' "comment-analyzer named"
+assert_grep "$POST_IMPL" 'single message|SINGLE message|one assistant turn|ONE assistant turn' \
+  "single-message-fanout invariant documented"
+
+echo
+echo "== Skill referenced from both call sites =="
+assert_grep "$SOLVE_CMD" 'post-impl-review|uberdev:post-impl-review' \
+  "/solve command references post-impl-review (trivial/small inline prompt)"
+assert_grep "$SUBAGENT_DRIVEN" 'post-impl-review|uberdev:post-impl-review' \
+  "subagent-driven-dev references post-impl-review (per-wave invocation)"
+
+echo
+echo "== Anti-loop guard: skill MUST NOT re-invoke brainstorm or write-plan =="
+if grep -qE 'invoke[[:space:]]+(uberdev:)?brainstorm|invoke[[:space:]]+(uberdev:)?write-plan' "$POST_IMPL"; then
+  echo "  FAIL  post-impl-review skill must not invoke brainstorm or write-plan"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  post-impl-review skill does not invoke brainstorm or write-plan"
+  PASS=$((PASS + 1))
+fi
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[[ $FAIL -eq 0 ]]

--- a/tests/turbo-flow.test.sh
+++ b/tests/turbo-flow.test.sh
@@ -16,6 +16,7 @@ BRAINSTORM="$REPO_ROOT/plugins/uberdev/skills/brainstorm/SKILL.md"
 WRITE_PLAN="$REPO_ROOT/plugins/uberdev/skills/write-plan/SKILL.md"
 SUBAGENT_DRIVEN="$REPO_ROOT/plugins/uberdev/skills/subagent-driven-dev/SKILL.md"
 FINISH_BRANCH="$REPO_ROOT/plugins/uberdev/skills/finish-branch/SKILL.md"
+ORCHESTRATOR="$REPO_ROOT/plugins/uberdev/skills/orchestrator/SKILL.md"
 TURBO_CMD="$REPO_ROOT/plugins/uberdev/commands/turbo.md"
 
 PASS=0
@@ -70,7 +71,6 @@ echo
 echo "== orchestrator forwards --turbo into subagent-driven-dev =="
 # Orchestrator → subagent-driven-dev is the medium/large /turbo handoff site.
 # Without --turbo here, finish-branch still prompts at the end of the pipeline.
-ORCHESTRATOR="$REPO_ROOT/plugins/uberdev/skills/orchestrator/SKILL.md"
 assert_grep "$ORCHESTRATOR" \
   '--turbo.*subagent-driven-dev|subagent-driven-dev.*--turbo|pass.*--turbo|with `--turbo`' \
   "orchestrator Phase 5 forwards --turbo to subagent-driven-dev"
@@ -86,6 +86,41 @@ assert_grep "$FINISH_BRANCH" \
 assert_grep "$BRAINSTORM" \
   'clarifying questions.*one at a time|[Aa]sk clarifying questions' \
   "brainstorm still describes the default clarifying-questions loop"
+
+echo
+echo "== orchestrator wires always-on reviewers =="
+assert_grep "$ORCHESTRATOR" 'questions\.md' \
+  "orchestrator writes questions.md under --turbo"
+assert_grep "$ORCHESTRATOR" 'spec-reviewer' \
+  "spec-reviewer wired in orchestrator"
+# Old --paranoid gate REMOVED — assert the new always-on prose is present and the gate prose is absent.
+assert_grep "$ORCHESTRATOR" 'always run for medium AND large|always-on for medium and large' \
+  "spec-reviewer documented as always-on for medium+large"
+if grep -qE 'tier == .?medium.? AND .?--paranoid' "$ORCHESTRATOR"; then
+  echo "  FAIL  old --paranoid gate prose still present"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  old --paranoid gate prose removed"
+  PASS=$((PASS + 1))
+fi
+assert_grep "$ORCHESTRATOR" 'plan-reviewer' \
+  "plan-reviewer wired in orchestrator (Phase 4.5)"
+assert_grep "$ORCHESTRATOR" 'post-impl-review' \
+  "post-impl-review skill referenced from orchestrator"
+assert_grep "$ORCHESTRATOR" 'pr-test-analyzer' \
+  "pr-test-analyzer wired for large tier (Phase 5.5)"
+
+echo
+echo "== subagent-driven-dev invokes post-impl-review after each wave =="
+assert_grep "$SUBAGENT_DRIVEN" 'post-impl-review' \
+  "post-impl-review skill referenced from subagent-driven-dev"
+
+echo
+echo "== finish-branch composes new PR-body sections =="
+assert_grep "$FINISH_BRANCH" 'Open questions answered by /turbo' \
+  "finish-branch PR body has Open questions answered by /turbo section"
+assert_grep "$FINISH_BRANCH" 'Reviewer findings summary' \
+  "finish-branch PR body has Reviewer findings summary section"
 
 echo
 echo "== Summary =="


### PR DESCRIPTION
## Summary

- **`/issue` Phase 2-4 fanout grows from 4 → 8 Task agents** in a single assistant turn: existing four (codebase, patterns, dup-search, label-validation) PLUS prior-art, constraints, security (Semgrep MCP + awesome-secure-defaults), test-coverage (test-surface mapping). Issue templates gain `## Current ecosystem`, `## Constraints`, and conditional `## Security signals` sections. `NO_EXPLORE=1` narrows to the four in-repo agents only.
- **Tier-independent quality bar via artifact reuse + always-on reviewers.** Orchestrator Phase 1 short-circuits per-topic against `.uberdev/research/issue-<N>/` (mirrors brainstorm). Spec-reviewer is always-on for medium AND large (`--paranoid` deprecated as no-op). New Phase 4.5 dispatches `plan-reviewer` (1-retry, non-blocking). New Phase 5.5 runs `pr-test-analyzer` pre-merge for large tier. New shared skill `uberdev:post-impl-review` (5-agent advisory fanout: code-reviewer, simplifier, silent-failure-hunter, type-design-analyzer, comment-analyzer) is invoked by `/solve` trivial/small inline prompts AND by `subagent-driven-dev` after each wave.
- **`/turbo` Q&A becomes non-blocking.** Orchestrator Phase 2 under `--turbo` auto-picks each clarifying answer using research-bundle synthesis and writes `questions.md`. `finish-branch` Option 2 reads it and appends `## Open questions answered by /turbo` (Question | Choice | Confidence) plus `## Reviewer findings summary` to the PR body.

Closes #11

## Test Plan

- [x] `tests/issue-causal-fanout.test.sh` — **39/39 pass** (8 new 8-agent assertions + 1 new `--no-explore` 4-agent assertion + 30 pre-existing)
- [x] `tests/turbo-flow.test.sh` — **19/19 pass** (9 new always-on-reviewer assertions + 10 pre-existing `--turbo` propagation canaries)
- [x] `tests/post-impl-review.test.sh` — **10/10 pass** (frontmatter + 5 reviewer agent names + single-message invariant + both call-site refs + anti-loop guard)
- [x] Single-message-fanout invariants survived (6 references across `issue.md`, `orchestrator/SKILL.md`, `post-impl-review/SKILL.md`)
- [x] Old `tier == medium AND --paranoid` gate prose REMOVED from orchestrator (verified count = 0)
- [x] `--paranoid` deprecation prose PRESENT (verified count = 2)
- [x] All 6 research topic names (codebase, patterns, prior-art, constraints, security, test-coverage) referenced from `brainstorm/SKILL.md` (count = 10)
- [x] `post-impl-review/SKILL.md` does NOT match `invoke[[:space:]]+(uberdev:)?(brainstorm|write-plan)` regex (anti-loop guard, count = 0)
- [x] `--turbo` propagation chain unbroken (orchestrator → subagent-driven-dev → finish-branch — pre-existing assertions still green)
- [x] finish-branch Option 2 no-cleanup rule preserved
- [ ] First post-merge dogfood — next medium/large `/solve` run will exercise the artifact-reuse short-circuit and per-wave `uberdev:post-impl-review` invocation end-to-end

## Open questions answered by /turbo

This PR was driven by `/uberdev:orchestrator` (non-turbo), so 2 questions were asked interactively rather than auto-picked. Captured here for review-time visibility:

| Question | Choice | Confidence |
|----------|--------|------------|
| Where does the post-impl 5-agent reviewer fanout wire for trivial/small tier? | New shared skill `uberdev:post-impl-review` (DRY single source of truth) | high |
| For `--no-explore` shallow-mode, which subset of agents should run? | In-repo agents only (codebase + patterns + constraints + test-coverage) | high |

## Reviewer findings summary

`uberdev:post-impl-review` is *introduced* by this PR (T5), so per-wave reviewer fanout was not invoked on this PR's own waves (no recursive dogfooding pre-merge). Wave-2 implementer agents each ran the plan's structural verification commands, and full test suites were run after every wave. First end-to-end exercise of the 5-agent fanout will be on the next medium/large issue solved after this merges.

The user's global CLAUDE.md `MANDATORY: run /uberdev:review-pr after pushing the PR` rule applies — that flow will run after push.

## Files changed (13 files, +639/-83)

| File | Kind | Purpose |
|------|------|---------|
| `plugins/uberdev/agents/research-security.md` | new | Semgrep MCP + awesome-secure-defaults research agent |
| `plugins/uberdev/agents/research-test-coverage.md` | new | Filename-stem heuristic test-surface mapper |
| `plugins/uberdev/skills/post-impl-review/SKILL.md` | new | Shared 5-agent advisory reviewer fanout |
| `plugins/uberdev/commands/issue.md` | modify | Phase 2-4 fanout 4→8; templates gain Ecosystem/Constraints/Security sections |
| `plugins/uberdev/skills/orchestrator/SKILL.md` | modify | Phase 1 reuse; --paranoid deprecation; Phase 4.5 plan-reviewer; Phase 5.5 pr-test-analyzer; Tier-profile table |
| `plugins/uberdev/skills/brainstorm/SKILL.md` | modify | Per-topic short-circuit extends to 6 topics |
| `plugins/uberdev/skills/subagent-driven-dev/SKILL.md` | modify | Per-wave `uberdev:post-impl-review` invocation |
| `plugins/uberdev/commands/solve.md` | modify | Trivial/small inline prompts read pre-collected research + invoke post-impl-review |
| `plugins/uberdev/skills/finish-branch/SKILL.md` | modify | Option 2 composes Open-questions + Reviewer-findings PR sections |
| `plugins/uberdev/commands/turbo.md` | modify | Documents non-blocking Q&A + reviewer audit-trail surfaces |
| `tests/issue-causal-fanout.test.sh` | modify | TDD canaries for 8-agent fanout + --no-explore narrowing; relax pre-existing brainstorm regex |
| `tests/turbo-flow.test.sh` | modify | TDD canaries for always-on reviewers + new PR-body sections |
| `tests/post-impl-review.test.sh` | new | Skill structural test (frontmatter, fanout, anti-loop guard, call-site refs) |

## Backwards compatibility

- Existing `.uberdev/research/issue-<N>/` directories with 2-4 artifacts remain readable; per-topic short-circuit reads what exists and dispatches what's missing.
- `--paranoid` flag is accepted (no-op, deprecation notice). Removal target: v1.0.0.
- All pre-existing test assertions still pass (no regression on `--turbo` propagation chain, default-mode menu, brainstorm short-circuit shape, or `/issue` causal-triple labels).

## Local-only artifacts

Per project policy (`docs/` is gitignored: "Local-only design docs, kept on disk, not published"), these orchestrator-pipeline outputs live on disk but ship nothing:

- `docs/uberdev/specs/2026-04-29-expand-issue-fanout-always-on-reviewers-design.md` (spec, sha 9b8b9748)
- `docs/uberdev/plans/2026-04-29-expand-issue-fanout-always-on-reviewers.md` (plan, sha d4e95192)
- `docs/rfc/2026-04-29-always-on-reviewers.md` (RFC — Context/Decision/Alternatives/Migration/Tradeoffs/Links)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added security scanning capability to issue investigations
  * Added automated test coverage analysis to research phase
  * New post-implementation code review process integrated across all implementation tiers
  * Enhanced turbo mode with automated question answering and intelligent synthesis

* **Improvements**
  * Expanded research phase to gather comprehensive insights from multiple angles
  * Improved artifact tracking and PR body composition with aggregated findings
  * Better reuse of prior research across investigation runs to streamline workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->