### PR TITLE
feat(uberdev): /merge true autopilot — no blocking prompts, agent-decided strategy

### DIFF
--- a/plugins/uberdev/commands/merge.md
+++ b/plugins/uberdev/commands/merge.md
@@ -1,6 +1,6 @@
 ---
 description: "After a PR is approved, lands it into the integration branch — ordering, strategy, conflict resolution, and local sync automated"
-argument-hint: "[<PR#> | --all] [--yes|-y] [--squash|--rebase|--merge] [--integration-branch=<name>] [--bypass-protections]"
+argument-hint: "[<PR#> | --all] [--yes|-y (deprecated)] [--squash|--rebase|--merge] [--integration-branch=<name>] [--bypass-protections]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 ---
 
@@ -10,16 +10,29 @@ Land approved PRs into the integration branch — ordering, strategy, conflict r
 
 **RULES:** Do NOT use the Task tool or internal subagents. The skill body owns all logic.
 
-**Usage:** `/merge [<PR#> | --all] [--yes|-y] [--squash|--rebase|--merge] [--integration-branch=<name>] [--bypass-protections]`
+**Usage:** `/merge [<PR#> | --all] [--yes|-y (deprecated)] [--squash|--rebase|--merge] [--integration-branch=<name>] [--bypass-protections]`
 
 - No args → land the PR for the current branch (errors if none). Single-PR scope auto-confirms by default.
 - `<PR#>` → land a specific PR. Single-PR scope auto-confirms by default.
 - `--all` → land every open APPROVED PR with passing CI. Multi-PR scope prompts unless `--yes` or `auto_confirm: true` config.
-- `--yes` / `-y` → skip the plan-confirm prompt and stale-branch per-branch prompts for this run.
+- `--yes` / `-y` → **(deprecated; no behavioural effect)** parsed for backward compat; `/merge` is fully unattended (autopilot) and skips all prompts unconditionally. First encounter per run emits a one-line stderr deprecation notice. See `## Deprecated Flags` below.
 - `--squash` / `--rebase` / `--merge` → override per-PR strategy heuristic.
 - `--integration-branch=<name>` → override config / env / repo-default.
 - `--bypass-protections` → admin-bypass branch protections (audit-logged with required free-text waiver).
 
-**Auto-confirm:** the plan-confirm `[y/N]` prompt is suppressed when (1) `--yes` / `-y` is passed, (2) `.claude/uberdev.local.md` sets `auto_confirm: true`, OR (3) the post-gate merge set contains exactly one PR (single-PR scope default — the explicit PR number is the consent). Under auto-confirm, the Phase 4.5 stale-branch offer also becomes list-only — no per-branch prompts and no auto-rebase. /merge **never** runs `git rebase` automatically; auto-confirm only suppresses the offer.
+**Autopilot:** /merge runs unattended end-to-end. The plan table renders for transparency; the queue proceeds without `[y/N]` prompts. Per-PR failures (test fail, conflict-resolver `AMBIGUOUS`/`REFUSED`) park ONE PR via `drop` strategy and the queue continues. Stale-branch handling executes safe rebases automatically (FF-able OR non-conflicting probe AND not a PR head ref AND no force-push protection); risky cases skip with rationale. **Defence-in-depth required:** `bot_authors_allow_list` is the trust boundary for external-author PRs. Combine with GitHub branch protections (required reviews, status checks) — autopilot does not substitute for those.
+
+## Deprecated Flags
+
+The following flags / config keys are accepted for backward compat but have no behavioural effect:
+
+- `--yes`, `-y` (CLI flags)
+- `auto_confirm: true|false` (config key in `.claude/uberdev.local.md`)
+
+On first encounter per run, /merge emits this stderr notice (verbatim):
+
+> `warning: --yes / -y / auto_confirm are deprecated; /merge is now fully unattended. The flag has no behavioural effect.`
+
+An audit event `deprecated_flag_used` is recorded once per encounter. No version-gated removal — flags stay parseable indefinitely. Pattern follows Terraform / npm CLI deprecation precedent.
 
 Now invoke the `uberdev:merge` skill — it owns the 4-phase pipeline (pre-flight gate, merge plan, merge + parallel conflict-resolve, post-merge local sync). The skill renders inline, so `$ARGUMENTS` remains in scope for its bash blocks.

--- a/plugins/uberdev/commands/merge.md
+++ b/plugins/uberdev/commands/merge.md
@@ -12,9 +12,9 @@ Land approved PRs into the integration branch — ordering, strategy, conflict r
 
 **Usage:** `/merge [<PR#> | --all] [--yes|-y (deprecated)] [--squash|--rebase|--merge] [--integration-branch=<name>] [--bypass-protections]`
 
-- No args → land the PR for the current branch (errors if none). Single-PR scope auto-confirms by default.
-- `<PR#>` → land a specific PR. Single-PR scope auto-confirms by default.
-- `--all` → land every open APPROVED PR with passing CI. Multi-PR scope prompts unless `--yes` or `auto_confirm: true` config.
+- No args → land the PR for the current branch (errors if none).
+- `<PR#>` → land a specific PR.
+- `--all` → land every open APPROVED PR with passing CI.
 - `--yes` / `-y` → **(deprecated; no behavioural effect)** parsed for backward compat; `/merge` is fully unattended (autopilot) and skips all prompts unconditionally. First encounter per run emits a one-line stderr deprecation notice. See `## Deprecated Flags` below.
 - `--squash` / `--rebase` / `--merge` → override per-PR strategy heuristic.
 - `--integration-branch=<name>` → override config / env / repo-default.

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -19,7 +19,7 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 
 | Name | Value | Used by |
 |---|---|---|
-| `STRATEGY_ENUM` | `squash`, `rebase`, `merge` | D11 (per-PR strategy), D-LABEL |
+| `STRATEGY_ENUM` | `squash`, `rebase`, `merge`, `defer`, `drop` | D11 (per-PR strategy), D-LABEL, Phase 3.3 (park), Phase 2.2 (defer) |
 | `WIP_MESSAGE_REGEX` | `/^(wip\|misc\|asdf\|address review\|typo)/i` | D11 |
 | `CONVENTIONAL_COMMIT_THRESHOLD` | 3 (max commit count for rebase candidate) | D11 |
 | `PATCH_LINE_CAP` | 200 | D16 (agent rejection threshold) |
@@ -27,7 +27,7 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `LOCK_FILE_PATH` | `.git/uberdev-merge.lock` | D14 |
 | `AUDIT_LOG_DIR_PATTERN` | `.uberdev/runs/<run-id>/` | D15 |
 | `AUDIT_LOG_FILENAME` | `audit.jsonl` | D15 |
-| `AUDIT_EVENT_ENUM` | `gate_pass`, `gate_fail`, `order_proposed`, `order_confirmed`, `strategy_chosen`, `probe_clean`, `probe_conflict`, `agent_dispatched`, `agent_returned`, `patch_applied`, `test_pass`, `test_fail`, `push_resolution`, `merge_executed`, `local_sync`, `branch_deleted`, `worktree_removed`, `admin_bypass`, `waiver_recorded`, `error` | D15 |
+| `AUDIT_EVENT_ENUM` | `gate_pass`, `gate_fail`, `order_proposed`, `order_confirmed`, `strategy_chosen`, `probe_clean`, `probe_conflict`, `agent_dispatched`, `agent_returned`, `patch_applied`, `test_pass`, `test_fail`, `push_resolution`, `merge_executed`, `local_sync`, `branch_deleted`, `worktree_removed`, `admin_bypass`, `waiver_recorded`, `error`, `pr_parked`, `pr_deferred`, `stale_branch_rebase_decision`, `deprecated_flag_used`, `agent_strategy_switch`, `test_fail_agent_decision` | D15 |
 | `SCRATCH_WORKTREE_PATTERN` | `.claude/worktrees/merge-<run-id>/` | D10 |
 | `BRANCH_NAME_REGEX` | `^[A-Za-z0-9._/-]{1,255}$` | D8 (validation before shell argv use) |
 | `MERGE_STRATEGY_LABEL_PREFIX` | `merge-strategy:` | D-LABEL |
@@ -35,11 +35,13 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `BOT_AUTHORS_DEFAULT` | `["dependabot[bot]", "renovate[bot]"]` | D-BOTS |
 | `INTEGRATION_BRANCH_KEY` | `integration_branch` (config key) | D8 |
 | `INTEGRATION_BRANCH_ENV_VAR` | `UBERDEV_INTEGRATION_BRANCH` | D8 |
-| `AUTO_CONFIRM_KEY` | `auto_confirm` (config key in `.claude/uberdev.local.md`) | Phase 2.4, Phase 4.5 |
-| `AUTO_CONFIRM_FLAGS` | `--yes`, `-y` (CLI flags) | Phase 2.4, Phase 4.5 |
-| `AUTO_CONFIRM_DEFAULT_MULTI` | `false` — `--all` / multi-PR scope prompts unless `--yes` or `auto_confirm: true` | Phase 2.4 |
-| `AUTO_CONFIRM_DEFAULT_SINGLE` | `true` — single-PR scope (no `--all`) skips the plan prompt by default | Phase 2.4 |
-| `AUTO_CONFIRM_REASON_ENUM` | `single-pr-default`, `cli-flag`, `config-auto_confirm` (audit-log `data.reason` values when auto-confirm is ON) | Phase 2.4 |
+| `AUTO_CONFIRM_KEY` | `auto_confirm` (config key in `.claude/uberdev.local.md`) **(deprecated; no behavioural effect)** | Phase 2.4, Phase 4.5 |
+| `AUTO_CONFIRM_FLAGS` | `--yes`, `-y` (CLI flags) **(deprecated; no behavioural effect)** | Phase 2.4, Phase 4.5 |
+| `AUTO_CONFIRM_REASON_ENUM` | `single-pr-default`, `cli-flag`, `config-auto_confirm`, `autopilot-default` (audit-log `data.reason` values for `order_confirmed`/`order_proposed` events) | Phase 2.4 |
+| `STRATEGY_REASON_ENUM` | `cli-flag`, `pr-label`, `heuristic-conventional`, `heuristic-wip`, `heuristic-single-commit`, `heuristic-mixed`, `external-author-deferred`, `agent-park-refused`, `agent-park-ambiguous`, `agent-park-test-fail-exhausted`, `agent-defer-flake` | Phase 2.2, Phase 3.3 (audit-log `data.reason` for `strategy_chosen`) |
+| `PARK_REASON_ENUM` | `REFUSED`, `AMBIGUOUS`, `test-fail-exhausted`, `push-non-ff`, `external-author-not-allow-listed` | Phase 3.3 (audit-log `data.reason` for `pr_parked`) |
+| `STALE_REBASE_DECISION_ENUM` | `rebased-ff-clean`, `rebased-non-conflicting`, `skipped-conflicts`, `skipped-pr-head-ref`, `skipped-non-tracking`, `rebase-aborted` | Phase 4.5 (audit-log `data.choice` for `stale_branch_rebase_decision`) |
+| `DEPRECATED_FLAGS_NOTE` | `warning: --yes / -y / auto_confirm are deprecated; /merge is now fully unattended. The flag has no behavioural effect.` | Phase 1 (stderr emission), `commands/merge.md` (Deprecated Flags section), `using-uberdev/SKILL.md` |
 
 ## Inputs
 

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -41,6 +41,7 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `STRATEGY_REASON_ENUM` | `cli-flag`, `pr-label`, `heuristic-conventional`, `heuristic-wip`, `heuristic-single-commit`, `heuristic-mixed`, `external-author-deferred`, `agent-park-refused`, `agent-park-ambiguous`, `agent-park-test-fail-exhausted`, `agent-defer-flake` | Phase 2.2, Phase 3.3 (audit-log `data.reason` for `strategy_chosen`) |
 | `PARK_REASON_ENUM` | `REFUSED`, `AMBIGUOUS`, `test-fail-exhausted`, `push-non-ff`, `external-author-not-allow-listed` | Phase 3.3 (audit-log `data.reason` for `pr_parked`) |
 | `STALE_REBASE_DECISION_ENUM` | `rebased-ff-clean`, `rebased-non-conflicting`, `skipped-conflicts`, `skipped-pr-head-ref`, `skipped-non-tracking`, `rebase-aborted` | Phase 4.5 (audit-log `data.choice` for `stale_branch_rebase_decision`) |
+| `TEST_FAIL_DECISION_ENUM` | `re-resolve`, `strategy-switch`, `park` | Phase 3.3v (audit-log `data.choice` for `test_fail_agent_decision`) |
 | `DEPRECATED_FLAGS_NOTE` | `warning: --yes / -y / auto_confirm are deprecated; /merge is now fully unattended. The flag has no behavioural effect.` | Phase 1 (stderr emission), `commands/merge.md` (Deprecated Flags section), `using-uberdev/SKILL.md` |
 
 ## Inputs
@@ -53,7 +54,7 @@ Argument parsing:
 - **`--squash` / `--rebase` / `--merge`** — per-invocation strategy override (see `STRATEGY_ENUM`); applies to every PR in the run.
 - **`--integration-branch=<name>`** — per-invocation override of the integration-branch precedence chain (see below).
 - **`--bypass-protections`** — admin-bypass branch protections; requires a free-text waiver and is audit-logged.
-- **`--yes` / `-y`** — skip the Phase 2.4 plan-confirm prompt and the Phase 4.5 stale-branch per-branch prompts for this run (see `AUTO_CONFIRM_FLAGS` and the auto-confirm resolution chain below).
+- **`--yes` / `-y`** — accepted for backward compat (deprecated; no behavioural effect — see `## Inputs` autopilot paragraph).
 
 Integration-branch resolution (four-tier precedence chain, highest wins):
 
