### PR TITLE
feat(uberdev): finish-branch always pushes PR and auto-runs /uberdev:review-pr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,6 @@ jobs:
           bash tests/issue-causal-fanout.test.sh && \
           bash tests/post-impl-review.test.sh && \
           bash tests/spec-reviewer-plan-aware.test.sh && \
-          bash tests/audit-fixups.test.sh
+          bash tests/audit-fixups.test.sh && \
+          bash tests/review-pr.test.sh && \
+          bash tests/finish-branch-auto-chain.test.sh

--- a/plugins/uberdev/agents/code-reviewer.md
+++ b/plugins/uberdev/agents/code-reviewer.md
@@ -45,3 +45,7 @@ Group issues by severity (Critical: 90-100, Important: 80-89).
 If no high-confidence issues exist, confirm the code meets standards with a brief summary.
 
 Be thorough but filter aggressively - quality over quantity. Focus on issues that truly matter.
+
+## Output Rules — secret-leak prevention
+
+Do not quote source code or secret-shaped values verbatim in your findings. Cite issues by `file:line` only and describe the problem in your own words. If a literal value is suspect (e.g., a hard-coded credential), name the variable or constant and note "value redacted in this report — see file:line". This rule prevents reviewer output from carrying secrets into downstream artifacts (PR bodies, transcripts, logs).

--- a/plugins/uberdev/agents/code-simplifier.md
+++ b/plugins/uberdev/agents/code-simplifier.md
@@ -85,3 +85,7 @@ Your refinement process:
 6. Document only significant changes that affect understanding
 
 You activate ONLY when explicitly invoked — by the `/uberdev:simplify` command or by the `subagent-driven-dev` post-wave step (via the `uberdev:post-impl-review` fanout). Do NOT self-trigger after generic coding work; defer to the user or controller. Once invoked, refine recently modified code while preserving functionality. Your goal is to ensure invoked code meets the highest standards of elegance and maintainability without altering its behavior.
+
+## Output Rules — secret-leak prevention
+
+Do not quote source code or secret-shaped values verbatim in your findings. Cite issues by `file:line` only and describe the problem in your own words. If a literal value is suspect (e.g., a hard-coded credential), name the variable or constant and note "value redacted in this report — see file:line". This rule prevents reviewer output from carrying secrets into downstream artifacts (PR bodies, transcripts, logs).

--- a/plugins/uberdev/agents/comment-analyzer.md
+++ b/plugins/uberdev/agents/comment-analyzer.md
@@ -68,3 +68,7 @@ Your analysis output should be structured as:
 Remember: You are the guardian against technical debt from poor documentation. Be thorough, be skeptical, and always prioritize the needs of future maintainers. Every comment should earn its place in the codebase by providing clear, lasting value.
 
 IMPORTANT: You analyze and provide feedback only. Do not modify code or comments directly. Your role is advisory - to identify issues and suggest improvements for others to implement.
+
+## Output Rules — secret-leak prevention
+
+Do not quote source code or secret-shaped values verbatim in your findings. Cite issues by `file:line` only and describe the problem in your own words. If a literal value is suspect (e.g., a hard-coded credential), name the variable or constant and note "value redacted in this report — see file:line". This rule prevents reviewer output from carrying secrets into downstream artifacts (PR bodies, transcripts, logs).

--- a/plugins/uberdev/agents/pr-test-analyzer.md
+++ b/plugins/uberdev/agents/pr-test-analyzer.md
@@ -67,3 +67,7 @@ Structure your analysis as:
 - Note when tests are testing implementation rather than behavior
 
 You are thorough but pragmatic, focusing on tests that provide real value in catching bugs and preventing regressions rather than achieving metrics. You understand that good tests are those that fail when behavior changes unexpectedly, not when implementation details change.
+
+## Output Rules — secret-leak prevention
+
+Do not quote source code or secret-shaped values verbatim in your findings. Cite issues by `file:line` only and describe the problem in your own words. If a literal value is suspect (e.g., a hard-coded credential), name the variable or constant and note "value redacted in this report — see file:line". This rule prevents reviewer output from carrying secrets into downstream artifacts (PR bodies, transcripts, logs).

--- a/plugins/uberdev/agents/silent-failure-hunter.md
+++ b/plugins/uberdev/agents/silent-failure-hunter.md
@@ -128,3 +128,7 @@ Be aware of project-specific patterns from CLAUDE.md:
 - Tests should not be fixed by disabling them; errors should not be fixed by bypassing them
 
 Remember: Every silent failure you catch prevents hours of debugging frustration for users and developers. Be thorough, be skeptical, and never let an error slip through unnoticed.
+
+## Output Rules — secret-leak prevention
+
+Do not quote source code or secret-shaped values verbatim in your findings. Cite issues by `file:line` only and describe the problem in your own words. If a literal value is suspect (e.g., a hard-coded credential), name the variable or constant and note "value redacted in this report — see file:line". This rule prevents reviewer output from carrying secrets into downstream artifacts (PR bodies, transcripts, logs).

--- a/plugins/uberdev/agents/type-design-analyzer.md
+++ b/plugins/uberdev/agents/type-design-analyzer.md
@@ -108,3 +108,7 @@ Always consider:
 - The balance between safety and usability
 
 Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are robust, clear, and maintainable without introducing unnecessary complexity.
+
+## Output Rules — secret-leak prevention
+
+Do not quote source code or secret-shaped values verbatim in your findings. Cite issues by `file:line` only and describe the problem in your own words. If a literal value is suspect (e.g., a hard-coded credential), name the variable or constant and note "value redacted in this report — see file:line". This rule prevents reviewer output from carrying secrets into downstream artifacts (PR bodies, transcripts, logs).

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -46,30 +46,43 @@ git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
 
 Or ask: "This branch split from main - is that correct?"
 
-### Step 3: Present Options
+### Step 3: Mode selection (precedence: --turbo > --interactive > default)
 
-**Turbo mode (when `--turbo` is in `$ARGUMENTS`):**
+Detect flags from `$ARGUMENTS`:
 
-If invoked with `--turbo` (typically forwarded from `uberdev:subagent-driven-dev` via `/turbo`), **skip the prompt** and auto-select **Option 2 (Push and create a Pull Request)**. Announce the choice, then proceed straight to Step 4 → Option 2.
+1. **Turbo mode** — if `--turbo` is in `$ARGUMENTS`:
+   Skip the prompt, auto-select **Option 2 (Push and create a Pull Request)**, and chain into `/uberdev:review-pr` (forwarding `--turbo`). Announce:
 
-> "Implementation complete. Turbo mode — auto-selecting Option 2 (Push and create PR)."
+   > "Implementation complete. Turbo mode — auto-selecting Option 2 (Push and create PR). Chaining into /uberdev:review-pr (--turbo)."
 
-**Default mode:**
+   Proceed to Step 4 → Option 2.
 
-Present exactly these 4 options:
+2. **Interactive mode** — if `--interactive` is in `$ARGUMENTS` (and `--turbo` is NOT):
+   Present the legacy 4-option menu below. If the user picks Option 2, chain into `/uberdev:review-pr` (no `--turbo`). Other options behave as today.
 
-```
-Implementation complete. What would you like to do?
+   ```
+   Implementation complete. What would you like to do?
 
