### PR TITLE
fix(uberdev): /solve Ghostty dispatch poisons instance with --command= (#31)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,5 @@ jobs:
           bash tests/review-pr.test.sh && \
           bash tests/finish-branch-auto-chain.test.sh && \
           bash tests/aliases.test.sh && \
-          bash tests/merge.test.sh
+          bash tests/merge.test.sh && \
+          bash tests/ghostty-dispatch-no-instance-leak.test.sh

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -295,40 +295,53 @@ case "$TERMINAL" in
     cmux new-workspace --name "$TAB_NAME" --description "$DESCRIPTION" --command "zsh -l $SCRIPT"
     ;;
   ghostty)
-    # Tab-spawn into the originating Ghostty window when /solve or /turbo was invoked from
-    # inside Ghostty (TERM_PROGRAM=ghostty). Ghostty's macOS CLI rejects
-    # `+new-window` ("not supported on this platform") and its AppleScript
-    # dictionary doesn't expose `make new tab` cleanly, so we drive the
-    # default Cmd+T keybind via System Events and type the launcher path.
-    # Fall through to legacy new-window dispatch when:
-    #   - SOLVE_GHOSTTY_NEW_WINDOW=1 (explicit opt-out),
-    #   - TERM_PROGRAM != ghostty (no originating window — e.g. SOLVE_TERMINAL=ghostty
-    #     forced from another terminal),
-    #   - or the AppleScript fails (Accessibility permission denied, custom keybind, etc.).
-    TAB_SPAWNED=0
-    if [[ "$SOLVE_GHOSTTY_NEW_WINDOW" != "1" ]] && [[ "$TERM_PROGRAM" == "ghostty" ]]; then
-      if osascript >/dev/null 2>&1 <<APPLESCRIPT
+    # Drive Ghostty via AppleScript keystrokes (Cmd+T for tab, Cmd+N for window)
+    # and type the launcher path into the new tab/window. Keystroke dispatch
+    # types into a shell that's already started — it never sets any instance
+    # default, so future tabs/windows the user opens manually stay clean.
+    #
+    # Why we DON'T use `open -na Ghostty --args --command="$SCRIPT"`: Ghostty
+    # treats `--command=` passed via `open --args` as the running instance's
+    # default command. Once set, every Cmd+T / Cmd+N the user opens manually
+    # re-runs the launcher, racing the original agent and "poisoning" the
+    # Ghostty process for its lifetime (issue #31). There is no Ghostty CLI
+    # form that reliably runs a command once without sticking it as the default.
+    #
+    # Tab vs window:
+    #   - Cmd+T (tab) when /solve was invoked from inside Ghostty
+    #     (TERM_PROGRAM=ghostty) and SOLVE_GHOSTTY_NEW_WINDOW != "1": we have
+    #     an originating window to tab into.
+    #   - Cmd+N (window) when SOLVE_GHOSTTY_NEW_WINDOW=1 (explicit opt-out) or
+    #     TERM_PROGRAM != ghostty (e.g. SOLVE_TERMINAL=ghostty from iTerm —
+    #     no originating window to tab into).
+    if [[ "$SOLVE_GHOSTTY_NEW_WINDOW" == "1" ]] || [[ "$TERM_PROGRAM" != "ghostty" ]]; then
+      GHOSTTY_SPAWN_KEY="n"   # Cmd+N → new window
+      GHOSTTY_LAUNCH_DELAY="0.5"  # cold-launch may need longer if Ghostty isn't running
+    else
+      GHOSTTY_SPAWN_KEY="t"   # Cmd+T → new tab in the originating window
+      GHOSTTY_LAUNCH_DELAY="0.15"
+    fi
+
+    if osascript >/dev/null 2>&1 <<APPLESCRIPT
 tell application "Ghostty" to activate
-delay 0.15
+delay $GHOSTTY_LAUNCH_DELAY
 tell application "System Events"
