### PR TITLE
feat(uberdev): /merge --yes / auto_confirm to skip plan-confirm prompt

### DIFF
--- a/plugins/uberdev/commands/merge.md
+++ b/plugins/uberdev/commands/merge.md
@@ -20,6 +20,6 @@ Land approved PRs into the integration branch — ordering, strategy, conflict r
 - `--integration-branch=<name>` → override config / env / repo-default.
 - `--bypass-protections` → admin-bypass branch protections (audit-logged with required free-text waiver).
 
-**Auto-confirm:** the plan-confirm `[y/N]` prompt is suppressed when (1) `--yes` / `-y` is passed, (2) `.claude/uberdev.local.md` sets `auto_confirm: true`, OR (3) the post-gate merge set contains exactly one PR (single-PR scope default — the explicit PR number is the consent).
+**Auto-confirm:** the plan-confirm `[y/N]` prompt is suppressed when (1) `--yes` / `-y` is passed, (2) `.claude/uberdev.local.md` sets `auto_confirm: true`, OR (3) the post-gate merge set contains exactly one PR (single-PR scope default — the explicit PR number is the consent). Under auto-confirm, the Phase 4.5 stale-branch offer also becomes list-only — no per-branch prompts and no auto-rebase. /merge **never** runs `git rebase` automatically; auto-confirm only suppresses the offer.
 
 Now invoke the `uberdev:merge` skill — it owns the 4-phase pipeline (pre-flight gate, merge plan, merge + parallel conflict-resolve, post-merge local sync). The skill renders inline, so `$ARGUMENTS` remains in scope for its bash blocks.

--- a/plugins/uberdev/commands/merge.md
+++ b/plugins/uberdev/commands/merge.md
@@ -1,6 +1,6 @@
 ---
 description: "After a PR is approved, lands it into the integration branch — ordering, strategy, conflict resolution, and local sync automated"
-argument-hint: "[<PR#> | --all] [--squash|--rebase|--merge] [--integration-branch=<name>] [--bypass-protections]"
+argument-hint: "[<PR#> | --all] [--yes|-y] [--squash|--rebase|--merge] [--integration-branch=<name>] [--bypass-protections]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 ---
 
@@ -10,13 +10,16 @@ Land approved PRs into the integration branch — ordering, strategy, conflict r
 
 **RULES:** Do NOT use the Task tool or internal subagents. The skill body owns all logic.
 
-**Usage:** `/merge [<PR#> | --all] [--squash|--rebase|--merge] [--integration-branch=<name>] [--bypass-protections]`
+**Usage:** `/merge [<PR#> | --all] [--yes|-y] [--squash|--rebase|--merge] [--integration-branch=<name>] [--bypass-protections]`
 
-- No args → land the PR for the current branch (errors if none)
-- `<PR#>` → land a specific PR
-- `--all` → land every open APPROVED PR with passing CI
-- `--squash` / `--rebase` / `--merge` → override per-PR strategy heuristic
-- `--integration-branch=<name>` → override config / env / repo-default
-- `--bypass-protections` → admin-bypass branch protections (audit-logged with required free-text waiver)
+- No args → land the PR for the current branch (errors if none). Single-PR scope auto-confirms by default.
+- `<PR#>` → land a specific PR. Single-PR scope auto-confirms by default.
+- `--all` → land every open APPROVED PR with passing CI. Multi-PR scope prompts unless `--yes` or `auto_confirm: true` config.
+- `--yes` / `-y` → skip the plan-confirm prompt and stale-branch per-branch prompts for this run.
+- `--squash` / `--rebase` / `--merge` → override per-PR strategy heuristic.
+- `--integration-branch=<name>` → override config / env / repo-default.
+- `--bypass-protections` → admin-bypass branch protections (audit-logged with required free-text waiver).
+
+**Auto-confirm:** the plan-confirm `[y/N]` prompt is suppressed when (1) `--yes` / `-y` is passed, (2) `.claude/uberdev.local.md` sets `auto_confirm: true`, OR (3) the post-gate merge set contains exactly one PR (single-PR scope default — the explicit PR number is the consent).
 
 Now invoke the `uberdev:merge` skill — it owns the 4-phase pipeline (pre-flight gate, merge plan, merge + parallel conflict-resolve, post-merge local sync). The skill renders inline, so `$ARGUMENTS` remains in scope for its bash blocks.

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -35,6 +35,10 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `BOT_AUTHORS_DEFAULT` | `["dependabot[bot]", "renovate[bot]"]` | D-BOTS |
 | `INTEGRATION_BRANCH_KEY` | `integration_branch` (config key) | D8 |
 | `INTEGRATION_BRANCH_ENV_VAR` | `UBERDEV_INTEGRATION_BRANCH` | D8 |
