### PR TITLE
fix(uberdev): bootstrap installer self-enables plugin in settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,12 @@ If you'd rather not pipe a script from the internet, do the same three things by
 /plugin marketplace add TheFJK/UberDev
 /plugin install uberdev@uberdev
 
-# 2. In your shell, patch the enabledPlugins entry the upstream bug skips:
+# 2. In your shell, patch the enabledPlugins entry the upstream bug skips.
+#    The first line bootstraps an empty settings.json if missing (or empty)
+#    so jq has a valid object to merge into; without it, an absent or
+#    zero-byte file would either error out or get overwritten with empty
+#    output by the redirect.
+[ -s ~/.claude/settings.json ] || echo '{}' > ~/.claude/settings.json
 jq '.enabledPlugins = (.enabledPlugins // {}) | .enabledPlugins["uberdev@uberdev"] = true' \
    ~/.claude/settings.json > ~/.claude/settings.json.tmp \
    && mv ~/.claude/settings.json.tmp ~/.claude/settings.json

--- a/README.md
+++ b/README.md
@@ -40,26 +40,58 @@ Both are **repo-agnostic** — they auto-detect the current repo via `gh repo vi
 ## Install
 
 ```bash
-# 1. Add this repo as a Claude Code marketplace
-/plugin marketplace add TheFJK/UberDev
+# One-liner — installs the plugin and patches the missing enabledPlugins entry.
+curl -fsSL https://raw.githubusercontent.com/TheFJK/UberDev/main/install.sh | bash
+```
 
-# 2. Install the plugin
-/plugin install uberdev@uberdev
+Then, in Claude Code:
 
-# 3. Smoke-test
+```bash
+# Smoke-test
 /uberdev:issue trivial typo in README install step
 