@@ -64,17 +65,21 @@ Integration-branch resolution (four-tier precedence chain, highest wins):
 
 Branch names (from any tier) MUST be validated against `BRANCH_NAME_REGEX` before being used as a shell argv. Reject and error out on any name that fails the regex; do not pass unvalidated input to `git`, `gh`, or any subprocess.
 
-Auto-confirm resolution (CLI flag wins, then config, then scope-based default):
-
-1. **CLI flag** `--yes` / `-y` (see `AUTO_CONFIRM_FLAGS`) → auto-confirm ON for this run.
-2. **Config file** `.claude/uberdev.local.md` YAML key `AUTO_CONFIRM_KEY` (`auto_confirm: true|false`) → repo-local default. `true` enables; `false` disables.
-3. **Scope-based default** (when neither flag nor config is set):
-   - Single-PR scope (exactly 1 PR in the post-gate merge set) → `AUTO_CONFIRM_DEFAULT_SINGLE` (`true`). The explicit PR number is the consent; the plan table still renders for transparency.
-   - Multi-PR scope (`--all`, more than 1 PR) → `AUTO_CONFIRM_DEFAULT_MULTI` (`false`). The PR list is computed, not user-specified, so confirmation is required.
-
-When auto-confirm is ON, Phase 2.4 skips the `[y/N]` prompt and Phase 4.5 lists stale branches without per-branch rebase prompts (see those phases for exact behavior).
+**Autopilot (always ON).** `--yes` / `-y` (see `AUTO_CONFIRM_FLAGS`) and the `auto_confirm:` config key (see `AUTO_CONFIRM_KEY`) are accepted for backward compat — parsed without error — but have **no behavioural effect**. On first encounter per run, /merge emits the verbatim `DEPRECATED_FLAGS_NOTE` to stderr and records a `deprecated_flag_used` audit event. The Phase 2.4 plan-confirm and Phase 4.5 stale-branch behaviours are unconditional autopilot — see those phases.
 
 ## Phase 1 — Pre-flight gate
+
+### Step 1.0 — Pre-flight banner
+
+At the very start of the run (before lock acquisition), emit a one-line banner to stderr:
+
+```
+/merge autopilot — allow-listed authors: <comma-separated bot_authors_allow_list contents>
+```
+
+This is transparency for the new trust boundary (see C9). The same allow-list is reprinted in the final run-summary block as an audit anchor — two prints, one at each lifecycle moment (start and end).
+
+**Failure handling:** if `.claude/uberdev.local.md` cannot be read or the YAML cannot be parsed, treat `bot_authors_allow_list` as empty (default-strict — every external-author PR will defer in Phase 2.2 step 3). Emit an `error` audit event with `data.reason="allow-list-read-failed"` and proceed with the safe-default empty list. The banner still emits, with `Allow-listed authors: <none>`.
 
 ### Step 1.1 — Acquire the single-instance lock
 
@@ -139,12 +144,15 @@ For each PR, compute strategy signal-by-signal:
 
 1. Per-invocation flag `--squash` / `--rebase` / `--merge` always wins.
 2. Else: PR label matching `MERGE_STRATEGY_LABEL_PREFIX<name>` where `<name>` ∈ `STRATEGY_ENUM` wins (D-LABEL).
-3. Else: heuristic.
+3. **External-author defer (D-BOTS):** if `author.login` is NOT in `bot_authors_allow_list` AND author is NOT a repo collaborator, emit strategy `defer` with `data.reason="external-author-deferred"` (∈ `STRATEGY_REASON_ENUM`). Emit `strategy_chosen` audit event. The PR is parked at the end of the run and promoted directly to `drop` in the final summary with `PARK_REASON_ENUM` value `external-author-not-allow-listed` (one-pass park; no end-of-run retry — stable cause, not flake). This step gates only the strategy decision; the existing fork preflight (Step 1.6) remains the authoritative gate for cross-repo PRs. **Failure handling:** if the `gh` API call to determine collaborator status fails (network, auth, rate limit, JSON parse error), treat author as NOT a collaborator (safe-default — defer rather than allow). Emit an `error` audit event with `data.reason="collaborator-check-failed"` alongside the `strategy_chosen` event.
+4. Else: heuristic.
    - All commits start with conventional-commit prefix (`feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`) → rebase candidate.
    - Any commit message matches `WIP_MESSAGE_REGEX` → squash candidate.
    - Commit count ≤ `CONVENTIONAL_COMMIT_THRESHOLD` (3) AND all conventional → rebase.
    - Single-commit PR → rebase.
    - Mixed signals → default to squash (safer for `git bisect` than a true merge commit).
+
+Note: `drop` and `defer` are NOT direct outputs of this heuristic for in-scope PRs (except step 3); they are emitted later — Phase 3.3v on `test-fail-exhausted`, Phase 3.3iv on AMBIGUOUS/REFUSED. Consumers disambiguate strategy outcomes via paired audit events — `strategy_chosen` followed by `merge_executed` (for git-merge strategies) vs. `pr_parked`/`pr_deferred` (for queue actions).
 
 Other label syntaxes (`strategy:<name>`, `merge:<name>`) are NOT recognised — only the `MERGE_STRATEGY_LABEL_PREFIX` literal matches.
 
@@ -152,22 +160,17 @@ Other label syntaxes (`strategy:<name>`, `merge:<name>`) are NOT recognised — 
 
 Render a single markdown table with these columns: `PR#`, `title`, `strategy`, `reasoning` (one-line citing the dominant signal — flag, label, conventional-commit ratio, etc.), `conflict-resolve-needed?` (Y/N from probe; Phase 3 will re-probe but a Phase-2 merge-tree pass gives the user a preview).
 
-### Step 2.4 — Plan-confirm gate (single, scope-conditional)
+### Step 2.4 — Plan-confirm gate (autopilot — no prompt)
 
-Resolve `auto_confirm` per the precedence chain in `## Inputs` (CLI flag → config → scope-based default).
+Render the unified plan table from Step 2.3 for transparency. Then, **unconditionally** and without any `[y/N]` prompt:
 
-**If auto-confirm is ON:**
-- Render the plan table for transparency.
-- Emit `order_proposed` + `order_confirmed` events to `audit.jsonl` with the resolution reason recorded in `data.reason` (one of `AUTO_CONFIRM_REASON_ENUM`: `single-pr-default`, `cli-flag`, `config-auto_confirm`). Use the literal enum value — do not invent new strings.
-- Proceed directly to Phase 3 — no `[y/N]` prompt.
+- Emit `order_proposed` to `audit.jsonl` with `data.order=[<pr#>...]`.
+- Emit `order_confirmed` to `audit.jsonl` with `data.reason="autopilot-default"` (∈ `AUTO_CONFIRM_REASON_ENUM`). Use the literal enum value — do not invent free-text strings.
+- Proceed directly to Phase 3.
 
-**If auto-confirm is OFF (default for `--all` / multi-PR scope unless `--yes` or `auto_confirm: true`):**
-- Display the plan table.
-- Prompt: `Apply this plan? [y/N]`.
-- On `y`: emit `order_confirmed`, proceed to Phase 3.
-- On anything else: abort cleanly, write `order_proposed` + `error` events to `audit.jsonl`, release the lock.
+The plan-table `strategy` column now ranges over the extended `STRATEGY_ENUM` (`squash`, `rebase`, `merge`, `defer`, `drop`). PRs with strategy `defer` enter Phase 3 and are parked-as-drop on the first pass (see C4 — external-author defer is one-pass park).
 
-**This is the ONLY plan-level confirm gate in /merge.** Do NOT prompt after each PR merges. (Spec Non-goal: "no mid-flow gates after each PR merges.") Phase 4.5 stale-branch handling has its own conditional prompt — see that step.
+**There is NO `Apply this plan?` prompt under any condition.** Autopilot is unconditional. `--yes` / `-y` / `auto_confirm` are no-ops; their first encounter per run emits `DEPRECATED_FLAGS_NOTE` to stderr and a `deprecated_flag_used` audit event, then the run continues.
 
 ## Phase 3 — Merge and conflict-resolve
 