+| `AUTO_CONFIRM_KEY` | `auto_confirm` (config key in `.claude/uberdev.local.md`) | Phase 2.4, Phase 4.5 |
+| `AUTO_CONFIRM_FLAGS` | `--yes`, `-y` (CLI flags) | Phase 2.4, Phase 4.5 |
+| `AUTO_CONFIRM_DEFAULT_MULTI` | `false` — `--all` / multi-PR scope prompts unless `--yes` or `auto_confirm: true` | Phase 2.4 |
+| `AUTO_CONFIRM_DEFAULT_SINGLE` | `true` — single-PR scope (no `--all`) skips the plan prompt by default | Phase 2.4 |
 
 ## Inputs
 
@@ -43,6 +47,10 @@ Argument parsing:
 - **No args** — use the current branch's PR if one exists. If the current branch has no open PR, error out with a clear message pointing to `finish-branch`.
 - **`<PR#>`** (single positional integer) — single-PR mode; operate on exactly that PR number.
 - **`--all`** — enumerate all open PRs that are APPROVED and have passing required CI checks; treat the result as the input set.
+- **`--squash` / `--rebase` / `--merge`** — per-invocation strategy override (see `STRATEGY_ENUM`); applies to every PR in the run.
+- **`--integration-branch=<name>`** — per-invocation override of the integration-branch precedence chain (see below).
+- **`--bypass-protections`** — admin-bypass branch protections; requires a free-text waiver and is audit-logged.
+- **`--yes` / `-y`** — skip the Phase 2.4 plan-confirm prompt and the Phase 4.5 stale-branch per-branch prompts for this run (see `AUTO_CONFIRM_FLAGS` and the auto-confirm resolution chain below).
 
 Integration-branch resolution (four-tier precedence chain, highest wins):
 
@@ -52,6 +60,16 @@ Integration-branch resolution (four-tier precedence chain, highest wins):
 4. **Fallback** `gh repo view --json defaultBranchRef` — GitHub's recorded default branch.
 
 Branch names (from any tier) MUST be validated against `BRANCH_NAME_REGEX` before being used as a shell argv. Reject and error out on any name that fails the regex; do not pass unvalidated input to `git`, `gh`, or any subprocess.
+
+Auto-confirm resolution (CLI flag wins, then config, then scope-based default):
+
+1. **CLI flag** `--yes` / `-y` (see `AUTO_CONFIRM_FLAGS`) → auto-confirm ON for this run.
+2. **Config file** `.claude/uberdev.local.md` YAML key `AUTO_CONFIRM_KEY` (`auto_confirm: true|false`) → repo-local default. `true` enables; `false` disables.
+3. **Scope-based default** (when neither flag nor config is set):
+   - Single-PR scope (no `--all`, exactly 1 PR in the post-gate merge set) → `AUTO_CONFIRM_DEFAULT_SINGLE` (`true`). The user named the PR explicitly; the [y/N] prompt is redundant. The plan table is still rendered for transparency.
+   - `--all` / multi-PR scope (`gh pr list` enumerated more than 1 PR) → `AUTO_CONFIRM_DEFAULT_MULTI` (`false`). User-explicit confirmation is required because the PR list is computed by /merge, not specified by the user.
+
+When auto-confirm is ON, Phase 2.4 skips the `[y/N]` prompt and Phase 4.5 lists stale branches without per-branch rebase prompts (see those phases for exact behavior).
 
 ## Phase 1 — Pre-flight gate
 
@@ -131,11 +149,22 @@ Other label syntaxes (`strategy:<name>`, `merge:<name>`) are NOT recognised — 
 
 Render a single markdown table with these columns: `PR#`, `title`, `strategy`, `reasoning` (one-line citing the dominant signal — flag, label, conventional-commit ratio, etc.), `conflict-resolve-needed?` (Y/N from probe; Phase 3 will re-probe but a Phase-2 merge-tree pass gives the user a preview).
 
-### Step 2.4 — Single confirm gate (the ONLY user-confirm point in /merge)
+### Step 2.4 — Plan-confirm gate (single, scope-conditional)
 
