### PR TITLE
chore(release): v0.16.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve spawns autonomous agents in cmux/Ghostty/iTerm; /issue creates well-investigated, deduped issues.",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "cmux", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-05-03
+
+### Fixed
+- **`finish-branch` permission-pattern `unmatched '` (#42, #45)** — Single-quoted heredoc delimiters (`<<'EOF_HEADER'`, `<<'PR_TITLE_EOF'`) in `plugins/uberdev/skills/finish-branch/SKILL.md` tripped Claude Code's permission-pattern evaluator with `(eval): unmatched '`, leaving `/finish-branch` and the `/finish` alias unrunnable (manual `gh pr create` was the only escape hatch). The evaluator's shell tokenizer doesn't honor heredoc literal-context semantics — it paired the delimiter's leading `'` with the next `'` it saw (the `PR_URL_REGEX='…'` assignment), inverted quote-balance from there, and surfaced the regex's trailing `'` as the unmatched-quote error. Fix: drop the quotes from both delimiters (`<<EOF_HEADER` / `<<PR_TITLE_EOF`); the agent contract now requires composed PR title and body bytes free of `$`, backticks, and backslash (typical PR Summary text already satisfies this). The title-injection guard is preserved end-to-end by the existing `gh --title "$PR_TITLE_VAR"` double-quoted byte-verbatim expansion. Test coverage adds an `assert_not_grep` regression canary that rejects any `<<'X'` or `<<"X"` form anywhere in the skill (`tests/finish-branch-auto-chain.test.sh` 23 → 24 assertions).
+
 ## [0.16.0] - 2026-05-03
 
 ### Added

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution, brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",


### PR DESCRIPTION
## Summary

- Patch release bundling the `finish-branch` heredoc fix (#42 / #45). Semver patch bump (0.16.0 → 0.16.1) — no new features, no breaking changes.
- `plugin.json` + `marketplace.json` versions bumped in lockstep.
- `CHANGELOG.md` `## [Unreleased]` placeholder promoted to `## [0.16.1] - 2026-05-03` with a single `### Fixed` entry citing #42 and #45.

## Test plan

- [x] `git diff --stat` confirms 3 files, 7 insertions, 2 deletions — version files + CHANGELOG only.
- [x] `plugin.json` and `marketplace.json` versions are in lockstep at 0.16.1.
- [x] CHANGELOG entry preserves Keep-a-Changelog format (`## [version] - date` with `### Fixed` section).
- [ ] CI on this PR re-runs the test suite at the new version (test files unchanged from #45 run, expect 408 assertions across 11 files all green).