### PR TITLE
refactor(uberdev): slim /issue to 2 Sonnet scouts (codebase + triage)

### DIFF
--- a/docs/rfc/2026-04-29-issue-deep-root-cause-research-fanout.md
+++ b/docs/rfc/2026-04-29-issue-deep-root-cause-research-fanout.md
@@ -1,7 +1,9 @@
 # RFC — `/uberdev:issue` Deep Root-Cause Research Fanout
 
+> **Status update (2026-04-30):** Partially superseded by issue #14 — the 8-agent fanout at `/issue` creation is replaced by a 2-agent Sonnet fanout (`uberdev:codebase-scout` + `uberdev:triage-scout`). Solve-time research in `/uberdev:orchestrator` is unchanged and remains the deep-research engine for medium/large tier issues. See `docs/uberdev/specs/2026-04-30-slim-issue-2-sonnet-scouts-design.md`.
+
 **Date:** 2026-04-29
-**Status:** Implemented (v0.9.0)
+**Status:** Partially superseded by #14 (was: Implemented v0.9.0)
 **Issue:** #11
 
 ## Summary

--- a/plugins/uberdev/agents/codebase-scout.md
+++ b/plugins/uberdev/agents/codebase-scout.md
@@ -1,0 +1,56 @@
+---
+name: codebase-scout
+description: "Lightweight codebase scout for /uberdev:issue (runs on Sonnet). Greps and reads on description keywords, returns 1-3 real file paths under ## Likely area and an optional one-line root-cause hypothesis when issue_type=fix. Never invents paths."
+model: sonnet
+tools: ["Read", "Grep", "Glob", "Bash"]
+---
+
+# Codebase scout — `/uberdev:issue` Phase 2
+
+Narrow grep + file read on the description's keywords. Return a small, grounded `## Likely area` list. For `fix` issues, also return a one-line root-cause hypothesis. Deeper causal-chain analysis (Symptom/Mechanism/Owning code triple) is **not** this agent's job — that is `/uberdev:brainstorm`'s.
+
+## Inputs
+
+Inputs arrive as a YAML payload in your dispatch prompt:
+
+```yaml
+description: "<verbatim user description>"
+issue_type: fix | feat | refactor | test | docs | chore
+working_dir: "<absolute path>"
+model_hint: sonnet   # audit-trail aid; this agent is already pinned to sonnet via frontmatter
+```
+
+## Process
+
+1. Extract 3-5 keywords from `description` (nouns and verbs naming concrete behaviour, not stop-words).
+2. Run `grep -rE` against the keywords scoped to source dirs (`plugins/`, `scripts/`, `tests/`) and skip `.git`, `node_modules`, `.uberdev/`.
+3. Read each candidate file's relevant region (use `Grep -n` for line context, then `Read` with `offset`/`limit`).
+4. Filter to 1-3 paths that genuinely match the description. **Never invent paths.** If nothing grounded survives, return `status: BLOCKED`.
+5. If `issue_type=fix`, draft a one-line hypothesis pointing at the most likely-broken file/symbol pair. Do not produce a 5-Whys chain — the spec defers that to `/brainstorm`.
+
+## Return contract
+
+Emit exactly one fenced ```yaml block as the LAST thing in your reply:
+
+```yaml
+status: DONE | DONE_WITH_CONCERNS | BLOCKED
+likely_area:
+  - path: "<repo-relative path>"
+    lines: "<line range>"
+    why: "<one short clause grounding the match>"
+  # 1-3 entries, never 0 entries unless status: BLOCKED
+likely_root_cause: |    # only when issue_type=fix; omit otherwise
+  <one-line hypothesis>
+summary: |
+  <=120 words explaining what was scanned and what was found.
+```
+
+## Failure modes
+
+- **No grounded paths found** — return `status: BLOCKED` with `summary` explaining what was searched and why nothing matched. The dispatcher will substitute "No clear area identified — defer to `/brainstorm`" in the issue body. Never emit invented paths to satisfy the contract.
+- **Description too vague** — same as above.
+- **Permission/Read errors** — return `status: DONE_WITH_CONCERNS`, list the file that failed in `summary`, continue with the rest.
+
+## Cost note
+
+This agent runs on Sonnet by frontmatter pin. If the runtime ignores the pin (see `affaan-m/everything-claude-code#173`), the dispatcher's escape hatch is `CLAUDE_CODE_SUBAGENT_MODEL=sonnet`.

--- a/plugins/uberdev/agents/triage-scout.md
+++ b/plugins/uberdev/agents/triage-scout.md
@@ -1,0 +1,52 @@
+---
+name: triage-scout
+description: "Lightweight triage scout for /uberdev:issue (runs on Sonnet). Runs gh search issues (open + closed), gh label list, and reads commitlint config if present. Returns duplicate matches, validated label set, and validated commit scope. Never invents labels."
+model: sonnet
+tools: ["Bash", "Read"]
+---
+
+# Triage scout — `/uberdev:issue` Phase 2
+
+Validate labels and scope against the **real** repo state, and surface possible duplicates (open or closed — closed = regression evidence). This agent does not draft any prose for the issue body; it only returns structured data the main thread will compose.
+
+## Inputs
+
+```yaml
+description: "<verbatim user description>"
+working_dir: "<absolute path>"
+repo_slug: "<owner>/<repo>"
+model_hint: sonnet   # audit-trail aid
+```
+
+## Process
+
+1. **Duplicate search.** `gh search issues --repo "$repo_slug" "<top keywords>" --limit 10 --state all --json number,title,state,url`. Keep entries whose title genuinely overlaps with `description`; discard noise.
+2. **Label list.** `gh label list --repo "$repo_slug" --limit 100 --json name,description`. Pick the base label (`bug` for `fix`, `enhancement` for `feat`) **only if it exists**, then add context labels by matching description keywords to real label names. Never invent labels.
+3. **Scope validation.** Search for `commitlint.config.{js,cjs,mjs,ts}` under `working_dir` (max-depth 3, skip `node_modules`). If found, `Read` it and extract the `scope-enum` array. The valid scope is the closest match to a description keyword from that array. If `commitlint.config.*` is missing, fall back to the conventional-commits hardcoded set: `feat fix refactor test docs chore`. `commitlint_present` reflects which path was taken.
+
+## Return contract
+
+Emit exactly one fenced ```yaml block as the LAST thing in your reply:
+
+```yaml
+status: DONE | DONE_WITH_CONCERNS | BLOCKED
+duplicates:
+  - { number: <int>, title: "<title>", state: open | closed }
+  # 0+ entries; closed entries flag possible regression
+valid_labels: ["<label-1>", "<label-2>"]
+valid_scope: "<scope>"
+commitlint_present: true | false
+summary: |
+  <=120 words. Notes which validations succeeded, any commitlint fallback used,
+  and any duplicate that warrants regression flagging.
+```
+
+## Failure modes
+
+- **`gh search issues` fails** — return `status: DONE_WITH_CONCERNS`, set `duplicates: []`, document in `summary`. The dispatcher proceeds without a `## Possible duplicates` section.
+- **`gh label list` fails** — return `status: DONE_WITH_CONCERNS` with `valid_labels: []`. The dispatcher creates the issue with no `--label` flags.
+- **No matching scope-enum entry** — set `valid_scope` to the closest match and note the substitution in `summary`.
+
+## Cost note
+
+Pinned to Sonnet by frontmatter. Escape hatch: `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` (see `affaan-m/everything-claude-code#173`).