@@ -197,9 +200,23 @@ This is the critical invariant. All Task() calls for this PR's conflict set MUST
 
 **Sequential degradation (Q1):** for same-file PR pairs flagged in Phase 1.5, the per-file fanout proceeds normally — same-file collisions only matter ACROSS PRs (PR-A's resolution must land first; PR-B re-probes against new tip). Within a single PR's resolution, all Task() agents own disjoint files by construction.
 
-iv. **Apply resolutions** in the scratch worktree as each agent returns. Aggregate the YAML returns; halt the queue if any agent returns `status: AMBIGUOUS` or `status: REFUSED` (clear handoff per AC).
+iv. **Apply resolutions** in the scratch worktree as each agent returns. Aggregate the YAML returns. **If any agent returns `status: AMBIGUOUS` or `status: REFUSED`:** park THIS PR via `drop` strategy. Emit `pr_parked` to `audit.jsonl` with `data.reason` set to the literal status (`AMBIGUOUS` or `REFUSED`, ∈ `PARK_REASON_ENUM`), `data.strategy="drop"`, and `data.rationale` carrying the agent's structured handoff. Surface the agent's structured handoff in the run summary. **Continue with the next PR — the queue does NOT halt.**
 
-v. **Pre-push test gate (D16, mandatory, no skip path).** Run the project's test command in the scratch worktree before any push. Test command discovery order: `package.json:scripts.test` > `Makefile` `test` target > `cargo test` if `Cargo.toml` exists > `pytest` if `pytest.ini`/`pyproject.toml` exists > `go test ./...` if `go.mod` exists. **Failing tests block the push for that PR; rest of queue continues.** No `--fast` mode, no override flag.
+v. **Pre-push test gate (D16, ALWAYS RUNS).** Test command discovery order: `package.json:scripts.test` > `Makefile` `test` target > `cargo test` if `Cargo.toml` exists > `pytest` if `pytest.ini`/`pyproject.toml` exists > `go test ./...` if `go.mod` exists.
+
+On test PASS: emit `test_pass`; proceed to push (step vi).
+
+On test FAIL: agent picks the best applicable branch from (a), (b), (c); (a) and (b) may each be exercised at most once before falling to (c). Each choice is logged as `test_fail_agent_decision` audit event with `data.choice` (∈ `TEST_FAIL_DECISION_ENUM`) and a one-line `data.rationale`:
+
+(a) **RE-RESOLVE** (`data.choice="re-resolve"`) — re-dispatch the conflict-resolver fanout (single-message Task() per conflicted file) for the same conflict set with the prior failure context attached. **Max 1 retry per PR per run.** On second test pass: proceed to push. On second test fail: agent may switch to (b) if the switch budget is unused, otherwise fall through to (c).
+
+(b) **STRATEGY-SWITCH** (`data.choice="strategy-switch"`) — switch strategy (e.g. `squash` ↔ `merge`), re-probe via `git merge-tree --write-tree`, re-resolve if the new probe reports conflicts. **Max 1 switch per PR per run.** Emits `agent_strategy_switch` audit event with `data.from`, `data.to`, `data.rationale`. On test pass after switch: proceed to push. On test fail after switch: fall through to (c).
+
+(c) **PARK** (`data.choice="park"`) — park this PR via `drop` strategy with `data.reason="test-fail-exhausted"` (∈ `PARK_REASON_ENUM`); emit `pr_parked`; surface in run summary with the failure tail; continue queue with next PR.
+
+**PARK is the terminal floor.** No further retry branches exist beyond (a) and (b). After both bounds are exhausted (max 1 retry from (a) + max 1 switch from (b), each consumed at most once), PARK is unconditional — the implementation MUST NOT introduce any additional retry path.
+
+**Bounds (max 1 retry, max 1 switch) are policy-enforced.** Worst-case: max 3 test runs per PR per run (initial fail → re-resolve+test fail → strategy-switch+re-resolve+test fail → park). Queue ALWAYS continues. Only data-integrity failures (push non-FF, dependency cycle) still halt the queue — see Step 3.4.
 
 vi. **Push the resolution commit (D13, non-force push only).**
 
@@ -213,7 +230,18 @@ viii. **Tear down the scratch worktree** per `using-git-worktrees` protocol: `gi
 
 ### Step 3.4 — Failure-mode summary
 
-On any single-PR failure (test gate fail, push fail, gh pr merge fail, agent AMBIGUOUS/REFUSED): abort REST of queue (or that PR only — see error-handling table in spec). Already-merged PRs stay merged. Emit structured event to `.uberdev/runs/<run-id>/audit.jsonl`. Surface clear handoff to user.
+| Failure mode | Action | Queue state |
+|---|---|---|
+| `test_fail` after exhausting (a)/(b)/(c) in Step 3.3v | park via `drop` (`data.reason="test-fail-exhausted"`) | continues |
+| `push_resolution` non-FF (Step 3.3vi) | halt rest of queue | halted (data integrity) |
+| `gh pr merge` failure (Step 3.2 / 3.3vii) | abort that PR; emit `merge_executed`+`error` | continues |
+| conflict-resolver `AMBIGUOUS` | park via `drop` (`data.reason="AMBIGUOUS"`) | continues |
+| conflict-resolver `REFUSED` | park via `drop` (`data.reason="REFUSED"`) | continues |
+| dependency cycle (Phase 2.1) | abort whole run; surface cycle path | n/a (already aborted) |
+| local pull non-FF (Phase 4.2) | fail loud, no auto-fix | halted (data integrity) |
+| external-author-not-allow-listed (Phase 2.2 step 3) | strategy `defer` → one-pass park via `drop` (`data.reason="external-author-not-allow-listed"`) | continues |
+
+Already-merged PRs stay merged. Every event hits `audit.jsonl`. Every parked PR appears in the run-summary block with its `PARK_REASON_ENUM` value and the structured handoff (where applicable).
 
 ## Phase 4 — Post-merge local sync
 
@@ -262,7 +290,7 @@ git branch -d <feature-branch>
 
 `-d` (not `-D`): refuse to delete branches not fully merged into integration. On refuse: surface message; do NOT escalate to `-D`.
 
-### Step 4.5 — Stale-branch list+offer (D17, NEVER auto-execute rebase)
+### Step 4.5 — Stale-branch agent-decides (D17 autopilot)
 
 Enumerate local branches whose merge-base with the new integration tip is older than the previous integration tip:
 
@@ -273,22 +301,25 @@ git for-each-ref --format='%(refname:short)' refs/heads | while read b; do
 done
 ```
 
-Display the list to the user. Behavior depends on the `auto_confirm` resolution from `## Inputs`:
+For each stale branch, the agent decides (per-branch). Each decision emits one `stale_branch_rebase_decision` audit event with `data.branch`, `data.choice` (∈ `STALE_REBASE_DECISION_ENUM`), and `data.rationale`.
 
-**If auto-confirm is ON** (CLI `--yes`, `auto_confirm: true` config, or single-PR scope default):
-- List the stale branches with a one-line note: `These branches will need a manual rebase next time you check them out.`
-- Do NOT prompt and do NOT auto-rebase. The rebase is destructive (rewrites history) and could break in-flight work — staying hands-off is the safe default in auto-confirm mode.
+1. **Probe rebaseability** via `git merge-tree --write-tree <integration_branch> <stale_branch>` — clean exit = rebase would be conflict-free. **FF detection:** run `git merge-base --is-ancestor <integration_branch> <stale_branch>` after the merge-tree clean check; ancestor relationship → FF-able (decision tree rule 1); non-ancestor + clean merge-tree → non-conflicting (decision tree rule 2).
+2. **Safety preconditions** (ALL must hold to rebase):
+   (a) the branch is NOT a PR head ref currently in the autopilot's merge set — cross-checked via `gh pr list --head <branch> --json number,state` (state ∈ {OPEN, MERGED}).
+   (b) the branch has a remote-tracking ref that does NOT have force-push protection (probed via `gh api repos/:owner/:repo/branches/<branch>/protection` — 200 with `allow_force_pushes.enabled=false` means protected). Local-only branches without a remote-tracking ref do NOT satisfy this precondition; they SKIP via the `skipped-non-tracking` rule below — local-only branches may represent in-progress unpushed work and are not safe to rebase blindly.
 
-**If auto-confirm is OFF:**
-- For each branch, offer per-branch rebase ONLY after typed user confirmation:
+   **Failure handling on API probes:** if `gh pr list --head <branch>` fails (network, auth, rate limit, JSON parse error), treat the branch as potentially a PR head ref (safe default) and emit `data.choice="skipped-pr-head-ref"` with `data.rationale="gh-pr-list-api-unreachable"`. If `gh api .../protection` fails, treat as protected and emit `data.choice="skipped-non-tracking"` with `data.rationale="protection-api-unreachable"`. Never rebase when safety status cannot be determined.
+3. **Decide** (decision tree, first match wins; emit `data.choice` ∈ `STALE_REBASE_DECISION_ENUM`):
+   - FF-able + safety met → `git rebase <integration_branch>`; emit choice `rebased-ff-clean`.
+   - Non-conflicting probe + safety met → `git rebase <integration_branch>`; emit choice `rebased-non-conflicting`.
+   - Conflicts in probe → SKIP; emit choice `skipped-conflicts` with `data.rationale` citing the conflicting file paths.
+   - PR head ref in scope → SKIP; emit choice `skipped-pr-head-ref`.
+   - No tracking branch → SKIP; emit choice `skipped-non-tracking`.
+   - `git rebase` fails mid-way → `git rebase --abort` to restore the original head; emit choice `rebase-aborted`; continue with the next branch.
 
-  ```
-  Rebase <branch> onto <integration_branch>? Type 'yes' to confirm: _
-  ```
+**Force-push to PR head refs remains absolutely forbidden.** Any branch with force-push protection that requires rewinding falls into `skipped-pr-head-ref` or `skipped-non-tracking`.
 
-- Anything other than the literal string `yes` skips. **Never auto-execute** — destructive enough to deserve explicit per-branch consent (spec Non-goal).
-
-**Invariant:** /merge **never** runs `git rebase` automatically. Auto-confirm suppresses the prompt and skips the offer; it does not substitute for the typed `yes` that interactive mode requires.
+**Invariant:** /merge never rebases without an explicit affirmative decision; the agent's typed decision-record is the affirmative form for autopilot mode. The structured decision-record (above — choice + rationale + safety-precondition checks, all written to `audit.jsonl`) supersedes the prior "never auto-rebase without typed `yes`" prose because the structured decision-record is an equivalently rigorous form of affirmation. Force-push to PR head refs remains forbidden absolutely.
 
 ### Step 4.6 — Release the lock
 
@@ -299,9 +330,9 @@ Display the list to the user. Behavior depends on the `auto_confirm` resolution 
 | Phase | Inputs | Outputs | Abort conditions |
 |---|---|---|---|
 | 1 — Pre-flight | argv, PR list, integration_branch (resolved), bot allow-list | passing PR set, file-overlap matrix, fork preflight verdicts, lock acquired | lock contention (default fail-fast); single-PR fail when only one PR in scope; gh JSON unreadable |
-| 2 — Merge plan | passing PR set + file-overlap matrix + auto-confirm resolution | ordered plan table {PR#, strategy, reasoning, conflict-resolve?}; user confirm IF auto-confirm OFF | hard-dep cycle; user declines confirm (only when prompted) |
-| 3 — Merge + resolve | confirmed plan | per-PR merge result (success/skipped/aborted) + audit events | test gate fail (that PR aborts); agent AMBIGUOUS/REFUSED (queue halts); push non-FF (queue halts); fork org-owned (that PR skips) |
-| 4 — Local sync | merged PR list | local integration ff'd, worktrees removed, branches deleted, stale-branch offers | `git pull --ff-only` non-FF (fail-loud); branch not fully merged (refuse `-d`) |
+| 2 — Merge plan | passing PR set + per-PR strategy heuristics | ordered plan table {PR#, strategy, reasoning, conflict-resolve?}; order_proposed + order_confirmed audit events | hard-dep cycle (auto-aborts run) |
+| 3 — Merge + resolve | confirmed plan | per-PR merge result (success/skipped/aborted) + audit events | test gate fail after re-resolve+strategy-switch (that PR parks via `drop`); agent AMBIGUOUS/REFUSED (that PR parks via `drop`); push non-FF (queue halts — data integrity); fork org-owned (that PR skips) |
+| 4 — Local sync | merged PR list | local integration ff'd, worktrees removed, branches deleted, stale-branch decisions logged via stale_branch_rebase_decision events | `git pull --ff-only` non-FF (fail-loud); branch not fully merged (refuse `-d`) |
 
 ## Common Mistakes
 
@@ -313,8 +344,8 @@ Display the list to the user. Behavior depends on the `auto_confirm` resolution 
 - **Splitting the conflict-resolver Task() fanout across multiple assistant turns.** Single message. Mirrors `uberdev:post-impl-review`.
 - **Writing the resolution patch outside the conflict set.** Each agent owns ONE file; touching `.github/`, `.git/`, hooks, or any path outside its file_path is rejected (treated as REFUSED).
 - **Skipping the test gate** before pushing the resolution commit. No skip path. Failing tests block that PR's merge.
-- **Auto-rebasing stale local branches** in Phase 4. Phase 4.5 invariant: never run `git rebase` automatically — auto-confirm only suppresses the offer.
-- **Prompting `[y/N]` after the user typed `/merge <PR#>`.** Single-PR scope is auto-confirm by default; the explicit PR number is the consent. Only `--all` / multi-PR scope keeps the prompt unless `--yes` or `auto_confirm: true`.
+- **Skipping safety preconditions on Phase 4.5 stale-branch rebase.** Autopilot's typed decision-record IS the affirmative form, but the FF-able-or-non-conflicting probe AND not-a-PR-head-ref AND no-force-push-protection checks are non-negotiable. A rebase without all three preconditions = bug. Force-push to PR head refs remains absolutely forbidden.
+- **Prompting under any condition.** /merge is autopilot end-to-end. No `[y/N]` plan-confirm. No per-branch typed-`yes` for stale rebase. No per-PR confirmation after merge. The plan table renders for transparency; the queue proceeds.
 - **Auto-creating a merge commit** when `git pull --ff-only` fails. Fail-loud; never recover via merge commit.
 - **`--admin`/`--bypass-protections` without a free-text waiver.** Every bypass invocation MUST log `admin_bypass`+`waiver_recorded` events with the user's stated reason.
 
@@ -329,7 +360,7 @@ Refuse signals — abort or skip the PR with clear handoff:
 - Out-of-hunk edits in agent patch (any change outside the conflict-set hunks)
 - Agent patch touches `.github/`, `.git/`, hooks, or any path outside the PR's conflict set
 - Generated/lockfile (`package-lock.json`, `Cargo.lock`, etc.) in conflict set with no clear textual evidence — defer to PR author
-- PR author NOT in `bot_authors_allow_list` AND NOT a repo collaborator AND no explicit per-PR consent given (Non-goal: auto-merging non-collaborator PRs)
+- PR author NOT in `bot_authors_allow_list` AND NOT a repo collaborator → strategy `defer` (Phase 2.2 step 3); promoted to `drop` with `PARK_REASON_ENUM` value `external-author-not-allow-listed` at end of run (one-pass park, no flake retry).
 - Hard-dependency cycle in Phase 2 ordering — never auto-break (AC + spec Non-goal)
 
 ## Integration
@@ -358,11 +389,25 @@ At end of run, emit a summary block:
 
 ```
 /merge complete.
+  Allow-listed authors: <comma-separated bot_authors_allow_list contents>
   Merged:   <N> PRs (<list of #N>)
   Skipped:  <M> PRs (<list with reasons>)
+  Parked:   <P> PRs (<list with park reason and one-line rationale>)
+  Deferred: <D> PRs (<list — defer outcomes that did not retry-into-merge>)
   Aborted:  <K> PRs (<list with reasons>)
   Audit:    <AUDIT_LOG_DIR_PATTERN><AUDIT_LOG_FILENAME>
   Duration: <wall-clock>
+
+Per-PR detail block (one per PR in the run):
+
+  PR #<N> — <title>
+    strategy: <merge|rebase|squash|defer|drop>
+    rationale: <one-line, citing dominant signal — flag, label, heuristic, agent-decided>
+    outcome: <Merged|Skipped|Parked|Deferred|Aborted>
+    park reason: <PARK_REASON_ENUM value>          (only if outcome is Parked)
+    audit events: <count>
 ```
 
-Per spec: every `skipped` / `false-positive` / `errored` MUST be surfaced in the final summary. **No silent skips.**
+**Print twice rule:** the `Allow-listed authors:` line MUST also be emitted at run start as a Phase 1.0 pre-flight banner (see Step 1.0). Two prints — pre-flight banner and run-summary block — anchor the trust boundary at both lifecycle moments.
+
+Per spec: every `skipped` / `parked` / `deferred` / `aborted` MUST be surfaced here. **No silent skips.** Audit log path printed last; users grep for `pr_parked`, `pr_deferred`, `stale_branch_rebase_decision`, `deprecated_flag_used`, `agent_strategy_switch`, `test_fail_agent_decision` to reconstruct the run.

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -37,9 +37,9 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `INTEGRATION_BRANCH_ENV_VAR` | `UBERDEV_INTEGRATION_BRANCH` | D8 |
 | `AUTO_CONFIRM_KEY` | `auto_confirm` (config key in `.claude/uberdev.local.md`) **(deprecated; no behavioural effect)** | Phase 2.4, Phase 4.5 |
 | `AUTO_CONFIRM_FLAGS` | `--yes`, `-y` (CLI flags) **(deprecated; no behavioural effect)** | Phase 2.4, Phase 4.5 |
-| `AUTO_CONFIRM_REASON_ENUM` | `single-pr-default`, `cli-flag`, `config-auto_confirm`, `autopilot-default` (audit-log `data.reason` values for `order_confirmed`/`order_proposed` events) | Phase 2.4 |
-| `STRATEGY_REASON_ENUM` | `cli-flag`, `pr-label`, `heuristic-conventional`, `heuristic-wip`, `heuristic-single-commit`, `heuristic-mixed`, `external-author-deferred`, `agent-park-refused`, `agent-park-ambiguous`, `agent-park-test-fail-exhausted`, `agent-defer-flake` | Phase 2.2, Phase 3.3 (audit-log `data.reason` for `strategy_chosen`) |
-| `PARK_REASON_ENUM` | `REFUSED`, `AMBIGUOUS`, `test-fail-exhausted`, `push-non-ff`, `external-author-not-allow-listed` | Phase 3.3 (audit-log `data.reason` for `pr_parked`) |
+| `AUTO_CONFIRM_REASON_ENUM` | `autopilot-default` (only value emitted under autopilot; `single-pr-default`, `cli-flag`, `config-auto_confirm` are historical from pre-autopilot runs and are unreachable now) | Phase 2.4 |
+| `STRATEGY_REASON_ENUM` | `cli-flag`, `pr-label`, `heuristic-conventional`, `heuristic-wip`, `heuristic-single-commit`, `heuristic-mixed`, `external-author-deferred` | Phase 2.2, Phase 3.3 (audit-log `data.reason` for `strategy_chosen`) |
+| `PARK_REASON_ENUM` | `refused`, `ambiguous`, `test-fail-exhausted`, `external-author-not-allow-listed` | Phase 3.3 (audit-log `data.reason` for `pr_parked`) |
 | `STALE_REBASE_DECISION_ENUM` | `rebased-ff-clean`, `rebased-non-conflicting`, `skipped-conflicts`, `skipped-pr-head-ref`, `skipped-non-tracking`, `rebase-aborted` | Phase 4.5 (audit-log `data.choice` for `stale_branch_rebase_decision`) |
 | `TEST_FAIL_DECISION_ENUM` | `re-resolve`, `strategy-switch`, `park` | Phase 3.3v (audit-log `data.choice` for `test_fail_agent_decision`) |
 | `DEPRECATED_FLAGS_NOTE` | `warning: --yes / -y / auto_confirm are deprecated; /merge is now fully unattended. The flag has no behavioural effect.` | Phase 1 (stderr emission), `commands/merge.md` (Deprecated Flags section), `using-uberdev/SKILL.md` |
@@ -79,7 +79,14 @@ At the very start of the run (before lock acquisition), emit a one-line banner t
 
 This is transparency for the new trust boundary (see C9). The same allow-list is reprinted in the final run-summary block as an audit anchor — two prints, one at each lifecycle moment (start and end).
 
-**Failure handling:** if `.claude/uberdev.local.md` cannot be read or the YAML cannot be parsed, treat `bot_authors_allow_list` as empty (default-strict — every external-author PR will defer in Phase 2.2 step 3). Emit an `error` audit event with `data.reason="allow-list-read-failed"` and proceed with the safe-default empty list. The banner still emits, with `Allow-listed authors: <none>`.
+**Failure handling:** if `.claude/uberdev.local.md` cannot be read or the YAML cannot be parsed:
+
+1. Emit a prominent stderr alert: `WARNING: /merge could not read or parse .claude/uberdev.local.md; defaulting bot_authors_allow_list to empty (no external authors allowed). Run will defer all external-author PRs. Check the config file and retry.`
+2. Emit an `error` audit event with `data.reason="allow-list-read-failed"`.
+3. Treat `bot_authors_allow_list` as empty (default-strict — every external-author PR will defer in Phase 2.2 step 3).
+4. The Phase 1.0 banner still emits, with `Allow-listed authors: <none>`.
+
+This is non-fatal — the run continues so the user can see it complete and re-run after fixing the config.
 
 ### Step 1.1 — Acquire the single-instance lock
 
@@ -200,7 +207,7 @@ This is the critical invariant. All Task() calls for this PR's conflict set MUST
 
 **Sequential degradation (Q1):** for same-file PR pairs flagged in Phase 1.5, the per-file fanout proceeds normally — same-file collisions only matter ACROSS PRs (PR-A's resolution must land first; PR-B re-probes against new tip). Within a single PR's resolution, all Task() agents own disjoint files by construction.
 
-iv. **Apply resolutions** in the scratch worktree as each agent returns. Aggregate the YAML returns. **If any agent returns `status: AMBIGUOUS` or `status: REFUSED`:** park THIS PR via `drop` strategy. Emit `pr_parked` to `audit.jsonl` with `data.reason` set to the literal status (`AMBIGUOUS` or `REFUSED`, ∈ `PARK_REASON_ENUM`), `data.strategy="drop"`, and `data.rationale` carrying the agent's structured handoff. Surface the agent's structured handoff in the run summary. **Continue with the next PR — the queue does NOT halt.**
+iv. **Apply resolutions** in the scratch worktree as each agent returns. Aggregate the YAML returns. **If any agent returns `status: AMBIGUOUS` or `status: REFUSED`:** park THIS PR via `drop` strategy. Emit `pr_parked` to `audit.jsonl` with `data.reason` set to the lowercase form (`ambiguous` or `refused`, ∈ `PARK_REASON_ENUM`); the agent's uppercase return status is normalized for audit-log uniformity. `data.strategy="drop"`, and `data.rationale` carrying the agent's structured handoff. Surface the agent's structured handoff in the run summary. **Continue with the next PR — the queue does NOT halt.**
 
 v. **Pre-push test gate (D16, ALWAYS RUNS).** Test command discovery order: `package.json:scripts.test` > `Makefile` `test` target > `cargo test` if `Cargo.toml` exists > `pytest` if `pytest.ini`/`pyproject.toml` exists > `go test ./...` if `go.mod` exists.
 
@@ -208,7 +215,7 @@ On test PASS: emit `test_pass`; proceed to push (step vi).
 
 On test FAIL: agent picks the best applicable branch from (a), (b), (c); (a) and (b) may each be exercised at most once before falling to (c). Each choice is logged as `test_fail_agent_decision` audit event with `data.choice` (∈ `TEST_FAIL_DECISION_ENUM`) and a one-line `data.rationale`:
 
-(a) **RE-RESOLVE** (`data.choice="re-resolve"`) — re-dispatch the conflict-resolver fanout (single-message Task() per conflicted file) for the same conflict set with the prior failure context attached. **Max 1 retry per PR per run.** On second test pass: proceed to push. On second test fail: agent may switch to (b) if the switch budget is unused, otherwise fall through to (c).
+(a) **RE-RESOLVE** (`data.choice="re-resolve"`) — re-dispatch the conflict-resolver fanout (single-message Task() per conflicted file) for the same conflict set with the prior failure context attached. **Max 1 retry per PR per run.** **On conflict-resolver agent dispatch failure during re-dispatch** (timeout, agent crash, unhandled error before all per-file resolutions return): treat as equivalent to test fail and proceed to (b) if the switch budget is unused, otherwise fall through to (c). Emit a `test_fail_agent_decision` event with `data.choice="re-resolve"` and `data.rationale="agent-dispatch-failure"`. On second test pass: proceed to push. On second test fail: agent may switch to (b) if the switch budget is unused, otherwise fall through to (c).
 
 (b) **STRATEGY-SWITCH** (`data.choice="strategy-switch"`) — switch strategy (e.g. `squash` ↔ `merge`), re-probe via `git merge-tree --write-tree`, re-resolve if the new probe reports conflicts. **Max 1 switch per PR per run.** Emits `agent_strategy_switch` audit event with `data.from`, `data.to`, `data.rationale`. On test pass after switch: proceed to push. On test fail after switch: fall through to (c).
 
@@ -235,8 +242,8 @@ viii. **Tear down the scratch worktree** per `using-git-worktrees` protocol: `gi
 | `test_fail` after exhausting (a)/(b)/(c) in Step 3.3v | park via `drop` (`data.reason="test-fail-exhausted"`) | continues |
 | `push_resolution` non-FF (Step 3.3vi) | halt rest of queue | halted (data integrity) |
 | `gh pr merge` failure (Step 3.2 / 3.3vii) | abort that PR; emit `merge_executed`+`error` | continues |
-| conflict-resolver `AMBIGUOUS` | park via `drop` (`data.reason="AMBIGUOUS"`) | continues |
-| conflict-resolver `REFUSED` | park via `drop` (`data.reason="REFUSED"`) | continues |
+| conflict-resolver `AMBIGUOUS` | park via `drop` (`data.reason="ambiguous"`) | continues |
+| conflict-resolver `REFUSED` | park via `drop` (`data.reason="refused"`) | continues |
 | dependency cycle (Phase 2.1) | abort whole run; surface cycle path | n/a (already aborted) |
 | local pull non-FF (Phase 4.2) | fail loud, no auto-fix | halted (data integrity) |
 | external-author-not-allow-listed (Phase 2.2 step 3) | strategy `defer` → one-pass park via `drop` (`data.reason="external-author-not-allow-listed"`) | continues |

--- a/plugins/uberdev/skills/using-uberdev/SKILL.md
+++ b/plugins/uberdev/skills/using-uberdev/SKILL.md
@@ -128,7 +128,7 @@ solve_terminal: ghostty          # one of: ghostty, iterm, cmux
 parallel_solve: true
 auto_install_aliases: true       # boolean — auto-install /issue, /solve, /turbo, /simplify, /review-pr, /merge at SessionStart (default: true; env override: UBERDEV_NO_AUTO_ALIAS=1)
 integration_branch: main         # branch /merge lands PRs into; default = repo default branch
-auto_confirm: false              # boolean — when true, /merge skips the Phase 2.4 plan-confirm prompt and Phase 4.5 stale-branch prompts (CLI flag --yes wins per-run)
+auto_confirm: false              # DEPRECATED — no behavioural effect. /merge is fully unattended (autopilot). Key parses for backward compat; first encounter emits a stderr deprecation notice.
 bot_authors_allow_list:          # PRs from these author logins bypass the
   - dependabot[bot]              # external-contributor refusal logic
   - renovate[bot]
@@ -145,6 +145,6 @@ Settings take effect on next SessionStart. Environment variables (`SOLVE_TERMINA
 
 **`bot_authors_allow_list` semantics:** literal `author.login` matched case-sensitively. Default covers Dependabot and Renovate.
 
-**`auto_confirm` precedence:** CLI flag `--yes` / `-y` (per-run) > config file `auto_confirm: true|false` > scope-based default. Scope-based default: single-PR scope auto-confirms (the explicit PR number is the consent); `--all` / multi-PR scope prompts. Auto-confirm suppresses the Phase 2.4 plan `[y/N]` prompt and the Phase 4.5 stale-branch per-branch prompts; it never authorises destructive actions like auto-rebase — those still require explicit per-branch typed `yes` even when prompted.
+**`auto_confirm` precedence:** **DEPRECATED.** As of the autopilot release, `auto_confirm` (config) and `--yes` / `-y` (CLI) are no-ops — `/merge` is fully unattended end-to-end. The flag is still parsed without error for backward compat; first encounter per run emits one stderr line: `warning: --yes / -y / auto_confirm are deprecated; /merge is now fully unattended. The flag has no behavioural effect.` An audit event `deprecated_flag_used` is recorded. No grace-window removal planned. See `commands/merge.md` `## Deprecated Flags`.
 
 **Recommendation:** commit this file to share workflow conventions across the team; or add it to `.gitignore` if individual preferences differ.

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -22,6 +22,18 @@
 #   M14 — agents/conflict-resolver.md exists with frontmatter + return contract.
 #   M15 — SKILL.md Phase 3 spells out chore(merge): commit format AND no-Claude-trailer rule (D13).
 #   M16 — SKILL.md Phase 1 atomic-write uses same-directory mktemp pattern (D8a).
+#   M17 — SKILL.md declares AUTO_CONFIRM_* constants (deprecated) and DEPRECATED_FLAGS_NOTE.
+#   M18 — SKILL.md Phase 2.4 is unconditional autopilot (no ON/OFF branches, no [y/N] prompt).
+#   M19 — SKILL.md Phase 4.5 carries autopilot affirmative-decision invariant.
+#   M20 — commands/merge.md surfaces --yes / -y as DEPRECATED.
+#   M21 — using-uberdev/SKILL.md flags auto_confirm as DEPRECATED.
+#   M22 — SKILL.md STRATEGY_ENUM declares defer and drop.
+#   M23 — SKILL.md AUDIT_EVENT_ENUM declares all new autopilot events.
+#   M24 — SKILL.md declares PARK_REASON_ENUM, STRATEGY_REASON_ENUM, STALE_REBASE_DECISION_ENUM.
+#   M25 — SKILL.md Phase 3.3v test-fail covers RE-RESOLVE/STRATEGY-SWITCH/PARK with bounds.
+#   M26 — SKILL.md Phase 4.5 documents agent-decided rebase with safety preconditions.
+#   M27 — SKILL.md run-summary block describes Parked and Deferred outcomes.
+#   M28 — SKILL.md prints bot_authors_allow_list at run start AND in run-summary block.
 
 set -u
 set -o pipefail

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -54,16 +54,24 @@ done
 PASS=0
 FAIL=0
 
+pass() {
+  echo "  PASS  $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL  $1"
+  FAIL=$((FAIL + 1))
+}
+
 assert_grep() {
   local file="$1" pattern="$2" desc="$3"
   if grep -qE -e "$pattern" "$file"; then
-    echo "  PASS  $desc"
-    PASS=$((PASS + 1))
+    pass "$desc"
   else
-    echo "  FAIL  $desc"
+    fail "$desc"
     echo "        file:    $file"
     echo "        pattern: $pattern"
-    FAIL=$((FAIL + 1))
   fi
 }
 
@@ -76,11 +84,9 @@ echo
 echo "== M2: commands/merge.md is a thin dispatcher (≤ 50 lines) =="
 LINE_COUNT=$(wc -l < "$CMD_FILE" | tr -d ' ')
 if [ "$LINE_COUNT" -le 50 ]; then
-  echo "  PASS  M2 — $LINE_COUNT lines (≤ 50)"
-  PASS=$((PASS + 1))
+  pass "M2 — $LINE_COUNT lines (≤ 50)"
 else
-  echo "  FAIL  M2 — $LINE_COUNT lines (> 50, dispatcher should stay thin)"
-  FAIL=$((FAIL + 1))
+  fail "M2 — $LINE_COUNT lines (> 50, dispatcher should stay thin)"
 fi
 
 echo
@@ -89,11 +95,9 @@ assert_grep "$CMD_FILE" 'uberdev:merge([^-A-Za-z0-9_]|$)' \
   "M3 — invokes uberdev:merge (not merge-prs or any other name)"
 # Negative: must NOT reference the rejected skill name 'merge-prs'.
 if grep -qE 'merge-prs\b' "$CMD_FILE"; then
-  echo "  FAIL  M3.neg — references rejected skill name 'merge-prs'"
-  FAIL=$((FAIL + 1))
+  fail "M3.neg — references rejected skill name 'merge-prs'"
 else
-  echo "  PASS  M3.neg — does NOT reference rejected skill name 'merge-prs'"
-  PASS=$((PASS + 1))
+  pass "M3.neg — does NOT reference rejected skill name 'merge-prs'"
 fi
 
 echo
@@ -165,8 +169,7 @@ assert_grep "$SKILL_FILE" 'org-owned|Organization' \
 echo
 echo "== M14: agents/conflict-resolver.md exists with frontmatter + return contract =="
 if [ ! -r "$AGENT_FILE" ]; then
-  echo "  FAIL  M14 — agent file missing: $AGENT_FILE"
-  FAIL=$((FAIL + 1))
+  fail "M14 — agent file missing: $AGENT_FILE"
 else
   assert_grep "$AGENT_FILE" '^name: conflict-resolver' \
     "M14.1 — agent has name frontmatter key"
@@ -190,12 +193,10 @@ assert_grep "$SKILL_FILE" 'chore\(merge\):' \
 # the marker whether it appears before OR after the Co-Authored-By literal,
 # which awk's forward-streaming approach misses.
 if grep -B5 -A5 'Co-Authored-By' "$SKILL_FILE" | grep -qE 'MUST NOT|must not'; then
-  echo "  PASS  M15.2 — 'MUST NOT' (or 'must not') near Co-Authored-By reference"
-  PASS=$((PASS + 1))
+  pass "M15.2 — 'MUST NOT' (or 'must not') near Co-Authored-By reference"
 else
-  echo "  FAIL  M15.2 — no 'MUST NOT' guard near Co-Authored-By in SKILL.md"
+  fail "M15.2 — no 'MUST NOT' guard near Co-Authored-By in SKILL.md"
   echo "         (D13 mandates the resolution commit MUST NOT include the Claude trailer)"
-  FAIL=$((FAIL + 1))
 fi
 
 echo
@@ -210,12 +211,10 @@ echo "== M16: SKILL.md Phase 1 atomic-write uses same-directory mktemp pattern (
 # mktemp and break atomicity.
 if awk '/^## Phase 1/,/^## Phase 2/' "$SKILL_FILE" | \
      grep -qE 'mktemp[^|`]*(--tmpdir="?\$\(dirname|"\$\{?TARGET\}?\.[A-Za-z]*X{3,}"|"\$TARGET\.[A-Za-z]*X{3,}")'; then
-  echo "  PASS  M16 — Phase 1 mktemp roots tempfile in target directory (atomic mv guaranteed)"
-  PASS=$((PASS + 1))
+  pass "M16 — Phase 1 mktemp roots tempfile in target directory (atomic mv guaranteed)"
 else
-  echo "  FAIL  M16 — Phase 1 mktemp must use same-directory pattern (--tmpdir=\"\$(dirname …)\" or \"\$TARGET.XXXXXX\")"
+  fail "M16 — Phase 1 mktemp must use same-directory pattern (--tmpdir=\"\$(dirname …)\" or \"\$TARGET.XXXXXX\")"
   echo "         (bare mktemp defaults to \$TMPDIR; mv -f across filesystems is NOT atomic)"
-  FAIL=$((FAIL + 1))
 fi
 
 echo
@@ -230,11 +229,9 @@ assert_grep "$SKILL_FILE" '`AUTO_CONFIRM_KEY`' \
 assert_grep "$SKILL_FILE" '`AUTO_CONFIRM_FLAGS`' \
   "M17.2 — AUTO_CONFIRM_FLAGS constant declared (CLI flags)"
 if grep -qE '^\| `AUTO_CONFIRM_DEFAULT_(SINGLE|MULTI)`' "$SKILL_FILE"; then
-  echo "  FAIL  M17.3 — AUTO_CONFIRM_DEFAULT_(SINGLE|MULTI) constants must be REMOVED for autopilot (no scope-based default)"
-  FAIL=$((FAIL + 1))
+  fail "M17.3 — AUTO_CONFIRM_DEFAULT_(SINGLE|MULTI) constants must be REMOVED for autopilot (no scope-based default)"
 else
-  echo "  PASS  M17.3 — AUTO_CONFIRM_DEFAULT_(SINGLE|MULTI) constants correctly absent (autopilot is unconditional)"
-  PASS=$((PASS + 1))
+  pass "M17.3 — AUTO_CONFIRM_DEFAULT_(SINGLE|MULTI) constants correctly absent (autopilot is unconditional)"
 fi
 assert_grep "$SKILL_FILE" 'Autopilot \(always ON\)|Autopilot.*always.*ON' \
   "M17.4 — Inputs section declares 'Autopilot (always ON)' (autopilot mode, no precedence chain)"
@@ -247,69 +244,52 @@ echo
 echo "== M18: SKILL.md Phase 2.4 is unconditional autopilot (no ON/OFF branches, no [y/N] prompt) =="
 PHASE_2_4=$(awk '/^### Step 2\.4/,/^## Phase 3/' "$SKILL_FILE")
 if echo "$PHASE_2_4" | grep -qE 'If auto-confirm is ON|If auto-confirm is OFF'; then
-  echo "  FAIL  M18.1 — Phase 2.4 must NOT contain 'If auto-confirm is ON/OFF' branches (autopilot is unconditional)"
-  FAIL=$((FAIL + 1))
+  fail "M18.1 — Phase 2.4 must NOT contain 'If auto-confirm is ON/OFF' branches (autopilot is unconditional)"
 else
-  echo "  PASS  M18.1 — Phase 2.4 has NO ON/OFF branches (autopilot is unconditional)"
-  PASS=$((PASS + 1))
+  pass "M18.1 — Phase 2.4 has NO ON/OFF branches (autopilot is unconditional)"
 fi
 if echo "$PHASE_2_4" | grep -qE 'autopilot|Autopilot'; then
-  echo "  PASS  M18.2 — Phase 2.4 carries autopilot prose"
-  PASS=$((PASS + 1))
+  pass "M18.2 — Phase 2.4 carries autopilot prose"
 else
-  echo "  FAIL  M18.2 — Phase 2.4 MUST mention autopilot"
-  FAIL=$((FAIL + 1))
+  fail "M18.2 — Phase 2.4 MUST mention autopilot"
 fi
 # A positive prompt would have either [y/N] near it, OR `Apply this plan?` without
 # a preceding "NO" / "no" within the same line. Scan for that pattern.
 if echo "$PHASE_2_4" | grep -qE '\[y/N\].*Apply this plan\?|Apply this plan\?.*\[y/N\]'; then
-  echo "  FAIL  M18.3 — Phase 2.4 must NOT contain a positive 'Apply this plan?' [y/N] prompt (autopilot is unconditional)"
-  FAIL=$((FAIL + 1))
+  fail "M18.3 — Phase 2.4 must NOT contain a positive 'Apply this plan?' [y/N] prompt (autopilot is unconditional)"
 elif echo "$PHASE_2_4" | grep -E 'Apply this plan\?' | grep -qvE '\bNO\b|\bno\b'; then
-  echo "  FAIL  M18.3 — Phase 2.4 has 'Apply this plan?' without a NO/no qualifier (likely a positive prompt)"
-  FAIL=$((FAIL + 1))
+  fail "M18.3 — Phase 2.4 has 'Apply this plan?' without a NO/no qualifier (likely a positive prompt)"
 else
-  echo "  PASS  M18.3 — Phase 2.4 has no positive 'Apply this plan?' prompt"
-  PASS=$((PASS + 1))
+  pass "M18.3 — Phase 2.4 has no positive 'Apply this plan?' prompt"
 fi
 if echo "$PHASE_2_4" | grep -qE 'autopilot-default'; then
-  echo "  PASS  M18.4 — Phase 2.4 emits 'autopilot-default' as data.reason for order_confirmed"
-  PASS=$((PASS + 1))
+  pass "M18.4 — Phase 2.4 emits 'autopilot-default' as data.reason for order_confirmed"
 else
-  echo "  FAIL  M18.4 — Phase 2.4 MUST emit data.reason='autopilot-default' for order_confirmed"
-  FAIL=$((FAIL + 1))
+  fail "M18.4 — Phase 2.4 MUST emit data.reason='autopilot-default' for order_confirmed"
 fi
 
 echo
 echo "== M19: SKILL.md Phase 4.5 carries the autopilot affirmative-decision invariant =="
 PHASE_4_5=$(awk '/^### Step 4\.5/,/^### Step 4\.6/' "$SKILL_FILE")
 if echo "$PHASE_4_5" | grep -qE 'never rebases without an explicit affirmative decision'; then
-  echo "  PASS  M19.1 — Phase 4.5 carries Q2 invariant 'never rebases without an explicit affirmative decision'"
-  PASS=$((PASS + 1))
+  pass "M19.1 — Phase 4.5 carries Q2 invariant 'never rebases without an explicit affirmative decision'"
 else
-  echo "  FAIL  M19.1 — Phase 4.5 MUST contain verbatim 'never rebases without an explicit affirmative decision'"
-  FAIL=$((FAIL + 1))
+  fail "M19.1 — Phase 4.5 MUST contain verbatim 'never rebases without an explicit affirmative decision'"
 fi
 if echo "$PHASE_4_5" | grep -qE "agent's typed decision-record is the affirmative form|typed decision-record is the affirmative form"; then
-  echo "  PASS  M19.2 — Phase 4.5 names the typed decision-record as the affirmative form"
-  PASS=$((PASS + 1))
+  pass "M19.2 — Phase 4.5 names the typed decision-record as the affirmative form"
 else
-  echo "  FAIL  M19.2 — Phase 4.5 MUST state 'the agent's typed decision-record is the affirmative form for autopilot mode'"
-  FAIL=$((FAIL + 1))
+  fail "M19.2 — Phase 4.5 MUST state 'the agent's typed decision-record is the affirmative form for autopilot mode'"
 fi
 if echo "$PHASE_4_5" | grep -qE 'If auto-confirm is ON|If auto-confirm is OFF'; then
-  echo "  FAIL  M19.3 — Phase 4.5 must NOT branch on auto-confirm (autopilot is unconditional)"
-  FAIL=$((FAIL + 1))
+  fail "M19.3 — Phase 4.5 must NOT branch on auto-confirm (autopilot is unconditional)"
 else
-  echo "  PASS  M19.3 — Phase 4.5 has no auto-confirm ON/OFF branching (autopilot is unconditional)"
-  PASS=$((PASS + 1))
+  pass "M19.3 — Phase 4.5 has no auto-confirm ON/OFF branching (autopilot is unconditional)"
 fi
 if echo "$PHASE_4_5" | grep -qE 'Force-push to PR head refs remains absolutely forbidden|Never `--force`|never --force|Force-push to PR head refs remains forbidden absolutely'; then
-  echo "  PASS  M19.4 — Phase 4.5 preserves the no-force-push invariant"
-  PASS=$((PASS + 1))
+  pass "M19.4 — Phase 4.5 preserves the no-force-push invariant"
 else
-  echo "  FAIL  M19.4 — Phase 4.5 MUST preserve the 'no force-push to PR head refs' invariant"
-  FAIL=$((FAIL + 1))
+  fail "M19.4 — Phase 4.5 MUST preserve the 'no force-push to PR head refs' invariant"
 fi
 
 echo
@@ -325,30 +305,25 @@ assert_grep "$CMD_FILE" 'no behavioural effect' \
 assert_grep "$CMD_FILE" '`--yes` / `-y`.*deprecated|deprecated.*`--yes` / `-y`' \
   "M20.5 — bullet for --yes / -y is annotated deprecated"
 if grep -qE 'autopilot|Autopilot' "$CMD_FILE"; then
-  echo "  PASS  M20.6 — commands/merge.md mentions autopilot mode"
-  PASS=$((PASS + 1))
+  pass "M20.6 — commands/merge.md mentions autopilot mode"
 else
-  echo "  FAIL  M20.6 — commands/merge.md MUST describe autopilot mode"
-  FAIL=$((FAIL + 1))
+  fail "M20.6 — commands/merge.md MUST describe autopilot mode"
 fi
 
 echo
 echo "== M21: using-uberdev/SKILL.md auto_confirm key documented as DEPRECATED =="
 USING_SKILL_FILE="$REPO_ROOT/plugins/uberdev/skills/using-uberdev/SKILL.md"
 if [ ! -r "$USING_SKILL_FILE" ]; then
-  echo "  FAIL  M21 — using-uberdev SKILL.md missing or unreadable: $USING_SKILL_FILE"
-  FAIL=$((FAIL + 1))
+  fail "M21 — using-uberdev SKILL.md missing or unreadable: $USING_SKILL_FILE"
 else
   assert_grep "$USING_SKILL_FILE" '^auto_confirm:' \
     "M21.1 — auto_confirm key still present in YAML example (parsed for backward compat)"
   assert_grep "$USING_SKILL_FILE" '\*\*`auto_confirm` precedence:\*\*' \
     "M21.2 — auto_confirm precedence paragraph still present (now flags deprecation)"
   if grep -qiE 'DEPRECATED' "$USING_SKILL_FILE"; then
-    echo "  PASS  M21.3 — using-uberdev/SKILL.md flags auto_confirm as DEPRECATED"
-    PASS=$((PASS + 1))
+    pass "M21.3 — using-uberdev/SKILL.md flags auto_confirm as DEPRECATED"
   else
-    echo "  FAIL  M21.3 — using-uberdev/SKILL.md MUST flag auto_confirm as DEPRECATED"
-    FAIL=$((FAIL + 1))
+    fail "M21.3 — using-uberdev/SKILL.md MUST flag auto_confirm as DEPRECATED"
   fi
 fi
 
@@ -356,22 +331,18 @@ echo
 echo "== M22: SKILL.md STRATEGY_ENUM declares defer and drop =="
 if grep -E '^\| `STRATEGY_ENUM` \|' "$SKILL_FILE" | grep -qE '`defer`' && \
    grep -E '^\| `STRATEGY_ENUM` \|' "$SKILL_FILE" | grep -qE '`drop`'; then
-  echo "  PASS  M22 — STRATEGY_ENUM lists both \`defer\` and \`drop\`"
-  PASS=$((PASS + 1))
+  pass "M22 — STRATEGY_ENUM lists both \`defer\` and \`drop\`"
 else
-  echo "  FAIL  M22 — STRATEGY_ENUM row in Constants must list both \`defer\` and \`drop\`"
-  FAIL=$((FAIL + 1))
+  fail "M22 — STRATEGY_ENUM row in Constants must list both \`defer\` and \`drop\`"
 fi
 
 echo
 echo "== M23: SKILL.md AUDIT_EVENT_ENUM declares all new autopilot events =="
 for ev in pr_parked pr_deferred stale_branch_rebase_decision deprecated_flag_used agent_strategy_switch test_fail_agent_decision; do
   if grep -E '^\| `AUDIT_EVENT_ENUM` \|' "$SKILL_FILE" | grep -qE "\`$ev\`"; then
-    echo "  PASS  M23.$ev — AUDIT_EVENT_ENUM declares \`$ev\`"
-    PASS=$((PASS + 1))
+    pass "M23.$ev — AUDIT_EVENT_ENUM declares \`$ev\`"
   else
-    echo "  FAIL  M23.$ev — AUDIT_EVENT_ENUM missing \`$ev\`"
-    FAIL=$((FAIL + 1))
+    fail "M23.$ev — AUDIT_EVENT_ENUM missing \`$ev\`"
   fi
 done
 
@@ -391,68 +362,52 @@ echo "== M25: SKILL.md Phase 3.3v test-fail response covers re-resolve / strateg
 PHASE_3_3V=$(awk '/^v\. \*\*Pre-push test gate/,/^vi\. \*\*Push the resolution/' "$SKILL_FILE")
 for branch in 'RE-RESOLVE' 'STRATEGY-SWITCH' 'PARK'; do
   if echo "$PHASE_3_3V" | grep -qE "$branch"; then
-    echo "  PASS  M25.$branch — Phase 3.3v documents $branch branch"
-    PASS=$((PASS + 1))
+    pass "M25.$branch — Phase 3.3v documents $branch branch"
   else
-    echo "  FAIL  M25.$branch — Phase 3.3v MUST document $branch branch (agent-decided test-fail response)"
-    FAIL=$((FAIL + 1))
+    fail "M25.$branch — Phase 3.3v MUST document $branch branch (agent-decided test-fail response)"
   fi
 done
 if echo "$PHASE_3_3V" | grep -qE 'Max 1 retry|max.{0,5}1.{0,5}retry'; then
-  echo "  PASS  M25.bound-retry — Phase 3.3v bounds re-resolve to max 1 retry"
-  PASS=$((PASS + 1))
+  pass "M25.bound-retry — Phase 3.3v bounds re-resolve to max 1 retry"
 else
-  echo "  FAIL  M25.bound-retry — Phase 3.3v MUST cap re-resolve at max 1 retry per PR per run"
-  FAIL=$((FAIL + 1))
+  fail "M25.bound-retry — Phase 3.3v MUST cap re-resolve at max 1 retry per PR per run"
 fi
 if echo "$PHASE_3_3V" | grep -qE 'Max 1 switch|max.{0,5}1.{0,5}switch'; then
-  echo "  PASS  M25.bound-switch — Phase 3.3v bounds strategy-switch to max 1 per PR per run"
-  PASS=$((PASS + 1))
+  pass "M25.bound-switch — Phase 3.3v bounds strategy-switch to max 1 per PR per run"
 else
-  echo "  FAIL  M25.bound-switch — Phase 3.3v MUST cap strategy-switch at max 1 per PR per run"
-  FAIL=$((FAIL + 1))
+  fail "M25.bound-switch — Phase 3.3v MUST cap strategy-switch at max 1 per PR per run"
 fi
 if echo "$PHASE_3_3V" | grep -qE 'max 3 test runs per PR per run|Worst-case test runs per PR per run:[[:space:]]*3|3 test runs per PR per run'; then
-  echo "  PASS  M25.worst-case — Phase 3.3v states max 3 test runs per PR per run"
-  PASS=$((PASS + 1))
+  pass "M25.worst-case — Phase 3.3v states max 3 test runs per PR per run"
 else
-  echo "  FAIL  M25.worst-case — Phase 3.3v MUST state max 3 test runs per PR per run (initial + re-resolve-retry + strategy-switch-retry)"
-  FAIL=$((FAIL + 1))
+  fail "M25.worst-case — Phase 3.3v MUST state max 3 test runs per PR per run (initial + re-resolve-retry + strategy-switch-retry)"
 fi
 
 echo
 echo "== M26: SKILL.md Phase 4.5 documents agent-decided rebase with safety preconditions =="
 PHASE_4_5=$(awk '/^### Step 4\.5/,/^### Step 4\.6/' "$SKILL_FILE")
 if echo "$PHASE_4_5" | grep -qE 'never rebases without an explicit affirmative decision'; then
-  echo "  PASS  M26.invariant — Phase 4.5 carries the Q2 'never rebases without affirmative decision' invariant"
-  PASS=$((PASS + 1))
+  pass "M26.invariant — Phase 4.5 carries the Q2 'never rebases without affirmative decision' invariant"
 else
-  echo "  FAIL  M26.invariant — Phase 4.5 MUST include verbatim 'never rebases without an explicit affirmative decision'"
-  FAIL=$((FAIL + 1))
+  fail "M26.invariant — Phase 4.5 MUST include verbatim 'never rebases without an explicit affirmative decision'"
 fi
 if echo "$PHASE_4_5" | grep -qE "agent's typed decision-record is the affirmative form|structured decision-record"; then
-  echo "  PASS  M26.affirmation — Phase 4.5 names the typed decision-record as the affirmative form"
-  PASS=$((PASS + 1))
+  pass "M26.affirmation — Phase 4.5 names the typed decision-record as the affirmative form"
 else
-  echo "  FAIL  M26.affirmation — Phase 4.5 MUST state the typed decision-record is the affirmative form for autopilot mode"
-  FAIL=$((FAIL + 1))
+  fail "M26.affirmation — Phase 4.5 MUST state the typed decision-record is the affirmative form for autopilot mode"
 fi
 for cond in 'merge-tree --write-tree' 'PR head ref' 'force-push'; do
   if echo "$PHASE_4_5" | grep -qE "$cond"; then
-    echo "  PASS  M26.precond[$cond] — Phase 4.5 references safety precondition: $cond"
-    PASS=$((PASS + 1))
+    pass "M26.precond[$cond] — Phase 4.5 references safety precondition: $cond"
   else
-    echo "  FAIL  M26.precond[$cond] — Phase 4.5 MUST reference $cond as part of safety preconditions"
-    FAIL=$((FAIL + 1))
+    fail "M26.precond[$cond] — Phase 4.5 MUST reference $cond as part of safety preconditions"
   fi
 done
 for choice in 'rebased-ff-clean' 'skipped-conflicts' 'skipped-pr-head-ref' 'rebase-aborted'; do
   if echo "$PHASE_4_5" | grep -qE "\`$choice\`"; then
-    echo "  PASS  M26.choice[$choice] — Phase 4.5 emits STALE_REBASE_DECISION_ENUM value \`$choice\`"
-    PASS=$((PASS + 1))
+    pass "M26.choice[$choice] — Phase 4.5 emits STALE_REBASE_DECISION_ENUM value \`$choice\`"
   else
-    echo "  FAIL  M26.choice[$choice] — Phase 4.5 MUST document STALE_REBASE_DECISION_ENUM value \`$choice\`"
-    FAIL=$((FAIL + 1))
+    fail "M26.choice[$choice] — Phase 4.5 MUST document STALE_REBASE_DECISION_ENUM value \`$choice\`"
   fi
 done
 
@@ -461,20 +416,16 @@ echo "== M27: SKILL.md run-summary block describes Parked and Deferred outcomes 
 SUMMARY_BLOCK=$(awk '/^### Run-summary block/,/^## /' "$SKILL_FILE")
 for outcome in Parked Deferred; do
   if echo "$SUMMARY_BLOCK" | grep -qE "^[[:space:]]*${outcome}:"; then
-    echo "  PASS  M27.$outcome — run-summary block names $outcome outcome at top level"
-    PASS=$((PASS + 1))
+    pass "M27.$outcome — run-summary block names $outcome outcome at top level"
   else
-    echo "  FAIL  M27.$outcome — run-summary block MUST list ${outcome}: <count> at top level (alongside Merged/Skipped/Aborted)"
-    FAIL=$((FAIL + 1))
+    fail "M27.$outcome — run-summary block MUST list ${outcome}: <count> at top level (alongside Merged/Skipped/Aborted)"
   fi
 done
 for field in 'strategy:' 'rationale:' 'outcome:' 'park reason:'; do
   if echo "$SUMMARY_BLOCK" | grep -qiE "$field"; then
-    echo "  PASS  M27.field[$field] — run-summary detail block names \"$field\" field"
-    PASS=$((PASS + 1))
+    pass "M27.field[$field] — run-summary detail block names \"$field\" field"
   else
-    echo "  FAIL  M27.field[$field] — run-summary detail block MUST include \"$field\" field"
-    FAIL=$((FAIL + 1))
+    fail "M27.field[$field] — run-summary detail block MUST include \"$field\" field"
   fi
 done
 
@@ -482,19 +433,15 @@ echo
 echo "== M28: SKILL.md prints bot_authors_allow_list at run start AND in run-summary block =="
 PHASE_1=$(awk '/^## Phase 1/,/^## Phase 2/' "$SKILL_FILE")
 if echo "$PHASE_1" | grep -qiE '/merge autopilot — allow-listed authors|/merge autopilot -- allow-listed authors|^### Step 1\.0|allow-listed authors:'; then
-  echo "  PASS  M28.preflight — Phase 1 prints bot_authors_allow_list summary at run start"
-  PASS=$((PASS + 1))
+  pass "M28.preflight — Phase 1 prints bot_authors_allow_list summary at run start"
 else
-  echo "  FAIL  M28.preflight — Phase 1 MUST print bot_authors_allow_list summary at run start (pre-flight banner)"
-  FAIL=$((FAIL + 1))
+  fail "M28.preflight — Phase 1 MUST print bot_authors_allow_list summary at run start (pre-flight banner)"
 fi
 SUMMARY_BLOCK=$(awk '/^### Run-summary block/,/^## /' "$SKILL_FILE")
 if echo "$SUMMARY_BLOCK" | grep -qiE 'Allow-listed authors|allow-list|bot_authors_allow_list'; then
-  echo "  PASS  M28.summary — run-summary block re-prints bot_authors_allow_list as audit anchor"
-  PASS=$((PASS + 1))
+  pass "M28.summary — run-summary block re-prints bot_authors_allow_list as audit anchor"
 else
-  echo "  FAIL  M28.summary — run-summary block MUST re-print bot_authors_allow_list (audit anchor)"
-  FAIL=$((FAIL + 1))
+  fail "M28.summary — run-summary block MUST re-print bot_authors_allow_list (audit anchor)"
 fi
 
 echo

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -284,6 +284,151 @@ else
 fi
 
 echo
+echo "== M22: SKILL.md STRATEGY_ENUM declares defer and drop =="
+if grep -E '^\| `STRATEGY_ENUM` \|' "$SKILL_FILE" | grep -qE '`defer`' && \
+   grep -E '^\| `STRATEGY_ENUM` \|' "$SKILL_FILE" | grep -qE '`drop`'; then
+  echo "  PASS  M22 — STRATEGY_ENUM lists both \`defer\` and \`drop\`"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M22 — STRATEGY_ENUM row in Constants must list both \`defer\` and \`drop\`"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== M23: SKILL.md AUDIT_EVENT_ENUM declares all new autopilot events =="
+for ev in pr_parked pr_deferred stale_branch_rebase_decision deprecated_flag_used agent_strategy_switch test_fail_agent_decision; do
+  if grep -E '^\| `AUDIT_EVENT_ENUM` \|' "$SKILL_FILE" | grep -qE "\`$ev\`"; then
+    echo "  PASS  M23.$ev — AUDIT_EVENT_ENUM declares \`$ev\`"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  M23.$ev — AUDIT_EVENT_ENUM missing \`$ev\`"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo
+echo "== M24: SKILL.md declares PARK_REASON_ENUM, STRATEGY_REASON_ENUM, STALE_REBASE_DECISION_ENUM =="
+for c in PARK_REASON_ENUM STRATEGY_REASON_ENUM STALE_REBASE_DECISION_ENUM; do
+  assert_grep "$SKILL_FILE" "\`$c\`" "M24.$c — \`$c\` constant declared"
+done
+# M24.PARK_REASON_ENUM values
+assert_grep "$SKILL_FILE" '`test-fail-exhausted`' \
+  "M24.PARK.test-fail — PARK_REASON_ENUM lists \`test-fail-exhausted\`"
+assert_grep "$SKILL_FILE" '`external-author-not-allow-listed`' \
+  "M24.PARK.ext-author — PARK_REASON_ENUM lists \`external-author-not-allow-listed\`"
+
+echo
+echo "== M25: SKILL.md Phase 3.3v test-fail response covers re-resolve / strategy-switch / park =="
+PHASE_3_3V=$(awk '/^v\. \*\*Pre-push test gate/,/^vi\. \*\*Push the resolution/' "$SKILL_FILE")
+for branch in 'RE-RESOLVE' 'STRATEGY-SWITCH' 'PARK'; do
+  if echo "$PHASE_3_3V" | grep -qE "$branch"; then
+    echo "  PASS  M25.$branch — Phase 3.3v documents $branch branch"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  M25.$branch — Phase 3.3v MUST document $branch branch (agent-decided test-fail response)"
+    FAIL=$((FAIL + 1))
+  fi
+done
+if echo "$PHASE_3_3V" | grep -qE 'Max 1 retry|max.{0,5}1.{0,5}retry'; then
+  echo "  PASS  M25.bound-retry — Phase 3.3v bounds re-resolve to max 1 retry"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M25.bound-retry — Phase 3.3v MUST cap re-resolve at max 1 retry per PR per run"
+  FAIL=$((FAIL + 1))
+fi
+if echo "$PHASE_3_3V" | grep -qE 'Max 1 switch|max.{0,5}1.{0,5}switch'; then
+  echo "  PASS  M25.bound-switch — Phase 3.3v bounds strategy-switch to max 1 per PR per run"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M25.bound-switch — Phase 3.3v MUST cap strategy-switch at max 1 per PR per run"
+  FAIL=$((FAIL + 1))
+fi
+if echo "$PHASE_3_3V" | grep -qE 'max 3 test runs per PR per run|Worst-case test runs per PR per run:[[:space:]]*3|3 test runs per PR per run'; then
+  echo "  PASS  M25.worst-case — Phase 3.3v states max 3 test runs per PR per run"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M25.worst-case — Phase 3.3v MUST state max 3 test runs per PR per run (initial + re-resolve-retry + strategy-switch-retry)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== M26: SKILL.md Phase 4.5 documents agent-decided rebase with safety preconditions =="
+PHASE_4_5=$(awk '/^### Step 4\.5/,/^### Step 4\.6/' "$SKILL_FILE")
+if echo "$PHASE_4_5" | grep -qE 'never rebases without an explicit affirmative decision'; then
+  echo "  PASS  M26.invariant — Phase 4.5 carries the Q2 'never rebases without affirmative decision' invariant"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M26.invariant — Phase 4.5 MUST include verbatim 'never rebases without an explicit affirmative decision'"
+  FAIL=$((FAIL + 1))
+fi
+if echo "$PHASE_4_5" | grep -qE "agent's typed decision-record is the affirmative form|structured decision-record"; then
+  echo "  PASS  M26.affirmation — Phase 4.5 names the typed decision-record as the affirmative form"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M26.affirmation — Phase 4.5 MUST state the typed decision-record is the affirmative form for autopilot mode"
+  FAIL=$((FAIL + 1))
+fi
+for cond in 'merge-tree --write-tree' 'PR head ref' 'force-push'; do
+  if echo "$PHASE_4_5" | grep -qE "$cond"; then
+    echo "  PASS  M26.precond[$cond] — Phase 4.5 references safety precondition: $cond"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  M26.precond[$cond] — Phase 4.5 MUST reference $cond as part of safety preconditions"
+    FAIL=$((FAIL + 1))
+  fi
+done
+for choice in 'rebased-ff-clean' 'skipped-conflicts' 'skipped-pr-head-ref' 'rebase-aborted'; do
+  if echo "$PHASE_4_5" | grep -qE "\`$choice\`"; then
+    echo "  PASS  M26.choice[$choice] — Phase 4.5 emits STALE_REBASE_DECISION_ENUM value \`$choice\`"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  M26.choice[$choice] — Phase 4.5 MUST document STALE_REBASE_DECISION_ENUM value \`$choice\`"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo
+echo "== M27: SKILL.md run-summary block describes Parked and Deferred outcomes =="
+SUMMARY_BLOCK=$(awk '/^### Run-summary block/,/^## /' "$SKILL_FILE")
+for outcome in Parked Deferred; do
+  if echo "$SUMMARY_BLOCK" | grep -qE "^[[:space:]]*${outcome}:"; then
+    echo "  PASS  M27.$outcome — run-summary block names $outcome outcome at top level"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  M27.$outcome — run-summary block MUST list ${outcome}: <count> at top level (alongside Merged/Skipped/Aborted)"
+    FAIL=$((FAIL + 1))
+  fi
+done
+for field in 'strategy:' 'rationale:' 'outcome:' 'park reason:'; do
+  if echo "$SUMMARY_BLOCK" | grep -qiE "$field"; then
+    echo "  PASS  M27.field[$field] — run-summary detail block names \"$field\" field"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  M27.field[$field] — run-summary detail block MUST include \"$field\" field"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo
+echo "== M28: SKILL.md prints bot_authors_allow_list at run start AND in run-summary block =="
+PHASE_1=$(awk '/^## Phase 1/,/^## Phase 2/' "$SKILL_FILE")
+if echo "$PHASE_1" | grep -qiE '/merge autopilot — allow-listed authors|/merge autopilot -- allow-listed authors|^### Step 1\.0|allow-listed authors:'; then
+  echo "  PASS  M28.preflight — Phase 1 prints bot_authors_allow_list summary at run start"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M28.preflight — Phase 1 MUST print bot_authors_allow_list summary at run start (pre-flight banner)"
+  FAIL=$((FAIL + 1))
+fi
+SUMMARY_BLOCK=$(awk '/^### Run-summary block/,/^## /' "$SKILL_FILE")
+if echo "$SUMMARY_BLOCK" | grep -qiE 'Allow-listed authors|allow-list|bot_authors_allow_list'; then
+  echo "  PASS  M28.summary — run-summary block re-prints bot_authors_allow_list as audit anchor"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M28.summary — run-summary block MUST re-print bot_authors_allow_list (audit anchor)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
 echo "== Summary =="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -137,9 +137,11 @@ assert_grep "$SKILL_FILE" '\.uberdev/runs/.*audit\.jsonl' \
   "M11 — audit log path declared"
 
 echo
-echo "== M12: SKILL.md mandates pre-push test gate (D16, no skip path) =="
-assert_grep "$SKILL_FILE" 'test gate|test command runs in scratch worktree|run the project' \
-  "M12 — pre-push test gate prose present"
+echo "== M12: SKILL.md mandates pre-push test gate runs ALWAYS, with agent-decided fail response =="
+assert_grep "$SKILL_FILE" 'ALWAYS RUNS|test gate.*always' \
+  "M12.1 — Phase 3.3v test gate ALWAYS RUNS prose present"
+assert_grep "$SKILL_FILE" 'agent picks ONE of three|agent picks one of three|agent picks the best applicable branch' \
+  "M12.2 — Phase 3.3v agent-decided test-fail response prose present"
 
 echo
 echo "== M13: SKILL.md describes fork-PR preflight refusal for org-owned forks (Q3) =="
@@ -215,72 +217,127 @@ assert_grep "$SKILL_FILE" '`AUTO_CONFIRM_KEY`' \
   "M17.1 — AUTO_CONFIRM_KEY constant declared"
 assert_grep "$SKILL_FILE" '`AUTO_CONFIRM_FLAGS`' \
   "M17.2 — AUTO_CONFIRM_FLAGS constant declared (CLI flags)"
-assert_grep "$SKILL_FILE" '`AUTO_CONFIRM_DEFAULT_(SINGLE|MULTI)`' \
-  "M17.3 — AUTO_CONFIRM_DEFAULT_SINGLE/MULTI constants declared"
-assert_grep "$SKILL_FILE" 'Auto-confirm resolution.*CLI flag wins' \
-  "M17.4 — auto-confirm precedence chain (CLI > config > scope) documented in Inputs"
+if grep -qE '^\| `AUTO_CONFIRM_DEFAULT_(SINGLE|MULTI)`' "$SKILL_FILE"; then
+  echo "  FAIL  M17.3 — AUTO_CONFIRM_DEFAULT_(SINGLE|MULTI) constants must be REMOVED for autopilot (no scope-based default)"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  M17.3 — AUTO_CONFIRM_DEFAULT_(SINGLE|MULTI) constants correctly absent (autopilot is unconditional)"
+  PASS=$((PASS + 1))
+fi
+assert_grep "$SKILL_FILE" 'Autopilot \(always ON\)|Autopilot.*always.*ON' \
+  "M17.4 — Inputs section declares 'Autopilot (always ON)' (autopilot mode, no precedence chain)"
+assert_grep "$SKILL_FILE" '`DEPRECATED_FLAGS_NOTE`' \
+  "M17.5 — DEPRECATED_FLAGS_NOTE constant declared"
+assert_grep "$SKILL_FILE" 'no behavioural effect' \
+  "M17.6 — DEPRECATED_FLAGS_NOTE value contains 'no behavioural effect'"
 
 echo
-echo "== M18: SKILL.md Phase 2.4 documents both auto-confirm ON and OFF branches =="
-# M18 prevents silent deletion of either branch — interactive [y/N]
-# users (auto-confirm OFF) and auto-mode users (auto-confirm ON) must
-# both stay supported.
-if awk '/^### Step 2\.4/,/^## Phase 3/' "$SKILL_FILE" | \
-     grep -qE 'If auto-confirm is ON' && \
-   awk '/^### Step 2\.4/,/^## Phase 3/' "$SKILL_FILE" | \
-     grep -qE 'If auto-confirm is OFF'; then
-  echo "  PASS  M18.1 — Phase 2.4 documents both auto-confirm ON and OFF branches"
+echo "== M18: SKILL.md Phase 2.4 is unconditional autopilot (no ON/OFF branches, no [y/N] prompt) =="
+PHASE_2_4=$(awk '/^### Step 2\.4/,/^## Phase 3/' "$SKILL_FILE")
+if echo "$PHASE_2_4" | grep -qE 'If auto-confirm is ON|If auto-confirm is OFF'; then
+  echo "  FAIL  M18.1 — Phase 2.4 must NOT contain 'If auto-confirm is ON/OFF' branches (autopilot is unconditional)"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  M18.1 — Phase 2.4 has NO ON/OFF branches (autopilot is unconditional)"
+  PASS=$((PASS + 1))
+fi
+if echo "$PHASE_2_4" | grep -qE 'autopilot|Autopilot'; then
+  echo "  PASS  M18.2 — Phase 2.4 carries autopilot prose"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL  M18.1 — Phase 2.4 must document BOTH 'If auto-confirm is ON' AND 'If auto-confirm is OFF'"
+  echo "  FAIL  M18.2 — Phase 2.4 MUST mention autopilot"
   FAIL=$((FAIL + 1))
 fi
-assert_grep "$SKILL_FILE" 'Apply this plan\?' \
-  "M18.2 — interactive-mode prompt 'Apply this plan?' present"
-
-echo
-echo "== M19: SKILL.md Phase 4.5 states the no-auto-rebase invariant AND covers both modes =="
-# M19 is load-bearing: Phase 4.5 stale-branch handling MUST never
-# auto-rebase. Auto-confirm only suppresses the offer; it never
-# authorises destructive history-rewriting. A future edit that wires
-# auto-confirm to auto-rebase "for efficiency" could silently rewind
-# the user's in-flight work.
-assert_grep "$SKILL_FILE" 'never\*\* runs `git rebase` automatically|Never auto-execute' \
-  "M19.1 — Phase 4.5 'never auto-rebase' invariant stated"
-if awk '/^### Step 4\.5/,/^### Step 4\.6/' "$SKILL_FILE" | \
-     grep -qE 'If auto-confirm is ON' && \
-   awk '/^### Step 4\.5/,/^### Step 4\.6/' "$SKILL_FILE" | \
-     grep -qE 'If auto-confirm is OFF'; then
-  echo "  PASS  M19.2 — Phase 4.5 documents both auto-confirm ON (list-only) and OFF (per-branch typed yes) branches"
+# A positive prompt would have either [y/N] near it, OR `Apply this plan?` without
+# a preceding "NO" / "no" within the same line. Scan for that pattern.
+if echo "$PHASE_2_4" | grep -qE '\[y/N\].*Apply this plan\?|Apply this plan\?.*\[y/N\]'; then
+  echo "  FAIL  M18.3 — Phase 2.4 must NOT contain a positive 'Apply this plan?' [y/N] prompt (autopilot is unconditional)"
+  FAIL=$((FAIL + 1))
+elif echo "$PHASE_2_4" | grep -E 'Apply this plan\?' | grep -qvE '\bNO\b|\bno\b'; then
+  echo "  FAIL  M18.3 — Phase 2.4 has 'Apply this plan?' without a NO/no qualifier (likely a positive prompt)"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  M18.3 — Phase 2.4 has no positive 'Apply this plan?' prompt"
+  PASS=$((PASS + 1))
+fi
+if echo "$PHASE_2_4" | grep -qE 'autopilot-default'; then
+  echo "  PASS  M18.4 — Phase 2.4 emits 'autopilot-default' as data.reason for order_confirmed"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL  M19.2 — Phase 4.5 must document BOTH 'If auto-confirm is ON' AND 'If auto-confirm is OFF'"
+  echo "  FAIL  M18.4 — Phase 2.4 MUST emit data.reason='autopilot-default' for order_confirmed"
   FAIL=$((FAIL + 1))
 fi
 
 echo
-echo "== M20: commands/merge.md exposes --yes / -y in argument-hint AND Usage line =="
-# M20 keeps the dispatcher's frontmatter and body in sync. argument-hint
-# powers slash-help auto-completion; Usage is the human-readable line.
-# Drift between the two confuses the user.
+echo "== M19: SKILL.md Phase 4.5 carries the autopilot affirmative-decision invariant =="
+PHASE_4_5=$(awk '/^### Step 4\.5/,/^### Step 4\.6/' "$SKILL_FILE")
+if echo "$PHASE_4_5" | grep -qE 'never rebases without an explicit affirmative decision'; then
+  echo "  PASS  M19.1 — Phase 4.5 carries Q2 invariant 'never rebases without an explicit affirmative decision'"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M19.1 — Phase 4.5 MUST contain verbatim 'never rebases without an explicit affirmative decision'"
+  FAIL=$((FAIL + 1))
+fi
+if echo "$PHASE_4_5" | grep -qE "agent's typed decision-record is the affirmative form|typed decision-record is the affirmative form"; then
+  echo "  PASS  M19.2 — Phase 4.5 names the typed decision-record as the affirmative form"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M19.2 — Phase 4.5 MUST state 'the agent's typed decision-record is the affirmative form for autopilot mode'"
+  FAIL=$((FAIL + 1))
+fi
+if echo "$PHASE_4_5" | grep -qE 'If auto-confirm is ON|If auto-confirm is OFF'; then
+  echo "  FAIL  M19.3 — Phase 4.5 must NOT branch on auto-confirm (autopilot is unconditional)"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  M19.3 — Phase 4.5 has no auto-confirm ON/OFF branching (autopilot is unconditional)"
+  PASS=$((PASS + 1))
+fi
+if echo "$PHASE_4_5" | grep -qE 'Force-push to PR head refs remains absolutely forbidden|Never `--force`|never --force|Force-push to PR head refs remains forbidden absolutely'; then
+  echo "  PASS  M19.4 — Phase 4.5 preserves the no-force-push invariant"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M19.4 — Phase 4.5 MUST preserve the 'no force-push to PR head refs' invariant"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== M20: commands/merge.md surfaces --yes / -y as DEPRECATED with stable user-facing notice =="
 assert_grep "$CMD_FILE" '^argument-hint:.*--yes\|-y' \
-  "M20.1 — argument-hint frontmatter lists --yes|-y"
+  "M20.1 — argument-hint frontmatter still lists --yes|-y (parsed for backward compat)"
 assert_grep "$CMD_FILE" '^\*\*Usage:\*\*.*--yes\|-y' \
-  "M20.2 — Usage line lists --yes|-y"
-assert_grep "$CMD_FILE" '`--yes` / `-y`.*skip' \
-  "M20.3 — doc bullet for --yes / -y describes prompt suppression"
+  "M20.2 — Usage line still lists --yes|-y"
+assert_grep "$CMD_FILE" '## Deprecated Flags' \
+  "M20.3 — '## Deprecated Flags' section present"
+assert_grep "$CMD_FILE" 'no behavioural effect' \
+  "M20.4 — deprecation notice text 'no behavioural effect' present"
+assert_grep "$CMD_FILE" '`--yes` / `-y`.*deprecated|deprecated.*`--yes` / `-y`' \
+  "M20.5 — bullet for --yes / -y is annotated deprecated"
+if grep -qE 'autopilot|Autopilot' "$CMD_FILE"; then
+  echo "  PASS  M20.6 — commands/merge.md mentions autopilot mode"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  M20.6 — commands/merge.md MUST describe autopilot mode"
+  FAIL=$((FAIL + 1))
+fi
 
 echo
-echo "== M21: using-uberdev/SKILL.md documents auto_confirm in YAML example AND precedence recap =="
+echo "== M21: using-uberdev/SKILL.md auto_confirm key documented as DEPRECATED =="
 USING_SKILL_FILE="$REPO_ROOT/plugins/uberdev/skills/using-uberdev/SKILL.md"
 if [ ! -r "$USING_SKILL_FILE" ]; then
   echo "  FAIL  M21 — using-uberdev SKILL.md missing or unreadable: $USING_SKILL_FILE"
   FAIL=$((FAIL + 1))
 else
   assert_grep "$USING_SKILL_FILE" '^auto_confirm:' \
-    "M21.1 — auto_confirm key present in YAML example"
+    "M21.1 — auto_confirm key still present in YAML example (parsed for backward compat)"
   assert_grep "$USING_SKILL_FILE" '\*\*`auto_confirm` precedence:\*\*' \
-    "M21.2 — auto_confirm precedence paragraph present"
+    "M21.2 — auto_confirm precedence paragraph still present (now flags deprecation)"
+  if grep -qiE 'DEPRECATED' "$USING_SKILL_FILE"; then
+    echo "  PASS  M21.3 — using-uberdev/SKILL.md flags auto_confirm as DEPRECATED"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  M21.3 — using-uberdev/SKILL.md MUST flag auto_confirm as DEPRECATED"
+    FAIL=$((FAIL + 1))
+  fi
 fi
 
 echo


### PR DESCRIPTION
## Summary

Make `/merge` a true autopilot — end-to-end multi-PR runs with zero `[y/N]` prompts, zero typed-`yes` gates, and zero "mandatory hard abort" gates. The agent picks per-PR strategy (`merge`/`rebase`/`squash`/`drop`/`defer`), responds to per-PR failures by re-resolving / strategy-switching / parking just that PR, and the queue keeps moving for everything else. Every decision lands in the transcript with a one-line rationale and an event in `audit.jsonl`.

Closes #34.

## Acceptance criteria

- [x] `/merge --all` runs end-to-end on a multi-PR queue with zero interactive prompts and zero `--yes`-style flags
- [x] Stale-branch rebases happen automatically when the agent judges them safe; skipped with a transcript note when not
- [x] Pre-push test failures trigger an agent decision (retry / re-resolve / park single PR), not a pipeline abort
- [x] A genuinely unresolvable PR (e.g. conflict-resolver `REFUSED`) parks just that PR with a clear transcript reason; remaining queue continues
- [x] `--yes` / `auto_confirm` flags still parse but emit a deprecation notice and have no behavioural effect
- [x] Transcript shows per-PR strategy choice (merge / rebase / squash / drop / defer) with one-line rationale

## What changed

**SKILL.md (`plugins/uberdev/skills/merge/SKILL.md`)**

- Inputs: replaced auto-confirm precedence chain with "Autopilot (always ON)"; `--yes`/`-y`/`auto_confirm` accepted for backward compat but no behavioural effect
- New **Phase 1.0 — Pre-flight banner**: emits `bot_authors_allow_list` summary to stderr at run start (audit-anchor twin with run-summary)
- Phase 2.2 step 3 (D-BOTS): external-author defer with `data.reason="external-author-deferred"`; one-pass park to `drop` (no flake retry)
- Phase 2.4: unconditional autopilot — no `[y/N]` prompt under any condition; emits `order_confirmed` with `data.reason="autopilot-default"`
- Phase 3.3iv: AMBIGUOUS/REFUSED park the PR via `drop`; queue continues (was: queue halts)
- Phase 3.3v: `test_fail_agent_decision` with three branches (RE-RESOLVE / STRATEGY-SWITCH / PARK), bounded `max 1 retry, max 1 switch, max 3 test runs per PR per run`; PARK is the terminal floor
- Phase 3.4: failure-mode summary table (8 rows) — only push non-FF and dependency cycle still halt the queue
- Phase 4.5: agent-decided per-branch with safety preconditions (FF detection via `git merge-base --is-ancestor`; not a PR head ref; no force-push protection); 6-choice `STALE_REBASE_DECISION_ENUM`; verbatim Q2 invariant: *"/merge never rebases without an explicit affirmative decision; the agent's typed decision-record is the affirmative form for autopilot mode."*
- Run-summary block: new `Parked` and `Deferred` outcome rows + per-PR detail block with `strategy`, `rationale`, `outcome`, `park reason`; `Allow-listed authors:` printed at both pre-flight banner AND summary block
- Constants: `STRATEGY_ENUM` gains `defer`/`drop`; new `STRATEGY_REASON_ENUM`, `PARK_REASON_ENUM`, `STALE_REBASE_DECISION_ENUM`, `TEST_FAIL_DECISION_ENUM`, `DEPRECATED_FLAGS_NOTE`; `AUDIT_EVENT_ENUM` gains `pr_parked`, `pr_deferred`, `stale_branch_rebase_decision`, `deprecated_flag_used`, `agent_strategy_switch`, `test_fail_agent_decision`; `AUTO_CONFIRM_DEFAULT_SINGLE/MULTI` removed (autopilot is unconditional)
- Failure-handling prose added for: allow-list config read failure, collaborator API failure, gh api probe failures (default-strict on every error)

**`plugins/uberdev/commands/merge.md`** — argument-hint and Usage line annotate `--yes|-y` as `(deprecated)`; new `## Deprecated Flags` section; new Autopilot description paragraph; defence-in-depth note about `bot_authors_allow_list` + GitHub branch protections.

**`plugins/uberdev/skills/using-uberdev/SKILL.md`** — `auto_confirm` config key flagged DEPRECATED in YAML example comment + precedence paragraph.

**`tests/merge.test.sh`** — new M22–M28 tests for the autopilot prose; rewritten/inverted M12, M17.3/M17.4, M18, M19, M20, M21; new M17.5/M17.6 for `DEPRECATED_FLAGS_NOTE`. Final state: **88 pass / 0 fail**. M18.3 uses a positive-form scan (filters by word-boundary `\bNO\b` qualifier) to avoid false-PASSes.

## Open questions answered by /turbo

The following questions were auto-picked by the orchestrator at solve time:

### Q1: Does "agent-decided" test gate mean the agent can skip running tests?
**Auto-pick:** Tests still run on every PR; "agent-decided" only applies to the response on failure (RE-RESOLVE / STRATEGY-SWITCH / PARK). Skipping test execution itself is not on the menu — the gate is demoted from "halt-pipeline-on-fail" to "park-PR-on-fail-and-keep-queue-moving".
**Confidence:** high

### Q2: How does Phase 4.5 reconcile "never auto-rebase" with "agent decides rebase / skip per branch"?
**Auto-pick:** Re-interpret the invariant as "never rebase without an explicit affirmative decision" — the agent's typed decision-record + safety preconditions (FF-able OR non-conflicting probe; not a PR head ref; no force-push protection) is the affirmative form. Force-push to PR head refs remains absolutely forbidden.
**Confidence:** medium

### Q3: drop and defer — separate strategies or one "park" outcome?
**Auto-pick:** Five distinct strategies: `merge` / `rebase` / `squash` (existing) + `defer` (try-later-same-run, e.g. transient flake) + `drop` (terminal park for this run, e.g. conflict-resolver REFUSED). `park` is a synonym for `drop` in transcript prose.
**Confidence:** high

### Q4: conflict-resolver AMBIGUOUS vs REFUSED — what should AMBIGUOUS do?
**Auto-pick:** Both park the affected PR (drop strategy); queue continues. Transcript records the distinction; queue behavior is identical.
**Confidence:** high

### Q5: bot_authors_allow_list as new sole consent surrogate — tighten or document?
**Auto-pick:** Document as new trust boundary; do NOT tighten. Pre-flight banner prints allow-list at run start; non-allow-listed external-contributor PRs auto-defer with rationale.
**Confidence:** high

## Reviewer findings summary

The orchestrator ran multi-axis post-impl review after each wave; findings are advisory.

**Wave 1** (scaffolding): 13 advisory blockers + 14 suggestions clustered around "phase prose must lock in audit-event emission at specific Phase steps" — addressed by T5 (Wave 2) which explicitly wired every `pr_parked`/`pr_deferred`/`stale_branch_rebase_decision`/`deprecated_flag_used`/`agent_strategy_switch`/`test_fail_agent_decision` event to its Phase step.

**Wave 2** (phase prose): 4 advisory blockers + 16 suggestions; the 4 blockers were addressed in a T5b fix-up:
1. Added `TEST_FAIL_DECISION_ENUM` for `data.choice` values
2. Phase 1.0 allow-list read failure handling (default-strict empty list + `error` event)
3. Phase 2.2 collaborator API failure handling (default-strict not-collaborator + `error` event)
4. Phase 3.3v "PARK is the terminal floor" sentence (no further retry branches)

**Wave 3** (test contract): 4 advisory test-suite-quality findings + 16 suggestions. The "blockers" were test-robustness improvements (M20 file-existence guard, M17.3 anchor brittleness, M18.3 multi-line gap, file-level header staleness) — none affect production behavior. M18.3 was tightened in a fix-up to use positive-form scanning with word-boundary `\bNO\b` qualifier.

## Test plan

- [x] `bash tests/merge.test.sh` → 88 pass / 0 fail
- [x] Smoke check: all 11 test files in `tests/` pass with no regressions
- [x] Verbatim Q2 invariant locked in by M19.1 + M26.invariant
- [x] All 6 new audit events declared and asserted (M23.×6)
- [x] Constants table extension covers `STRATEGY_ENUM`+`defer`/`drop`, all 4 new reason enums, `DEPRECATED_FLAGS_NOTE`
- [x] commands/merge.md ≤ 50 lines (38) — M2 contract preserved
- [x] SKILL.md ≤ 500 lines (413) — line budget honoured

## Known follow-ups (deferred to separate PRs)

- **Test-suite refactor:** M19/M26 have ~80% Phase 4.5 invariant overlap; could fold into one block in cleanup pass.
- **Constants hygiene:** `AUTO_CONFIRM_REASON_ENUM` retains 3 historical values (`single-pr-default`, `cli-flag`, `config-auto_confirm`) only `autopilot-default` is now emitted; `STRATEGY_REASON_ENUM` declares `agent-park-*` values not yet emitted by phase prose; `PARK_REASON_ENUM` `push-non-ff` declared but Phase 3.4 says push non-FF halts (no park).
- **Spec cross-references:** SKILL.md prose references "C9", "C4" component IDs from the design spec — opaque to a reader of SKILL.md alone.
- **Casing alignment:** `PARK_REASON_ENUM` mixes UPPERCASE (`REFUSED`, `AMBIGUOUS`) with lower-kebab (`test-fail-exhausted`, etc.) — could normalize.
- **Test-file header:** leading comment block lists M1–M16 only; file now contains M1–M28.

## Spec & plan

- Design spec: `docs/uberdev/specs/2026-05-01-merge-autopilot-no-gates-design.md`
- Wave-decomposed plan: `docs/uberdev/plans/2026-05-01-merge-autopilot-no-gates.md`
- Orchestrator run: `.uberdev/research/20260501-182502-22be4be/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * `/merge` now operates fully unattended without user prompts
  * `--yes`, `-y`, and `auto_confirm` flags are deprecated; usage triggers a deprecation warning
  * Failed pull requests are parked and processing continues automatically
  * Plan transparency enhanced and stale-branch handling improved
  * New audit event recorded for legacy flag usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->