### PR TITLE
feat(uberdev): top-level aliases for plugin commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,18 @@ Both are **repo-agnostic** — they auto-detect the current repo via `gh repo vi
 
 # 3. Smoke-test
 /uberdev:issue trivial typo in README install step
+
+# 4. (Recommended) Install short-form aliases so /issue, /solve, /turbo,
+#    /simplify, /review-pr work without the /uberdev: prefix.
+/uberdev:install-aliases
 ```
 
-Optional — once verified, deconflict any pre-existing global commands so the unqualified `/solve` and `/issue` resolve to the plugin:
-
-```bash
-rm -i ~/.claude/commands/solve.md ~/.claude/commands/issue.md
-```
+Step 4 is the ergonomics step: by default, plugin commands are addressed
+as `/uberdev:<command>` because Claude Code's plugin manifest enforces a
+`<plugin-name>:` prefix on every command. The `/uberdev:install-aliases`
+helper drops one-way forwarders into `~/.claude/commands/` so you can
+type `/issue …` instead of `/uberdev:issue …`. The long form keeps
+working — this is purely additive. See [Short-form aliases](#short-form-aliases) below.
 
 ---
 
@@ -78,6 +83,53 @@ Or interactively: `/plugin` → **Installed** → select `uberdev` → re-instal
 > **Disabling everything:** set `DISABLE_AUTOUPDATER=1` in your shell environment to globally disable Claude Code's auto-updater (affects Claude Code itself + every plugin).
 
 Each release bumps the `version` field in `.claude-plugin/plugin.json`, so auto-update users get clean version transitions; manual users see the new version listed under the marketplace entry.
+
+---
+
+## Short-form aliases
+
+Plugin commands are addressed as `/uberdev:<command>` by default — the
+`uberdev:` prefix is required by Claude Code's plugin manifest, which has
+no field for declaring top-level (un-namespaced) commands. For a daily
+driver, that 9-character tax adds up.
+
+`/uberdev:install-aliases` resolves it by dropping five short-form
+forwarders into `~/.claude/commands/`:
+
+| Short form    | Canonical             |
+|---            |---                    |
+| `/issue`      | `/uberdev:issue`      |
+| `/solve`      | `/uberdev:solve`      |
+| `/turbo`      | `/uberdev:turbo`      |
+| `/simplify`   | `/uberdev:simplify`   |
+| `/review-pr`  | `/uberdev:review-pr`  |
+
+```bash
+/uberdev:install-aliases             # install forwarders (skip-if-exists)
+/uberdev:install-aliases --dry-run   # preview without writing
+/uberdev:install-aliases --force     # refresh existing managed forwarders
+/uberdev:uninstall-aliases           # remove (only marker-tagged files)
+```
+
+**Design notes:**
+
+- **One-way forwarding, not duplication.** Each forwarder is a thin file
+  that points at the canonical `/uberdev:<command>` body — there is no
+  second copy of `issue.md` to maintain.
+- **Backwards-compatible.** Existing `/uberdev:<command>` invocations
+  keep working unchanged. Docs, plugin manifests, and muscle memory that
+  reference the long form are unaffected.
+- **Collision-safe.** If a short name is already taken (built-in like
+  `/review`, another plugin's command, or a hand-authored
+  `~/.claude/commands/<name>.md`), the install command skips it with a
+  warning rather than overwriting. That's why this proposal uses
+  `/review-pr` — `/review` is a Claude Code built-in.
+- **Marker-scoped uninstall.** Forwarders carry `<!-- managed-by:
+  uberdev-aliases -->` so `/uberdev:uninstall-aliases` only removes
+  files we own.
+- **Re-run after plugin reinstall.** Forwarders capture the absolute
+  plugin path at install time. If you reinstall the plugin to a
+  different location, run `/uberdev:install-aliases --force` to refresh.
 
 ---
 

--- a/plugins/uberdev/commands/install-aliases.md
+++ b/plugins/uberdev/commands/install-aliases.md
@@ -46,19 +46,32 @@ DRY_RUN=0
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
 if [ -z "$PLUGIN_ROOT" ] || [ ! -d "$PLUGIN_ROOT/commands" ]; then
-  echo "❌ CLAUDE_PLUGIN_ROOT not set or invalid; cannot resolve canonical commands."
-  echo "   This command must be run from within Claude Code with the uberdev plugin enabled."
+  echo "❌ CLAUDE_PLUGIN_ROOT not set or invalid; cannot resolve canonical commands." >&2
+  echo "   This command must be run from within Claude Code with the uberdev plugin enabled." >&2
   exit 1
 fi
 
 DEST_DIR="$HOME/.claude/commands"
-[ "$DRY_RUN" = "1" ] || mkdir -p "$DEST_DIR"
+if [ "$DRY_RUN" != "1" ]; then
+  mkdir -p "$DEST_DIR" || {
+    echo "❌ Failed to create $DEST_DIR (permissions? disk full?)" >&2
+    exit 1
+  }
+fi
 
 # Per-alias config: short-name|canonical-name|JSON-array-of-allowed-tools.
-# allowed-tools is mirrored from each canonical's frontmatter so the
-# forwarder grants exactly the same tool surface — no more, no less. If a
-# canonical is updated to need a new tool, this list must be updated too;
-# the alias contract is "behave as the canonical".
+#
+# allowed-tools is HARDCODED here, not auto-extracted from each canonical's
+# frontmatter. It must be kept byte-identical to the canonical's
+# `allowed-tools` line so the forwarder grants the same tool surface — no
+# more, no less. If a canonical is updated to need a new tool, this table
+# must be updated to match.
+#
+# `tests/aliases.test.sh` section A6 enforces this drift-detection contract:
+# the suite reads each canonical's `allowed-tools` line and asserts the
+# matching ALIASES row contains the same value. So forgetting to update
+# this list will fail CI rather than silently shipping under-privileged
+# forwarders.
 ALIASES='issue|issue|["Bash", "Glob", "Grep", "Read", "Task"]
 solve|solve|["Bash", "Read", "Task"]
 turbo|turbo|["Bash", "Read", "Task"]
@@ -121,9 +134,12 @@ while IFS='|' read -r SHORT CANON TOOLS; do
   fi
 
   # Write the forwarder. Heredoc is unquoted so $SHORT/$CANON/$TOOLS/
-  # $PLUGIN_ROOT/$CANON_FILE expand at install time. Variables we want
-  # left literal in the file ($ARGUMENTS, ${CLAUDE_PLUGIN_ROOT}) are
-  # escaped with a leading backslash.
+  # $PLUGIN_ROOT/$CANON_FILE expand HERE — those values are baked into
+  # the forwarder once at install time. $ARGUMENTS and ${CLAUDE_PLUGIN_ROOT}
+  # are escaped with a leading backslash so they remain LITERAL in the
+  # written file; Claude Code's harness substitutes them later, when the
+  # user actually invokes the alias (so each invocation gets the user's
+  # then-current args, not the empty $ARGUMENTS at install time).
   cat > "$TARGET" <<EOF
 ---
 description: "Alias for /uberdev:$CANON"
@@ -168,7 +184,3 @@ echo "Remove with: /uberdev:uninstall-aliases"
 ```
 
 After running the script, briefly relay the per-alias outcome to the user.
-Do not invoke any of the canonical commands (`/uberdev:issue`, etc.) as
-part of installation — installation is purely a filesystem operation, and
-running the canonicals here would be confusing side-effects from a setup
-command.

--- a/plugins/uberdev/commands/install-aliases.md
+++ b/plugins/uberdev/commands/install-aliases.md
@@ -82,6 +82,13 @@ review-pr|review-pr|["Bash(git*)", "Bash(gh*)", "Glob", "Grep", "Read", "Task"]'
 # /review is the load-bearing entry here (we already use /review-pr to dodge
 # it, but if someone adds another canonical short-named like a built-in, the
 # guard catches it).
+#
+# Manually maintained — Claude Code's plugin reference doesn't expose a
+# machine-readable list of reserved short-names, so on a major Claude Code
+# release this list should be re-checked against the current built-in set
+# (https://code.claude.com/docs/en/plugins-reference). If a new built-in
+# is added that collides with an alias, this list is the right place to
+# add the guard.
 BUILTINS='init review security-review statusline-setup help clear plugin'
 
 echo "Installing uberdev short-form aliases…"

--- a/plugins/uberdev/commands/install-aliases.md
+++ b/plugins/uberdev/commands/install-aliases.md
@@ -1,0 +1,174 @@
+---
+description: "Install short-form aliases (/issue, /solve, /turbo, /simplify, /review-pr) as one-way forwarders to /uberdev:<command>"
+argument-hint: "[--force] [--dry-run]"
+allowed-tools: ["Bash", "Read"]
+---
+
+# Install short-form aliases
+
+User flags: `$ARGUMENTS` (`--force` to refresh existing managed forwarders, `--dry-run` to preview without writing)
+
+Plugin commands are addressed as `/uberdev:<command>` because Claude Code's
+plugin manifest enforces the `<plugin-name>:` prefix. The manifest has no
+field for top-level aliases, so the only mechanism is shipping forwarder
+files into the user's standalone `~/.claude/commands/` directory (where
+filename = command name, no plugin prefix). See issue #16.
+
+This command writes five such forwarders. Each is **one-way** — it points
+at the canonical `/uberdev:<command>` rather than duplicating its body.
+Existing `/uberdev:<command>` invocations are unaffected; this is purely
+additive ergonomics.
+
+## What gets installed
+
+| Short form | Canonical |
+|---|---|
+| `/issue`     | `/uberdev:issue` |
+| `/solve`     | `/uberdev:solve` |
+| `/turbo`     | `/uberdev:turbo` |
+| `/simplify`  | `/uberdev:simplify` |
+| `/review-pr` | `/uberdev:review-pr` |
+
+Note `/review-pr` rather than `/review`: `/review` is a built-in
+Claude Code command, and the issue's collision rule is "plugin namespacing
+always wins over short alias" — but built-ins ship with Claude Code itself,
+so we sidestep the collision by using a slightly different short name.
+
+## Run
+
+```bash
+set -e
+
+FORCE=0
+DRY_RUN=0
+[[ " $ARGUMENTS " == *" --force "* ]] && FORCE=1
+[[ " $ARGUMENTS " == *" --dry-run "* ]] && DRY_RUN=1
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+if [ -z "$PLUGIN_ROOT" ] || [ ! -d "$PLUGIN_ROOT/commands" ]; then
+  echo "❌ CLAUDE_PLUGIN_ROOT not set or invalid; cannot resolve canonical commands."
+  echo "   This command must be run from within Claude Code with the uberdev plugin enabled."
+  exit 1
+fi
+
+DEST_DIR="$HOME/.claude/commands"
+[ "$DRY_RUN" = "1" ] || mkdir -p "$DEST_DIR"
+
+# Per-alias config: short-name|canonical-name|JSON-array-of-allowed-tools.
+# allowed-tools is mirrored from each canonical's frontmatter so the
+# forwarder grants exactly the same tool surface — no more, no less. If a
+# canonical is updated to need a new tool, this list must be updated too;
+# the alias contract is "behave as the canonical".
+ALIASES='issue|issue|["Bash", "Glob", "Grep", "Read", "Task"]
+solve|solve|["Bash", "Read", "Task"]
+turbo|turbo|["Bash", "Read", "Task"]
+simplify|simplify|["Bash", "Edit", "Glob", "Grep", "MultiEdit", "Read", "Task", "Write"]
+review-pr|review-pr|["Bash(git*)", "Bash(gh*)", "Glob", "Grep", "Read", "Task"]'
+
+# Built-in Claude Code commands; never overwrite these even with --force.
+# /review is the load-bearing entry here (we already use /review-pr to dodge
+# it, but if someone adds another canonical short-named like a built-in, the
+# guard catches it).
+BUILTINS='init review security-review statusline-setup help clear plugin'
+
+echo "Installing uberdev short-form aliases…"
+echo "  source: $PLUGIN_ROOT/commands"
+echo "  dest:   $DEST_DIR"
+[ "$DRY_RUN" = "1" ] && echo "  mode:   dry-run (no files written)"
+[ "$FORCE" = "1" ] && echo "  mode:   --force (refresh managed forwarders)"
+echo
+
+INSTALLED=0
+SKIPPED=0
+
+while IFS='|' read -r SHORT CANON TOOLS; do
+  TARGET="$DEST_DIR/${SHORT}.md"
+  CANON_FILE="$PLUGIN_ROOT/commands/${CANON}.md"
+
+  if [ ! -f "$CANON_FILE" ]; then
+    echo "  SKIP  /$SHORT — canonical not found at $CANON_FILE"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Built-in collision — refuse even with --force, since clobbering a
+  # built-in would brick the user's environment.
+  if [[ " $BUILTINS " == *" $SHORT "* ]]; then
+    echo "  SKIP  /$SHORT — collides with a Claude Code built-in; use /uberdev:$CANON"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Collision check: a single grep against TARGET answers both "does it
+  # exist?" and "is it ours?" — grep with 2>/dev/null returns non-zero
+  # silently if the file is missing, so we don't need a separate -e stat.
+  if grep -q 'managed-by: uberdev-aliases' "$TARGET" 2>/dev/null; then
+    if [ "$FORCE" != "1" ]; then
+      echo "  KEEP  /$SHORT — already installed (use --force to refresh)"
+      SKIPPED=$((SKIPPED + 1))
+      continue
+    fi
+    echo "  REPL  /$SHORT — refreshing existing managed forwarder"
+  elif [ -e "$TARGET" ]; then
+    echo "  SKIP  /$SHORT — $TARGET exists and is not managed by uberdev (won't overwrite)"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "  PLAN  /$SHORT → /uberdev:$CANON  (would write $TARGET)"
+    continue
+  fi
+
+  # Write the forwarder. Heredoc is unquoted so $SHORT/$CANON/$TOOLS/
+  # $PLUGIN_ROOT/$CANON_FILE expand at install time. Variables we want
+  # left literal in the file ($ARGUMENTS, ${CLAUDE_PLUGIN_ROOT}) are
+  # escaped with a leading backslash.
+  cat > "$TARGET" <<EOF
+---
+description: "Alias for /uberdev:$CANON"
+argument-hint: "<args>  # forwarded to /uberdev:$CANON"
+allowed-tools: $TOOLS
+---
+
+<!-- managed-by: uberdev-aliases -->
+<!-- Generated by /uberdev:install-aliases. Remove via /uberdev:uninstall-aliases. -->
+<!-- Do not edit by hand — re-run /uberdev:install-aliases --force to regenerate. -->
+
+# /$SHORT — alias for /uberdev:$CANON
+
+This is a top-level shorthand for the canonical \`/uberdev:$CANON\`.
+Treat this invocation exactly as if the user had typed
+\`/uberdev:$CANON \$ARGUMENTS\`. There is no logic here — the canonical
+command file lives in the uberdev plugin install.
+
+- **canonical command**: \`$CANON_FILE\`
+- **\${CLAUDE_PLUGIN_ROOT}** (resolved at install time): \`$PLUGIN_ROOT\`
+- **user arguments**: \`\$ARGUMENTS\`
+
+**Action:** Read the canonical command file with the \`Read\` tool, then
+follow its instructions exactly. Wherever the canonical references
+\`\${CLAUDE_PLUGIN_ROOT}\`, substitute the resolved path above. Pass
+\`\$ARGUMENTS\` through unchanged.
+
+If the canonical path is stale (e.g. you reinstalled the plugin to a
+different location), re-run \`/uberdev:install-aliases --force\` to
+regenerate this file.
+EOF
+  echo "  OK    /$SHORT → /uberdev:$CANON"
+  INSTALLED=$((INSTALLED + 1))
+done <<< "$ALIASES"
+
+echo
+echo "Summary: $INSTALLED installed, $SKIPPED skipped"
+[ "$DRY_RUN" = "1" ] && echo "(dry-run — no files actually written)"
+echo
+echo "Test with:  /issue some test description"
+echo "Remove with: /uberdev:uninstall-aliases"
+```
+
+After running the script, briefly relay the per-alias outcome to the user.
+Do not invoke any of the canonical commands (`/uberdev:issue`, etc.) as
+part of installation — installation is purely a filesystem operation, and
+running the canonicals here would be confusing side-effects from a setup
+command.

--- a/plugins/uberdev/commands/uninstall-aliases.md
+++ b/plugins/uberdev/commands/uninstall-aliases.md
@@ -1,0 +1,70 @@
+---
+description: "Remove short-form aliases (/issue, /solve, /turbo, /simplify, /review-pr) installed by /uberdev:install-aliases"
+argument-hint: "[--dry-run]"
+allowed-tools: ["Bash"]
+---
+
+# Uninstall short-form aliases
+
+User flags: `$ARGUMENTS` (`--dry-run` to preview without removing)
+
+Removes the user-level forwarder files written by `/uberdev:install-aliases`.
+Marker-scoped: only files carrying `managed-by: uberdev-aliases` are
+removed, so a hand-authored `~/.claude/commands/issue.md` (or any other
+short name) is preserved untouched.
+
+## Run
+
+```bash
+set -e
+
+DRY_RUN=0
+[[ " $ARGUMENTS " == *" --dry-run "* ]] && DRY_RUN=1
+
+DEST_DIR="$HOME/.claude/commands"
+SHORTS='issue solve turbo simplify review-pr'
+
+REMOVED=0
+KEPT=0
+
+echo "Removing uberdev-managed short-form aliases…"
+echo "  scan:  $DEST_DIR"
+[ "$DRY_RUN" = "1" ] && echo "  mode:  dry-run (no files removed)"
+echo
+
+for SHORT in $SHORTS; do
+  TARGET="$DEST_DIR/${SHORT}.md"
+
+  if [ ! -e "$TARGET" ]; then
+    echo "  ----  /$SHORT — not installed"
+    continue
+  fi
+
+  # Marker check is the safety contract. Without it, this command could
+  # delete a user's hand-authored alias file that just happens to share
+  # one of the short names. grep -q is the smallest possible check that
+  # answers "did install-aliases write this?".
+  if ! grep -q 'managed-by: uberdev-aliases' "$TARGET" 2>/dev/null; then
+    echo "  KEEP  /$SHORT — $TARGET exists but is not managed by uberdev"
+    KEPT=$((KEPT + 1))
+    continue
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "  PLAN  /$SHORT — would remove $TARGET"
+    continue
+  fi
+
+  rm -f "$TARGET"
+  echo "  GONE  /$SHORT — removed"
+  REMOVED=$((REMOVED + 1))
+done
+
+echo
+echo "Summary: $REMOVED removed, $KEPT kept"
+[ "$DRY_RUN" = "1" ] && echo "(dry-run — nothing actually removed)"
+echo
+echo "Reinstall with: /uberdev:install-aliases"
+```
+
+After running, briefly relay the per-alias outcome to the user.

--- a/tests/aliases.test.sh
+++ b/tests/aliases.test.sh
@@ -30,11 +30,16 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 INSTALL_CMD="$REPO_ROOT/plugins/uberdev/commands/install-aliases.md"
 UNINSTALL_CMD="$REPO_ROOT/plugins/uberdev/commands/uninstall-aliases.md"
 README="$REPO_ROOT/README.md"
+CANON_DIR="$REPO_ROOT/plugins/uberdev/commands"
 
 # Pre-flight: refuse to run if any asserted-against file is missing or
 # unreadable. Without this, every assertion fails with a confusing "pattern
 # not found" instead of the real cause (mirrors audit-fixups.test.sh).
-for f in "$INSTALL_CMD" "$UNINSTALL_CMD" "$README"; do
+# Section A6 also reads each canonical's frontmatter, so those files are
+# pre-flighted too.
+for f in "$INSTALL_CMD" "$UNINSTALL_CMD" "$README" \
+         "$CANON_DIR/issue.md" "$CANON_DIR/solve.md" "$CANON_DIR/turbo.md" \
+         "$CANON_DIR/simplify.md" "$CANON_DIR/review-pr.md"; do
   if [ ! -r "$f" ]; then
     echo "FATAL: required file missing or unreadable: $f" >&2
     exit 2
@@ -170,6 +175,40 @@ for short in /issue /solve /turbo /simplify /review-pr; do
   assert_grep "$README" \
     "${short}\\b" \
     "README mentions short form ${short}"
+done
+
+echo
+echo "== A6: alias forwarders mirror each canonical's allowed-tools =="
+# The ALIASES table in install-aliases.md hardcodes per-alias allowed-tools.
+# That value MUST equal the canonical command's `allowed-tools:` line, byte
+# for byte — otherwise the forwarder grants a different (usually narrower)
+# tool surface than the canonical, and the alias silently breaks at the
+# first tool the canonical needs but the forwarder can't use.
+#
+# We grep the canonical's allowed-tools line, normalize whitespace, and
+# look for a matching ALIASES row in install-aliases.md that contains
+# both the canonical name and the same JSON array. The check is
+# fixed-string (-F) on the JSON tail, so trivial reformatting that
+# preserves byte-equality stays green.
+for canonical in issue solve turbo simplify review-pr; do
+  canon_file="$CANON_DIR/${canonical}.md"
+  # Strip the `allowed-tools: ` prefix, leaving just the JSON array.
+  canon_tools=$(grep -E '^allowed-tools:[[:space:]]*' "$canon_file" \
+                | head -1 | sed -E 's/^allowed-tools:[[:space:]]*//')
+  if [ -z "$canon_tools" ]; then
+    echo "  FAIL  /$canonical — could not extract allowed-tools from $canon_file"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+  if grep -F "${canonical}|${canonical}|${canon_tools}" "$INSTALL_CMD" > /dev/null; then
+    echo "  PASS  /$canonical — ALIASES row matches canonical allowed-tools"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  /$canonical — ALIASES row drift detected"
+    echo "        canonical allowed-tools: $canon_tools"
+    echo "        expected ALIASES row:    ${canonical}|${canonical}|${canon_tools}"
+    FAIL=$((FAIL + 1))
+  fi
 done
 
 echo

--- a/tests/aliases.test.sh
+++ b/tests/aliases.test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Tests for issue #16 — top-level aliases for the five most-used uberdev
+# commands (/issue, /solve, /turbo, /simplify, /review-pr).
+#
+# Plugin commands are addressed as `/uberdev:<command>` because Claude Code's
+# plugin manifest enforces the `<plugin-name>:` prefix on every plugin
+# command. There is no manifest field for declaring a top-level alias, so
+# the only viable mechanism is shipping forwarders into the user's
+# standalone `~/.claude/commands/` directory, where filename = command name
+# with no plugin prefix.
+#
+# This file asserts the contract for the install-aliases / uninstall-aliases
+# plugin commands that do that work. It intentionally does NOT shell out to
+# Claude Code itself — these are grep-based structural assertions in the
+# style of tests/audit-fixups.test.sh and tests/turbo-flow.test.sh, runnable
+# in CI before merge without an interactive harness.
+#
+# Sections:
+#   A1 — install-aliases.md exists, references all 5 aliases, has marker
+#   A2 — install-aliases.md performs collision detection (skip-if-exists)
+#   A3 — install-aliases.md generates ONE-WAY forwarders, not duplicates
+#   A4 — uninstall-aliases.md exists and only removes marker-tagged files
+#   A5 — README documents the short forms and the install command
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+INSTALL_CMD="$REPO_ROOT/plugins/uberdev/commands/install-aliases.md"
+UNINSTALL_CMD="$REPO_ROOT/plugins/uberdev/commands/uninstall-aliases.md"
+README="$REPO_ROOT/README.md"
+
+# Pre-flight: refuse to run if any asserted-against file is missing or
+# unreadable. Without this, every assertion fails with a confusing "pattern
+# not found" instead of the real cause (mirrors audit-fixups.test.sh).
+for f in "$INSTALL_CMD" "$UNINSTALL_CMD" "$README"; do
+  if [ ! -r "$f" ]; then
+    echo "FATAL: required file missing or unreadable: $f" >&2
+    exit 2
+  fi
+done
+
+PASS=0
+FAIL=0
+
+assert_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        file:    $file"
+    echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_grep_not() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  FAIL  $desc — pattern '$pattern' should not appear"
+    echo "        file: $file"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+echo "== A1: install-aliases command exists and registers all 5 aliases =="
+# Each canonical /uberdev:<name> must be wired up. We grep for the literal
+# canonical command names since those are the targets the forwarders must
+# point at; if any is missing, the user-visible alias for that command
+# silently won't be installed.
+for canonical in issue solve turbo simplify review-pr; do
+  assert_grep "$INSTALL_CMD" \
+    "uberdev:${canonical}\\b" \
+    "install-aliases references canonical /uberdev:${canonical}"
+done
+
+# Marker is the safe-uninstall contract — uninstall-aliases keys off this
+# string to know which user-level files belong to us. Without the marker,
+# uninstall would either be unsafe (might delete user-authored files) or
+# impossible (couldn't tell ours apart). Both files must agree on the literal.
+MARKER='managed-by:[[:space:]]*uberdev-aliases'
+assert_grep "$INSTALL_CMD" "$MARKER" \
+  "install-aliases writes the 'managed-by: uberdev-aliases' marker into forwarders"
+assert_grep "$UNINSTALL_CMD" "$MARKER" \
+  "uninstall-aliases keys off the same 'managed-by: uberdev-aliases' marker"
+
+echo
+echo "== A2: install-aliases performs collision detection =="
+# The issue's acceptance criterion: pre-flight detects collisions with
+# existing user-level commands (built-in /review, other plugins claiming
+# the short name, or hand-authored files) and degrades gracefully —
+# warning + skip rather than overwrite. The phrasing has multiple valid
+# expressions; accept any of them so the assertion doesn't ossify around
+# a single wording.
+assert_grep "$INSTALL_CMD" \
+  'skip|already exists|collision|conflict|-e[[:space:]]+"\$' \
+  "install-aliases skips on collision rather than overwriting"
+
+# Negative: install must not contain blast-radius-y patterns that would
+# bypass collision detection. We forbid the specifically-dangerous shapes
+# (`cp -f`, `rm -rf $HOME...`) rather than the literal flag name `--force`,
+# because `--force` is also the legitimate user-flag NAME the command
+# accepts (gated behind the marker check, so safe). The dangerous shapes
+# below are unambiguous: any of them in this file would be a footgun.
+assert_grep_not "$INSTALL_CMD" \
+  'cp[[:space:]]+-f[[:space:]]|rm[[:space:]]+-rf[[:space:]]+"?\$HOME[/"]' \
+  "install-aliases does NOT contain cp -f or rm -rf \$HOME patterns"
+
+echo
+echo "== A3: forwarders are one-way pointers, not file duplication =="
+# The issue is explicit: "The mapping must be one-way forwarding, not file
+# duplication — maintaining two copies of issue.md is exactly the trap we'd
+# be falling into."
+#
+# The forwarder template inside install-aliases must NOT inline the body of
+# any canonical command. We pick a fingerprint from each canonical that
+# would never appear in a thin forwarder: a Phase heading or a substantial
+# bash block unique to that file. If install-aliases contains the
+# fingerprint, it's duplicating instead of forwarding.
+assert_grep_not "$INSTALL_CMD" \
+  'Phase 0: Detect repo \+ parse flags' \
+  "install-aliases does NOT inline issue.md's Phase 0 body"
+assert_grep_not "$INSTALL_CMD" \
+  'DUPLICATION NOTE — KEEP IN SYNC' \
+  "install-aliases does NOT inline solve.md/turbo.md's duplication-note block"
+assert_grep_not "$INSTALL_CMD" \
+  'Phase 1: Identify Changes' \
+  "install-aliases does NOT inline simplify.md's Phase 1 body"
+
+# Positive: forwarder must reference the canonical's path so dispatch
+# resolves at runtime. Any of `${CLAUDE_PLUGIN_ROOT}`, an `@`-include, or
+# an absolute-path placeholder that's filled in at install time satisfies
+# the one-way-pointer contract.
+assert_grep "$INSTALL_CMD" \
+  'CLAUDE_PLUGIN_ROOT|commands/(issue|solve|turbo|simplify|review-pr)\.md' \
+  "install-aliases forwarder template points at canonical command files"
+
+echo
+echo "== A4: uninstall-aliases is marker-scoped =="
+# Without marker scoping, uninstall could delete user-authored files that
+# happen to share a short name. Assert that uninstall reads/checks the
+# marker before removing.
+assert_grep "$UNINSTALL_CMD" \
+  'grep|-q|managed-by' \
+  "uninstall-aliases checks for the marker before removing files"
+
+# Belt-and-braces: uninstall must NOT do an unguarded rm of all 5 paths.
+assert_grep_not "$UNINSTALL_CMD" \
+  'rm[[:space:]]+-f[[:space:]]+"?\$HOME/\.claude/commands/(issue|solve|turbo|simplify|review-pr)\.md"?[[:space:]]*$' \
+  "uninstall-aliases does NOT unconditionally rm forwarder paths"
+
+echo
+echo "== A5: README documents the short forms =="
+# Discoverability acceptance criterion. README must mention at least one of
+# the short forms AND the install command — otherwise the feature is
+# invisible to new users.
+assert_grep "$README" \
+  '/issue.*alias|short.?form|/uberdev:install-aliases' \
+  "README documents the short-form aliases or install command"
+
+# All five short forms should appear somewhere in the README so users can
+# search for them.
+for short in /issue /solve /turbo /simplify /review-pr; do
+  assert_grep "$README" \
+    "${short}\\b" \
+    "README mentions short form ${short}"
+done
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[[ $FAIL -eq 0 ]]

--- a/tests/aliases.test.sh
+++ b/tests/aliases.test.sh
@@ -179,6 +179,18 @@ done
 
 echo
 echo "== A6: alias forwarders mirror each canonical's allowed-tools =="
+# Bind the drift contract to the actual write logic. A6 below verifies the
+# ALIASES table matches each canonical's frontmatter, but doesn't catch a
+# bug where the heredoc writes a different variable to the forwarder's
+# `allowed-tools` line (e.g., `allowed-tools: $WRONGVAR`). This thin
+# assertion closes that gap by requiring the write line to read exactly
+# `allowed-tools: $TOOLS` — same variable name parsed from the ALIASES
+# rows. Together, A6's two halves guarantee canonical → ALIASES → written
+# forwarder share one source of truth.
+assert_grep "$INSTALL_CMD" \
+  '^allowed-tools: \$TOOLS$' \
+  "install-aliases heredoc writes the \$TOOLS variable from the ALIASES table"
+
 # The ALIASES table in install-aliases.md hardcodes per-alias allowed-tools.
 # That value MUST equal the canonical command's `allowed-tools:` line, byte
 # for byte — otherwise the forwarder grants a different (usually narrower)


### PR DESCRIPTION
## Summary

- `/uberdev:install-aliases` drops one-way forwarders into `~/.claude/commands/` so the five daily-driver commands work without the `uberdev:` namespace prefix: `/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr`.
- `/uberdev:uninstall-aliases` removes them — marker-scoped, so hand-authored files are preserved.
- Existing `/uberdev:<command>` invocations are unchanged (additive only).

Plugin manifests have no field for top-level aliases — Claude Code enforces `<plugin-name>:` namespacing on every plugin command. Standalone forwarders in `~/.claude/commands/` are the only viable mechanism, so we ship a one-shot helper rather than asking users to hand-author them.

Forwarders capture the absolute plugin-install path at write time and delegate to the canonical body — no file duplication. Marker `managed-by: uberdev-aliases` ties install/uninstall together. `/review-pr` instead of `/review` because `/review` is a Claude Code built-in.

## Test plan

- [x] `tests/aliases.test.sh` — 21 structural assertions (canonical references, marker contract, collision detection, no body duplication, README discoverability)
- [x] Sandbox smoke: fresh install, re-run KEEP, `--force` REPL, `--dry-run` no writes, uninstall preserves hand-authored files, missing `CLAUDE_PLUGIN_ROOT` errors cleanly
- [x] Full repo test suite still green (`tests/audit-fixups`, `issue-causal-fanout`, `post-impl-review`, `spec-reviewer-plan-aware`, `turbo-flow`)
- [ ] After merge, run `/uberdev:install-aliases` against a fresh marketplace install and verify `/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr` resolve end-to-end

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added command alias management system enabling users to install short-form commands (`/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr`) as shortcuts to longer prefixed variants.
  * Added `/uberdev:install-aliases` and `/uberdev:uninstall-aliases` commands for managing alias installation and removal.

* **Documentation**
  * Updated README with alias installation guidance and available alias management options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->