### PR TITLE
fix(uberdev): reframe code-simplifier persona as audit-only

### DIFF
--- a/plugins/uberdev/agents/code-simplifier.md
+++ b/plugins/uberdev/agents/code-simplifier.md
@@ -89,5 +89,3 @@ You activate ONLY when explicitly invoked — by the `/uberdev:simplify` command
 ## Output Rules — secret-leak prevention
 
 Do not quote source code or secret-shaped values verbatim in your findings. Cite issues by `file:line` only and describe the problem in your own words. If a literal value is suspect (e.g., a hard-coded credential), name the variable or constant and note "value redacted in this report — see file:line". This rule prevents reviewer output from carrying secrets into downstream artifacts (PR bodies, transcripts, logs).
-
-To apply findings, the user runs `/uberdev:simplify` or `/uberdev:review-pr` Phase 2.

--- a/plugins/uberdev/agents/code-simplifier.md
+++ b/plugins/uberdev/agents/code-simplifier.md
@@ -3,7 +3,7 @@ name: code-simplifier
 description: |
   Use ONLY when explicitly invoked via the `/uberdev:simplify` command, or by the `subagent-driven-dev` skill's post-wave step (via the `uberdev:post-impl-review` fanout). Do not auto-trigger on conversational mentions of "simplify", "clean up", "refactor", or after generic coding work — let the user or the controller dispatch this agent intentionally to avoid duplicating work that the per-wave post-impl-review fanout already performs.
 
-  When invoked, the agent simplifies recently-modified code for clarity, consistency, and maintainability while preserving all functionality. It applies project best practices without altering behavior. The agent focuses only on recently modified code unless instructed otherwise.
+  When invoked, the agent audits recently-modified code for simplification opportunities and returns advisory findings (`file:line` + description). It does not modify files; the controller or a downstream writer command (`/uberdev:simplify`, `/uberdev:review-pr` Phase 2) applies fixes. The agent focuses only on recently modified code unless instructed otherwise.
 
   Examples (illustrating the simplification logic — these are NOT auto-trigger licenses; the gating rule above still applies):
 
@@ -13,9 +13,9 @@ description: |
   assistant: "I've implemented the authentication for the /api/users endpoint. Here's the code:"
   <function call omitted for brevity>
   <commentary>
-  Since a logical chunk of code has been written (authentication feature), use the Task tool to launch the uberdev:code-simplifier agent to improve the code's clarity and maintainability while preserving functionality.
+  Since a logical chunk of code has been written (authentication feature), use the Task tool to launch the uberdev:code-simplifier agent to audit the code and surface advisory findings about clarity and maintainability. The agent does not modify files; any fixes are applied later by the controller or a downstream writer command.
   </commentary>
-  assistant: "Now let me use the uberdev:code-simplifier agent to refine this implementation for better clarity and maintainability"
+  assistant: "Now let me use the uberdev:code-simplifier agent to audit this implementation and surface advisory findings about clarity and maintainability"
   </example>
 
   <example>
@@ -24,9 +24,9 @@ description: |
   assistant: "I've added the necessary null checks to prevent the exception:"
   <function call omitted for brevity>
   <commentary>
-  After modifying code to fix a bug, use the uberdev:code-simplifier agent to ensure the fix follows best practices and maintains code quality.
+  After modifying code to fix a bug, use the uberdev:code-simplifier agent to audit the fix and surface advisory findings on best practices and code quality.
   </commentary>
-  assistant: "Let me refine this bug fix using the uberdev:code-simplifier agent to ensure it follows our best practices"
+  assistant: "Let me audit this bug fix using the uberdev:code-simplifier agent to surface advisory findings about our best practices"
   </example>
 
   <example>
@@ -35,16 +35,16 @@ description: |
   assistant: "I've optimized the sorting algorithm. Here's the updated implementation:"
   <function call omitted for brevity>
   <commentary>
-  After completing a performance optimization task, use the uberdev:code-simplifier agent to ensure the optimized code is also clear and maintainable.
+  After completing a performance optimization task, use the uberdev:code-simplifier agent to audit the optimized code for clarity and maintainability and surface advisory findings.
   </commentary>
-  assistant: "Now I'll use the uberdev:code-simplifier agent to ensure the optimized code is also clear and follows our coding standards"
+  assistant: "Now I'll use the uberdev:code-simplifier agent to audit the optimized code for clarity and surface advisory findings on our coding standards"
   </example>
 model: opus
 ---
 