-Display the plan table to the user. Prompt: "Apply this plan? [y/N]". On `y`: proceed to Phase 3. On anything else: abort cleanly, write `order_proposed`+`error` events to `audit.jsonl`, release the lock.
+Resolve `auto_confirm` per the precedence chain in `## Inputs` (CLI flag → config → scope-based default).
 
-**There are no other user-confirm gates in /merge.** Do NOT prompt after each PR merges. (Spec Non-goal: "no mid-flow gates after each PR merges.")
+**If auto-confirm is ON:**
+- Render the plan table for transparency.
+- Emit `order_proposed` + `order_confirmed` events to `audit.jsonl` with the resolution reason recorded in `data` (e.g., `{"reason": "single-pr-default"}`, `{"reason": "cli-flag"}`, `{"reason": "config-auto_confirm"}`).
+- Proceed directly to Phase 3 — no `[y/N]` prompt.
+
+**If auto-confirm is OFF (default for `--all` / multi-PR scope unless `--yes` or `auto_confirm: true`):**
+- Display the plan table.
+- Prompt: `Apply this plan? [y/N]`.
+- On `y`: emit `order_confirmed`, proceed to Phase 3.
+- On anything else: abort cleanly, write `order_proposed` + `error` events to `audit.jsonl`, release the lock.
+
+**This is the ONLY plan-level confirm gate in /merge.** Do NOT prompt after each PR merges. (Spec Non-goal: "no mid-flow gates after each PR merges.") Phase 4.5 stale-branch handling has its own conditional prompt — see that step.
 
 ## Phase 3 — Merge and conflict-resolve
 
@@ -241,13 +270,22 @@ git for-each-ref --format='%(refname:short)' refs/heads | while read b; do
 done
 ```
 
-Display the list to the user. For each branch, offer per-branch rebase ONLY after typed user confirmation:
+Display the list to the user. Behavior depends on the `auto_confirm` resolution from `## Inputs`:
 
-```
-Rebase <branch> onto <integration_branch>? Type 'yes' to confirm: _
-```
+**If auto-confirm is ON** (CLI `--yes`, `auto_confirm: true` config, or single-PR scope default):
+- List the stale branches with a one-line note: `These branches will need a manual rebase next time you check them out.`
+- Do NOT prompt and do NOT auto-rebase. The rebase is destructive (rewrites history) and could break in-flight work — staying hands-off is the safe default in auto-confirm mode.
 
-Anything other than the literal string `yes` skips. **Never auto-execute** — destructive enough to deserve explicit per-branch consent (spec Non-goal).
+**If auto-confirm is OFF:**
+- For each branch, offer per-branch rebase ONLY after typed user confirmation:
+
+  ```
+  Rebase <branch> onto <integration_branch>? Type 'yes' to confirm: _
+  ```
+
+- Anything other than the literal string `yes` skips. **Never auto-execute** — destructive enough to deserve explicit per-branch consent (spec Non-goal).
+
+In either mode, /merge **never auto-rebases** stale local branches without an explicit per-branch typed `yes`. Auto-confirm only suppresses the prompt; it does not authorise the action.
 
 ### Step 4.6 — Release the lock
 
@@ -258,7 +296,7 @@ Anything other than the literal string `yes` skips. **Never auto-execute** — d
 | Phase | Inputs | Outputs | Abort conditions |
 |---|---|---|---|
 | 1 — Pre-flight | argv, PR list, integration_branch (resolved), bot allow-list | passing PR set, file-overlap matrix, fork preflight verdicts, lock acquired | lock contention (default fail-fast); single-PR fail when only one PR in scope; gh JSON unreadable |