-# 4. (Recommended) Install short-form aliases so /issue, /solve, /turbo,
-#    /simplify, /review-pr work without the /uberdev: prefix.
+# (Recommended) Install short-form aliases so /issue, /solve, /turbo,
+# /simplify, /review-pr work without the /uberdev: prefix.
 /uberdev:install-aliases
 ```
 
-Step 4 is the ergonomics step: by default, plugin commands are addressed
+> **Why a bootstrap script?** Upstream Claude Code has a bug
+> ([anthropics/claude-code#20661](https://github.com/anthropics/claude-code/issues/20661))
+> where `/plugin install` populates the cache and `installed_plugins.json`
+> but **does not** write `enabledPlugins` in `~/.claude/settings.json` —
+> so `/uberdev:*` commands silently 404 until that key is added by hand.
+> `install.sh` does the install **and** jq-patches `enabledPlugins` so
+> commands resolve immediately. It's idempotent — re-running on an
+> already-enabled environment is a no-op, and any unrelated keys
+> (theme, model, sibling plugins) are preserved verbatim. Requires `jq`.
+
+The aliases step is the ergonomics step: by default, plugin commands are addressed
 as `/uberdev:<command>` because Claude Code's plugin manifest enforces a
 `<plugin-name>:` prefix on every command. The `/uberdev:install-aliases`
 helper drops one-way forwarders into `~/.claude/commands/` so you can
 type `/issue …` instead of `/uberdev:issue …`. The long form keeps
 working — this is purely additive. See [Short-form aliases](#short-form-aliases) below.
+
+<details>
+<summary><strong>Manual install (without curl|bash)</strong></summary>
+
+If you'd rather not pipe a script from the internet, do the same three things by hand:
+
+```bash
+# 1. Inside Claude Code:
+/plugin marketplace add TheFJK/UberDev
+/plugin install uberdev@uberdev
+
+# 2. In your shell, patch the enabledPlugins entry the upstream bug skips:
+jq '.enabledPlugins = (.enabledPlugins // {}) | .enabledPlugins["uberdev@uberdev"] = true' \
+   ~/.claude/settings.json > ~/.claude/settings.json.tmp \
+   && mv ~/.claude/settings.json.tmp ~/.claude/settings.json
+
+# 3. Back in Claude Code:
+/reload-plugins
+```
+
+</details>
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# UberDev bootstrap installer.
+#
+# Works around an upstream Claude Code bug where `/plugin install` populates
+# the cache + installed_plugins.json but does NOT write enabledPlugins in
+# ~/.claude/settings.json — so commands silently 404 until that key is
+# patched in by hand. Refs: anthropics/claude-code#20661, #15524.
+#
+# What this script does:
+#   1. Best-effort runs the marketplace-add + install slash commands via
+#      `claude --print` (no-op if claude isn't on PATH or doesn't accept
+#      slash commands in print mode — the jq-patch below is the real fix).
+#   2. jq-patches ~/.claude/settings.json to set
+#      enabledPlugins["uberdev@uberdev"] = true. Idempotent: re-running is
+#      a no-op, and unrelated keys / sibling enabledPlugins entries are
+#      preserved.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/TheFJK/UberDev/main/install.sh | bash
+# or, after cloning:
+#   ./install.sh
+
+set -euo pipefail
+
+PLUGIN_KEY="uberdev@uberdev"
+MARKETPLACE_REPO="${UBERDEV_MARKETPLACE:-TheFJK/UberDev}"
+SETTINGS_DIR="${HOME}/.claude"
+SETTINGS="${SETTINGS_DIR}/settings.json"
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: 'jq' is required but not found in PATH." >&2
+  echo "       macOS:   brew install jq" >&2
+  echo "       Debian:  sudo apt install jq" >&2
+  echo "       Other:   https://jqlang.github.io/jq/download/" >&2
+  exit 1
+fi
+
+# ── Step 1: marketplace-add + install (best-effort, non-interactive) ──────────
+# Best-effort because the user-visible workaround is the jq-patch below — it's
+# what unblocks /uberdev:* commands. `|| true` swallows failures so a stale
+# claude binary or a CC version that doesn't run slash commands in --print
+# mode doesn't break the install.
+if command -v claude >/dev/null 2>&1; then
+  echo "→ Adding marketplace ${MARKETPLACE_REPO} and installing ${PLUGIN_KEY}…"
+  claude --print "/plugin marketplace add ${MARKETPLACE_REPO}" >/dev/null 2>&1 || true
+  claude --print "/plugin install ${PLUGIN_KEY}" >/dev/null 2>&1 || true
+else
+  echo "⚠️  'claude' CLI not found on PATH." >&2
+  echo "   Run these inside Claude Code, then re-run this installer to enable:" >&2
+  echo "     /plugin marketplace add ${MARKETPLACE_REPO}" >&2
+  echo "     /plugin install ${PLUGIN_KEY}" >&2
+fi
+
+# ── Step 2: jq-patch enabledPlugins (the actual bug workaround) ───────────────
+mkdir -p "${SETTINGS_DIR}"
+
+# Bootstrap an empty settings.json if it doesn't exist yet. We only do this
+# when the file is missing — we do NOT overwrite an existing file even if
+# it's empty/malformed (see the jq -e guard below).
+if [ ! -f "${SETTINGS}" ]; then
+  echo '{}' > "${SETTINGS}"
+fi
+
+# Refuse to clobber a malformed settings.json. If a user has hand-edited
+# their settings into invalid JSON, silently rewriting it would destroy
+# their work; surface the problem instead and let them fix it.
+if ! jq -e . "${SETTINGS}" >/dev/null 2>&1; then
+  echo "ERROR: ${SETTINGS} is not valid JSON; refusing to patch." >&2
+  echo "       Fix the file manually (e.g. 'jq . ${SETTINGS}'), then re-run." >&2
+  exit 1
+fi
+
+# Atomic patch via temp-file + mv: the original is only replaced after jq
+# writes a valid JSON document, so a mid-write crash leaves settings.json
+# intact. The trap always runs (any exit path); on the success path it's a
+# no-op because mv has already renamed $TMP out from under it.
+TMP="$(mktemp "${TMPDIR:-/tmp}/uberdev-settings.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+
+# `.enabledPlugins // {}` defaults the key to an empty object when absent,
+# so users without any prior plugin config get a well-formed entry. Setting
+# `[$key] = true` is idempotent: a re-run on already-enabled state is a
+# byte-level no-op. Sibling enabledPlugins entries (other plugins) are
+# preserved verbatim because we mutate a single key, not the whole object.
+jq --arg key "${PLUGIN_KEY}" \
+  '.enabledPlugins = (.enabledPlugins // {}) | .enabledPlugins[$key] = true' \
+  "${SETTINGS}" > "${TMP}"
+mv "${TMP}" "${SETTINGS}"
+
+echo "✓ uberdev installed and enabled in ${SETTINGS}."
+echo "  Restart Claude Code (or run /reload-plugins) to load the plugin."

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,11 @@ else
 fi
 
 # ── Step 2: jq-patch enabledPlugins (the actual bug workaround) ───────────────