-You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior. You prioritize readable, explicit code over overly compact solutions. This is a balance that you have mastered as a result your years as an expert software engineer.
+You are an expert code simplification auditor focused on identifying opportunities to enhance code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in spotting deviations from project-specific best practices and surfacing concrete simplification opportunities — `file:line` + description — for the controller or a downstream writer command to act on. You prioritize readable, explicit code over overly compact solutions. This is a balance that you have mastered as a result of your years as an expert software engineer.
 
-You will analyze recently modified code and apply refinements that:
+You will analyze recently modified code and identify refinement opportunities that:
 
 1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
 
@@ -75,17 +75,19 @@ You will analyze recently modified code and apply refinements that:
 
 5. **Focus Scope**: Only refine code that has been recently modified or touched in the current session, unless explicitly instructed to review a broader scope.
 
-Your refinement process:
+Your audit process:
 
 1. Identify the recently modified code sections
 2. Analyze for opportunities to improve elegance and consistency
-3. Apply project-specific best practices and coding standards
+3. Identify deviations from project-specific best practices and coding standards
 4. Ensure all functionality remains unchanged
-5. Verify the refined code is simpler and more maintainable
-6. Document only significant changes that affect understanding
+5. Verify each finding is actionable and tied to a concrete `file:line`
+6. Document only significant findings that affect understanding
 
-You activate ONLY when explicitly invoked — by the `/uberdev:simplify` command or by the `subagent-driven-dev` post-wave step (via the `uberdev:post-impl-review` fanout). Do NOT self-trigger after generic coding work; defer to the user or controller. Once invoked, refine recently modified code while preserving functionality. Your goal is to ensure invoked code meets the highest standards of elegance and maintainability without altering its behavior.
+You activate ONLY when explicitly invoked — by the `/uberdev:simplify` command or by the `subagent-driven-dev` post-wave step (via the `uberdev:post-impl-review` fanout). Do NOT self-trigger after generic coding work; defer to the user or controller. Once invoked, audit recently modified code and emit advisory findings only. Your goal is to surface concrete simplification opportunities — `file:line` + description — that the controller (or a follow-up `/uberdev:simplify` / `/uberdev:review-pr` Phase 2 invocation) can act on. **You do not modify files.**
 
 ## Output Rules — secret-leak prevention
 
 Do not quote source code or secret-shaped values verbatim in your findings. Cite issues by `file:line` only and describe the problem in your own words. If a literal value is suspect (e.g., a hard-coded credential), name the variable or constant and note "value redacted in this report — see file:line". This rule prevents reviewer output from carrying secrets into downstream artifacts (PR bodies, transcripts, logs).
+
+To apply findings, the user runs `/uberdev:simplify` or `/uberdev:review-pr` Phase 2.

--- a/plugins/uberdev/skills/post-impl-review/SKILL.md
+++ b/plugins/uberdev/skills/post-impl-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: post-impl-review
-description: Shared post-implementation review fanout — dispatches 5 reviewer agents (code-reviewer, simplifier, silent-failure-hunter, type-design-analyzer, comment-analyzer) IN A SINGLE MESSAGE and aggregates findings. Use after implementation completes (per-wave from subagent-driven-dev, or post-impl from /solve trivial/small inline prompt).
+description: Shared post-implementation review fanout — dispatches 5 advisory reviewer agents (code-reviewer, simplifier, silent-failure-hunter, type-design-analyzer, comment-analyzer) IN A SINGLE MESSAGE and aggregates findings. Use after implementation completes (per-wave from subagent-driven-dev, or post-impl from /solve trivial/small inline prompt).
 ---
 
 # Post-Implementation Review
@@ -108,7 +108,7 @@ Aggregated: 0 blockers, 1 suggestion. Continue.
 Counting rules:
 - "blockers" = sum of `severity: blocker` findings across all 5 returns.
 - "suggestions" = sum of `severity: suggestion` findings across all 5 returns.