-| 2 — Merge plan | passing PR set + file-overlap matrix | ordered plan table {PR#, strategy, reasoning, conflict-resolve?} + user confirm | hard-dep cycle; user declines confirm |
+| 2 — Merge plan | passing PR set + file-overlap matrix + auto-confirm resolution | ordered plan table {PR#, strategy, reasoning, conflict-resolve?}; user confirm IF auto-confirm OFF | hard-dep cycle; user declines confirm (only when prompted) |
 | 3 — Merge + resolve | confirmed plan | per-PR merge result (success/skipped/aborted) + audit events | test gate fail (that PR aborts); agent AMBIGUOUS/REFUSED (queue halts); push non-FF (queue halts); fork org-owned (that PR skips) |
 | 4 — Local sync | merged PR list | local integration ff'd, worktrees removed, branches deleted, stale-branch offers | `git pull --ff-only` non-FF (fail-loud); branch not fully merged (refuse `-d`) |
 
@@ -272,7 +310,8 @@ Anything other than the literal string `yes` skips. **Never auto-execute** — d
 - **Splitting the conflict-resolver Task() fanout across multiple assistant turns.** Single message. Mirrors `uberdev:post-impl-review`.
 - **Writing the resolution patch outside the conflict set.** Each agent owns ONE file; touching `.github/`, `.git/`, hooks, or any path outside its file_path is rejected (treated as REFUSED).
 - **Skipping the test gate** before pushing the resolution commit. No skip path. Failing tests block that PR's merge.
-- **Auto-rebasing stale local branches** in Phase 4. List + offer only. Per-branch typed confirmation.
+- **Auto-rebasing stale local branches** in Phase 4. List only (auto-confirm mode) or list + per-branch typed confirmation (interactive mode). Auto-confirm suppresses the prompt; it does NOT authorise auto-rebase.
+- **Prompting `[y/N]` after the user typed `/merge <PR#>`.** Single-PR scope is auto-confirm by default; the explicit PR number is the consent. Only `--all` / multi-PR scope keeps the prompt unless `--yes` or `auto_confirm: true`.
 - **Auto-creating a merge commit** when `git pull --ff-only` fails. Fail-loud; never recover via merge commit.
 - **`--admin`/`--bypass-protections` without a free-text waiver.** Every bypass invocation MUST log `admin_bypass`+`waiver_recorded` events with the user's stated reason.
 

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -39,6 +39,7 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `AUTO_CONFIRM_FLAGS` | `--yes`, `-y` (CLI flags) | Phase 2.4, Phase 4.5 |
 | `AUTO_CONFIRM_DEFAULT_MULTI` | `false` — `--all` / multi-PR scope prompts unless `--yes` or `auto_confirm: true` | Phase 2.4 |
 | `AUTO_CONFIRM_DEFAULT_SINGLE` | `true` — single-PR scope (no `--all`) skips the plan prompt by default | Phase 2.4 |
+| `AUTO_CONFIRM_REASON_ENUM` | `single-pr-default`, `cli-flag`, `config-auto_confirm` (audit-log `data.reason` values when auto-confirm is ON) | Phase 2.4 |
 
 ## Inputs
 
@@ -66,8 +67,8 @@ Auto-confirm resolution (CLI flag wins, then config, then scope-based default):
 1. **CLI flag** `--yes` / `-y` (see `AUTO_CONFIRM_FLAGS`) → auto-confirm ON for this run.
 2. **Config file** `.claude/uberdev.local.md` YAML key `AUTO_CONFIRM_KEY` (`auto_confirm: true|false`) → repo-local default. `true` enables; `false` disables.
 3. **Scope-based default** (when neither flag nor config is set):
-   - Single-PR scope (no `--all`, exactly 1 PR in the post-gate merge set) → `AUTO_CONFIRM_DEFAULT_SINGLE` (`true`). The user named the PR explicitly; the [y/N] prompt is redundant. The plan table is still rendered for transparency.
-   - `--all` / multi-PR scope (`gh pr list` enumerated more than 1 PR) → `AUTO_CONFIRM_DEFAULT_MULTI` (`false`). User-explicit confirmation is required because the PR list is computed by /merge, not specified by the user.
+   - Single-PR scope (exactly 1 PR in the post-gate merge set) → `AUTO_CONFIRM_DEFAULT_SINGLE` (`true`). The explicit PR number is the consent; the plan table still renders for transparency.
+   - Multi-PR scope (`--all`, more than 1 PR) → `AUTO_CONFIRM_DEFAULT_MULTI` (`false`). The PR list is computed, not user-specified, so confirmation is required.
 
 When auto-confirm is ON, Phase 2.4 skips the `[y/N]` prompt and Phase 4.5 lists stale branches without per-branch rebase prompts (see those phases for exact behavior).
 
@@ -155,7 +156,7 @@ Resolve `auto_confirm` per the precedence chain in `## Inputs` (CLI flag → con
 
 **If auto-confirm is ON:**
 - Render the plan table for transparency.
-- Emit `order_proposed` + `order_confirmed` events to `audit.jsonl` with the resolution reason recorded in `data` (e.g., `{"reason": "single-pr-default"}`, `{"reason": "cli-flag"}`, `{"reason": "config-auto_confirm"}`).
+- Emit `order_proposed` + `order_confirmed` events to `audit.jsonl` with the resolution reason recorded in `data.reason` (one of `AUTO_CONFIRM_REASON_ENUM`: `single-pr-default`, `cli-flag`, `config-auto_confirm`). Use the literal enum value — do not invent new strings.
 - Proceed directly to Phase 3 — no `[y/N]` prompt.
 
 **If auto-confirm is OFF (default for `--all` / multi-PR scope unless `--yes` or `auto_confirm: true`):**
@@ -285,7 +286,7 @@ Display the list to the user. Behavior depends on the `auto_confirm` resolution 
 
 - Anything other than the literal string `yes` skips. **Never auto-execute** — destructive enough to deserve explicit per-branch consent (spec Non-goal).
 
-In either mode, /merge **never auto-rebases** stale local branches without an explicit per-branch typed `yes`. Auto-confirm only suppresses the prompt; it does not authorise the action.
+**Invariant:** /merge **never** runs `git rebase` automatically. Auto-confirm suppresses the prompt and skips the offer; it does not substitute for the typed `yes` that interactive mode requires.
 
 ### Step 4.6 — Release the lock
 
@@ -310,7 +311,7 @@ In either mode, /merge **never auto-rebases** stale local branches without an ex
 - **Splitting the conflict-resolver Task() fanout across multiple assistant turns.** Single message. Mirrors `uberdev:post-impl-review`.
 - **Writing the resolution patch outside the conflict set.** Each agent owns ONE file; touching `.github/`, `.git/`, hooks, or any path outside its file_path is rejected (treated as REFUSED).
 - **Skipping the test gate** before pushing the resolution commit. No skip path. Failing tests block that PR's merge.
-- **Auto-rebasing stale local branches** in Phase 4. List only (auto-confirm mode) or list + per-branch typed confirmation (interactive mode). Auto-confirm suppresses the prompt; it does NOT authorise auto-rebase.
+- **Auto-rebasing stale local branches** in Phase 4. Phase 4.5 invariant: never run `git rebase` automatically — auto-confirm only suppresses the offer.
 - **Prompting `[y/N]` after the user typed `/merge <PR#>`.** Single-PR scope is auto-confirm by default; the explicit PR number is the consent. Only `--all` / multi-PR scope keeps the prompt unless `--yes` or `auto_confirm: true`.
 - **Auto-creating a merge commit** when `git pull --ff-only` fails. Fail-loud; never recover via merge commit.
 - **`--admin`/`--bypass-protections` without a free-text waiver.** Every bypass invocation MUST log `admin_bypass`+`waiver_recorded` events with the user's stated reason.

--- a/plugins/uberdev/skills/using-uberdev/SKILL.md
+++ b/plugins/uberdev/skills/using-uberdev/SKILL.md
@@ -128,6 +128,7 @@ solve_terminal: ghostty          # one of: ghostty, iterm, cmux
 parallel_solve: true
 auto_install_aliases: true       # boolean — auto-install /issue, /solve, /turbo, /simplify, /review-pr, /merge at SessionStart (default: true; env override: UBERDEV_NO_AUTO_ALIAS=1)
 integration_branch: main         # branch /merge lands PRs into; default = repo default branch
+auto_confirm: false              # boolean — when true, /merge skips the Phase 2.4 plan-confirm prompt and Phase 4.5 stale-branch prompts (CLI flag --yes wins per-run)
 bot_authors_allow_list:          # PRs from these author logins bypass the
   - dependabot[bot]              # external-contributor refusal logic
   - renovate[bot]
@@ -143,5 +144,7 @@ Settings take effect on next SessionStart. Environment variables (`SOLVE_TERMINA
 **`integration_branch` precedence:** CLI flag `--integration-branch=<name>` > env var `UBERDEV_INTEGRATION_BRANCH` > config file (this YAML) > `gh repo view --json defaultBranchRef`. If all four tiers are empty, `/merge` asks once and offers to persist the answer to this file via an atomic `mktemp + mv` write.
 
 **`bot_authors_allow_list` semantics:** literal `author.login` matched case-sensitively. Default covers Dependabot and Renovate.
+
+**`auto_confirm` precedence:** CLI flag `--yes` / `-y` (per-run) > config file `auto_confirm: true|false` > scope-based default. Scope-based default: single-PR scope auto-confirms (the explicit PR number is the consent); `--all` / multi-PR scope prompts. Auto-confirm suppresses the Phase 2.4 plan `[y/N]` prompt and the Phase 4.5 stale-branch per-branch prompts; it never authorises destructive actions like auto-rebase — those still require explicit per-branch typed `yes` even when prompted.
 
 **Recommendation:** commit this file to share workflow conventions across the team; or add it to `.gitignore` if individual preferences differ.

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -205,6 +205,85 @@ else
 fi
 
 echo
+echo "== M17: SKILL.md declares AUTO_CONFIRM_* constants and the auto-confirm precedence chain =="
+# M17 locks the new auto-confirm spec invariants from the PR that
+# softened Phase 2.4. Without these asserts, a future "simplify the
+# prose" pass could silently delete the constants or the precedence
+# chain — the implementation would still work, but readers (human and
+# LLM) would lose the contract.
+assert_grep "$SKILL_FILE" '`AUTO_CONFIRM_KEY`' \
+  "M17.1 — AUTO_CONFIRM_KEY constant declared"
+assert_grep "$SKILL_FILE" '`AUTO_CONFIRM_FLAGS`' \
+  "M17.2 — AUTO_CONFIRM_FLAGS constant declared (CLI flags)"
+assert_grep "$SKILL_FILE" '`AUTO_CONFIRM_DEFAULT_(SINGLE|MULTI)`' \
+  "M17.3 — AUTO_CONFIRM_DEFAULT_SINGLE/MULTI constants declared"
+assert_grep "$SKILL_FILE" 'Auto-confirm resolution.*CLI flag wins' \
+  "M17.4 — auto-confirm precedence chain (CLI > config > scope) documented in Inputs"
+
+echo
+echo "== M18: SKILL.md Phase 2.4 documents both auto-confirm ON and OFF branches =="
+# M18 prevents silent deletion of either branch — interactive [y/N]
+# users (auto-confirm OFF) and auto-mode users (auto-confirm ON) must
+# both stay supported.
+if awk '/^### Step 2\.4/,/^## Phase 3/' "$SKILL_FILE" | \
+     grep -qE 'If auto-confirm is ON' && \
+   awk '/^### Step 2\.4/,/^## Phase 3/' "$SKILL_FILE" | \
+     grep -qE 'If auto-confirm is OFF'; then
+  echo "  PASS  M18.1 — Phase 2.4 documents both auto-confirm ON and OFF branches"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M18.1 — Phase 2.4 must document BOTH 'If auto-confirm is ON' AND 'If auto-confirm is OFF'"
+  FAIL=$((FAIL + 1))
+fi
+assert_grep "$SKILL_FILE" 'Apply this plan\?' \
+  "M18.2 — interactive-mode prompt 'Apply this plan?' present"
+
+echo
+echo "== M19: SKILL.md Phase 4.5 states the no-auto-rebase invariant AND covers both modes =="
+# M19 is load-bearing: Phase 4.5 stale-branch handling MUST never
+# auto-rebase. Auto-confirm only suppresses the offer; it never
+# authorises destructive history-rewriting. A future edit that wires
+# auto-confirm to auto-rebase "for efficiency" could silently rewind
+# the user's in-flight work.
+assert_grep "$SKILL_FILE" 'never\*\* runs `git rebase` automatically|Never auto-execute' \
+  "M19.1 — Phase 4.5 'never auto-rebase' invariant stated"
+if awk '/^### Step 4\.5/,/^### Step 4\.6/' "$SKILL_FILE" | \
+     grep -qE 'If auto-confirm is ON' && \
+   awk '/^### Step 4\.5/,/^### Step 4\.6/' "$SKILL_FILE" | \
+     grep -qE 'If auto-confirm is OFF'; then
+  echo "  PASS  M19.2 — Phase 4.5 documents both auto-confirm ON (list-only) and OFF (per-branch typed yes) branches"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M19.2 — Phase 4.5 must document BOTH 'If auto-confirm is ON' AND 'If auto-confirm is OFF'"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== M20: commands/merge.md exposes --yes / -y in argument-hint AND Usage line =="
+# M20 keeps the dispatcher's frontmatter and body in sync. argument-hint
+# powers slash-help auto-completion; Usage is the human-readable line.
+# Drift between the two confuses the user.
+assert_grep "$CMD_FILE" '^argument-hint:.*--yes\|-y' \
+  "M20.1 — argument-hint frontmatter lists --yes|-y"
+assert_grep "$CMD_FILE" '^\*\*Usage:\*\*.*--yes\|-y' \
+  "M20.2 — Usage line lists --yes|-y"
+assert_grep "$CMD_FILE" '`--yes` / `-y`.*skip' \
+  "M20.3 — doc bullet for --yes / -y describes prompt suppression"
+
+echo
+echo "== M21: using-uberdev/SKILL.md documents auto_confirm in YAML example AND precedence recap =="
+USING_SKILL_FILE="$REPO_ROOT/plugins/uberdev/skills/using-uberdev/SKILL.md"
+if [ ! -r "$USING_SKILL_FILE" ]; then
+  echo "  FAIL  M21 — using-uberdev SKILL.md missing or unreadable: $USING_SKILL_FILE"
+  FAIL=$((FAIL + 1))
+else
+  assert_grep "$USING_SKILL_FILE" '^auto_confirm:' \
+    "M21.1 — auto_confirm key present in YAML example"
+  assert_grep "$USING_SKILL_FILE" '\*\*`auto_confirm` precedence:\*\*' \
+    "M21.2 — auto_confirm precedence paragraph present"
+fi
+
+echo
 echo "== Summary =="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"


### PR DESCRIPTION
## Summary

After all the gates in `/merge` Phase 1 (`state OPEN`, `isDraft false`, `reviewDecision APPROVED`, CI green, author check) and after `/uberdev:review-pr` has already run, the Phase 2.4 `[y/N]` prompt felt redundant — especially for `/merge <PR#>` where the user explicitly named the PR. The merge would compute the plan, list one row, then ask the user to press a button. This PR softens that.

## What changed

Three ways to skip the plan-confirm prompt:

- **`--yes` / `-y`** CLI flag — per-run override
- **`auto_confirm: true`** in `.claude/uberdev.local.md` — repo-level default
- **Single-PR scope** (no `--all`, exactly one PR in the post-gate merge set) — new default. The explicit PR number is the consent; the plan table still renders for transparency.

`--all` / multi-PR scope still prompts unless `--yes` or `auto_confirm: true` — the PR list there is computed by `/merge`, not user-specified, so confirmation remains the safe default.

Phase 4.5 stale-branch handling under auto-confirm: list only, **no prompts and no auto-rebase**. Auto-confirm suppresses prompts; it does NOT authorise destructive history-rewriting actions. Interactive mode keeps the per-branch typed-`yes` gate unchanged.

## Files

- `plugins/uberdev/skills/merge/SKILL.md` — new constants (`AUTO_CONFIRM_KEY`, `AUTO_CONFIRM_FLAGS`, `AUTO_CONFIRM_DEFAULT_MULTI`, `AUTO_CONFIRM_DEFAULT_SINGLE`); flag bullets in `## Inputs`; auto-confirm resolution chain; Phase 2.4 rewrite (scope-conditional); Phase 4.5 rewrite (auto-confirm branch lists only).
- `plugins/uberdev/commands/merge.md` — `--yes` / `-y` in argument-hint, Usage line, doc bullet, auto-confirm summary block.
- `plugins/uberdev/skills/using-uberdev/SKILL.md` — `auto_confirm: false` in YAML example, precedence paragraph.

## Resolution precedence

```
CLI flag --yes / -y  >  auto_confirm: true|false (config)  >  scope-based default
                                                              ├─ single-PR → ON
                                                              └─ multi-PR / --all → OFF
```

## Test plan

- [x] `bash tests/merge.test.sh` — 29 PASS, 0 FAIL (no shape-check regressions; new constants and flags coexist with all existing M1–M16 invariants)
- [x] Full CI shape-check suite — 235 PASS across 9 test files (turbo-flow, issue-causal-fanout, post-impl-review, spec-reviewer-plan-aware, audit-fixups, review-pr, finish-branch-auto-chain, aliases, merge)
- [x] Spot-checked auto-confirm phrasing across all three docs is consistent (CLI flag wins → config → scope default)
- [ ] Manual: `/merge <PR#>` on a real approved PR confirms no `[y/N]` prompt
- [ ] Manual: `/merge --all` on multiple approved PRs still prompts (default-OFF)
- [ ] Manual: `/merge --all --yes` skips the prompt
- [ ] Manual: with `auto_confirm: true` in `.claude/uberdev.local.md`, `/merge --all` skips the prompt without `--yes`