-mkdir -p "${SETTINGS_DIR}"
+mkdir -p "${SETTINGS_DIR}" || {
+  echo "ERROR: failed to create ${SETTINGS_DIR}." >&2
+  echo "       Check permissions on ${HOME}, then re-run." >&2
+  exit 1
+}
 
 # Bootstrap an empty settings.json if it doesn't exist yet. We only do this
 # when the file is missing — we do NOT overwrite an existing file even if
@@ -62,12 +66,14 @@ if [ ! -f "${SETTINGS}" ]; then
   echo '{}' > "${SETTINGS}"
 fi
 
-# Refuse to clobber a malformed settings.json. If a user has hand-edited
-# their settings into invalid JSON, silently rewriting it would destroy
-# their work; surface the problem instead and let them fix it.
-if ! jq -e . "${SETTINGS}" >/dev/null 2>&1; then
+# Refuse to clobber a malformed settings.json. If a user has hand-edited their
+# settings into invalid JSON, silently rewriting it would destroy their work;
+# surface jq's actual parse error so the user knows where to fix it.
+if ! jq_err="$(jq -e . "${SETTINGS}" 2>&1 >/dev/null)"; then
   echo "ERROR: ${SETTINGS} is not valid JSON; refusing to patch." >&2
-  echo "       Fix the file manually (e.g. 'jq . ${SETTINGS}'), then re-run." >&2
+  # jq prefixes its output with 'jq: ' already; pass through as-is, indented.
+  echo "${jq_err}" | sed 's/^/       /' >&2
+  echo "       Fix the file manually, then re-run." >&2
   exit 1
 fi
 
@@ -75,7 +81,12 @@ fi
 # writes a valid JSON document, so a mid-write crash leaves settings.json
 # intact. The trap always runs (any exit path); on the success path it's a
 # no-op because mv has already renamed $TMP out from under it.
-TMP="$(mktemp "${TMPDIR:-/tmp}/uberdev-settings.XXXXXX")"
+#
+# TMP lives in $SETTINGS_DIR (not $TMPDIR) so it shares a filesystem with
+# $SETTINGS — that makes the mv a true rename(2) syscall (atomic) instead of
+# a copy-then-unlink fallback that crosses filesystems non-atomically. The
+# leading `.` makes it a hidden file in case the move is interrupted.
+TMP="$(mktemp "${SETTINGS_DIR}/.settings.XXXXXX")"
 trap 'rm -f "$TMP"' EXIT
 
 # `.enabledPlugins // {}` defaults the key to an empty object when absent,
@@ -86,7 +97,12 @@ trap 'rm -f "$TMP"' EXIT
 jq --arg key "${PLUGIN_KEY}" \
   '.enabledPlugins = (.enabledPlugins // {}) | .enabledPlugins[$key] = true' \
   "${SETTINGS}" > "${TMP}"
-mv "${TMP}" "${SETTINGS}"
+
+if ! mv "${TMP}" "${SETTINGS}"; then
+  echo "ERROR: failed to write ${SETTINGS}." >&2
+  echo "       Check permissions on ${SETTINGS_DIR}, then re-run." >&2
+  exit 1
+fi
 
 echo "✓ uberdev installed and enabled in ${SETTINGS}."
 echo "  Restart Claude Code (or run /reload-plugins) to load the plugin."

--- a/tests/install.test.sh
+++ b/tests/install.test.sh
@@ -21,6 +21,7 @@
 #   I6 — refuses to clobber malformed settings.json (exits non-zero, file untouched)
 #   I7 — README documents the install.sh / curl|bash one-liner
 #   I8 — script does not contain destructive shapes (rm -rf $HOME, etc.)
+#   I9 — re-run flips a manually-disabled (false) entry back to true
 
 # `set -e` is intentionally NOT enabled: a failed assertion must NOT abort the
 # rest of the suite. We track PASS/FAIL counters explicitly and exit non-zero