-  keystroke "t" using command down
+  keystroke "$GHOSTTY_SPAWN_KEY" using command down
   delay 0.25
   keystroke "zsh -l $SCRIPT"
   keystroke return
 end tell
 APPLESCRIPT
-      then
-        TAB_SPAWNED=1
-      else
-        echo "warning: ghostty tab-spawn failed (Accessibility permission or non-default keybind?); falling back to new window." >&2
-      fi
-    fi
-    if [[ "$TAB_SPAWNED" != "1" ]]; then
-      # Legacy new-window dispatch. --command= rather than -e: Ghostty's -e appends to
-      # its login shell, which on macOS parses post-username tokens as KEY=VALUE env
-      # assignments — `-e "zsh -l $SCRIPT"` would never run the script. The launcher's
-      # `#!/bin/zsh -l` shebang preserves login-shell semantics inside `--command=`.
-      open -na Ghostty --args --command="$SCRIPT"
+    then
+      :  # dispatched via keystroke; no instance default was set
+    else
+      # AppleScript path failed (Accessibility permission denied or non-default
+      # Cmd+T/Cmd+N keybind). Fall back to a detached nohup run — never to
+      # `open -na Ghostty --args --command=...` because that re-introduces the
+      # issue #31 instance-default poison.
+      GHOSTTY_LOG="/tmp/solve-$ISSUE_NUM.log"
+      nohup zsh -l "$SCRIPT" > "$GHOSTTY_LOG" 2>&1 &
+      echo "warning: ghostty AppleScript dispatch failed (Accessibility permission or non-default Cmd+T/N keybind?); spawned detached agent (PID $!). Logs: $GHOSTTY_LOG" >&2
     fi
     ;;
   iterm)

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -333,12 +333,14 @@ tell application "System Events"
 end tell
 APPLESCRIPT
     then
-      :  # dispatched via keystroke; no instance default was set
+      echo "Dispatched into Ghostty (Cmd+$GHOSTTY_SPAWN_KEY)."
     else
       # AppleScript path failed (Accessibility permission denied or non-default
-      # Cmd+T/Cmd+N keybind). Fall back to a detached nohup run — never to
-      # `open -na Ghostty --args --command=...` because that re-introduces the
-      # issue #31 instance-default poison.
+      # Cmd+T/Cmd+N keybind). Fall back to a detached nohup run — nohup runs the
+      # launcher in a background shell of the current process, never passing any
+      # flag to the Ghostty app itself, so it can't reintroduce the issue #31
+      # instance-default poison the way `open -na Ghostty --args --command=...`
+      # would.
       GHOSTTY_LOG="/tmp/solve-$ISSUE_NUM.log"
       nohup zsh -l "$SCRIPT" > "$GHOSTTY_LOG" 2>&1 &
       echo "warning: ghostty AppleScript dispatch failed (Accessibility permission or non-default Cmd+T/N keybind?); spawned detached agent (PID $!). Logs: $GHOSTTY_LOG" >&2

--- a/tests/ghostty-dispatch-no-instance-leak.test.sh
+++ b/tests/ghostty-dispatch-no-instance-leak.test.sh
@@ -91,6 +91,19 @@ assert_grep "$GHOSTTY" \
   '(keystroke "t"|="t"[[:space:]]*(#|$))' \
   "ghostty tab-spawn path still uses Cmd+T (no regression on the originally-working path)"
 
+# If the dispatch parameterizes via a spawn-key variable (current
+# implementation), the AppleScript heredoc must consume it via
+# `keystroke "$GHOSTTY_SPAWN_KEY"` — otherwise both `="n"` and `="t"`
+# assignments could exist while the keystroke is hardcoded to one of them,
+# silently breaking the path that doesn't match the hardcode. Hedge: skip
+# this check if neither path uses the variable form (i.e. both are inlined
+# as separate heredocs), which is also contract-compliant.
+if grep -qE 'GHOSTTY_SPAWN_KEY=' <<<"$GHOSTTY"; then
+  assert_grep "$GHOSTTY" \
+    'keystroke "\$GHOSTTY_SPAWN_KEY"' \
+    "AppleScript heredoc consumes the spawn-key via variable (not hardcoded once both branches set it)"
+fi
+
 # When AppleScript itself is unusable (Accessibility denied, custom keybind),
 # the final fallback must be nohup — never `open -na Ghostty --args --command=`.
 # Anchored within the ghostty arm so the default `nohup|*)` arm doesn't satisfy this.

