### PR TITLE
feat(uberdev): /review-pr chains a mandatory simplify-pass after review-and-fix

### DIFF
--- a/plugins/uberdev/commands/review-pr.md
+++ b/plugins/uberdev/commands/review-pr.md
@@ -79,7 +79,7 @@ Pass `--no-simplify` (anywhere in the arguments) to skip Phase 2 and preserve th
 
    **Advisory-only findings** (where a lens declines to edit because the change carries behavior risk, or the agent flags a concern outside the iron-rule envelope) are **never silently dropped** — they surface in the Phase 2 row of the final aggregation table (step 8) so the human reviewer sees them.
 
-   **Non-blocking**: if the simplify-phase fanout itself fails (timeout, agent error, parse failure), `/review-pr` still exits successfully and reports the Phase 2 outcome as `BLOCKED` in the final aggregation. Phase 1 review-fix work is **not undone**, and the command continues regardless of Phase 2 verdicts.
+   **Non-blocking**: if the simplify-phase fanout itself fails (timeout, agent error, parse failure), `/review-pr` still exits successfully and reports the Phase 2 row's Status as `blocked` in the final aggregation (lowercase, matching the Status enum in step 9). Phase 1 review-fix work is **not undone**, and the command continues regardless of Phase 2 verdicts.
 
 8. **Final Aggregation — distinguish review-phase vs simplify-phase findings**
 

--- a/plugins/uberdev/commands/review-pr.md
+++ b/plugins/uberdev/commands/review-pr.md
@@ -1,7 +1,7 @@
 ---
 description: "Comprehensive PR review using specialized agents"
-argument-hint: "[review-aspects]"
-allowed-tools: ["Bash(git*)", "Bash(gh*)", "Glob", "Grep", "Read", "Task"]
+argument-hint: "[review-aspects] [--no-simplify]"
+allowed-tools: ["Bash(git*)", "Bash(gh*)", "Edit", "Glob", "Grep", "MultiEdit", "Read", "Task", "Write"]
 ---
 
 # Comprehensive PR Review
@@ -10,12 +10,20 @@ Run a comprehensive pull request review using multiple specialized agents, each 
 
 **Review Aspects (optional):** "$ARGUMENTS"
 