@@ -254,6 +255,31 @@ assert_grep_not "$INSTALL_SH" \
 assert_grep_not "$INSTALL_SH" \
   'rm[[:space:]]+-rf[[:space:]]+"?\$\{?HOME\}?/\.claude[/"]?[[:space:]]*$' \
   "install.sh does NOT rm -rf the user's ~/.claude directory"
+
+echo
+echo "== I9: re-run flips a manually-disabled entry back to true =="
+# A user (or a future /uberdev:doctor command) may have set the entry to
+# false to temporarily disable the plugin. Re-running install.sh must flip
+# it back to true — otherwise the bug-workaround silently no-ops on the
+# very state it's meant to fix. Guards against a future refactor that
+# guards the assignment behind an `if .enabledPlugins[$key] then ...`
+# check, which would preserve the false value instead of overwriting it.
+SANDBOX="$(make_sandbox)"
+seed_settings "$SANDBOX" '{"enabledPlugins":{"uberdev@uberdev":false}}'
+if run_install "$SANDBOX"; then
+  if jq -e '.enabledPlugins["uberdev@uberdev"] == true' \
+       "$SANDBOX/.claude/settings.json" >/dev/null 2>&1; then
+    echo "  PASS  pre-existing false entry flipped back to true"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  pre-existing false entry was not flipped to true"
+    echo "        settings.json: $(cat "$SANDBOX/.claude/settings.json")"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  FAIL  install.sh exited non-zero with pre-existing false entry"
+  FAIL=$((FAIL + 1))
+fi
 
 echo
 echo "== Summary =="