--- a/tests/ghostty-dispatch-no-instance-leak.test.sh
+++ b/tests/ghostty-dispatch-no-instance-leak.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Regression test for issue #31:
+#   `open -na Ghostty --args --command=$SCRIPT` makes --command= the running
+#   Ghostty instance's default — every Cmd+T/Cmd+N the user opens manually
+#   re-runs the launcher script, "poisoning" the instance for its lifetime.
+#
+# This test locks the contract: solve-pipeline must NOT use that flag form,
+# and the ghostty dispatch case must rely on keystroke-based AppleScript
+# (which doesn't set any instance default) with a clean nohup fallback.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SOLVE_PIPELINE="$REPO_ROOT/plugins/uberdev/skills/solve-pipeline/SKILL.md"
+
+PASS=0
+FAIL=0
+
+# String-based variants of the sibling-test `assert_grep` / `assert_grep_not`
+# helpers. Take a content blob as the first arg (instead of a path) so we can
+# scope assertions to a sub-section of the file without round-tripping through
+# tempfiles.
+assert_grep() {
+  local input="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" <<<"$input"; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_grep_not() {
+  local input="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" <<<"$input"; then
+    echo "  FAIL  $desc"
+    echo "        pattern: $pattern (must not appear)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# Strip shell-comment lines so the rationale comment that *names* the bad
+# pattern in order to warn against it doesn't trigger the regression-guard
+# assertion.
+NONCOMMENT=$(grep -vE '^[[:space:]]*#' "$SOLVE_PIPELINE")
+
+# Just the dispatch case under "### 6. Spawn agent in new terminal session" —
+# avoids accidental matches against the earlier validation block (which also
+# has a `ghostty)` arm but with different content).
+DISPATCH=$(awk '/^### 6\. Spawn agent in new terminal session$/,/^### 7\./' "$SOLVE_PIPELINE")
+
+# Just the ghostty arm body (between `  ghostty)` and the next `    ;;`) so the
+# nohup-fallback assertion proves the fallback lives inside the ghostty case,
+# not in the default `nohup|*)` arm at the bottom of the dispatch.
+GHOSTTY=$(awk '
+  /^  ghostty\)/ { in_arm=1; print; next }
+  in_arm && /^    ;;/ { print; in_arm=0; next }
+  in_arm { print }
+' <<<"$DISPATCH")
+
+echo "== Issue #31: ghostty dispatch must not leak --command= as instance default =="
+
+# Root-cause regression guard. The toxic pattern persists --command= for the
+# Ghostty process lifetime; every subsequent Cmd+T/Cmd+N re-runs the launcher.
+assert_grep_not "$NONCOMMENT" \
+  'open -na Ghostty --args --command=' \
+  "solve-pipeline must NOT execute 'open -na Ghostty --args --command=' (#31 sticky-flag poison)"
+
+# The dispatch section must drive Ghostty via AppleScript keystrokes (Cmd+T or
+# Cmd+N) — keystroke dispatch types into a tab/window without setting any
+# instance default, so it doesn't poison the Ghostty process. Accept either
+# a literal `keystroke "t"`/`keystroke "n"` or a `keystroke "$VAR"` form fed
+# by a `="t"`/`="n"` assignment, since either is contract-compliant.
+assert_grep "$DISPATCH" \
+  'keystroke .* using command down' \
+  "ghostty dispatch uses AppleScript keystroke + command-modifier (no instance default)"
+
+# Cmd+N path (SOLVE_GHOSTTY_NEW_WINDOW=1 or invoked from outside Ghostty).
+# Accepts literal `keystroke "n"` OR a variable assigned ="n".
+assert_grep "$GHOSTTY" \
+  '(keystroke "n"|="n"[[:space:]]*(#|$))' \
+  "ghostty new-window path uses Cmd+N (literal keystroke or via spawn-key variable)"
+
+# Cmd+T path (existing tab-spawn behavior). Same matching strategy.
+assert_grep "$GHOSTTY" \
+  '(keystroke "t"|="t"[[:space:]]*(#|$))' \
+  "ghostty tab-spawn path still uses Cmd+T (no regression on the originally-working path)"
+
+# When AppleScript itself is unusable (Accessibility denied, custom keybind),
+# the final fallback must be nohup — never `open -na Ghostty --args --command=`.
+# Anchored within the ghostty arm so the default `nohup|*)` arm doesn't satisfy this.
+assert_grep "$GHOSTTY" \
+  'nohup zsh -l' \
+  "ghostty arm itself falls back to nohup when AppleScript unavailable"
+
+# Reference issue #31 in a comment so future contributors who might reintroduce
+# `open --args --command=` see the rationale before they do.
+assert_grep "$GHOSTTY" \
+  '#31|issue 31' \
+  "ghostty arm comments reference issue #31 (rationale for avoiding --command=)"
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

- The `/solve` and `/turbo` Ghostty new-window fallback executed `open -na Ghostty --args --command="$SCRIPT"`, which Ghostty treats as the running instance's *default command*. Every Cmd+T / Cmd+N the user opens manually after that re-runs the launcher script, racing the original agent and "poisoning" the Ghostty process for its entire lifetime.
- Replaced the `open --args --command=` fallback with AppleScript Cmd+N keystroke dispatch (mirror of the existing Cmd+T tab-spawn path). Keystroke dispatch types into a tab/window without setting any instance default, so future tabs the user opens stay clean.
- When AppleScript itself is unavailable (Accessibility denied or non-default Cmd+T/N keybind), the ghostty arm now falls through to a detached `nohup` run — never back to `open --args --command=`.

## Root cause

`open -na Ghostty --args --command=...` looks like a one-shot command, but Ghostty stores the flag as the running process's instance-level default command. AppleScript-driven Cmd+T types into a shell that's already started, which doesn't set any instance default. There is no Ghostty CLI form that runs a command once *and* leaves the instance default clean, so the fix removes the CLI path entirely.

## Test plan

- [x] New regression test `tests/ghostty-dispatch-no-instance-leak.test.sh` (6 assertions, all green) locks the contract: SKILL.md must not execute the toxic pattern, dispatch must use AppleScript keystrokes for both paths (Cmd+T + Cmd+N), ghostty arm itself must fall back to `nohup`, and the rationale comment must reference issue #31.
- [x] TDD red→green confirmed: ran new test against pre-fix SKILL.md, 4 of 6 assertions failed for the expected reasons (toxic pattern present, Cmd+N missing, ghostty-arm nohup missing, #31 ref missing); ran against post-fix SKILL.md, all 6 pass.
- [x] Wired new test into `.github/workflows/test.yml`.
- [x] Full local suite: 11 test files, 266 assertions, 0 failures.
- [ ] Manual verification on user's Ghostty: run `/turbo <issue>` from inside Ghostty, then open ≥3 new tabs (Cmd+T) — expect a clean shell prompt in each new tab, not the launcher.

## Notes for reviewer

- The new ghostty arm parameterizes Cmd+T vs Cmd+N via `GHOSTTY_SPAWN_KEY` rather than duplicating the `osascript` heredoc twice. Cold-launch case (Ghostty not yet running) gets `GHOSTTY_LAUNCH_DELAY=0.5` to let the app fully foreground before the keystroke; warm path keeps the original `0.15`.
- Already-running Ghostty instances that were poisoned by the old code persist their bad instance default until the user fully quits Ghostty once. After that, this fix prevents re-poisoning.

Closes #31