+`/uberdev:review-pr` is a true **two-phase** command. Both phases run by default — flow: **review fanout → fix loop → simplify fanout → final aggregation**.
+
+- **Phase 1 — Review + Fix loop**: parallel review fanout, then auto-apply fixes for the findings.
+- **Phase 2 — Simplify pass**: parallel fanout of the three simplify lenses (reuse / quality / efficiency) defined in `/uberdev:simplify`, with auto-applied edits committed separately. Single-message dispatch per the `uberdev:post-impl-review` contract.
+
+Pass `--no-simplify` (anywhere in the arguments) to skip Phase 2 and preserve the legacy single-pass behavior. Cost trade-off: Phase 2 adds three extra agent invocations per run; opt out for fast feedback loops on iterative review (e.g. when you've already run `/uberdev:simplify` separately).
+
 ## Review Workflow:
 
 1. **Determine Review Scope**
    - Check git status to identify changed files
    - Parse arguments to see if user requested specific review aspects
-   - Default: Run all applicable reviews
+   - Detect `--no-simplify` token in `$ARGUMENTS` and strip it from the aspect list — sets `SIMPLIFY_PHASE=0`, otherwise `SIMPLIFY_PHASE=1` (default)
+   - Default: Run all applicable reviews + Phase 2 simplify pass
 
 2. **Available Review Aspects:**
 
@@ -52,28 +60,59 @@ Run a comprehensive pull request review using multiple specialized agents, each 
    - Useful for interactive walkthroughs where you want to act on each report before the next
    - Otherwise, prefer parallel — wall-time scales with the slowest reviewer, not the sum
 
-6. **Aggregate Results**
+6. **Apply Phase 1 Fixes**
 
-   After agents complete, summarize:
+   Auto-apply the review fixes from the agent findings as one or more `fix:` / `refactor:` conventional commits. These are the **review-phase commits** — keep them distinct from the Phase 2 simplify commit (separate-commit invariant below).
+
+7. **Phase 2 — Mandatory Simplify Pass** (skip iff `SIMPLIFY_PHASE=0`)
+
+   After Phase 1 fixes land, dispatch the three simplify lenses (**Code Reuse Review**, **Code Quality Review**, **Code Efficiency Review**) as a parallel fanout — **all three Task() calls in a SINGLE assistant message, ONE assistant turn**, mirroring the `uberdev:post-impl-review` single-message dispatch contract. The lens-by-lens checklist (what each agent looks for) is the canonical definition in `/uberdev:simplify` Phase 2 — refer there rather than restate.
+
+   **Brief preparation** (mirrors `uberdev:post-impl-review` Step 1):
+
+   - Compute the post-Phase-1 diff once via `git diff <base>..HEAD` and pass the same brief verbatim to all three Task() calls.
+   - Truncation rule: if the diff exceeds 2000 lines, summarise per-file (path + 1-line summary) and inline only the files where per-line scrutiny matters for that lens. Same rule as `uberdev:post-impl-review` SKILL Step 1.
+
+   Each lens preserves the iron rule from `/uberdev:simplify`: **behavior preservation is non-negotiable.**
+
+   **Auto-apply simplify edits** in a separate `refactor:` conventional commit, distinct from the Phase 1 review-fix commits. Reviewers must be able to tell "review fixes" apart from "simplify pass" by commit boundary alone — this distinct commit boundary is mandatory, not stylistic.
+
+   **Advisory-only findings** (where a lens declines to edit because the change carries behavior risk, or the agent flags a concern outside the iron-rule envelope) are **never silently dropped** — they surface in the Phase 2 row of the final aggregation table (step 8) so the human reviewer sees them.
+
+   **Non-blocking**: if the simplify-phase fanout itself fails (timeout, agent error, parse failure), `/review-pr` still exits successfully and reports the Phase 2 outcome as `BLOCKED` in the final aggregation. Phase 1 review-fix work is **not undone**, and the command continues regardless of Phase 2 verdicts.
+
+8. **Final Aggregation — distinguish review-phase vs simplify-phase findings**
+
+   After Phase 1 fixes land and (if enabled) Phase 2 simplify edits land, summarize both phases in a single table that **distinguishes review-phase findings from simplify-phase findings**:
+
    - **Critical Issues** (must fix before merge)
    - **Important Issues** (should fix)
    - **Suggestions** (nice to have)
    - **Positive Observations** (what's good)
 
-7. **Provide Action Plan**
+9. **Provide Action Plan**
 
-   Organize findings:
+   Organize findings, with the review-phase vs simplify-phase distinction preserved in every row:
+
    ```markdown
    # PR Review Summary
 
+   ## Phase outcomes
+   | Phase | Status | Verdict | Auto-applied | Advisory findings |
+   |---|---|---|---|---|
+   | Phase 1 — Review + Fix | ran | APPROVE / REVISIONS_REQUIRED / REJECT | <commit shas> | <count> |
+   | Phase 2 — Simplify     | ran / blocked / skipped | APPROVE / REVISIONS_REQUIRED / REJECT (omit if status≠ran) | <commit sha or ∅> | <count> |
+
+   `Verdict` reuses the canonical `uberdev:post-impl-review` reviewer enum (APPROVE | REVISIONS_REQUIRED | REJECT). `Status` is orthogonal: `ran` (the fanout completed), `blocked` (fanout failure — see "Non-blocking" above), `skipped` (`--no-simplify` was set).
+
    ## Critical Issues (X found)
-   - [agent-name]: Issue description [file:line]
+   - [phase: review | simplify] [agent-name]: Issue description [file:line]
 
    ## Important Issues (X found)
-   - [agent-name]: Issue description [file:line]
+   - [phase: review | simplify] [agent-name]: Issue description [file:line]
 
    ## Suggestions (X found)
-   - [agent-name]: Suggestion [file:line]
+   - [phase: review | simplify] [agent-name]: Suggestion [file:line]
 
    ## Strengths
    - What's well-done in this PR
@@ -108,6 +147,15 @@ Run a comprehensive pull request review using multiple specialized agents, each 
 ```
 /uberdev:review-pr all sequential
 # Force one-at-a-time dispatch — use only for interactive walkthroughs
+```
+
+**Skip Phase 2 simplify pass** (legacy single-pass behavior):
+```
+/uberdev:review-pr --no-simplify
+# Run only Phase 1 review-and-fix; skip the mandatory simplify fanout.
+# Use when only correctness review is wanted (e.g. pre-merge gate after a
+# /simplify pass already ran). Combinable with aspect args:
+/uberdev:review-pr tests errors --no-simplify
 ```
 
 ## Agent Descriptions:

--- a/plugins/uberdev/lib/aliases-sync.sh
+++ b/plugins/uberdev/lib/aliases-sync.sh
@@ -25,7 +25,7 @@ ALIASES='issue|issue|["Bash", "Glob", "Grep", "Read", "Task"]
 solve|solve|["Bash", "Read", "Task"]
 turbo|turbo|["Bash", "Read", "Task"]
 simplify|simplify|["Bash", "Edit", "Glob", "Grep", "MultiEdit", "Read", "Task", "Write"]
-review-pr|review-pr|["Bash(git*)", "Bash(gh*)", "Glob", "Grep", "Read", "Task"]
+review-pr|review-pr|["Bash(git*)", "Bash(gh*)", "Edit", "Glob", "Grep", "MultiEdit", "Read", "Task", "Write"]
 merge|merge|["Bash", "Glob", "Grep", "Read", "Task"]'
 
 # Built-in Claude Code commands; never overwrite these.

--- a/tests/review-pr.test.sh
+++ b/tests/review-pr.test.sh
@@ -77,6 +77,57 @@ for f in "${AGENT_FILES[@]}"; do
 done
 
 echo
+echo "== Mandatory simplify pass after review-and-fix loop (#30) =="
+# /uberdev:review-pr is a true two-phase command: review fanout + fix loop,
+# THEN a mandatory simplify-agent fanout (the three lenses from /simplify),
+# THEN a final aggregation. Each assertion below shape-locks one acceptance
+# criterion from issue #30.
+# Anchor on the ordered arrow form "review fanout → fix loop → simplify
+# fanout → final aggregation". The arrows are the load-bearing landmarks —
+# without them, any prose mentioning the four words anywhere passes (the
+# previous loose alternative was tautological).
+assert_grep "$REVIEW_PR" \
+  'review fanout.*fix loop.*simplify fanout.*final aggregation' \
+  "phase ordering documented (review → fix → simplify → aggregation)"
+assert_grep "$REVIEW_PR" \
+  '[Cc]ode [Rr]euse|reuse[- ]review|reuse lens' \
+  "simplify lens 1: reuse named"
+assert_grep "$REVIEW_PR" \
+  '[Cc]ode [Qq]uality|quality[- ]review|quality lens' \
+  "simplify lens 2: quality named"
+assert_grep "$REVIEW_PR" \
+  '[Cc]ode [Ee]fficiency|efficiency[- ]review|efficiency lens' \
+  "simplify lens 3: efficiency named"
+# Case-insensitive collapses SINGLE/single and ONE/one — three alternatives
+# instead of six.
+if grep -qiE 'simplify.*single message|simplify.*one assistant turn|single message.*simplify' "$REVIEW_PR"; then
+  echo "  PASS  simplify-phase agents dispatched in a single message"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  simplify-phase agents dispatched in a single message"
+  echo "        file: $REVIEW_PR"
+  FAIL=$((FAIL + 1))
+fi
+assert_grep "$REVIEW_PR" \
+  'separate commit|distinct commit|separately from the review[- ]fix' \
+  "auto-applied simplify edits commit separately from review-fix commits"
+assert_grep "$REVIEW_PR" \
+  '--no-simplify' \
+  "--no-simplify opt-out flag documented"
+# Anchor advisory routing on the WHERE (Phase 2 / aggregation), not just the
+# bare word "advisory" anywhere in the file.
+assert_grep "$REVIEW_PR" \
+  '[Aa]dvisory[- ]only.*surface|surface in the Phase 2 row|never silently dropped|advisory.*aggregation' \
+  "advisory simplify findings appear in final aggregation"
+# Anchor non-blocking on Phase 2 / simplify context, not just the bare word
+# anywhere in the file.
+assert_grep "$REVIEW_PR" \
+  '[Ss]implify[- ]phase fanout itself fails|simplify.*do(es)? not undo|[Nn]on-blocking.*simplify|simplify.*[Nn]on-blocking|continues regardless of Phase 2' \
+  "non-blocking: simplify-phase failure does not undo review-and-fix"
+assert_grep "$REVIEW_PR" \
+  'review[- ]phase.*simplify[- ]phase|simplify[- ]phase.*review[- ]phase|review-phase vs simplify-phase|distinguish.*phase' \
+  "final aggregation distinguishes review-phase vs simplify-phase findings"
+
+echo
 echo "== Summary =="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"

--- a/tests/review-pr.test.sh
+++ b/tests/review-pr.test.sh
@@ -110,6 +110,13 @@ fi
 assert_grep "$REVIEW_PR" \
   'separate commit|distinct commit|separately from the review[- ]fix' \
   "auto-applied simplify edits commit separately from review-fix commits"
+# Lock the conventional-commit TYPE (refactor:), not just "separately". A change
+# from refactor: to chore:/fix:/feat: would otherwise pass the assertion above.
+# The pattern requires "refactor:" within scanning distance of "simplify" so the
+# bare token doesn't false-positive on unrelated prose mentioning refactor:.
+assert_grep "$REVIEW_PR" \
+  'simplify.*refactor:|refactor:.*simplify|[Aa]uto-apply simplify.*refactor:' \
+  "auto-applied simplify edits commit as refactor: conventional commit"
 assert_grep "$REVIEW_PR" \
   '--no-simplify' \
   "--no-simplify opt-out flag documented"


### PR DESCRIPTION
## Summary

- `/uberdev:review-pr` is now a **true two-phase command**: review fanout → fix loop → simplify fanout → final aggregation.
- After Phase 1 (existing review-and-fix loop), Phase 2 dispatches the three simplify lenses (Reuse / Quality / Efficiency) from `/uberdev:simplify` in a **single assistant turn**, mirroring the `uberdev:post-impl-review` dispatch contract (same brief, 2000-line truncation rule inherited).
- Auto-applied simplify edits land in a **separate `refactor:` commit**, distinct from the Phase 1 fix commits. Advisory-only findings surface in the Phase 2 row of the final aggregation — never silently dropped. Phase 2 fanout failures are **non-blocking**: Phase 1 work isn't undone, command exits successfully, failure reported as `blocked`.
- Final aggregation table distinguishes review-phase vs simplify-phase findings in every row. `Verdict` column reuses the canonical `uberdev:post-impl-review` enum (`APPROVE | REVISIONS_REQUIRED | REJECT`); `Status` is orthogonal (`ran / blocked / skipped`). Eliminates the previous `SKIPPED`-as-verdict divergence.
- `--no-simplify` opt-out preserves the legacy single-pass behavior (e.g. pre-merge gate after `/simplify` already ran).

## Acceptance criteria from #30

- [x] After `/review-pr`: review fanout → fix loop → simplify fanout → final aggregation
- [x] Simplify-phase agents dispatched in a SINGLE assistant message
- [x] Auto-applied simplify edits committed separately from review-fix commits
- [x] Advisory-only simplify findings appear in final summary
- [x] Existing single-pass behavior reachable via `--no-simplify` flag
- [x] Final aggregation distinguishes review-phase vs simplify-phase findings

## Test plan

- [x] Extended `tests/review-pr.test.sh` with 10 new shape-locks for issue #30 (phase ordering anchored on arrow form, three named lenses, single-message dispatch, separate-commit invariant, advisory-finding routing, non-blocking semantics, review-vs-simplify distinction, `--no-simplify` flag).
- [x] Phase-ordering pattern hardened against the tautological-second-alternative regression flagged during `/uberdev:simplify` review.
- [x] Advisory and non-blocking patterns anchored on Phase 2 / simplify context (no bare-word loophole).
- [x] Full shape-check suite green: `tests/aliases.test.sh` (55), `tests/review-pr.test.sh` (32), `tests/post-impl-review.test.sh` (11), and 7 others — 270 assertions, 0 failures.
- [x] `aliases-sync.sh` row for `review-pr` synced to canonical `allowed-tools` (Edit / MultiEdit / Write added — required because Phase 2 auto-applies edits in the orchestrator's own turn).

## Notes

The lens-by-lens checklists (what each agent looks for) are **referenced**, not restated, to prevent silent drift from `/uberdev:simplify`. Iron rule (behavior preservation) is cross-referenced for the same reason. Single-source-of-truth is `simplify.md`; `review-pr.md` carries only the integration contract.

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Two-phase review pipeline: Phase 1 auto-applies review fixes; optional Phase 2 runs simplification lenses and applies edits.
  * Added `--no-simplify` flag to disable Phase 2 while preserving Phase 1 behavior.

* **Documentation**
  * Updated review-pr command workflow, output format, and phase-aware aggregation table with status tracking and phase-prefixed issue rows.

* **Tests**
  * Enhanced test coverage for the two-phase pipeline, simplify phase validation, and `--no-simplify` opt-out flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->