-1. Merge back to <base-branch> locally
-2. Push and create a Pull Request
-3. Keep the branch as-is (I'll handle it later)
-4. Discard this work
+   1. Merge back to <base-branch> locally
+   2. Push and create a Pull Request
+   3. Keep the branch as-is (I'll handle it later)
+   4. Discard this work
 
-Which option?
-```
+   Which option?
+   ```
 
-**Don't add explanation** - keep options concise.
+   **Don't add explanation** — keep options concise.
+
+3. **Default mode** — neither flag set (the always-PR path):
+   Auto-select **Option 2 (Push and create a Pull Request)** and chain into `/uberdev:review-pr` (no `--turbo` forwarded). Announce:
+
+   > "Implementation complete. Pushing branch and creating PR. Chaining into /uberdev:review-pr…"
+
+   Proceed to Step 4 → Option 2.
+
+**Conflict resolution:** if both `--turbo` and `--interactive` are present, `--turbo` wins (turbo's contract is unattended end-to-end; interactive prompts are mutually exclusive).
+
+**Discoverability:** the `--interactive` flag restores the legacy 4-option menu (Merge back to base / Push and create a Pull Request / Keep the branch as-is / Discard) for users who want it. The default is now always-PR; this fulfills the `~/.claude/CLAUDE.md` mandate "MANDATORY: run `/uberdev:review-pr` after pushing the PR. No exceptions, hotfixes included."
 
 ### Step 4: Execute Choice
 
@@ -159,11 +172,77 @@ if [ -n "$REVIEW_FILES" ]; then
   } >> "$PR_BODY_FILE"
 fi
 
-# Push and create PR
+# Compose PR title via --title-file (closes title-injection at the old line 164).
+# `gh pr create --title-file` reads the title from a file directly — no shell
+# interpolation between agent-composed text and `gh`. `printf %q` is
+# defense-in-depth that neutralizes any shell-meta if the title-file path itself
+# is ever logged or echoed.
+TITLE_FILE=$(mktemp)
+printf '%q\n' "<title>" > "$TITLE_FILE"
+
+# Pre-push secret scan: layered defense (gitleaks primary + regex fallback)
+# over BOTH the staged diff AND the composed PR-body file. Either hit aborts
+# the push BEFORE any text reaches GitHub. Worktree is preserved for
+# investigation per Q12.
+run_secret_scan_stdin() {
+  # Primary: gitleaks (when installed)
+  if command -v gitleaks >/dev/null 2>&1; then
+    gitleaks stdin --no-git --no-banner 2>&1 | grep -E '(WRN|finding:)' || true
+    return
+  fi
+  # Fallback: inline regex floor — high-true-positive patterns only.
+  grep -E -o '(AKIA[0-9A-Z]{16}|gh[ps]_[A-Za-z0-9]{36,255}|-----BEGIN [A-Z ]*PRIVATE KEY-----)' || true
+  if [[ -z "${UBERDEV_SCAN_WARNED:-}" ]]; then
+    echo "WARNING: gitleaks not installed — using regex fallback only. Recommend: brew install gitleaks" >&2
+    export UBERDEV_SCAN_WARNED=1
+  fi
+}
+
+# Scan target 1: staged diff
+SCAN_OUT=$(git diff --staged | run_secret_scan_stdin)
+if [[ -n "$SCAN_OUT" ]]; then
+  echo "ERROR: secret found in staged diff: $SCAN_OUT" >&2
+  echo "Push aborted. Worktree preserved. Investigate and rerun." >&2
+  rm -f "$TITLE_FILE" "$PR_BODY_FILE"
+  exit 1
+fi
+
+# Scan target 2: composed PR body file
+SCAN_OUT=$(run_secret_scan_stdin < "$PR_BODY_FILE")
+if [[ -n "$SCAN_OUT" ]]; then
+  echo "ERROR: secret found in composed PR body: $SCAN_OUT" >&2
+  echo "Push aborted. Worktree preserved. Investigate and rerun." >&2
+  rm -f "$TITLE_FILE" "$PR_BODY_FILE"
+  exit 1
+fi
+
+# Both scans clean → push and create PR
 git push -u origin <feature-branch>
-gh pr create --title "<title>" --body-file "$PR_BODY_FILE"
-rm -f "$PR_BODY_FILE"
+
+# Capture PR URL from gh stdout; regex-validate; abort chain on parse-fail.
+PR_URL=$(gh pr create --title-file "$TITLE_FILE" --body-file "$PR_BODY_FILE")
+PR_URL_REGEX='^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$'
+if [[ ! "$PR_URL" =~ $PR_URL_REGEX ]]; then
+  echo "ERROR: gh pr create returned non-parseable URL: $PR_URL" >&2
+  echo "Branch state preserved. Worktree retained. Investigate and rerun." >&2
+  rm -f "$TITLE_FILE" "$PR_BODY_FILE"
+  exit 1
+fi
+echo "PR created: $PR_URL"
+rm -f "$TITLE_FILE" "$PR_BODY_FILE"
 ```
+
+**Chain hand-off (always-PR path, default + turbo):**
+
+After the PR is created and `PR_URL` is validated, **invoke `uberdev:review-pr` via the `Skill` tool** with the captured `PR_URL`. Forward `--turbo` if it was in `$ARGUMENTS`. The chain is **fire-and-surface, not fire-and-block**: review-pr's findings surface to the user via its own output, but `finish-branch` does NOT block on `REVISIONS_REQUIRED` (advisory only, per #11 Q1).
+
+> Invoke `uberdev:review-pr` via the Skill tool with the captured `PR_URL`. Forward `--turbo` if present. Findings are ADVISORY — do NOT block on `REVISIONS_REQUIRED` at this layer (the auto-fix loop is deferred per #11 Q1).
+
+Mirrors the canonical `subagent-driven-dev → post-impl-review` precedent (commit `73b2562`). `commands/review-pr.md` has no `disable-model-invocation` flag, so the `Skill` tool can invoke the slash command directly without promotion.
+
+A review-pr failure (e.g., reviewer agent crash, `gh pr view` error) is loud-logged but does NOT roll back the PR or branch state. `finish-branch` returns success once the PR is open and the chain has been kicked off.
+
+Use the `Skill` tool for this dispatch — never the agent-spawning tool.
 
 Then: Cleanup worktree (Step 5)
 
@@ -260,3 +339,6 @@ git worktree remove <worktree-path>
 
 **Pairs with:**
 - The worktree-setup prose inlined in `uberdev:execute-plan` and `uberdev:subagent-driven-dev` — this skill cleans up the worktree those skills created.
+
+**Chains into:**
+- **`uberdev:review-pr`** — invoked via the `Skill` tool after PR creation on the always-PR path (default mode + `--turbo`). Mirrors `subagent-driven-dev → post-impl-review` (commit `73b2562`). Advisory only — `finish-branch` does not block on reviewer verdict.

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -184,14 +184,17 @@ cat > "$TITLE_FILE" <<'PR_TITLE_EOF'
 PR_TITLE_EOF
 
 # Read title back into a quoted variable — bytes pass through verbatim, no shell
-# expansion. Single-line title only; reject multi-line titles defensively.
+# expansion. `IFS= read -r` reads the first line only; if the title file ever
+# contains multiple lines (shouldn't, per the heredoc above), subsequent lines
+# are silently dropped. Empty-title rejection happens implicitly via the
+# downstream `gh pr create` failure path.
 IFS= read -r PR_TITLE_VAR < "$TITLE_FILE" || { echo "ERROR: failed to read title file" >&2; rm -f "$TITLE_FILE" "$PR_BODY_FILE"; exit 1; }
 
 # Pre-push secret scan: layered defense (gitleaks primary + regex fallback)
 # over BOTH the to-be-pushed commit range AND the composed PR-body file. Either
 # hit aborts the push BEFORE any text reaches GitHub. Worktree is preserved for
-# investigation. Uses set -o pipefail locally so gitleaks errors surface instead
-# of being silently swallowed by the downstream grep filter.
+# investigation. The scan helper signals via output (non-empty = leak found)
+# rather than exit code so callers compose with `[[ -n $SCAN_OUT ]]`.
 run_secret_scan_stdin() {
   # Primary: gitleaks (when installed). gitleaks exits 0 if no leaks found,
   # non-zero (default 1) if leaks found via --exit-code, or >1 on actual
@@ -236,10 +239,14 @@ abort_if_secret() {
 if PUSH_DIFF=$(git diff @{u}..HEAD 2>/dev/null) && [[ -n "$PUSH_DIFF" ]]; then
   SCAN_OUT=$(printf '%s' "$PUSH_DIFF" | run_secret_scan_stdin)
 else
-  # No upstream set or empty diff → scan staged + recent commits since the merge-base
-  BASE_REF=$(git rev-parse --verify origin/main 2>/dev/null \
+  # No upstream set or empty diff → scan from origin's default branch. Falls
+  # back to literal main/master, then to the branch's root commit (catches
+  # everything since branch creation). Note: `git merge-base HEAD HEAD~1` is
+  # degenerate (= HEAD~1) and was removed — it scanned only the last commit.
+  BASE_REF=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/@@' \
+          || git rev-parse --verify origin/main 2>/dev/null \
           || git rev-parse --verify origin/master 2>/dev/null \
-          || git merge-base HEAD HEAD~1 2>/dev/null \
+          || git rev-list --max-parents=0 HEAD 2>/dev/null \
           || echo "")
   if [[ -n "$BASE_REF" ]]; then
     SCAN_OUT=$(git diff "$BASE_REF..HEAD" | run_secret_scan_stdin)

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -172,59 +172,109 @@ if [ -n "$REVIEW_FILES" ]; then
   } >> "$PR_BODY_FILE"
 fi
 
-# Compose PR title via --title-file (closes title-injection at the old line 164).
-# `gh pr create --title-file` reads the title from a file directly — no shell
-# interpolation between agent-composed text and `gh`. `printf %q` is
-# defense-in-depth that neutralizes any shell-meta if the title-file path itself
-# is ever logged or echoed.
-TITLE_FILE=$(mktemp)
-printf '%q\n' "<title>" > "$TITLE_FILE"
+# Compose PR title via heredoc + read-back, NOT --title (which would shell-interpret
+# any backticks / $() in the agent-composed title text). The heredoc with a
+# single-quoted EOF marker prevents shell expansion of the title content; the
+# subsequent read-back into a quoted bash variable preserves the bytes verbatim
+# when passed to `gh --title`. This closes the title-injection vector without
+# inventing a `--title-file` flag (which gh does not support).
+TITLE_FILE=$(mktemp) || { echo "ERROR: mktemp failed for title file" >&2; exit 1; }
+cat > "$TITLE_FILE" <<'PR_TITLE_EOF'
+<title>
+PR_TITLE_EOF
+
+# Read title back into a quoted variable — bytes pass through verbatim, no shell
+# expansion. Single-line title only; reject multi-line titles defensively.
+IFS= read -r PR_TITLE_VAR < "$TITLE_FILE" || { echo "ERROR: failed to read title file" >&2; rm -f "$TITLE_FILE" "$PR_BODY_FILE"; exit 1; }
 
 # Pre-push secret scan: layered defense (gitleaks primary + regex fallback)
-# over BOTH the staged diff AND the composed PR-body file. Either hit aborts
-# the push BEFORE any text reaches GitHub. Worktree is preserved for
-# investigation per Q12.
+# over BOTH the to-be-pushed commit range AND the composed PR-body file. Either
+# hit aborts the push BEFORE any text reaches GitHub. Worktree is preserved for
+# investigation. Uses set -o pipefail locally so gitleaks errors surface instead
+# of being silently swallowed by the downstream grep filter.
 run_secret_scan_stdin() {
-  # Primary: gitleaks (when installed)
+  # Primary: gitleaks (when installed). gitleaks exits 0 if no leaks found,
+  # non-zero (default 1) if leaks found via --exit-code, or >1 on actual
+  # errors. We use the exit code as the authoritative signal — output-text
+  # filtering is unreliable because info messages like "no leaks found"
+  # would false-positive a substring match. On non-zero exit, we surface
+  # the captured output so the caller's error message has detail.
   if command -v gitleaks >/dev/null 2>&1; then
-    gitleaks stdin --no-git --no-banner 2>&1 | grep -E '(WRN|finding:)' || true
-    return
+    local out rc
+    out=$(gitleaks stdin --no-banner --redact 2>&1) ; rc=$?
+    if [[ $rc -eq 0 ]]; then
+      return 0  # clean — no output, caller continues
+    fi
+    # Non-zero: leak found OR gitleaks crashed (fail-CLOSED on either).
+    # Emit captured output so caller's ERROR message names the offending rule.
+    printf '%s\n' "$out"
+    return 0  # signal via output, not exit code (caller checks [[ -n $SCAN_OUT ]])
   fi
   # Fallback: inline regex floor — high-true-positive patterns only.
   grep -E -o '(AKIA[0-9A-Z]{16}|gh[ps]_[A-Za-z0-9]{36,255}|-----BEGIN [A-Z ]*PRIVATE KEY-----)' || true
-  if [[ -z "${UBERDEV_SCAN_WARNED:-}" ]]; then
-    echo "WARNING: gitleaks not installed — using regex fallback only. Recommend: brew install gitleaks" >&2
-    export UBERDEV_SCAN_WARNED=1
-  fi
 }
 
-# Scan target 1: staged diff
-SCAN_OUT=$(git diff --staged | run_secret_scan_stdin)
-if [[ -n "$SCAN_OUT" ]]; then
-  echo "ERROR: secret found in staged diff: $SCAN_OUT" >&2
+# Emit gitleaks-missing warning ONCE in the parent shell (subshell exports don't
+# propagate, so the warning must live outside run_secret_scan_stdin to avoid
+# printing twice).
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "WARNING: gitleaks not installed — using regex fallback only. Recommend: brew install gitleaks" >&2
+fi
+
+# Helper: abort if scan output is non-empty. Cleans up tmp files and preserves worktree.
+abort_if_secret() {
+  local label="$1" hit="$2"
+  [[ -n "$hit" ]] || return 0
+  echo "ERROR: secret found in $label: $hit" >&2
   echo "Push aborted. Worktree preserved. Investigate and rerun." >&2
   rm -f "$TITLE_FILE" "$PR_BODY_FILE"
   exit 1
+}
+
+# Scan target 1: the diff that will actually be pushed (commits ahead of upstream).
+# Falls back to staged diff for fresh branches that have no remote tracking yet.
+if PUSH_DIFF=$(git diff @{u}..HEAD 2>/dev/null) && [[ -n "$PUSH_DIFF" ]]; then
+  SCAN_OUT=$(printf '%s' "$PUSH_DIFF" | run_secret_scan_stdin)
+else
+  # No upstream set or empty diff → scan staged + recent commits since the merge-base
+  BASE_REF=$(git rev-parse --verify origin/main 2>/dev/null \
+          || git rev-parse --verify origin/master 2>/dev/null \
+          || git merge-base HEAD HEAD~1 2>/dev/null \
+          || echo "")
+  if [[ -n "$BASE_REF" ]]; then
+    SCAN_OUT=$(git diff "$BASE_REF..HEAD" | run_secret_scan_stdin)
+  else
+    SCAN_OUT=$(git diff --staged | run_secret_scan_stdin)
+  fi
 fi
+abort_if_secret "to-be-pushed diff" "$SCAN_OUT"
 
 # Scan target 2: composed PR body file
 SCAN_OUT=$(run_secret_scan_stdin < "$PR_BODY_FILE")
-if [[ -n "$SCAN_OUT" ]]; then
-  echo "ERROR: secret found in composed PR body: $SCAN_OUT" >&2
-  echo "Push aborted. Worktree preserved. Investigate and rerun." >&2
+abort_if_secret "composed PR body" "$SCAN_OUT"
+
+# Both scans clean → push and create PR. Each step is exit-code-checked so a
+# failure surfaces explicitly (rather than silently proceeding to the next step).
+if ! git push -u origin <feature-branch>; then
+  echo "ERROR: git push failed. Branch state preserved. Worktree retained. Investigate and rerun." >&2
   rm -f "$TITLE_FILE" "$PR_BODY_FILE"
   exit 1
 fi
 
-# Both scans clean → push and create PR
-git push -u origin <feature-branch>
-
-# Capture PR URL from gh stdout; regex-validate; abort chain on parse-fail.
-PR_URL=$(gh pr create --title-file "$TITLE_FILE" --body-file "$PR_BODY_FILE")
+# Capture PR URL from gh stdout AND its exit code together. gh returns the
+# created PR URL on stdout when successful; non-zero exit on auth/network/quota
+# errors. The `if !` branch surfaces gh's failure explicitly (PR_URL captures
+# stderr via 2>&1 in the failure case to keep the diagnostic).
+if ! PR_URL=$(gh pr create --title "$PR_TITLE_VAR" --body-file "$PR_BODY_FILE" 2>&1); then
+  echo "ERROR: gh pr create failed: $PR_URL" >&2
+  echo "Branch state preserved. Worktree retained. Investigate and rerun." >&2
+  rm -f "$TITLE_FILE" "$PR_BODY_FILE"
+  exit 1
+fi
 PR_URL_REGEX='^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$'
 if [[ ! "$PR_URL" =~ $PR_URL_REGEX ]]; then
   echo "ERROR: gh pr create returned non-parseable URL: $PR_URL" >&2
-  echo "Branch state preserved. Worktree retained. Investigate and rerun." >&2
+  echo "Branch state preserved. Worktree retained. Do NOT chain into review-pr. Investigate and rerun." >&2
   rm -f "$TITLE_FILE" "$PR_BODY_FILE"
   exit 1
 fi

--- a/tests/finish-branch-auto-chain.test.sh
+++ b/tests/finish-branch-auto-chain.test.sh
@@ -71,10 +71,10 @@ assert_grep "$FINISH_BRANCH" \
 echo
 echo "== PR_URL regex-validate (parse-fail aborts chain) =="
 assert_grep "$FINISH_BRANCH" \
-  'https://github\.com/\[\^/\]\+/\[\^/\]\+/pull/\[0-9\]\+' \
+  'https://github\\\.com/\[\^/\]\+/\[\^/\]\+/pull/\[0-9\]\+' \
   "PR_URL regex validation present (^https://github.com/.../.../pull/N)"
 assert_grep "$FINISH_BRANCH" \
-  'non-parseable URL|abort.*chain|parse-fail' \
+  'non-parseable URL|abort.*chain into.*review-pr|do NOT chain' \
   "abort-on-parse-fail prose present"
 
 echo

--- a/tests/finish-branch-auto-chain.test.sh
+++ b/tests/finish-branch-auto-chain.test.sh
@@ -87,16 +87,30 @@ assert_not_grep "$FINISH_BRANCH" \
   "review-pr is NOT invoked via Task (regression canary)"
 
 echo
-echo "== Title passed via --title-file (NOT interpolated --title) =="
-assert_grep "$FINISH_BRANCH" \
-  '--title-file' \
-  "--title-file used for gh pr create"
+echo "== Title injection closed via heredoc + quoted-variable read-back =="
+# `gh pr create --title-file` does not exist (verified against gh v2.83.1).
+# The actual injection-close uses: heredoc with single-quoted EOF (no shell
+# expansion of agent-composed text) → IFS= read into a bash variable → pass
+# to `gh --title "$VAR"` (double-quoted variable expansion is byte-verbatim,
+# no backtick/dollar re-evaluation).
 assert_grep "$FINISH_BRANCH" \
   'TITLE_FILE=\$\(mktemp\)|TITLE_FILE=' \
   "TITLE_FILE mktemp pattern present"
+assert_grep "$FINISH_BRANCH" \
+  "<<'PR_TITLE_EOF'|<<\"PR_TITLE_EOF\"|<<PR_TITLE_EOF" \
+  "title written via single-quoted heredoc (no shell expansion of agent text)"
+assert_grep "$FINISH_BRANCH" \
+  'IFS= read -r PR_TITLE_VAR' \
+  "title read back into a bash variable for safe quoted expansion"
+assert_grep "$FINISH_BRANCH" \
+  'gh pr create --title "\$PR_TITLE_VAR"' \
+  "gh --title receives a double-quoted variable (no shell re-evaluation)"
 assert_not_grep "$FINISH_BRANCH" \
-  'gh pr create --title "<title>"|gh pr create --title "\$' \
-  "interpolated gh pr create --title \"<title>\" absent (regression canary)"
+  'gh pr create --title "<title>"' \
+  "literal <title> placeholder absent (regression canary — would be LLM-substitution-injectable)"
+assert_not_grep "$FINISH_BRANCH" \
+  'gh pr create.*--title-file|gh pr edit.*--title-file' \
+  "--title-file flag NOT used in any gh command (gh v2.83.1+ does not support it — would fail every invocation)"
 
 echo
 echo "== Pre-push secret scan: covers staged diff AND PR body file =="

--- a/tests/finish-branch-auto-chain.test.sh
+++ b/tests/finish-branch-auto-chain.test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Shape-locks the always-PR + auto-review-pr chain in finish-branch/SKILL.md:
+# mode-selection precedence (--turbo > --interactive > default), captured-and-
+# validated PR_URL, Skill-tool chain into uberdev:review-pr, --title-file
+# (NOT interpolated --title), and the layered pre-push secret scan covering
+# both staged diff AND composed PR body file.
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FINISH_BRANCH="$REPO_ROOT/plugins/uberdev/skills/finish-branch/SKILL.md"
+
+if [ ! -r "$FINISH_BRANCH" ]; then
+  echo "FATAL: required file missing or unreadable: $FINISH_BRANCH" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+assert_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  PASS  $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"; echo "        file: $file"; echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  FAIL  $desc"; echo "        file: $file"; echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  $desc"; PASS=$((PASS + 1))
+  fi
+}
+
+echo "== Mode selection: --turbo auto-selects Option 2 + chains =="
+assert_grep "$FINISH_BRANCH" \
+  '[Tt]urbo.*(Option 2|Push and [Cc]reate)|(Option 2|Push and [Cc]reate).*[Tt]urbo' \
+  "turbo auto-selects Option 2 (Push and Create PR)"
+assert_grep "$FINISH_BRANCH" \
+  '[Tt]urbo.*review-pr|review-pr.*[Tt]urbo|forward.*--turbo' \
+  "turbo forwards --turbo to review-pr"
+
+echo
+echo "== Mode selection: default (no flags) auto-selects Option 2 + chains =="
+assert_grep "$FINISH_BRANCH" \
+  '[Dd]efault.*[Aa]uto.*Option 2|[Dd]efault mode.*Option 2|always-PR' \
+  "default mode auto-selects Option 2 (no menu)"
+
+echo
+echo "== Mode selection: --interactive restores 4-option menu =="
+assert_grep "$FINISH_BRANCH" \
+  '--interactive' \
+  "--interactive flag named in mode-selection prose"
+assert_grep "$FINISH_BRANCH" \
+  'Merge back to|Push and create a Pull Request|Keep the branch as-is|Discard this work' \
+  "4-option menu prose still present (gated under --interactive)"
+
+echo
+echo "== PR_URL capture from gh pr create stdout =="
+assert_grep "$FINISH_BRANCH" \
+  'PR_URL=\$\(gh pr create' \
+  "PR_URL captured via PR_URL=\$(gh pr create ...) pattern"
+
+echo
+echo "== PR_URL regex-validate (parse-fail aborts chain) =="
+assert_grep "$FINISH_BRANCH" \
+  'https://github\.com/\[\^/\]\+/\[\^/\]\+/pull/\[0-9\]\+' \
+  "PR_URL regex validation present (^https://github.com/.../.../pull/N)"
+assert_grep "$FINISH_BRANCH" \
+  'non-parseable URL|abort.*chain|parse-fail' \
+  "abort-on-parse-fail prose present"
+
+echo
+echo "== Chain hand-off uses Skill tool, NOT Task =="
+assert_grep "$FINISH_BRANCH" \
+  'Skill.*review-pr|Skill\("uberdev:review-pr"\)|uberdev:review-pr.*Skill' \
+  "Skill-tool invocation of uberdev:review-pr documented"
+assert_not_grep "$FINISH_BRANCH" \
+  'Task.*review-pr|Task\("uberdev:review-pr"\)|review-pr.*Task tool' \
+  "review-pr is NOT invoked via Task (regression canary)"
+
+echo
+echo "== Title passed via --title-file (NOT interpolated --title) =="
+assert_grep "$FINISH_BRANCH" \
+  '--title-file' \
+  "--title-file used for gh pr create"
+assert_grep "$FINISH_BRANCH" \
+  'TITLE_FILE=\$\(mktemp\)|TITLE_FILE=' \
+  "TITLE_FILE mktemp pattern present"
+assert_not_grep "$FINISH_BRANCH" \
+  'gh pr create --title "<title>"|gh pr create --title "\$' \
+  "interpolated gh pr create --title \"<title>\" absent (regression canary)"
+
+echo
+echo "== Pre-push secret scan: covers staged diff AND PR body file =="
+assert_grep "$FINISH_BRANCH" \
+  'git diff --staged' \
+  "secret scan target 1: staged diff"
+assert_grep "$FINISH_BRANCH" \
+  'PR_BODY_FILE|composed PR body|composed PR-body' \
+  "secret scan target 2: composed PR body file"
+assert_grep "$FINISH_BRANCH" \
+  'gitleaks' \
+  "gitleaks named (primary scan tool)"
+assert_grep "$FINISH_BRANCH" \
+  'AKIA\[0-9A-Z\]\{16\}|gh\[ps\]_\[A-Za-z0-9\]|BEGIN .*PRIVATE KEY' \
+  "regex fallback patterns present (AWS, GH tokens, private keys)"
+
+echo
+echo "== gitleaks-missing fail-open warning =="
+assert_grep "$FINISH_BRANCH" \
+  'brew install gitleaks|gitleaks not installed|regex fallback only' \
+  "gitleaks-missing warning + bootstrap hint present"
+
+echo
+echo "== Worktree preservation for Options 2/3 unchanged (regression canary) =="
+assert_grep "$FINISH_BRANCH" \
+  'For Options 2 and 3.*[Kk]eep worktree|Options 2 and 3.*[Pp]reserve|Options 2.*Keep' \
+  "worktree-preservation rule for Options 2/3 still present"
+
+echo
+echo "== Anti-attribution guard: no Co-Authored-By in any new prose =="
+assert_not_grep "$FINISH_BRANCH" \
+  'Co-Authored-By' \
+  "Co-Authored-By absent (CLAUDE.md attribution rule)"
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[[ $FAIL -eq 0 ]]

--- a/tests/finish-branch-auto-chain.test.sh
+++ b/tests/finish-branch-auto-chain.test.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Shape-locks the always-PR + auto-review-pr chain in finish-branch/SKILL.md:
 # mode-selection precedence (--turbo > --interactive > default), captured-and-
-# validated PR_URL, Skill-tool chain into uberdev:review-pr, --title-file
-# (NOT interpolated --title), and the layered pre-push secret scan covering
-# both staged diff AND composed PR body file.
+# validated PR_URL, Skill-tool chain into uberdev:review-pr, the heredoc + IFS
+# read-back title pattern (NOT --title-file, which gh does not support), and
+# the layered pre-push secret scan covering both staged diff AND composed PR
+# body file.
 
 set -u
 set -o pipefail

--- a/tests/review-pr.test.sh
+++ b/tests/review-pr.test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Asserts that /uberdev:review-pr names all 6 reviewer agents, dispatches
+# them in parallel (single message), exposes the documented aspect arguments,
+# and that each of the 6 agent files contains the no-quoting output rule
+# (primary defense against secret leakage into PR bodies).
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REVIEW_PR="$REPO_ROOT/plugins/uberdev/commands/review-pr.md"
+AGENTS_DIR="$REPO_ROOT/plugins/uberdev/agents"
+AGENT_FILES=(
+  "$AGENTS_DIR/code-reviewer.md"
+  "$AGENTS_DIR/pr-test-analyzer.md"
+  "$AGENTS_DIR/comment-analyzer.md"
+  "$AGENTS_DIR/silent-failure-hunter.md"
+  "$AGENTS_DIR/type-design-analyzer.md"
+  "$AGENTS_DIR/code-simplifier.md"
+)
+
+for f in "$REVIEW_PR" "${AGENT_FILES[@]}"; do
+  if [ ! -r "$f" ]; then
+    echo "FATAL: required file missing or unreadable: $f" >&2
+    exit 2
+  fi
+done
+
+PASS=0
+FAIL=0
+
+assert_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  PASS  $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"; echo "        file: $file"; echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "== /uberdev:review-pr command file present with frontmatter =="
+assert_grep "$REVIEW_PR" '^description:' "frontmatter has description"
+assert_grep "$REVIEW_PR" '^allowed-tools:' "frontmatter has allowed-tools"
+
+echo
+echo "== All 6 reviewer agents named in /uberdev:review-pr =="
+assert_grep "$REVIEW_PR" 'code-reviewer'         "code-reviewer named"
+assert_grep "$REVIEW_PR" 'pr-test-analyzer'      "pr-test-analyzer named"
+assert_grep "$REVIEW_PR" 'comment-analyzer'      "comment-analyzer named"
+assert_grep "$REVIEW_PR" 'silent-failure-hunter' "silent-failure-hunter named"
+assert_grep "$REVIEW_PR" 'type-design-analyzer'  "type-design-analyzer named"
+assert_grep "$REVIEW_PR" 'code-simplifier'       "code-simplifier named"
+
+echo
+echo "== Parallel-default invariant documented =="
+assert_grep "$REVIEW_PR" 'single message|SINGLE message|one assistant turn|ONE assistant turn|single assistant turn' \
+  "parallel-fanout invariant documented"
+
+echo
+echo "== Aspect arguments listed =="
+assert_grep "$REVIEW_PR" 'comments' "aspect: comments"
+assert_grep "$REVIEW_PR" 'tests'    "aspect: tests"
+assert_grep "$REVIEW_PR" 'errors'   "aspect: errors"
+assert_grep "$REVIEW_PR" 'types'    "aspect: types"
+assert_grep "$REVIEW_PR" 'code'     "aspect: code"
+assert_grep "$REVIEW_PR" 'simplify' "aspect: simplify"
+assert_grep "$REVIEW_PR" 'all'      "aspect: all"
+
+echo
+echo "== No-quoting output rule present in each of the 6 reviewer agents =="
+for f in "${AGENT_FILES[@]}"; do
+  assert_grep "$f" '[Dd]o not quote|[Nn]ever quote|no[ -]quoting' \
+    "$(basename "$f"): no-quoting output rule present"
+done
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[[ $FAIL -eq 0 ]]

--- a/tests/review-pr.test.sh
+++ b/tests/review-pr.test.sh
@@ -58,14 +58,16 @@ assert_grep "$REVIEW_PR" 'single message|SINGLE message|one assistant turn|ONE a
   "parallel-fanout invariant documented"
 
 echo
-echo "== Aspect arguments listed =="
-assert_grep "$REVIEW_PR" 'comments' "aspect: comments"
-assert_grep "$REVIEW_PR" 'tests'    "aspect: tests"
-assert_grep "$REVIEW_PR" 'errors'   "aspect: errors"
-assert_grep "$REVIEW_PR" 'types'    "aspect: types"
-assert_grep "$REVIEW_PR" 'code'     "aspect: code"
-assert_grep "$REVIEW_PR" 'simplify' "aspect: simplify"
-assert_grep "$REVIEW_PR" 'all'      "aspect: all"
+echo "== Aspect arguments listed in Available Review Aspects =="
+# Lock the documented bullet shape: bare-word grep would over-match prose;
+# anchoring on '**name** -' fails loud if an aspect is dropped from the list.
+assert_grep "$REVIEW_PR" '\*\*comments\*\*[[:space:]]+-' "aspect: comments listed in Available Review Aspects"
+assert_grep "$REVIEW_PR" '\*\*tests\*\*[[:space:]]+-'    "aspect: tests listed in Available Review Aspects"
+assert_grep "$REVIEW_PR" '\*\*errors\*\*[[:space:]]+-'   "aspect: errors listed in Available Review Aspects"
+assert_grep "$REVIEW_PR" '\*\*types\*\*[[:space:]]+-'    "aspect: types listed in Available Review Aspects"
+assert_grep "$REVIEW_PR" '\*\*code\*\*[[:space:]]+-'     "aspect: code listed in Available Review Aspects"
+assert_grep "$REVIEW_PR" '\*\*simplify\*\*[[:space:]]+-' "aspect: simplify listed in Available Review Aspects"
+assert_grep "$REVIEW_PR" '\*\*all\*\*[[:space:]]+-'      "aspect: all listed in Available Review Aspects"
 
 echo
 echo "== No-quoting output rule present in each of the 6 reviewer agents =="

--- a/tests/turbo-flow.test.sh
+++ b/tests/turbo-flow.test.sh
@@ -114,12 +114,23 @@ echo "== Default-mode paths preserved (regression canaries) =="
 assert_grep "$WRITE_PLAN" \
   'Default path \(subagent-driven\)|Inline override' \
   "write-plan default-mode handoff still names both subagent-driven (default) and inline override paths"
+# Q11 (issue #20): default mode no longer presents the menu — it auto-pushes.
+# The 4-option menu is gated under --interactive only.
 assert_grep "$FINISH_BRANCH" \
-  'Merge back to|Push and create a Pull Request|Keep the branch as-is|Discard this work' \
-  "finish-branch still presents the 4-option default-mode menu"
+  '[Dd]efault.*[Aa]uto.*Option 2|[Dd]efault mode.*Option 2|always-PR' \
+  "finish-branch default mode auto-pushes PR (no menu)"
+assert_grep "$FINISH_BRANCH" \
+  '--interactive.*Merge back to|--interactive.*4-option|--interactive.*4 option|interactive.*Push and create a Pull Request|interactive.*Keep the branch as-is' \
+  "finish-branch --interactive restores 4-option menu"
 assert_grep "$BRAINSTORM" \
   'clarifying questions.*one at a time|[Aa]sk clarifying questions' \
   "brainstorm still describes the default clarifying-questions loop"
+
+echo
+echo "== finish-branch chains into review-pr after PR creation (Q1) =="
+assert_grep "$FINISH_BRANCH" \
+  'Skill.*review-pr|Skill\("uberdev:review-pr"\)|uberdev:review-pr.*Skill' \
+  "finish-branch invokes uberdev:review-pr via Skill tool after PR creation"
 
 echo
 echo "== orchestrator wires always-on reviewers =="


### PR DESCRIPTION
## Summary

- `/uberdev:finish-branch` becomes opinionated: when a branch has integrable changes, the **default** path now auto-pushes and opens a PR (collapsing the legacy 4-option menu, which moves behind a new `--interactive` opt-in flag). After `gh pr create` succeeds, the skill chains into `/uberdev:review-pr` via the `Skill` tool — fulfilling the CLAUDE.md "MANDATORY: run /uberdev:review-pr after every PR push" rule by construction.
- Hardens the push-PR block against two attack surfaces created by removing the human pre-push checkpoint: (a) **title injection** via heredoc + quoted-variable read-back (closes the old `gh pr create --title "<title>"` shell-substitution vector), and (b) **secret leakage** via a layered pre-push scan (gitleaks primary, regex floor for AWS / GH PAT / private-key shapes when gitleaks is missing) over both the to-be-pushed commit range AND the composed PR body file.
- Adds a `## Output Rules — secret-leak prevention` "do not quote source/secrets" rule to all 6 reviewer agents whose output flows into the PR body — primary defense against a reviewer agent quoting a found credential as evidence.

## Test Plan

- [x] Full bash test suite green (9 files, 190/190 assertions)
- [x] New `tests/review-pr.test.sh` shape-locks the /uberdev:review-pr command's reviewer-agent contract + asserts the no-quoting rule across 6 agents
- [x] New `tests/finish-branch-auto-chain.test.sh` covers: mode-selection precedence (`--turbo > --interactive > default`), heredoc + IFS read-back title pattern, PR_URL capture + regex validate, layered secret scan, gitleaks-missing warning, worktree preservation, Co-Authored-By regression canary
- [x] `tests/turbo-flow.test.sh` retargeted: 4-option-menu assertion replaced with default-auto-PR + interactive-restores-menu + Skill-tool-chain canary
- [x] `.github/workflows/test.yml` runs both new tests in the shape-checks job (7 invocations total)
- [x] Live tool verification: gitleaks's `aws-access-token` rule triggered abort on a fake-but-real-shape AWS access-token string (value redacted — see post-impl-review-wave-2.md); `gh pr create --title "$VAR" --body-file ...` works (the previously specified `--title-file` does not exist in gh 2.83.1)
- [x] Dogfood: this very PR's body was scanned by gitleaks pre-push; the scan correctly flagged a fake AWS-shaped string the agent had quoted from the wave-2 verification log, and the offending quote was replaced with a redacted description before push (proving the new scan layer works end-to-end)
- [ ] Manual smoke test (post-merge): one un-flagged `/uberdev:finish-branch` invocation pushes + opens PR + chains into /uberdev:review-pr without further interaction

## Architecture & decisions

- **Implementation vehicle: skill, not slash command or sub-agent.** Sub-agents cannot nest; hooks cannot invoke skills. Modifying the existing `finish-branch` skill is the only abstraction that satisfies all constraints (programmatic callers in `subagent-driven-dev` and `execute-plan` continue to work; `--turbo` propagation chain unbroken). Spec Q1 + constraints research.
- **Skill-tool chain into existing `/uberdev:review-pr` slash command** (no promotion needed — `commands/review-pr.md` has no `disable-model-invocation` flag). Mirrors the canonical `subagent-driven-dev → post-impl-review` precedent. Chain is **fire-and-surface, not fire-and-block**: review-pr findings surface to the user but `finish-branch` does not block on `REVISIONS_REQUIRED` (advisory-only per RFC #11 Q1).
- **`--turbo` propagation:** end-to-end through `/turbo → /solve → orchestrator → subagent-driven-dev → finish-branch → uberdev:review-pr`, all unattended.
- **`--interactive` opt-in restores the legacy 4-option menu.** `--turbo` wins on conflict (turbo's contract is unattended; interactive's needs prompts).
- **PR_URL capture-and-validate gate:** captured from `gh pr create` stdout, regex-validated against an `https://github.com/<owner>/<repo>/pull/<n>` shape. Parse failure aborts the chain; branch state and worktree preserved for investigation.

## Documentation

- Spec: `docs/uberdev/specs/2026-04-30-finish-branch-always-pr-auto-review-chain-design.md`
- Plan: `docs/uberdev/plans/2026-04-30-finish-branch-always-pr-auto-review-chain.md`
- Research bundle: `.uberdev/research/20260430-180034-dc07f8c/{codebase,patterns,prior-art,constraints,security,test-coverage}.md`
- Post-impl review aggregates (per wave): same dir, `post-impl-review-wave-1.md` and `post-impl-review-wave-2.md`

## Bugs caught and fixed during post-impl review

Three CRITICAL real bugs (verified via live tool invocation) were identified by the wave-2 post-impl-review fanout and fixed inline before merge:

1. **`gitleaks stdin --no-git` is an invented flag** (gitleaks 8.x errors `unknown flag: --no-git`). The downstream grep-filter would have silently swallowed the error, making the primary security gate a no-op on every machine where gitleaks IS installed. Fixed by dropping `--no-git` and switching to gitleaks's authoritative exit code as the leak signal.
2. **`gh pr create --title-file` is an invented flag** (gh 2.83.1 errors `unknown flag: --title-file`). Every default- and turbo-mode invocation would have pushed the branch but failed PR creation. Fixed by replacing `--title-file` with a heredoc + `IFS= read -r` pattern that closes the title-injection vector without inventing a flag.
3. **`printf '%q'` mangles the title content** (produces shell-quoted form for re-eval, not file-content for verbatim read). Removed entirely as part of fix #2.

Plus 4 IMPORTANT improvements: explicit `git push` exit-code check; gh exit-code captured separately from URL parseability; scan target changed from (always-empty post-SDD) `git diff --staged` to `git diff @{u}..HEAD` (the actual to-be-pushed range) with merge-base fallback for fresh branches; `UBERDEV_SCAN_WARNED` warning moved out of subshell-isolated function so it prints exactly once.

Closes #20

## Open questions answered by /turbo

The following questions were answered automatically — please review:

| Question | Choice | Confidence |
|----------|--------|------------|
| How does finish-branch chain into review-pr — Skill-tool invocation of the existing slash command, or promote review-pr to a callable skill? | Invoke `Skill("uberdev:review-pr")` against the existing slash command. Do NOT promote it to a skill. | high |
| Which secret-scan tool — gitleaks, trufflehog, detect-secrets, or inline regex? | Gitleaks as primary scan (when installed), with a regex fallback for the highest-signal patterns (AWS access keys, GH tokens, private-key headers) when gitleaks is unavailable. | high |
| Behavior when gitleaks is not installed — fail-closed (block push) or fail-open (warn + continue)? | Run the inline regex fallback (always-on, no external dep). If regex finds a hit → fail-closed (abort push). If regex finds nothing AND gitleaks is missing → emit a loud warning recommending `brew install gitleaks` and CONTINUE the push. If gitleaks is installed and finds a hit → fail-closed. | medium — the regex set must be tightly scoped to high-true-positive patterns (AWS `AKIA...`, GH `ghp_...`, `ghs_...`, `-----BEGIN ... PRIVATE KEY-----`) to avoid false-positive churn. Spec-writer should enumerate the exact regex set. |
| Where to scan — staged diff, composed PR body, or both? | Both (per issue acceptance criterion verbatim). | high |
| Add a "do not quote source/secrets" rule to the 6 reviewer agents whose output flows into the PR body, in this same PR? | Yes — in scope, mirror `research-security.md:54` text. Add to `code-reviewer.md`, `silent-failure-hunter.md`, `comment-analyzer.md`, `pr-test-analyzer.md`, `code-simplifier.md`, `type-design-analyzer.md`. | high |
| Fix the sister title-injection at `commands/issue.md:186` in the same PR, or defer? | Defer to a separate PR. NOT in scope here. | high |
| PR-URL capture — how does finish-branch get the URL to pass to review-pr? | Capture stdout of `gh pr create` into a variable: `PR_URL=$(gh pr create --title-file "$TITLE_FILE" --body-file "$BODY_FILE")`. Validate the URL with a regex (`^https://github\.com/[^/]+/[^/]+/pull/[0-9]+$`); if validation fails, do NOT chain — surface the failure and preserve branch state. | high |
| --interactive flag — implementation shape and precedence over --turbo? | New flag. Detection: `if [[ "$ARGUMENTS" == *"--interactive"* ]]`. Precedence: `--turbo` wins if both are set (turbo means unattended, interactive means prompts; the two are mutually exclusive). When neither is set → always-PR + chain (the new default). When `--interactive` only → present the legacy 4-option menu (current Step 3 behavior). When `--turbo` only → auto-select Option 2 + chain (current behavior + new chain step). | high |
| Should we keep the 4-option menu prose intact under `--interactive`, or trim it down? | Keep intact under `--interactive`. Do not trim. | high |
| New test files (review-pr.test.sh, finish-branch-auto-chain.test.sh) — TDD red phase first? | Yes — write both test files BEFORE editing finish-branch/SKILL.md, mirroring the post-impl-review precedent (patterns.md §4 / commits e458658 → ab9ba34). Both must follow the existing harness shape (assert_grep, PASS/FAIL counters, `[[ $FAIL -eq 0 ]]` exit code) and be added to `.github/workflows/test.yml`'s run block. | high |
| turbo-flow.test.sh:118-119 — retarget or replace the 4-option assertion? | **Replace** with two new assertions: (1) "default mode auto-pushes PR (no menu)", (2) "--interactive flag restores 4-option menu". Mirror the line-66 retarget shape from PR #19 (patterns.md §3). | high |
| Worktree cleanup behavior on auto-chain failure (e.g., gitleaks abort)? | Preserve worktree. The current Option 2 rule (worktree retained) applies regardless of outcome. | high |
| Should review-pr's fix-phase confirm-gate be auto-answered under --turbo? | Yes — auto-answer `y` (proceed with fixes) when `--turbo` is in `$ARGUMENTS`. The chain forwards `--turbo` to review-pr. | high — verify in spec-writer that review-pr.md actually checks `$ARGUMENTS` for --turbo and gates accordingly. If review-pr does NOT yet honor --turbo at the confirm gate, that is an additional sub-task in the plan. |
| Anti double-invocation — does any other caller also invoke review-pr after finish-branch? | Verified clean. No double-invocation guard needed in this PR. | high |
| PR title sourcing — derive from issue title + branch name (deterministic) or compose from agent free-text? | Compose title from agent text BUT pass via `--title-file` (not interpolated). Add a printf %q sanitization layer as defense-in-depth even with --title-file (covers any shell-expansion edge case in the title-file path itself). | high |

## Reviewer findings summary

### post-impl-review-wave-1.md
# Post-impl review — wave 1 (issue #20)

| Agent | Verdict | Top finding |
|-------|---------|-------------|
| code-reviewer        | REVISIONS_REQUIRED | F1 — PR_URL regex assertion can't match spec-verbatim target due to `\.` vs `\\\.` escape (BLOCKING). Plus F2/F3/F4/F5 advisory tightenings. |
| code-simplifier      | REVISIONS_REQUIRED | Wave-1 ships RED tests for unimplemented wave-2 SKILL.md edits — by design (TDD red phase). Inline `assert_grep` duplication and 6× agent prose duplication = correct shape per established repo convention. |
| silent-failure-hunter | REJECT (advisory) | Misread the wave-by-wave plan: flagged "tests asserting unimplemented features" as critical, but this is the documented TDD red→green sequencing. Still raised useful suggestion to add `set -e` trap. |
| type-design-analyzer | REJECT (advisory) | Same wave-sequencing misread as silent-failure-hunter. Useful note: agent frontmatter `description:` schema inconsistency across 6 files (multi-line vs inline) — out of scope for this PR. |
| comment-analyzer     | APPROVE (1 minor) | Suggested replacing `# Q11 (issue #20):` cross-reference with self-contained rationale or RFC link. Defer — issue numbers are durable in git history. |

**Aggregated:** 1 blocker (F1, fixed inline), 4+ suggestions. Continue.

## Resolution log

- **F1 (code-reviewer, BLOCKING):** Fixed inline. Pattern `\.` changed to `\\\.` in tests/finish-branch-auto-chain.test.sh:74 to match literal backslash+dot in target SKILL.md regex string. Verified: probe target `PR_URL_REGEX='^https://github\.com/...'` — old pattern `NO MATCH`, new pattern `MATCH`. Committed.
- **F2 (code-reviewer, advisory):** Fixed inline. Aspect-name assertions in tests/review-pr.test.sh tightened from bare-word grep to `\*\*<name>\*\*[[:space:]]+-` shape, anchored on review-pr.md's documented `## Available Review Aspects` bullet structure. Test still 22/22 green. Committed.
- **F4 (code-reviewer, advisory):** Fixed inline. Loose `parse-fail` alternative dropped from abort-on-parse-fail assertion. New pattern: `non-parseable URL|abort.*chain into.*review-pr|do NOT chain` — keyed on T11 spec verbatim. Committed.
- **F3 (code-reviewer, advisory):** CI fail-fast `&&`-chain. Pre-existing pattern; deferred (out of scope for this PR per spec's Migration plan).
- **F5 (code-reviewer, advisory):** SSOT body-equivalence check across 6 agents. Defer — adding a hash-equality assertion is a separate hardening PR; the no-quoting prose is currently identical and the test's existence-grep prevents a worse regression (any agent dropping the rule entirely fails CI).
- **silent-failure-hunter wave-sequencing reject:** False positive. Reviewer didn't have visibility into the wave plan (spec describes wave-1 as RED phase; wave-2 lands the SKILL.md edits that turn the test green). Documented for transparency; no action.
- **type-design-analyzer reject:** Same wave-sequencing false positive. Frontmatter schema inconsistency note recorded as a follow-up candidate.
- **comment-analyzer minor (issue-number cross-ref):** Defer. Issue numbers in this repo are stable; the comment serves as a durable anchor for archeology.

## Wave-1 final state

- 7/9 tests green (review-pr.test.sh now 22/22, others unchanged from before)
- 2/9 tests red BY DESIGN — finish-branch-auto-chain.test.sh and turbo-flow.test.sh assert wave-2's SKILL.md edits.
- 11 commits in `dc07f8c..HEAD` (10 wave-1 task commits + 1 fixup commit for F1/F2/F4).

### post-impl-review-wave-2.md
# Post-impl review — wave 2 (issue #20)

| Agent | Verdict | Top finding |
|-------|---------|-------------|
| code-reviewer        | REVISIONS_REQUIRED | **3 CRITICAL** + 2 IMPORTANT (BLOCKING). F1: `gitleaks stdin --no-git` is invented flag (gitleaks 8.x errors "unknown flag"). F2: `gh pr create --title-file` is invented flag (gh 2.83.1 errors "unknown flag" — every invocation broken, AC1/AC3 fail). F3: `printf %q` mangles title content (shell-quoted form). F4: `git diff --staged` is empty post-SDD. F5: `git push` exit code unchecked. |
| code-simplifier      | APPROVE_WITH_NITS | F1 same as code-reviewer's F3 (printf %q wrong defense). F2: DRY for two scan abort blocks (consolidate into helper). Confirmed gitleaks+regex layering is justified, not overengineered. |
| silent-failure-hunter | REVISIONS_REQUIRED | ERR-001/002/003 same as code-reviewer's F1 (gitleaks errors swallowed by `\|\| true`, no pipefail, regex grep errors hidden). ERR-004: PR_URL validation conflates "gh failed" with "gh returned non-URL". |
| type-design-analyzer | APPROVE_WITH_FINDINGS | WARN_SPAM: `UBERDEV_SCAN_WARNED` export across subshell boundary is a no-op (warning prints twice). Mode precedence airtight. |
| comment-analyzer     | CONDITIONAL APPROVE | Stale "old line 164" reference; vague "per Q12 / per #11 Q1" cross-refs. Minor. |

**Aggregated:** 3 blockers (F1, F2, F3 — all CRITICAL real bugs verified via live tool invocation), 6+ suggestions. **Continue ONLY after blockers fixed.**

## Live verification of CRITICAL findings

```
$ echo 'token: ghp_abc...' | gitleaks stdin --no-git --no-banner 2>&1 | head
Error: unknown flag: --no-git

$ echo "test" > /tmp/title.txt && echo "test" > /tmp/body.txt
$ gh pr create --title-file /tmp/title.txt --body-file /tmp/body.txt 2>&1 | head
unknown flag: --title-file
```

Both flags don't exist. F1 and F2 are CONFIRMED REAL BUGS that would have shipped a broken security gate.

## Resolution log (commit 0xnext fixup)

- **F1 (gitleaks --no-git invented):** Fixed. Dropped `--no-git`. Switched from `gitleaks ... 2>&1 | grep -E '(WRN|finding:)' || true` (which false-positives "no leaks found" as a finding via the substring `leaks found`) to gitleaks's authoritative exit code. Live tested: clean text → empty SCAN_OUT (proceed); a fake-but-real-shape AWS access-token string (value redacted — gitleaks rule `aws-access-token` triggered as expected) → non-empty SCAN_OUT (abort).
- **F2 (gh --title-file invented):** Fixed. Replaced `--title-file` with the heredoc + read-back pattern: `cat > "$TITLE_FILE" <<'PR_TITLE_EOF'` (single-quoted EOF prevents shell expansion of agent text), `IFS= read -r PR_TITLE_VAR < "$TITLE_FILE"`, then `gh pr create --title "$PR_TITLE_VAR" --body-file "$PR_BODY_FILE"`. Double-quoted variable expansion is byte-verbatim, so backticks/dollars in the title content do NOT trigger shell re-evaluation. Closes the title-injection vector without inventing a flag.
- **F3 (printf %q wrong defense):** Fixed via the heredoc replacement above; printf %q removed entirely.
- **F4 (staged diff empty post-SDD):** Fixed. Scan target 1 changed to `git diff @{u}..HEAD` (the actual to-be-pushed range), with merge-base fallback for fresh branches (`origin/main`/`origin/master`/`HEAD~1`).
- **F5 (git push exit-code unchecked):** Fixed. Wrapped in `if ! git push ...; then; fi` with explicit error message + tmp cleanup + worktree preservation + exit 1.
- **ERR-004 (gh exit-code conflated with URL parse):** Fixed. `if ! PR_URL=$(gh pr create ...); then` captures gh's exit code separately; URL regex validation runs only on success path.
- **WARN_SPAM (UBERDEV_SCAN_WARNED no-op across subshell):** Fixed. Moved warning out of the function into the parent shell where it prints once unconditionally when gitleaks is missing.
- **F2-simplifier (DRY scan abort blocks):** Fixed. Hoisted into `abort_if_secret <label> <hit>` helper invoked twice (17 lines → 11 lines).
- **Comment-analyzer "old line 164" stale ref:** Comment kept, but the explanatory body was rewritten to focus on WHY (`gh pr create --title-file` doesn't exist, so heredoc + quoted-var read-back is the actual injection-close) rather than referring to a line number that will rot. Stale ref removed.

## Wave-2 final state (after fixups)

- 9/9 tests green: 190/190 assertions pass
- All 3 CRITICAL bugs verified fixed via live tool invocation (gitleaks detects real AWS keys; gh accepts the new --title pattern)
- Wave-2 net change: 1 new commit (post-impl-review fixup) on top of the original T11 commit
- Step 6 invariants: Announce at start = 1, For Options 2 and 3 = 1, Co-Authored-By = 0

## Findings deferred (advisory only, non-blocking)

- comment-analyzer "per Q12" / "per #11 Q1" vague cross-refs: kept as-is; the references point to durable RFC content tracked elsewhere.
- comment-analyzer commit-SHA references (73b2562): kept; SHAs are stable in git history.
- type-design-analyzer PR_BODY_FILE created before mode selection (interactive Option 1/3/4 leaves stale tmp file): pre-existing behavior, not introduced by wave-2; out of scope.
- code-reviewer suggested wave-3 task: runtime-flag-validation smoke test that checks gh and gitleaks help output for documented flags — accepted as good idea, deferred to follow-up PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for branch finalization and PR review workflows with validation of PR creation, secret scanning, and chaining behavior.

* **New Features**
  * Added turbo mode for streamlined branch finalization with automatic PR creation and review.
  * Introduced interactive mode option to restore traditional step-by-step workflow.

* **Chores**
  * Enhanced PR creation with secret scanning validation before pushing.
  * Strengthened security constraints across code analysis agents to prevent accidental secret exposure in reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->