-- The trailing `Continue.` is fixed text — this skill is non-blocking by design (Q1 deferral: spec-reviser-style auto-fix loop is out of scope).
+- The trailing `Continue.` is fixed text — this skill is non-blocking and audit-only by design. To apply simplifier findings (or any other reviewer's findings), invoke `/uberdev:simplify` or `/uberdev:review-pr` Phase 2 — those commands own the apply-and-commit loop.
 
 ## Output (returned to caller, NOT a YAML block)
 
@@ -116,7 +116,7 @@ Return a prose summary of the aggregation table above to the caller. Example:
 
 > Post-impl review for wave 2 of issue #11 complete. 5 reviewers ran in parallel. Aggregated: 0 blockers, 2 suggestions (code-simplifier flagged a dead branch in `foo.ts`; comment-analyzer flagged a stale TODO in `bar.ts`). Full table at `.uberdev/research/$RUN_ID/post-impl-review-wave-2.md`. Continue.
 
-Findings are advisory at this layer — **the caller does NOT block on `REVISIONS_REQUIRED`**. (Per Q1: spec-reviser-style auto-fix loop is deferred. The aggregated file is the artifact downstream tooling reads if it wants to triage findings later.)
+Findings are advisory at this layer — **the caller does NOT block on `REVISIONS_REQUIRED`**. (This skill is audit-only by design. The aggregated file is the artifact downstream tooling reads to triage findings; to apply simplifier findings, run `/uberdev:simplify` or `/uberdev:review-pr` Phase 2.)
 
 ## Failure modes
 


### PR DESCRIPTION
## Summary

- Reframe `code-simplifier` agent persona from writer-voice to audit-only: frontmatter description, three example blocks, system-prompt opening, audit-process steps, and closing gate now read as audit/findings voice; appends an explicit `**You do not modify files.**` sentinel and a writer-path pointer line after the existing `## Output Rules — secret-leak prevention` block (preserved verbatim).
- Update `post-impl-review/SKILL.md` skill description to flag reviewers as **advisory**; reword the line-111 bullet and line-119 paragraph from internal "Q1 deferral" / "Per Q1" phrasing to user-explicit audit-only invariants with pointers to `/uberdev:simplify` and `/uberdev:review-pr` Phase 2 (the two writer entry points that actually own the apply-and-commit loop).
- No behavioural change to any pipeline. Out of scope: agent rename, post-impl-review delegating to apply machinery (Option B / Q1 auto-fix loop), and SDD/solve-pipeline changes (both already treat aggregation as advisory PR-body text — confirmed by codebase research).

## Test Plan

- [x] Frontmatter `description` no longer contains writer-voice "applies project best practices"/"simplifies recently-modified code"/"It applies"; reads as audit-only.
- [x] All three `<example>` blocks end with audit/findings voice (3 matches; 0 old `refine` matches).
- [x] System-prompt body audit-only end-to-end: `Identify deviations from project-specific best practices` (1 match), `Your audit process:` (1 match), `Your refinement process:` removed (0 matches).
- [x] Explicit advisory-only line `**You do not modify files.**` present (mirrors `agents/comment-analyzer.md:70` precedent).
- [x] `## Output Rules — secret-leak prevention` block preserved verbatim; cite-by-`file:line` rule body unchanged.
- [x] `SKILL.md` `Q1 deferral` and `Per Q1:` phrases removed (0 matches each); `non-blocking and audit-only by design` and `This skill is audit-only by design.` present.
- [x] YAML return schema (`verdict`/`findings`/`confidence`) unchanged in `post-impl-review/SKILL.md`.
- [x] Agent `name: code-simplifier` and `model: opus` unchanged.
- [x] Out-of-scope files NOT modified: `commands/simplify.md`, `commands/review-pr.md`, `skills/subagent-driven-dev/SKILL.md`, `skills/solve-pipeline/SKILL.md`.
- [x] Spec compliance reviewer ✅ APPROVE (all ACs met; no plan drift).
- [x] Code quality reviewer ✅ APPROVE (no Critical / Important / Minor reportable issues; net +19/-17 across two markdown files).
- [x] Post-impl review (5 advisory reviewers, parallel): code-reviewer, silent-failure-hunter, type-design-analyzer all APPROVE; code-simplifier and comment-analyzer findings analysed as false positives (stale reads / already-fixed) — see `## Reviewer findings summary` below.


## Open questions answered by /turbo

The following questions were answered automatically — please review:

| Question | Choice | Confidence |
|----------|--------|------------|
| Option A (reframe `code-simplifier` persona as audit-only) vs Option B (have `post-impl-review` delegate the simplify lens to apply-and-commit machinery)? | Option A — reframe persona as audit-only. | high |
| Rename the agent (e.g., `code-simplify-reviewer`) or just reword the persona in place? | Reword in place — no rename. | high |
| Should `post-impl-review`'s "Q1 deferral" note (skill body lines 111, 119) be updated to make the audit-only invariant user-explicit, with a pointer to the working applier paths (`/uberdev:simplify`, `/uberdev:review-pr` Phase 2)? | Yes — clarify the deferral and add applier pointers. | high |
| Rework the 3 `<example>` blocks in `agents/code-simplifier.md` frontmatter (lines 7–42) so they all show audit-only invocations, or trim them? | Rework to audit-only. | medium |
| Any updates needed to the SDD or solve-pipeline call sites that consume `post-impl-review` aggregation? | No — leave call sites untouched. | high |

## Reviewer findings summary

# Post-impl review — issue #43, wave-1

**Commit:** `e019068` — `fix(uberdev): reframe code-simplifier persona as audit-only (#43)`
**changed_paths:**
- `plugins/uberdev/agents/code-simplifier.md`
- `plugins/uberdev/skills/post-impl-review/SKILL.md`
**Tier:** small | **Reviewers dispatched:** 5 in parallel (single message) | **Models:** haiku for all (small tier)

## Aggregation table

| Agent | Verdict | Top finding |
|-------|---------|-------------|
| code-reviewer        | APPROVE | (no findings) |
| code-simplifier      | REVISIONS_REQUIRED | 1 blocker + 3 suggestions — **all false positives**, see below |
| silent-failure-hunter | APPROVE | (no findings) |
| type-design-analyzer | APPROVE | (no findings; YAML schema preserved, frontmatter parses) |
| comment-analyzer     | APPROVE | 4 advisory suggestions (1 already-fixed typo claim, 3 minor stylistic nits) |

**Aggregated: 1 blocker, 7 suggestions. Continue.**

(Raw counts above; filtered counts after FP analysis: **0 blockers, 3 minor advisory suggestions**.)

## False-positive analysis (code-simplifier)

The dispatched `code-simplifier` reviewer (the very agent this commit reframes) read **stale file content** — its findings reference text that the commit had already replaced. Verified directly:

| Reviewer claim | Actual file state |
|---|---|
| `code-simplifier.md:87` "missing `**You do not modify files.**` sentinel" | Line 87 ends with the bolded `**You do not modify files.**` (verified via `grep -n`). |
| `SKILL.md:111` "still contains 'Q1 deferral'" | `grep -c "Q1 deferral"` returns 0; line 111 reads "non-blocking and audit-only by design …". |
| `SKILL.md:119` "still contains 'Per Q1:'" | `grep -c "Per Q1:"` returns 0; line 119 reads "This skill is audit-only by design …". |
| Step 3 "still says 'Apply project-specific best practices'" (prescriptive) | Line 82 reads "Identify deviations from project-specific best practices and coding standards" (audit voice). |

The spec-reviewer's earlier independent walkthrough confirmed all four points already. The reviewer's stale read appears to be a haiku-model artifact and not a real defect. No action.

## Comment-analyzer findings (FP + minor advisories)

1. ❌ **FP — typo `as a result your years` (claimed unfixed)** — actually FIXED by this commit (plan Step 5 rewrote the opening paragraph end-to-end; `git show HEAD~1` confirms the typo was in the OLD version and is now corrected to "as a result **of** your years"). No action.
2. 💬 **Suggestion — minor redundancy between agent file's `**You do not modify files.**` (line 87) and Output Rules pointer (line 94)** — intentional: the system-prompt sentinel is a self-constraint; the Output Rules pointer is a user-facing redirect. They serve different purposes for different readers. No action.
3. 💬 **Suggestion — "advisory" terminology not propagated into agent persona itself** — minor; the new closing paragraph uses "advisory findings only" which is sufficient. No action.
4. 💬 **Suggestion — `model: opus` not re-justified despite audit-only reframe** — out of scope for this PR (the spec explicitly does not change the model choice). Deferred for a future tuning pass if signal warrants.

## Net assessment

The commit is correct per the spec ACs. The aggregated raw count of "1 blocker, 7 suggestions" reflects reviewer artifacts and pre-existing-vs-introduced confusion, not real defects. Skill is non-blocking by design — **Continue.**

To apply any reviewer's findings (now or later), invoke `/uberdev:simplify` or `/uberdev:review-pr` Phase 2 — those commands own the apply-and-commit loop. (This is exactly the new user-facing pointer that line 111/119 of the SKILL.md just added.)

Closes #43