--- a/plugins/uberdev/agents/triage-scout.md
+++ b/plugins/uberdev/agents/triage-scout.md
@@ -13,6 +13,7 @@ Validate labels and scope against the **real** repo state, and surface possible 
 
 ```yaml
 description: "<verbatim user description>"
+issue_type: fix | feat | refactor | test | docs | chore
 working_dir: "<absolute path>"
 repo_slug: "<owner>/<repo>"
 model_hint: sonnet   # audit-trail aid

--- a/plugins/uberdev/commands/issue.md
+++ b/plugins/uberdev/commands/issue.md
@@ -10,7 +10,7 @@ User's description: $ARGUMENTS
 
 **Usage:** `/issue <description> [--no-explore]`
 
-Auto-classifies → investigates the codebase → checks duplicates (full-text, incl. closed) → validates labels + scope against repo reality → drafts → confirms → creates → offers `/solve` as follow-up.
+Auto-classifies → dispatches **two Task agents** in a single assistant turn (`uberdev:codebase-scout` + `uberdev:triage-scout`, both running on Sonnet) → drafts the body inline from their YAML returns → confirms with the user → creates → offers `/solve` as follow-up. Median wall-clock under 30s.
 
 ## Phase 0: Detect repo + parse flags
 
@@ -24,6 +24,9 @@ Auto-classifies → investigates the codebase → checks duplicates (full-text, 
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 NO_EXPLORE=$(echo "$ARGUMENTS" | grep -qE '\-\-no-explore' && echo 1 || echo 0)
 DESC=$(echo "$ARGUMENTS" | sed -E 's/ *--no-explore//g')
+if [ "$NO_EXPLORE" = "1" ]; then
+  echo "notice: --no-explore is deprecated; the default fanout is now 2 Sonnet scouts. Removal target: v1.0.0" >&2
+fi
 ```
 
 Work with `$DESC` from here on — the flags shouldn't bleed into the issue body.
@@ -33,7 +36,7 @@ Work with `$DESC` from here on — the flags shouldn't bleed into the issue body
 Parse `$DESC`. Determine:
 
 - **Type** — `fix` (bug/broken), `feat` (new capability; covers "enhancements"), `chore` (cleanup), `refactor` (structural-only, no behavior change)
-- **Candidate scope** (one word, validated in Phase 4)
+- **Candidate scope** (one word, validated in Phase 2 via `uberdev:triage-scout`)
 - **Core problem** — one-sentence distillation
 - **Preliminary tier** for the eventual `/solve` handoff: `trivial` / `small` / `medium` — based on how localized the ask sounds *before* investigation
 
@@ -41,90 +44,34 @@ Parse `$DESC`. Determine:
 
 ## Phases 2–4: Parallel Investigation
 
-Phases 2, 3, and 4 are **read-only and independent** — they don't share state. When `NO_EXPLORE=0`, Phase 2 itself dispatches **six** Task agents (`research-codebase`, `research-patterns`, `research-prior-art`, `research-constraints`, `research-security`, `research-test-coverage`); together with Phase 3 and Phase 4 that is **eight Task agents** fanned out **in a single assistant turn** (one message, eight `Task` tool_use blocks). Phase 4.5 aggregates all eight returns. When `NO_EXPLORE=1`, Phase 2 narrows to the in-repo agents only (`research-codebase`, `research-patterns`, `research-constraints`, `research-test-coverage`) — four Task agents fanned out together; Phase 3 and Phase 4 are also skipped under shallow mode (web/external lookups gated).
+Phase 2 dispatches **two Task agents** in a single assistant turn (one message, two `Task` tool_use blocks): `uberdev:codebase-scout` and `uberdev:triage-scout`. Both pin `model: sonnet` in their frontmatter and re-name Sonnet in their description string for audit-trail visibility. Their returns are inline YAML; nothing is persisted to disk.
 
-## Phase 1.5: Pre-fanout — resolve variables (CRITICAL)
+> **Model-pinning escape hatch.** If you observe the scouts running on Opus despite their frontmatter, set `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` as a global override (tracked at `affaan-m/everything-claude-code#173`).
 
-Subagents have no shell context, so resolve every variable here and interpolate literal values into each brief.
+## Phase 2: Dispatch the two Sonnet scouts (single assistant turn)
 