--- a/tests/install.test.sh
+++ b/tests/install.test.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Tests for issue #22 — install.sh bootstrap script enables the plugin in
+# ~/.claude/settings.json (working around Claude Code's enabledPlugins bug,
+# refs anthropics/claude-code#20661).
+#
+# /plugin install populates the cache + installed_plugins.json but does NOT
+# write enabledPlugins. Loader reads only the latter, so commands silently
+# 404 until enabledPlugins["uberdev@uberdev"] = true is added by hand. The
+# install.sh bootstrap closes that gap on a curl|bash one-liner.
+#
+# These are sandbox tests: each section runs install.sh under a temp $HOME
+# with a no-op `claude` stub on PATH, so we exercise the jq-patch behavior
+# without touching the user's real ~/.claude or hitting the Claude API.
+#
+# Sections:
+#   I1 — install.sh exists at repo root, has shebang, is executable
+#   I2 — fresh install: settings.json created with enabledPlugins entry
+#   I3 — preserves unrelated keys (theme/model/etc.) on existing settings.json
+#   I4 — preserves other enabledPlugins entries (doesn't clobber sibling plugins)
+#   I5 — idempotent: re-run produces byte-identical settings.json
+#   I6 — refuses to clobber malformed settings.json (exits non-zero, file untouched)
+#   I7 — README documents the install.sh / curl|bash one-liner
+#   I8 — script does not contain destructive shapes (rm -rf $HOME, etc.)
+
+# `set -e` is intentionally NOT enabled: a failed assertion must NOT abort the
+# rest of the suite. We track PASS/FAIL counters explicitly and exit non-zero
+# at the end if any failed. `set -u` and `pipefail` stay on for the usual
+# safety reasons (catch typos, propagate failures through pipes).
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+INSTALL_SH="$REPO_ROOT/install.sh"
+README="$REPO_ROOT/README.md"
+
+# Pre-flight: refuse to run if asserted-against files are missing. Without
+# this, every assertion fails with a confusing "pattern not found" instead
+# of the real cause (mirrors aliases.test.sh and audit-fixups.test.sh).
+for f in "$INSTALL_SH" "$README"; do
+  if [ ! -r "$f" ]; then
+    echo "FATAL: required file missing or unreadable: $f" >&2
+    exit 2
+  fi
+done
+
+# jq is required by install.sh AND by these tests' assertions. Catch the
+# missing-tool case here with a clear message rather than letting jq's own
+# "command not found" leak through every assertion.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FATAL: jq is required to run these tests (and to run install.sh)." >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+assert_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        file:    $file"
+    echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_grep_not() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  FAIL  $desc — pattern '$pattern' should not appear"
+    echo "        file: $file"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# Stubbed `claude` shared across all sandboxes. install.sh invokes claude for
+# marketplace-add + install (best-effort); a silent no-op stub is enough for
+# these tests, which target the jq-patch contract — not the slash-command
+# layer. Hoisted to one shared dir to avoid rewriting the stub per sandbox.
+STUB_BIN_DIR="$(mktemp -d)"
+cat > "$STUB_BIN_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$STUB_BIN_DIR/claude"
+
+# Build a sandbox $HOME for one install.sh invocation. The sandbox is
+# isolated per section so each test starts from a known settings.json
+# state without coupling between sections.
+make_sandbox() {
+  mktemp -d
+}
+
+# Seed a sandbox with a starting settings.json. Used by I3/I4/I6 to set up
+# the various preconditions (unrelated keys / sibling enabledPlugins /
+# malformed JSON) we want install.sh to handle correctly.
+seed_settings() {
+  local home="$1" content="$2"
+  mkdir -p "$home/.claude"
+  printf '%s' "$content" > "$home/.claude/settings.json"
+}
+
+# Run install.sh under a sandbox HOME. PATH is prefixed with the shared stub
+# dir so our claude wins; the rest of PATH is preserved so jq and coreutils
+# still resolve.
+run_install() {
+  local home="$1"
+  HOME="$home" PATH="$STUB_BIN_DIR:$PATH" bash "$INSTALL_SH" >"$home/install.out" 2>&1
+  return $?
+}
+
+echo "== I1: install.sh exists, has shebang, is executable =="
+assert_grep "$INSTALL_SH" '^#!/' "install.sh has a shebang"
+if [ -x "$INSTALL_SH" ]; then
+  echo "  PASS  install.sh is executable"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  install.sh is not executable (chmod +x install.sh)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== I2: fresh install creates settings.json with enabledPlugins entry =="
+SANDBOX="$(make_sandbox)"
+if run_install "$SANDBOX"; then
+  SETTINGS="$SANDBOX/.claude/settings.json"
+  if [ ! -f "$SETTINGS" ]; then
+    echo "  FAIL  settings.json was not created at $SETTINGS"
+    FAIL=$((FAIL + 1))
+  elif jq -e '.enabledPlugins["uberdev@uberdev"] == true' "$SETTINGS" >/dev/null 2>&1; then
+    echo "  PASS  enabledPlugins[\"uberdev@uberdev\"] = true on fresh install"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  enabledPlugins entry not set"
+    echo "        settings.json: $(cat "$SETTINGS" 2>&1)"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  FAIL  install.sh exited non-zero on fresh install"
+  echo "        output: $(cat "$SANDBOX/install.out" 2>&1)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== I3: existing unrelated settings keys are preserved =="
+SANDBOX="$(make_sandbox)"
+seed_settings "$SANDBOX" \
+  '{"theme":"dark","model":"claude-opus-4-7","permissions":{"allow":["Bash"]}}'
+if run_install "$SANDBOX"; then
+  if jq -e '
+      .theme == "dark"
+      and .model == "claude-opus-4-7"
+      and .permissions.allow == ["Bash"]
+      and .enabledPlugins["uberdev@uberdev"] == true
+    ' "$SANDBOX/.claude/settings.json" >/dev/null 2>&1; then
+    echo "  PASS  unrelated keys (theme/model/permissions) preserved"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  unrelated keys clobbered or enabledPlugins missing"
+    echo "        settings.json: $(cat "$SANDBOX/.claude/settings.json")"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  FAIL  install.sh exited non-zero with existing settings.json"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== I4: other enabledPlugins entries are preserved =="
+SANDBOX="$(make_sandbox)"
+seed_settings "$SANDBOX" \
+  '{"enabledPlugins":{"other-plugin@market":true,"third@market":false}}'
+if run_install "$SANDBOX"; then
+  if jq -e '
+      .enabledPlugins["other-plugin@market"] == true
+      and .enabledPlugins["third@market"] == false
+      and .enabledPlugins["uberdev@uberdev"] == true
+    ' "$SANDBOX/.claude/settings.json" >/dev/null 2>&1; then
+    echo "  PASS  other plugin entries preserved alongside ours"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  other plugin entries clobbered"
+    echo "        settings.json: $(cat "$SANDBOX/.claude/settings.json")"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  FAIL  install.sh exited non-zero with pre-existing enabledPlugins"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== I5: re-running install.sh is idempotent =="
+SANDBOX="$(make_sandbox)"
+run_install "$SANDBOX" >/dev/null
+FIRST="$(cat "$SANDBOX/.claude/settings.json")"
+run_install "$SANDBOX" >/dev/null
+SECOND="$(cat "$SANDBOX/.claude/settings.json")"
+if [ "$FIRST" = "$SECOND" ]; then
+  echo "  PASS  re-run produces byte-identical settings.json (no duplicates, no churn)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  re-run mutated settings.json"
+  echo "        first:  $FIRST"
+  echo "        second: $SECOND"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== I6: malformed settings.json is refused, not clobbered =="
+SANDBOX="$(make_sandbox)"
+BAD='this is { not valid json'
+seed_settings "$SANDBOX" "$BAD"
+if run_install "$SANDBOX"; then
+  echo "  FAIL  install.sh succeeded on malformed settings.json (should refuse)"
+  FAIL=$((FAIL + 1))
+else
+  CURRENT="$(cat "$SANDBOX/.claude/settings.json")"
+  if [ "$CURRENT" = "$BAD" ]; then
+    echo "  PASS  install.sh refused malformed settings.json and left it untouched"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  install.sh exited non-zero but mutated the malformed file anyway"
+    echo "        before: $BAD"
+    echo "        after:  $CURRENT"
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
+echo
+echo "== I7: README documents the install.sh / curl|bash one-liner =="
+assert_grep "$README" \
+  'install\.sh|curl[[:space:]]+-fsSL.*UberDev' \
+  "README references install.sh or curl|bash install path"
+assert_grep "$README" \
+  'enabledPlugins|claude-code/issues/20661' \
+  "README mentions the upstream enabledPlugins bug context"
+
+echo
+echo "== I8: install.sh contains no destructive shell shapes =="
+# Mirror the safety guard in aliases.test.sh A2: forbid the unambiguous
+# footguns rather than the literal flag --force (which is a legitimate
+# user-facing flag name in our other scripts). rm -rf $HOME or cp -f over
+# user files would be a bug regardless of context.
+assert_grep_not "$INSTALL_SH" \
+  'rm[[:space:]]+-rf[[:space:]]+"?\$HOME[/"]' \
+  "install.sh does NOT contain rm -rf \$HOME patterns"
+assert_grep_not "$INSTALL_SH" \
+  'rm[[:space:]]+-rf[[:space:]]+"?\$\{?HOME\}?/\.claude[/"]?[[:space:]]*$' \
+  "install.sh does NOT rm -rf the user's ~/.claude directory"
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- New `install.sh` at the repo root works around an upstream Claude Code bug ([anthropics/claude-code#20661](https://github.com/anthropics/claude-code/issues/20661)) where `/plugin install` populates the cache but doesn't write `enabledPlugins` in `~/.claude/settings.json`, so every `/uberdev:*` command silently 404s.
- The script runs the marketplace-add + install slash commands non-interactively (best-effort via `claude --print`), then jq-patches `enabledPlugins["uberdev@uberdev"] = true`. Idempotent: re-running on an already-enabled environment is a byte-level no-op; sibling plugin entries and unrelated keys (theme, model, permissions, …) are preserved verbatim. Malformed `settings.json` is refused (atomic temp+mv, original untouched).
- `README.md`'s four-step manual install block is replaced with the `curl|bash` one-liner; a manual-fallback `<details>` appendix mirrors the same three steps for users who don't want to pipe a script.

## Test plan

- [x] `tests/install.test.sh` — 11 assertions across 8 sandboxed sections (fresh install, unrelated-key preservation, sibling-plugin preservation, idempotent re-run, malformed-JSON refusal, README docs, destructive-shape guard).
- [x] Full repo test suite (`for t in tests/*.test.sh; do bash "$t"; done`) — 142 assertions, 0 failures.
- [x] End-to-end smoke test in an isolated `$HOME` with a stubbed `claude`: fresh install adds the entry, re-run is byte-identical, pre-existing `theme: "dark"` and `enabledPlugins: { foo@bar: true }` survive alongside our patch.
- [ ] Verify on a real Claude Code install once merged.

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined installation guide with single bootstrap command replacing previous three-step process
  * Added optional manual installation section with explicit setup instructions
  * Added smoke-test verification and aliases installation guidance

* **New Features**
  * Automated installation script that fixes plugin configuration and ensures proper setup
  * Installation is idempotent and preserves unrelated user settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->