-```bash
-# Already resolved in Phase 0: $REPO, $DESC, $NO_EXPLORE
-KEYWORDS="<top 3-5 keywords from $DESC, space-separated>"
-COMMITLINT=$(find . -maxdepth 3 \( -name "commitlint.config.js" -o -name "commitlint.config.cjs" -o -name "commitlint.config.mjs" -o -name "commitlint.config.ts" \) -not -path "*/node_modules/*" | head -1)
-RUN_ID="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD 2>/dev/null || echo nohead)"
-SUMMARY_DIR=".uberdev/research/run-$RUN_ID"
-mkdir -p "$SUMMARY_DIR"
-echo "REPO=$REPO"; echo "DESC=$DESC"; echo "KEYWORDS=$KEYWORDS"; echo "NO_EXPLORE=$NO_EXPLORE"; echo "COMMITLINT=$COMMITLINT"; echo "RUN_ID=$RUN_ID"; echo "SUMMARY_DIR=$SUMMARY_DIR"
-```
+Dispatch both scouts in **one message, two `Task` tool_use blocks**. Each brief carries the literal resolved values for `description` (the user's `$DESC` from Phase 0), `working_dir` (the absolute repo root), and `repo_slug` (the resolved `$REPO`).
 
-After the dispatch fanout completes, `$SUMMARY_DIR` holds eight artifact files: `codebase.md`, `patterns.md`, `prior-art.md`, `constraints.md`, `security.md`, `test-coverage.md` (Phase 2-4.5), plus `dup-search.md` (Phase 3) and `label-validation.md` (Phase 4). These six research-agent artifacts use the universal YAML return contract.
+- **`uberdev:codebase-scout`** — receives `{description, issue_type, working_dir, model_hint: sonnet}` and returns YAML with `likely_area: [paths]` and (if `issue_type=fix`) `likely_root_cause: "one-line hypothesis"`. Drives the bug template's `## Likely area` and `## Likely root cause` sections.
+- **`uberdev:triage-scout`** — receives `{description, working_dir, repo_slug, model_hint: sonnet}` and returns YAML with `duplicates: [{number, title, state}]`, `valid_labels: [...]`, `valid_scope: "..."`, `commitlint_present: true|false`. Drives the duplicate section, the `--label` flags, and the title scope.
 
-Every Phase 2-4 agent brief below interpolates these literal resolved values (including `$SUMMARY_DIR` resolved as e.g. `.uberdev/research/run-20260429-143022-604fdb3`); never `$VAR` references.
+If the codebase scout returns `status: BLOCKED` (no real paths grounded), the main thread substitutes `"No clear area identified — defer to /brainstorm"` in the `## Likely area` section. **Never invent paths.**
 
-## Phase 2: Investigate Codebase
+If the triage scout returns `status: DONE_WITH_CONCERNS` for `valid_labels` (e.g. `gh label list` failed), the main thread proceeds without a `--label` flag and notes the omission to the user before Phase 4.
 
-Investigate the codebase for the issue described in `$DESC` (resolved). Repo is the resolved `$REPO`. NO_EXPLORE flag is the resolved `$NO_EXPLORE` (0 or 1).
+## Phase 3: Compose body from scout returns
 
-**Gate the depth:**
+Parse both YAML returns from Phase 2 and:
 
-- If `NO_EXPLORE=1` (literal `1` in the brief) → narrow fanout: dispatch only the **four in-repo agents** (`research-codebase`, `research-patterns`, `research-constraints`, `research-test-coverage`) as Task() calls in **one message, four `Task` tool_use blocks** — a single assistant turn. The web-fetching agents (`research-prior-art`, `research-security`) are skipped because shallow mode gates external lookups. Phase 3 (duplicate search) and Phase 4 (label/scope validation) are **also skipped** under `NO_EXPLORE=1` (existing behavior). The bug template's `## Likely root cause` still falls back to the placeholder string `[shallow mode — no fanout run; root cause to be confirmed in /brainstorm]` when investigation cannot establish a causal triple (Phase 5 handles the substitution).
-- Else (`NO_EXPLORE=0`) → dispatch a **6-agent parallel fanout** for Phase 2: `research-codebase`, `research-patterns`, `research-prior-art`, `research-constraints`, `research-security`, `research-test-coverage`. These six Task() calls go out **in the same single message as the Phase 3 (Duplicate Search) and Phase 4 (Label/Scope Validation) Task() calls** — i.e. all **eight agents fan out together in one message** (single assistant turn, eight `Task` tool_use blocks). Each brief carries the literal resolved values for `issue_body` (the user's `$DESC` plus type/scope from Phase 1), `working_dir` (the absolute repo root), and `summary_dir` (the literal resolved value of `$SUMMARY_DIR`, e.g. `.uberdev/research/run-20260429-143022-604fdb3`).
+1. Pick the bug or feat template based on the Phase 1 classification.
+2. Insert `## Likely area` (unconditional, from `codebase-scout.likely_area`).
+3. For `fix` issues, insert `## Likely root cause` populated with the one-line `codebase-scout.likely_root_cause`. **Do not** generate a Symptom/Mechanism/Owning-code triple here — the bug template's existing causal-triple labels remain in the file as a hard contract, but populating them is `/uberdev:brainstorm`'s job. Authoring note in the rendered template makes this explicit.
+4. Add `## Possible duplicates` only if `triage-scout.duplicates` is non-empty. Closed matches get a regression-warning suffix.
+5. Set `--label` flags on `gh issue create` from `triage-scout.valid_labels`.
+6. Use `triage-scout.valid_scope` in the title's `<type(scope):>` prefix.
+7. **Do not** include the deprecated "Current ecosystem", "Constraints", or "Security signals" headings — they are removed from the templates entirely (see Phase 4 templates below).
 
-Each research agent writes its summary to `<summary_dir>/<artifact>.md` and returns the universal YAML block per the orchestrator contract:
-
-- `research-codebase` → `codebase.md` — symptom/mechanism/owning-code triple + likely-area list grounded in real symbols.
-- `research-patterns` → `patterns.md` — prior bug/feature patterns in this repo's history relevant to the issue.
-- `research-prior-art` → `prior-art.md` — relevant external libraries/patterns/RFCs (web fetch); skipped under `NO_EXPLORE=1`.
-- `research-constraints` → `constraints.md` — repo-policy / dependency / architectural constraints bounding implementation.
-- `research-security` → `security.md` — Semgrep findings (or equivalent) with severity; skipped under `NO_EXPLORE=1`.
-- `research-test-coverage` → `test-coverage.md` — coverage signals around the touched code (uncovered surface flagged).
-
-The producer (Phase 4.5) reads the YAML returns and the summary files; it holds pointers, not raw research content.
-
-Either path must produce a **Likely area** list with real file paths and symbol names. Never guess paths. If you can't find anything relevant, say so explicitly in the draft rather than inventing.
-
-The investigation also refines the preliminary tier from Phase 1: if investigation shows the change sprawls across ≥3 packages, bump the tier up.
-
-## Phase 3: Duplicate Search — full-text, includes closed
-
-Run a command shaped like:
-
-```bash
-gh search issues --repo TheFJK/UberDev "auth login token" --limit 10 --json number,title,state,url
-```
-
-Review results:
-
-- **Open match** → show the URL, ask whether to comment on it or close-as-dup instead of creating a new issue.
-- **Closed match** → potential **regression** signal. Include the closed issue URL in the new issue's `## Related` section.
-
-## Phase 4: Label + scope validation against repo reality
-
-Run a command shaped like:
-
-```bash
-gh label list --repo TheFJK/UberDev --limit 100 --json name,description > /tmp/issue-labels-$$.json
-```
-
-If `$COMMITLINT` resolved to an empty string in Phase 1.5, skip scope validation; otherwise use the resolved literal path (e.g. `./commitlint.config.ts`).
-
-- **Labels:** open `/tmp/issue-labels-$$.json`, pick the base (`bug` for `fix`, `enhancement` for `feat`) **only if it exists in the repo**, then add context labels by matching investigation keywords against real label names (e.g., `infrastructure`, `dx`, `security`, `docs`). Never invent labels.
-- **Scope:** if a commitlint path was provided in the brief, Read it, extract the `scope-enum` array, and constrain the Phase 1 scope pick to that list. If the derived scope isn't in the list, flag to the user and propose the closest match.
-
-## Phase 4.5: Aggregate
-
-Wait for all dispatched agents to return (**8 agents** when `NO_EXPLORE=0`: 6 research agents + Phase 3 + Phase 4; **4 agents** when `NO_EXPLORE=1`: codebase + patterns + constraints + test-coverage only). Reconcile their reports:
-
-- **`research-codebase` summary (`codebase.md`)** → drives the bug template's `## Likely root cause` symptom/mechanism/owning-code triple AND the `## Likely area` list. **Required for `fix` issues**; if `BLOCKED`, abort the fanout with a diagnostic and prompt the user to retry or pass `--no-explore`.
-- **`research-patterns` summary (`patterns.md`)** → drives the `## Related` section's prior-pattern bullets and informs the causal chain when prior bugs exist. Optional — if `BLOCKED`, log a one-line warning and continue without it.
-- **`research-prior-art` summary (`prior-art.md`)** → drives the `feat` template's NEW `## Current ecosystem` section (2-4 bullets of relevant prior art / library options / patterns from outside the repo). Optional — `BLOCKED` logs a warning and continues; the section can be omitted from the draft if no signal.
-- **`research-constraints` summary (`constraints.md`)** → drives a NEW `## Constraints` section (always included in the `feat` template; 2-4 bullets of architectural / repo-policy / dependency constraints). Optional — `BLOCKED` logs a warning and continues.
-- **`research-security` summary (`security.md`)** → drives the `fix` template's NEW `## Security signals` section IF any `extra.severity === "ERROR"` findings; otherwise the section is omitted. Optional — `BLOCKED` logs a warning and continues.
-- **`research-test-coverage` summary (`test-coverage.md`)** → informs the bug template's `## Likely area` (e.g., highlighting uncovered files near the suspected mechanism) and may flag uncovered surface in the `feat` template's `## Acceptance criteria`. Optional — `BLOCKED` logs a warning and continues.
-- **Phase 3 output** → `## Related` section closed/open issue links, plus regression flagging if a closed issue matches.
-- **Phase 4 output** → final label set + validated scope (or a flag if commitlint scope-enum doesn't include the proposed scope).
-
-If any agent returns a blocking question (e.g., "open match found, comment instead?") raise it to the user **before** drafting Phase 5.
+If any blocking concern surfaces (e.g. an open duplicate match), raise it to the user **before** drafting Phase 4.
 
 ## Body authoring rules — WHAT, not HOW
 
@@ -132,7 +79,7 @@ The issue body says *what* is broken or wanted; it never says *how* to fix it. S
 
 This boundary is enforced both by the templates below (the bug template's `## Likely root cause` is a causal triple; the feat template's `## What changes` describes externally visible result, not implementation) and by the rules subsection at the end of this file.
 
-## Phase 5: Draft Issue
+## Phase 4: Draft Issue
 
 Show the user a complete draft BEFORE creating.
 
@@ -167,16 +114,11 @@ Show the user a complete draft BEFORE creating.
 - **Mechanism:** [the specific code/data path that produces the symptom; cite a concrete artifact such as a function call site, log line, or config value]
 - **Owning code:** `path/to/File` — `Class.method()` — [why this is the assumption to challenge]
 
-<!-- AUTHORING NOTE (do not include in rendered issue body): For non-trivial bugs, expand mechanism into a 5 Whys causal chain (each rung citing a file+symbol). -->
-<!-- AUTHORING NOTE (do not include in rendered issue body): Bare file-path lists are forbidden in this section — use `## Likely area` for those. The triple is the smallest causal unit; this rule is a hard contract enforced by `tests/issue-causal-fanout.test.sh`. -->
+<!-- AUTHORING NOTE (do not include in rendered issue body): The codebase-scout populates a one-line hypothesis here at /issue creation time. The full Symptom/Mechanism/Owning-code triple is filled in by /uberdev:brainstorm at solve time when running on fresh code. -->
 
 ## Likely area
 
 - `path/to/File` — `ClassName.methodName()` — [why relevant]
-
-## Security signals
-
-[Pulled from `security.md` summary IF any `extra.severity === "ERROR"` findings; otherwise omit this section. List Semgrep findings in `file:line — rule_id — message` format, max 5.]
 
 ## Reproduction
 
@@ -184,12 +126,10 @@ Show the user a complete draft BEFORE creating.
 
 ## Related
 
-- [Any closed/open issues from Phase 3, else "none"]
+- [Any closed/open issues from `triage-scout.duplicates`, else "none"]
 
 **Triage hint:** <trivial|small|medium>
 ```
-
-> **`--no-explore` placeholder.** When `NO_EXPLORE=1` and type=`fix`, substitute the entire `## Likely root cause` section body with the literal string `[shallow mode — no fanout run; root cause to be confirmed in /brainstorm]` (one paragraph, no bullets). The section heading itself stays. Reader knows root cause was deferred, not omitted.
 
 ### Feature (`feat`) — covers enhancements
 
@@ -208,14 +148,6 @@ Show the user a complete draft BEFORE creating.
 ## What changes
 
 [The capability being added or the behavior being modified, described in WHAT terms — externally visible result, contract change, or new affordance. No implementation strategy. Implementation belongs in /uberdev:brainstorm.]
-
-## Current ecosystem
-
-[Pulled from `prior-art.md` summary — 2-4 bullets of relevant prior art / library options / patterns from outside the repo.]
-
-## Constraints
-
-[Pulled from `constraints.md` summary — 2-4 bullets of architectural / repo-policy / dependency constraints that bound the implementation.]
 
 ## Acceptance criteria
 
@@ -245,49 +177,25 @@ Show the user a complete draft BEFORE creating.
 **Triage hint:** <trivial|small|medium>
 ```
 
-## Phase 6: Confirm
+## Phase 5: Confirm
 
 **STOP and show the draft to the user.** Wait for confirmation, edits, or approval. Do not create the issue yet.
 
-## Phase 7: Create issue
+## Phase 6: Create issue
 
 ```bash
 ISSUE_URL=$(gh issue create \
   --title "<type(scope): description>" \
   --label "<comma,separated,labels>" \
   --body "$(cat <<'EOF'
-<body from Phase 5>
+<body from Phase 4>
 EOF
 )")
 echo "$ISSUE_URL"
 ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 ```
 
-```bash
-if [ -z "$ISSUE_NUM" ]; then
-  echo "error: gh issue create did not return a parseable URL: '$ISSUE_URL'" >&2
-  echo "error: research artifacts remain at $SUMMARY_DIR (not bound to an issue)" >&2
-  return 1
-fi
-if [ -d "$SUMMARY_DIR" ]; then
-  if ! mv "$SUMMARY_DIR" ".uberdev/research/issue-$ISSUE_NUM" 2>/dev/null; then
-    # mv failed (typically cross-filesystem EXDEV; could also be perms/disk).
-    if cp -R "$SUMMARY_DIR" ".uberdev/research/issue-$ISSUE_NUM"; then
-      echo "warning: SUMMARY_DIR rename used cp+rm fallback (cross-filesystem)" >&2
-      if ! rm -rf "$SUMMARY_DIR"; then
-        echo "warning: cp succeeded but rm failed; both copies remain on disk" >&2
-      fi
-    else
-      echo "error: both mv and cp failed; research artifacts remain at $SUMMARY_DIR (manual cleanup required)" >&2
-      return 1
-    fi
-  fi
-fi
-```
-
-This binds research artifacts to the issue number atomically (or via cp+rm fallback). `/uberdev:brainstorm` looks up `.uberdev/research/issue-<N>/` keyed on the issue number to short-circuit duplicate research.
-
-## Phase 8: Offer follow-up
+## Phase 7: Offer follow-up
 
 Print a structured confirmation so the user can copy-paste the next action:
 
@@ -314,3 +222,4 @@ Next step: /solve $ISSUE_NUM
 - **Always confirm** — show the full draft, wait for explicit approval before `gh issue create`.
 - **No screenshots section** — user adds those manually after creation if needed.
 - **WHAT/HOW boundary enforced** — issue body never contains an implementation checklist or fix design; that work belongs in `/uberdev:brainstorm`. Bug template's `## Likely root cause` is a causal triple (symptom/mechanism/owning code), not a file list. Feat template's `## What changes` describes externally visible result, not implementation strategy.
+- **Model-pinning escape hatch** — if you observe the scouts running on Opus despite frontmatter `model: sonnet`, set `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` as a global override. Tracked at `affaan-m/everything-claude-code#173`.

--- a/plugins/uberdev/commands/issue.md
+++ b/plugins/uberdev/commands/issue.md
@@ -42,15 +42,13 @@ Parse `$DESC`. Determine:
 
 > `enhancement` is a **label**, never a commit type. Titles always use `feat(scope):` / `fix(scope):` / `chore(scope):` / `refactor(scope):`.
 
-## Phases 2–4: Parallel Investigation
+## Phase 2: Dispatch the two Sonnet scouts (single assistant turn)
 
 Phase 2 dispatches **two Task agents** in a single assistant turn (one message, two `Task` tool_use blocks): `uberdev:codebase-scout` and `uberdev:triage-scout`. Both pin `model: sonnet` in their frontmatter and re-name Sonnet in their description string for audit-trail visibility. Their returns are inline YAML; nothing is persisted to disk.
 
 > **Model-pinning escape hatch.** If you observe the scouts running on Opus despite their frontmatter, set `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` as a global override (tracked at `affaan-m/everything-claude-code#173`).
 
-## Phase 2: Dispatch the two Sonnet scouts (single assistant turn)
-
-Dispatch both scouts in **one message, two `Task` tool_use blocks**. Each brief carries the literal resolved values for `description` (the user's `$DESC` from Phase 0), `working_dir` (the absolute repo root), and `repo_slug` (the resolved `$REPO`).
+Each brief carries the literal resolved values for `description` (the user's `$DESC` from Phase 0), `issue_type` (from Phase 1 classification), `working_dir` (the absolute repo root), and `repo_slug` (the resolved `$REPO`).
 
 - **`uberdev:codebase-scout`** — receives `{description, issue_type, working_dir, model_hint: sonnet}` and returns YAML with `likely_area: [paths]` and (if `issue_type=fix`) `likely_root_cause: "one-line hypothesis"`. Drives the bug template's `## Likely area` and `## Likely root cause` sections.
 - **`uberdev:triage-scout`** — receives `{description, issue_type, working_dir, repo_slug, model_hint: sonnet}` and returns YAML with `duplicates: [{number, title, state}]`, `valid_labels: [...]`, `valid_scope: "..."`, `commitlint_present: true|false`. Drives the duplicate section, the `--label` flags, and the title scope. (`issue_type` is required so the scout picks the base label — `bug` for `fix`, `enhancement` for `feat` — without re-classifying.)

--- a/plugins/uberdev/commands/issue.md
+++ b/plugins/uberdev/commands/issue.md
@@ -53,7 +53,7 @@ Phase 2 dispatches **two Task agents** in a single assistant turn (one message, 
 Dispatch both scouts in **one message, two `Task` tool_use blocks**. Each brief carries the literal resolved values for `description` (the user's `$DESC` from Phase 0), `working_dir` (the absolute repo root), and `repo_slug` (the resolved `$REPO`).
 
 - **`uberdev:codebase-scout`** — receives `{description, issue_type, working_dir, model_hint: sonnet}` and returns YAML with `likely_area: [paths]` and (if `issue_type=fix`) `likely_root_cause: "one-line hypothesis"`. Drives the bug template's `## Likely area` and `## Likely root cause` sections.
-- **`uberdev:triage-scout`** — receives `{description, working_dir, repo_slug, model_hint: sonnet}` and returns YAML with `duplicates: [{number, title, state}]`, `valid_labels: [...]`, `valid_scope: "..."`, `commitlint_present: true|false`. Drives the duplicate section, the `--label` flags, and the title scope.
+- **`uberdev:triage-scout`** — receives `{description, issue_type, working_dir, repo_slug, model_hint: sonnet}` and returns YAML with `duplicates: [{number, title, state}]`, `valid_labels: [...]`, `valid_scope: "..."`, `commitlint_present: true|false`. Drives the duplicate section, the `--label` flags, and the title scope. (`issue_type` is required so the scout picks the base label — `bug` for `fix`, `enhancement` for `feat` — without re-classifying.)
 
 If the codebase scout returns `status: BLOCKED` (no real paths grounded), the main thread substitutes `"No clear area identified — defer to /brainstorm"` in the `## Likely area` section. **Never invent paths.**
 

--- a/plugins/uberdev/commands/solve.md
+++ b/plugins/uberdev/commands/solve.md
@@ -162,7 +162,7 @@ Solve GH issue #$ISSUE_NUM directly. Triaged as TRIVIAL.
 
 Steps:
 1. \`gh issue view $ISSUE_NUM\` — read the ask.
-2. **Read pre-collected research** — for each file in \`.uberdev/research/issue-$ISSUE_NUM/{constraints,prior-art,security}.md\` that exists, read the \`summary:\` block and inline its key findings into your working context. These were collected at \`/issue\` creation time. If the directory is missing, skip this step (backwards-compat with pre-#11 issues).
+2. **Read pre-collected research (legacy cache)** — for each file in \`.uberdev/research/issue-$ISSUE_NUM/{constraints,prior-art,security}.md\` that exists, read the \`summary:\` block and inline its key findings into your working context. After issue #14 the cache is no longer written by \`/issue\`, so this step typically no-ops; left in place for legacy issues whose research was persisted under the previous fanout.
 3. Make the minimal edit. No redesign, no surrounding refactor, no "while I'm here" cleanup.
 4. Add/update a test ONLY if the touched code is already tested.
 5. Run the relevant test file + lint for that package.
@@ -182,7 +182,7 @@ Solve GH issue #$ISSUE_NUM with a lightweight plan. Triaged as SMALL.
 
 Steps:
 1. \`gh issue view $ISSUE_NUM\` — read the ask.
-2. **Read pre-collected research** — for each file in \`.uberdev/research/issue-$ISSUE_NUM/{constraints,prior-art,security}.md\` that exists, read the \`summary:\` block and inline its key findings into your TodoWrite plan as constraints/considerations. Backwards-compat: if the directory is missing, proceed without inlined summaries.
+2. **Read pre-collected research (legacy cache)** — for each file in \`.uberdev/research/issue-$ISSUE_NUM/{constraints,prior-art,security}.md\` that exists, read the \`summary:\` block and inline its key findings into your TodoWrite plan as constraints/considerations. After issue #14 the cache is no longer written by \`/issue\`, so this step typically no-ops; left in place for legacy issues.
 3. Write 3–6 TodoWrite tasks. Skip /uberdev:brainstorm — scope is clear.
 4. TDD: write the failing test first, then implement, then green.
 5. /uberdev:simplify before push (mandatory).

--- a/plugins/uberdev/skills/brainstorm/SKILL.md
+++ b/plugins/uberdev/skills/brainstorm/SKILL.md
@@ -24,7 +24,7 @@ Every project goes through this process. A todo list, a single-function utility,
 You MUST create a task for each of these items and complete them in order:
 
 1. **Explore project context** — check files, docs, recent commits
-2. **Dispatch parallel research agents** (heuristic from prompt) — 2-3 `Explore`/`general-purpose` agents in one message researching codebase patterns, prior art, and library docs; synthesize findings (3-5 bullets) before continuing. Skip only for truly trivial tasks. **Issue-research short-circuit:** if invoked with an issue number context (e.g. via `/solve <N>` or `/turbo <N>`) and `.uberdev/research/issue-<N>/` exists, read its summaries (`codebase.md` and, if present, `patterns.md`) and treat them as the codebase + in-repo-prior-art research input — skip dispatching the equivalent agents. The short-circuit is **per-topic**, not all-or-nothing: continue to dispatch agents for topics not covered (e.g. external prior art via WebSearch/Context7). See "Parallel research dispatch" and "Issue-research short-circuit" below.
+2. **Dispatch parallel research agents** (heuristic from prompt) — 2-3 `Explore`/`general-purpose` agents in one message researching codebase patterns, prior art, and library docs; synthesize findings (3-5 bullets) before continuing. Skip only for truly trivial tasks. See "Parallel research dispatch" below.
 3. **Offer visual companion** (if topic will involve visual questions) — its own message, not combined with a clarifying question. See the Visual Companion section below.
 4. **Ask clarifying questions** — one at a time, informed by research; understand purpose/constraints/success criteria *(skipped in turbo mode — see "Turbo Mode" section)*
 5. **Propose 2-3 approaches** — with trade-offs and your recommendation, grounded in research findings
@@ -83,54 +83,6 @@ Heuristics for inferring research questions:
 Synthesize findings into a brief summary before engaging the user with clarifying questions. The 2-3 approaches you propose later MUST be grounded in this research, not speculation.
 
 For architecturally consequential choices, this pattern also supports independent parallel exploration of design directions (one agent per direction). See `uberdev:dispatching-parallel-agents`.
-
-**Issue-research short-circuit (when an issue number is in scope):**
-
-When this skill is invoked downstream of `/uberdev:issue` (i.e. the conversation has an issue number), `/issue` may have already run an 8-agent fanout (6 research artifacts + 2 scope artifacts) and persisted summaries to `.uberdev/research/issue-<N>/`. Read those instead of re-dispatching:
-
-```bash
-RESEARCH_DIR=".uberdev/research/issue-$ISSUE"
-SHORTCIRCUIT_CODEBASE=0
-SHORTCIRCUIT_PATTERNS=0
-SHORTCIRCUIT_PRIOR_ART=0
-SHORTCIRCUIT_CONSTRAINTS=0
-SHORTCIRCUIT_SECURITY=0
-SHORTCIRCUIT_TEST_COVERAGE=0
-if [ -d "$RESEARCH_DIR" ]; then
-  ISSUE_UPDATED_ISO=$(gh issue view "$ISSUE" --json updatedAt --jq .updatedAt 2>/dev/null)
-  if [ -z "$ISSUE_UPDATED_ISO" ]; then
-    echo "warning: failed to fetch issue #$ISSUE updatedAt (gh auth/network/missing); using full parallel dispatch" >&2
-  else
-    ISSUE_UPDATED_EPOCH=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ISSUE_UPDATED_ISO" +%s 2>/dev/null \
-                        || date -d "$ISSUE_UPDATED_ISO" +%s 2>/dev/null)
-    for TOPIC in codebase patterns prior-art constraints security test-coverage; do
-      F="$RESEARCH_DIR/${TOPIC}.md"
-      [ -f "$F" ] || continue
-      if ! grep -q '^summary:' "$F"; then
-        echo "warning: $F missing 'summary:' field; using full parallel dispatch for $TOPIC" >&2
-        continue
-      fi
-      F_MTIME_EPOCH=$(stat -f %m "$F" 2>/dev/null || stat -c %Y "$F" 2>/dev/null)
-      if [ -z "$ISSUE_UPDATED_EPOCH" ] || [ -z "$F_MTIME_EPOCH" ]; then
-        echo "warning: failed to normalise updatedAt or $F mtime; using full parallel dispatch for $TOPIC" >&2
-        continue
-      fi
-      if [ "$F_MTIME_EPOCH" -lt "$ISSUE_UPDATED_EPOCH" ]; then
-        # Stale: research summary older than issue update — fall through to dispatch.
-        continue
-      fi
-      # Fresh: set the per-topic skip flag.
-      VAR="SHORTCIRCUIT_$(echo "$TOPIC" | tr '[:lower:]-' '[:upper:]_')"
-      declare "$VAR=1"  # was: eval "$VAR=1" — safer indirection, no shell-injection risk if VAR ever becomes attacker-controlled
-    done
-  fi
-fi
-```
-
-- **Per-topic skip, not all-or-nothing.** Six topic flags (codebase, patterns, prior-art, constraints, security, test-coverage) are checked independently; brainstorm dispatches only the agents whose flag is 0.
-- **Stale check.** Per-topic: if the topic's `<topic>.md` mtime < `gh issue view <N> --json updatedAt` epoch, fall through to dispatch for that topic.
-- **Malformed-summary fallback.** Per-topic: if `<topic>.md` is missing the `summary:` field, log a one-line warning and dispatch for that topic.
-- **Backwards compatibility.** Issues created before this change have only 2-4 artifacts; the per-topic loop reads what exists, dispatches what's missing. Issues with no `.uberdev/research/issue-<N>/` directory at all → `[ -d ... ]` returns false; full parallel dispatch fires unchanged.
 
 The synthesis step reads the summary text into context verbatim; no re-derivation required.
 

--- a/tests/issue-causal-fanout.test.sh
+++ b/tests/issue-causal-fanout.test.sh
@@ -79,6 +79,9 @@ assert_grep "$ISSUE_CMD" \
 assert_grep "$ISSUE_CMD" \
   'single message|one message|same single message|single assistant turn' \
   "Phase 2 keeps the single-message-fanout invariant"
+assert_grep "$ISSUE_CMD" \
+  'issue_type' \
+  "Phase 2 dispatch payload includes issue_type (so triage-scout picks base label without re-classifying)"
 
 echo
 echo "== 8-agent fanout removed from /issue =="

--- a/tests/issue-causal-fanout.test.sh
+++ b/tests/issue-causal-fanout.test.sh
@@ -12,11 +12,13 @@ set -o pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ISSUE_CMD="$REPO_ROOT/plugins/uberdev/commands/issue.md"
 BRAINSTORM="$REPO_ROOT/plugins/uberdev/skills/brainstorm/SKILL.md"
+CODEBASE_SCOUT="$REPO_ROOT/plugins/uberdev/agents/codebase-scout.md"
+TRIAGE_SCOUT="$REPO_ROOT/plugins/uberdev/agents/triage-scout.md"
 
 # Pre-flight: refuse to run if the files we're asserting against are missing
 # or unreadable — without this, every assertion fails with a confusing
 # "pattern not found" instead of the real cause.
-for f in "$ISSUE_CMD" "$BRAINSTORM"; do
+for f in "$ISSUE_CMD" "$BRAINSTORM" "$CODEBASE_SCOUT" "$TRIAGE_SCOUT"; do
   if [ ! -r "$f" ]; then
     echo "FATAL: required file missing or unreadable: $f" >&2
     exit 2
@@ -52,54 +54,61 @@ assert_no_grep() {
   fi
 }
 
-echo "== Phase 1.5 resolves RUN_ID and SUMMARY_DIR =="
-assert_grep "$ISSUE_CMD" \
-  'RUN_ID="\$\(date \+%Y%m%d-%H%M%S\)-\$\(git rev-parse --short HEAD' \
-  "Phase 1.5 sets RUN_ID with date+git-sha"
-assert_grep "$ISSUE_CMD" \
-  'git rev-parse --short HEAD 2>/dev/null \|\| echo nohead' \
-  "Phase 1.5 RUN_ID has defensive nohead fallback (mirrors orchestrator)"
-assert_grep "$ISSUE_CMD" \
-  'SUMMARY_DIR="\.uberdev/research/run-\$RUN_ID"' \
-  "Phase 1.5 sets SUMMARY_DIR under .uberdev/research/run-"
-assert_grep "$ISSUE_CMD" \
+echo "== Phase 1.5 SUMMARY_DIR setup is removed =="
+assert_no_grep "$ISSUE_CMD" \
+  'RUN_ID="\$\(date \+%Y%m%d-%H%M%S\)' \
+  "Phase 1.5 RUN_ID stamping removed"
+assert_no_grep "$ISSUE_CMD" \
+  'SUMMARY_DIR="\.uberdev/research/run-' \
+  "Phase 1.5 SUMMARY_DIR removed"
+assert_no_grep "$ISSUE_CMD" \
   'mkdir -p "\$SUMMARY_DIR"' \
-  "Phase 1.5 mkdir -p \$SUMMARY_DIR"
+  "Phase 1.5 mkdir removed"
 
 echo
-echo "== Phase 2 dispatches research-codebase + research-patterns =="
+echo "== Phase 2 dispatches the two Sonnet scouts =="
 assert_grep "$ISSUE_CMD" \
-  'research-codebase' \
-  "Phase 2 names research-codebase agent"
+  'two Task agents|2 Task agents' \
+  "/issue prose mentions 2-agent count"
 assert_grep "$ISSUE_CMD" \
-  'research-patterns' \
-  "Phase 2 names research-patterns agent"
+  'uberdev:codebase-scout' \
+  "/issue dispatches uberdev:codebase-scout"
+assert_grep "$ISSUE_CMD" \
+  'uberdev:triage-scout' \
+  "/issue dispatches uberdev:triage-scout"
 assert_grep "$ISSUE_CMD" \
   'single message|one message|same single message|single assistant turn' \
   "Phase 2 keeps the single-message-fanout invariant"
 
 echo
-echo "== Phase 2-4 dispatches all 8 research/scope agents =="
-assert_grep "$ISSUE_CMD" 'research-codebase' "research-codebase agent named in /issue"
-assert_grep "$ISSUE_CMD" 'research-patterns' "research-patterns agent named in /issue"
-assert_grep "$ISSUE_CMD" 'research-prior-art' "research-prior-art agent named in /issue"
-assert_grep "$ISSUE_CMD" 'research-constraints' "research-constraints agent named in /issue"
-assert_grep "$ISSUE_CMD" 'research-security' "research-security agent named in /issue"
-assert_grep "$ISSUE_CMD" 'research-test-coverage' "research-test-coverage agent named in /issue"
-assert_grep "$ISSUE_CMD" 'eight Task agents|8 Task agents' "/issue prose mentions 8-agent count"
-assert_grep "$ISSUE_CMD" 'security\.md' "security.md aggregated in Phase 4.5"
-assert_grep "$ISSUE_CMD" 'test-coverage\.md' "test-coverage.md aggregated in Phase 4.5"
+echo "== 8-agent fanout removed from /issue =="
+assert_no_grep "$ISSUE_CMD" 'research-codebase' "research-codebase no longer dispatched by /issue"
+assert_no_grep "$ISSUE_CMD" 'research-patterns' "research-patterns no longer dispatched by /issue"
+assert_no_grep "$ISSUE_CMD" 'research-prior-art' "research-prior-art no longer dispatched by /issue"
+assert_no_grep "$ISSUE_CMD" 'research-constraints' "research-constraints no longer dispatched by /issue"
+assert_no_grep "$ISSUE_CMD" 'research-security' "research-security no longer dispatched by /issue"
+assert_no_grep "$ISSUE_CMD" 'research-test-coverage' "research-test-coverage no longer dispatched by /issue"
+assert_no_grep "$ISSUE_CMD" 'eight Task agents|8 Task agents' "8-agent count prose removed"
+assert_no_grep "$ISSUE_CMD" 'security\.md' "security.md aggregation removed from /issue"
+assert_no_grep "$ISSUE_CMD" 'test-coverage\.md' "test-coverage.md aggregation removed from /issue"
 
 echo
-echo "== --no-explore narrows to 4 in-repo agents =="
-assert_grep "$ISSUE_CMD" 'NO_EXPLORE=1.*codebase.*patterns.*constraints.*test-coverage|in-repo agents only' \
-  "/issue --no-explore documents 4-agent in-repo subset (codebase + patterns + constraints + test-coverage)"
-
-echo
-echo "== --no-explore placeholder verbatim =="
+echo "== --no-explore is soft-deprecated =="
+assert_no_grep "$ISSUE_CMD" \
+  'NO_EXPLORE=1.*codebase.*patterns.*constraints.*test-coverage|in-repo agents only' \
+  "/issue --no-explore 4-agent subset prose removed"
 assert_grep "$ISSUE_CMD" \
+  'notice: --no-explore is deprecated' \
+  "/issue emits soft-deprecation notice for --no-explore"
+assert_grep "$ISSUE_CMD" \
+  'Removal target: v1\.0\.0' \
+  "/issue --no-explore deprecation cites removal target v1.0.0"
+
+echo
+echo "== --no-explore placeholder string removed =="
+assert_no_grep "$ISSUE_CMD" \
   'shallow mode — no fanout run; root cause to be confirmed in /brainstorm' \
-  "--no-explore placeholder string appears verbatim"
+  "shallow-mode placeholder string removed (no longer reachable)"
 
 echo
 echo "== Bug template: causal triple labels =="
@@ -132,19 +141,16 @@ assert_grep "$ISSUE_CMD" \
   "bug template severity checkbox block default-P2 preserved"
 
 echo
-echo "== Phase 7 binds artifacts to issue number =="
-assert_grep "$ISSUE_CMD" \
-  'mv "\$SUMMARY_DIR" "\.uberdev/research/issue-\$ISSUE_NUM"' \
-  "Phase 7 renames SUMMARY_DIR to .uberdev/research/issue-\$ISSUE_NUM"
-assert_grep "$ISSUE_CMD" \
+echo "== Phase 7 cache-binding step removed =="
+assert_no_grep "$ISSUE_CMD" \
+  'mv "\$SUMMARY_DIR"' \
+  "Phase 7 mv \$SUMMARY_DIR removed"
+assert_no_grep "$ISSUE_CMD" \
   'warning: SUMMARY_DIR rename used cp\+rm fallback' \
-  "Phase 7 cp+rm fallback emits a stderr warning"
-assert_grep "$ISSUE_CMD" \
-  'error: gh issue create did not return a parseable URL' \
-  "Phase 7 guards against empty ISSUE_NUM with explicit error"
-assert_grep "$ISSUE_CMD" \
+  "Phase 7 cp+rm fallback warning removed"
+assert_no_grep "$ISSUE_CMD" \
   'error: both mv and cp failed' \
-  "Phase 7 escalates when both mv and cp fail (no silent loss)"
+  "Phase 7 mv/cp escalation removed"
 
 echo
 echo "== Body authoring rules subsection present =="
@@ -156,31 +162,58 @@ assert_grep "$ISSUE_CMD" \
   "Rules subsection has WHAT/HOW boundary bullet"
 
 echo
-echo "== Brainstorm short-circuit reads .uberdev/research/issue-N =="
-assert_grep "$BRAINSTORM" \
+echo "== Brainstorm short-circuit subsection removed =="
+assert_no_grep "$BRAINSTORM" \
   '\.uberdev/research/issue-' \
-  "brainstorm references .uberdev/research/issue- path"
-assert_grep "$BRAINSTORM" \
+  "brainstorm no longer references .uberdev/research/issue- path"
+assert_no_grep "$BRAINSTORM" \
   'Issue-research short-circuit' \
-  "brainstorm has Issue-research short-circuit subsection"
-assert_grep "$BRAINSTORM" \
+  "brainstorm Issue-research short-circuit subsection removed"
+assert_no_grep "$BRAINSTORM" \
   'gh issue view.*updatedAt|updatedAt.*gh issue view' \
-  "brainstorm stale check uses gh issue view updatedAt"
-assert_grep "$BRAINSTORM" \
+  "brainstorm no longer uses gh issue view updatedAt stale check"
+assert_no_grep "$BRAINSTORM" \
   '_MTIME_EPOCH.*-lt.*ISSUE_UPDATED_EPOCH' \
-  "brainstorm stale check uses -lt operator (summary older than issue update = stale)"
-assert_grep "$BRAINSTORM" \
-  'missing.*summary:.*field|summary:.*missing' \
-  "brainstorm implements the malformed-summary fallback the prose claims"
-assert_grep "$BRAINSTORM" \
-  'failed to fetch.*updatedAt|gh auth/network' \
-  "brainstorm warns and falls through when gh issue view returns empty"
-assert_grep "$BRAINSTORM" \
+  "brainstorm no longer uses mtime stale comparison"
+assert_no_grep "$BRAINSTORM" \
   'Per-topic skip|per-topic, not all-or-nothing' \
-  "brainstorm short-circuit is documented as per-topic, not all-or-nothing"
-assert_grep "$BRAINSTORM" \
-  'Backwards compatibility|Backward compatibility' \
-  "brainstorm documents backwards-compat fallthrough"
+  "brainstorm no longer documents per-topic skip"
+
+echo
+echo "== Scout agents pinned to Sonnet (defence-in-depth) =="
+assert_grep "$CODEBASE_SCOUT" \
+  '^model: sonnet$' \
+  "codebase-scout YAML frontmatter pins model: sonnet"
+assert_grep "$CODEBASE_SCOUT" \
+  'runs on Sonnet|Sonnet)' \
+  "codebase-scout description names Sonnet (audit trail)"
+assert_grep "$TRIAGE_SCOUT" \
+  '^model: sonnet$' \
+  "triage-scout YAML frontmatter pins model: sonnet"
+assert_grep "$TRIAGE_SCOUT" \
+  'runs on Sonnet|Sonnet)' \
+  "triage-scout description names Sonnet (audit trail)"
+assert_grep "$ISSUE_CMD" \
+  'CLAUDE_CODE_SUBAGENT_MODEL' \
+  "/issue documents CLAUDE_CODE_SUBAGENT_MODEL escape hatch"
+
+echo
+echo "== Surviving bug-template sections =="
+assert_grep "$ISSUE_CMD" \
+  '## Likely area' \
+  "## Likely area heading survives in bug template"
+assert_grep "$ISSUE_CMD" \
+  '## Likely root cause' \
+  "## Likely root cause heading survives in bug template"
+assert_no_grep "$ISSUE_CMD" \
+  '## Security signals' \
+  "## Security signals heading removed from bug template"
+assert_no_grep "$ISSUE_CMD" \
+  '## Current ecosystem' \
+  "## Current ecosystem heading removed from feat template"
+assert_no_grep "$ISSUE_CMD" \
+  '## Constraints' \
+  "## Constraints heading removed from feat template"
 
 echo
 echo "== Summary =="


### PR DESCRIPTION
## Summary

- Replace `/uberdev:issue`'s 8-Opus-agent research fanout (Phases 1.5/2-4/4.5/7) with a thin 2-Sonnet-scout fanout dispatched in a single assistant turn — median wall-clock drops from minutes to under 30s.
- New dedicated agents `plugins/uberdev/agents/codebase-scout.md` and `triage-scout.md`, both pinning `model: sonnet` with four-layer defence-in-depth against the upstream `affaan-m/everything-claude-code#173` model-frontmatter regression. Documented escape hatch: `CLAUDE_CODE_SUBAGENT_MODEL=sonnet`.
- `--no-explore` soft-deprecated (notice + no-op, removal target v1.0.0); `## Security signals` / `## Current ecosystem` / `## Constraints` removed from `/issue` templates; `brainstorm/SKILL.md`'s issue-research short-circuit removed (orchestrator solve-time fanout unchanged); RFC 2026-04-29 annotated as partially superseded; `solve.md` legacy-cache prose updated. TDD: tests rewritten first (red), then prose (green) — 91/91 across 5 shell tests.

Closes #14

## Test Plan

- [x] `bash tests/issue-causal-fanout.test.sh` → 47/47 passing (encodes the 2-Sonnet-scout contract end-to-end)
- [x] `bash tests/turbo-flow.test.sh` → 19/19 passing (ensures `/turbo` flow + finish-branch PR-body composition still hold)
- [x] `bash tests/post-impl-review.test.sh` → 10/10 passing (post-impl-review skill invariants hold)
- [x] `bash tests/spec-reviewer-plan-aware.test.sh` → 3/3 passing (spec-reviewer dispatch contract intact)
- [x] `bash tests/audit-fixups.test.sh` → 12/12 passing (top-level skill invariants intact)
- [ ] **Manual smoke test:** run `/issue add a footer to README` against this repo and confirm wall-clock under 30s with both scouts visibly running on Sonnet (per advisory check in spec testing strategy).
- [ ] **Defence-in-depth verification:** confirm Phase 2 dispatch payload includes both `model: sonnet` (frontmatter) AND a `model_hint: sonnet` audit-trail aid; if scouts silently run on Opus, set `CLAUDE_CODE_SUBAGENT_MODEL=sonnet`.

## Open questions answered by /turbo

Auto-picked from research bundle (10 questions). One non-high-confidence row worth a glance (Q5 — `medium` confidence on solve.md / finish-branch prose updates).

| Question | Choice (truncated) | Confidence |
|----------|--------------------|------------|
| How should the two scouts be expressed in `issue.md`? | Two new dedicated agent files at `plugins/uberdev/agents/codebase-scout.md` | high |
| Which model — `sonnet` or `haiku`? | `sonnet` (specifically Sonnet 4.6). | high |
| Phase 7 cache-binding step — delete entirely or keep for the 2 new artifacts? | Delete entirely. `/issue` no longer writes any artifact directory. | high |
| Should `brainstorm/SKILL.md` and `orchestrator/SKILL.md` short-circuit logic ... | Update `brainstorm/SKILL.md` to remove the `.uberdev/research/issue-<N>/` | high |
| Should `solve.md` and `finish-branch/SKILL.md` references to the cache be upd... | Update prose-only mentions of "8-agent fanout" and "research from `/issue`" | medium |
| Should the RFC at `docs/rfc/2026-04-29-*.md` be superseded? | Annotate the RFC with a `> **Status update (2026-04-30):** Partially | high |
| TDD approach — write failing test first or update prose first? | TDD. Rewrite `tests/issue-causal-fanout.test.sh` to encode the new 2-agent | high |
| Should `--no-explore` flag be hard-removed or kept as a no-op deprecation? | Soft-deprecate: keep the flag in `argument-hint` (bracketed), have it | high |
| Bug template — is `## Likely root cause` a mandatory output of the codebase... | Only when type=fix. The codebase-scout agent's contract emits `## Likely | high |
| Should `commitlint.config.*` be required or best-effort? | Best-effort. Triage scout reads it if present; otherwise falls back to a | high |

Full Q&A log: `.uberdev/research/20260430-125942-3c1f45d/questions.md`.

## Reviewer findings summary

Post-impl review fired 5 reviewer agents in parallel (`code-reviewer`, `code-simplifier`, `silent-failure-hunter`, `type-design-analyzer`, `comment-analyzer`).

**Aggregated:** 4 blockers (1 auto-fixed inline, 3 advisory), 24 suggestions. **Continue.**

### Auto-fixed inline (commit `887e667`)

- **code-reviewer (BLOCKER):** `triage-scout` was missing `issue_type` in its Inputs schema yet its label-picking process needs it (`bug` for `fix`, `enhancement` for `feat`). Added `issue_type` to both `triage-scout.md` Inputs and `issue.md` Phase 2 dispatch payload. Tests still 47/47.

### Advisory findings (deferred to follow-up issues)

| Reviewer | Verdict | Top finding |
|----------|---------|-------------|
| code-reviewer        | REVISIONS_REQUIRED | (4 advisory) Stale doc anchor in orchestrator/SKILL.md:35; vestigial `Phases 2–4` umbrella heading; bug-template field-shape divergence vs scout returns |
| code-simplifier      | REVISIONS_REQUIRED | (5 advisory) Same stale anchor; orphan "Escalate to Explore" rule; cost-note duplication between scouts; escape-hatch text duplicated in issue.md |
| silent-failure-hunter | REVISIONS_REQUIRED | (3 advisory) `--no-explore` deprecation on stderr could be CI-suppressed; scout BLOCKED/DONE_WITH_CONCERNS fallback states lack mechanized user notification; model-pinning escape hatch has no runtime detection |
| type-design-analyzer | APPROVE | (7 suggestions) YAML schema validation gaps: `lines` field format unspecified, `valid_scope` untyped, dispatcher does not validate scout returns |
| comment-analyzer     | APPROVE | (5 minor) All comments load-bearing and accurate; nice-to-have rationale notes for the `model_hint` audit-trail field |

Full per-reviewer details: `.uberdev/research/20260430-125942-3c1f45d/post-impl-review-wave-2.md`.

All findings are **advisory** at this layer (per spec design Q1: auto-fix loop deferred). The 3 remaining "blocker"-flagged findings are scope-widening UX/runtime concerns appropriate for a follow-up issue, not gating this PR.
