### PR TITLE
refactor(uberdev): move post-impl-review from per-wave to end-of-issue (#48)

### DIFF
--- a/plugins/uberdev/agents/code-simplifier.md
+++ b/plugins/uberdev/agents/code-simplifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-simplifier
 description: |
-  Use ONLY when explicitly invoked via the `/uberdev:simplify` command, or by the `subagent-driven-dev` skill's post-wave step (via the `uberdev:post-impl-review` fanout). Do not auto-trigger on conversational mentions of "simplify", "clean up", "refactor", or after generic coding work — let the user or the controller dispatch this agent intentionally to avoid duplicating work that the per-wave post-impl-review fanout already performs.
+  Use ONLY when explicitly invoked via the `/uberdev:simplify` command, or by the `subagent-driven-dev` skill's `uberdev:post-impl-review` fanout. Do not auto-trigger on conversational mentions of "simplify", "clean up", "refactor", or after generic coding work — let the user or the controller dispatch this agent intentionally to avoid duplicating work that the end-of-issue post-impl-review fanout already performs.
 
   When invoked, the agent audits recently-modified code for simplification opportunities and returns advisory findings (`file:line` + description). It does not modify files; the controller or a downstream writer command (`/uberdev:simplify`, `/uberdev:review-pr` Phase 2) applies fixes. The agent focuses only on recently modified code unless instructed otherwise.
 
@@ -84,7 +84,7 @@ Your audit process:
 5. Verify each finding is actionable and tied to a concrete `file:line`
 6. Document only significant findings that affect understanding
 
-You activate ONLY when explicitly invoked — by the `/uberdev:simplify` command or by the `subagent-driven-dev` post-wave step (via the `uberdev:post-impl-review` fanout). Do NOT self-trigger after generic coding work; defer to the user or controller. Once invoked, audit recently modified code and emit advisory findings only. Your goal is to surface concrete simplification opportunities — `file:line` + description — that the controller (or a follow-up `/uberdev:simplify` / `/uberdev:review-pr` Phase 2 invocation) can act on. **You do not modify files.**
+You activate ONLY when explicitly invoked — by the `/uberdev:simplify` command or by the `subagent-driven-dev` skill's `uberdev:post-impl-review` fanout. Do NOT self-trigger after generic coding work; defer to the user or controller. Once invoked, audit recently modified code and emit advisory findings only. Your goal is to surface concrete simplification opportunities — `file:line` + description — that the controller (or a follow-up `/uberdev:simplify` / `/uberdev:review-pr` Phase 2 invocation) can act on. **You do not modify files.**
 
 ## Output Rules — secret-leak prevention
 

--- a/plugins/uberdev/commands/turbo.md
+++ b/plugins/uberdev/commands/turbo.md
@@ -12,7 +12,7 @@ Spawn an autonomous Claude agent in a new cmux workspace per GitHub issue in **#
 
 **Behavior vs `/solve`:**
 - **trivial / small tiers:** identical to `/solve` except `uberdev:post-impl-review` is NOT invoked (asymmetry preserved from prior behavior).
-- **medium / large tiers:** brainstorm runs WITHOUT the clarifying-question loop. Parallel research still runs (recommendation grounding preserved). `/uberdev:orchestrator` is dispatched with the unattended-mode flag; `subagent-driven-dev` invokes `uberdev:post-impl-review` per wave; large tier additionally fires `pr-test-analyzer` pre-merge. Findings are summarised in the PR body under `## Reviewer findings summary`.
+- **medium / large tiers:** brainstorm runs WITHOUT the clarifying-question loop. Parallel research still runs (recommendation grounding preserved). `/uberdev:orchestrator` is dispatched with the unattended-mode flag; `subagent-driven-dev` invokes `uberdev:post-impl-review` once at end-of-issue (consolidated across all waves); large tier additionally fires `pr-test-analyzer` pre-merge. Findings are summarised in the PR body under `## Reviewer findings summary`.
 
 **Multi-issue dispatch:** `/turbo 5 6 7` validates all three issues up front (open + classifiable) and then spawns three independent agents — one terminal tab/workspace each, all running in parallel. If any issue is closed, missing, or fails `gh` fetch, the run aborts before spawning anything (`no agents dispatched`). Override flags apply batch-wide.
 

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -112,7 +112,7 @@ Then: Cleanup worktree (Step 5)
 Option 2 PR-body composition: in addition to the standard Summary + Test Plan, two conditional sections are appended when their source artifacts exist:
 
 - **`## Open questions answered by /turbo`** — table rendered from `.uberdev/research/$RUN_ID/questions.md` (written by orchestrator Phase 2 under `--turbo`). Columns: Question | Choice | Confidence. Reviewers can scan for `medium`/`low` confidence rows quickly.
-- **`## Reviewer findings summary`** — the consolidated end-of-issue post-impl-review aggregate (written by `uberdev:post-impl-review` from `subagent-driven-dev`, single `post-impl-review-wave-final.md` artifact) and any `pr-test-analyzer` output (large tier only). The bash glob `post-impl-review-wave-*.md` at the read site below is intentionally broad and continues to match legacy per-wave files from older runs as well as the new `-final.md` filename.
+- **`## Reviewer findings summary`** — the consolidated end-of-issue post-impl-review aggregate (`post-impl-review-wave-final.md`, written by `uberdev:post-impl-review` from `subagent-driven-dev`) and any `pr-test-analyzer` output (large tier only). The read-site glob below (`post-impl-review-wave-*.md`) deliberately matches the new `-final.md` filename and any legacy per-wave artifacts.
 
 Both sections are read-only dumps; finish-branch does not block on confidence threshold or reviewer verdict (per #11 Q1: advisory only, auto-fix deferred).
 

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -112,7 +112,7 @@ Then: Cleanup worktree (Step 5)
 Option 2 PR-body composition: in addition to the standard Summary + Test Plan, two conditional sections are appended when their source artifacts exist:
 
 - **`## Open questions answered by /turbo`** — table rendered from `.uberdev/research/$RUN_ID/questions.md` (written by orchestrator Phase 2 under `--turbo`). Columns: Question | Choice | Confidence. Reviewers can scan for `medium`/`low` confidence rows quickly.
-- **`## Reviewer findings summary`** — concatenated post-impl-review aggregates (per-wave, written by `uberdev:post-impl-review` from `subagent-driven-dev`) and any `pr-test-analyzer` output (large tier only).
+- **`## Reviewer findings summary`** — the consolidated end-of-issue post-impl-review aggregate (written by `uberdev:post-impl-review` from `subagent-driven-dev`, single `post-impl-review-wave-final.md` artifact) and any `pr-test-analyzer` output (large tier only). The bash glob `post-impl-review-wave-*.md` at the read site below is intentionally broad and continues to match legacy per-wave files from older runs as well as the new `-final.md` filename.
 
 Both sections are read-only dumps; finish-branch does not block on confidence threshold or reviewer verdict (per #11 Q1: advisory only, auto-fix deferred).
 

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -184,7 +184,7 @@ Trivial/small tier bypass orchestrator entirely; plan-reviewer is N/A there.
 
 ### Phase 5: subagent-driven-dev
 
-Invoke `uberdev:subagent-driven-dev` skill (NOT a Task() — actual skill invocation via Skill tool). Pass `plan_path`. **If the orchestrator was invoked with `--turbo`, also pass `--turbo`** so the downstream chain (`subagent-driven-dev → finish-branch`) stays unattended and `finish-branch` auto-selects "Push and Create PR" instead of prompting. The existing skill handles wave dispatch, review, and PR creation. `subagent-driven-dev` internally calls `uberdev:post-impl-review` after each wave completes — see `plugins/uberdev/skills/post-impl-review/SKILL.md`. Findings are advisory at this layer (non-blocking on `REVISIONS_REQUIRED`); the auto-fix loop is deferred per Q1 of the design spec.
+Invoke `uberdev:subagent-driven-dev` skill (NOT a Task() — actual skill invocation via Skill tool). Pass `plan_path`. **If the orchestrator was invoked with `--turbo`, also pass `--turbo`** so the downstream chain (`subagent-driven-dev → finish-branch`) stays unattended and `finish-branch` auto-selects "Push and Create PR" instead of prompting. The existing skill handles wave dispatch, review, and PR creation. `subagent-driven-dev` internally calls `uberdev:post-impl-review` once after all waves complete (consolidated end-of-issue invocation) — see `plugins/uberdev/skills/post-impl-review/SKILL.md`. Findings are advisory at this layer (non-blocking on `REVISIONS_REQUIRED`); the auto-fix loop is deferred per Q1 of the design spec.
 
 ### Phase 5.5: pr-test-analyzer (large tier only, pre-merge)
 
@@ -200,8 +200,8 @@ Why large-only: signal-to-noise on smaller changes is poor; medium tier may revi
 |---|---|---|---|---|---|---|
 | trivial | (orchestrator should not be invoked) | — | — | — | — | — |
 | small | 1 (codebase only) | none | none | 1 | — (orch not invoked) | — |
-| medium | 6 (gated by SHORTCIRCUIT_<TOPIC>) | always | always | 3 | per-wave (via SDD) | — |
-| large | 6 (gated by SHORTCIRCUIT_<TOPIC>) | always | always | 3 | per-wave (via SDD) | pre-merge |
+| medium | 6 (gated by SHORTCIRCUIT_<TOPIC>) | always | always | 3 | end-of-issue (via SDD) | — |
+| large | 6 (gated by SHORTCIRCUIT_<TOPIC>) | always | always | 3 | end-of-issue (via SDD) | pre-merge |
 
 `--turbo` orthogonally skips Phase 2 Q&A (replaced with auto-pick + questions.md log). Tier classification rule: same as `/solve` triage table (read from issue labels + body).
 

--- a/plugins/uberdev/skills/post-impl-review/SKILL.md
+++ b/plugins/uberdev/skills/post-impl-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: post-impl-review
-description: Shared post-implementation review fanout — dispatches 5 advisory reviewer agents (code-reviewer, simplifier, silent-failure-hunter, type-design-analyzer, comment-analyzer) IN A SINGLE MESSAGE and aggregates findings. Use after implementation completes (per-wave from subagent-driven-dev, or post-impl from /solve trivial/small inline prompt).
+description: Shared post-implementation review fanout — dispatches 5 advisory reviewer agents (code-reviewer, simplifier, silent-failure-hunter, type-design-analyzer, comment-analyzer) IN A SINGLE MESSAGE and aggregates findings. Use after implementation completes (end-of-issue from subagent-driven-dev, or post-impl from /solve trivial/small inline prompt).
 ---
 
 # Post-Implementation Review
@@ -13,7 +13,7 @@ description: Shared post-implementation review fanout — dispatches 5 advisory 
 
 ## When to invoke
 
-- **`uberdev:subagent-driven-dev`** — after each wave commits, before moving to the next wave. Findings inform (but do not block) the next wave dispatch.
+- **`uberdev:subagent-driven-dev`** — once after all waves complete, before handing off to `finish-branch`. Findings are advisory and surface in the PR body's `## Reviewer findings summary`.
 - **`/solve` trivial/small inline prompt** — after the implementer's commit lands. Findings get attached to the PR body or follow-up issue.
 
 ## Critical invariant — single-message fanout
@@ -88,7 +88,7 @@ Failure handling:
 Aggregate the 5 returns into the table format below plus the bottom line `Aggregated: N blockers, M suggestions. Continue.`
 
 Write the aggregation to:
-- `.uberdev/research/$RUN_ID/post-impl-review-wave-$WAVE.md` (per-wave use from `subagent-driven-dev`)
+- `.uberdev/research/$RUN_ID/post-impl-review-wave-final.md` (end-of-issue use from `subagent-driven-dev`; `WAVE=final` is the only value passed)
 - `.uberdev/research/issue-$N/post-impl-review.md` (trivial/small inline use from `/solve`)
 
 Aggregation table format:
@@ -131,7 +131,7 @@ Findings are advisory at this layer — **the caller does NOT block on `REVISION
 ## Integration
 
 **Called by:**
-- **`uberdev:subagent-driven-dev`** — after each wave's implementer commits land, before dispatching the next wave.
+- **`uberdev:subagent-driven-dev`** — once after all waves' implementer commits land, before handing off to `finish-branch`.
 - **`/solve` trivial/small inline prompt** — after the implementer's single commit lands.
 
 **Does NOT call:**

--- a/plugins/uberdev/skills/post-impl-review/SKILL.md
+++ b/plugins/uberdev/skills/post-impl-review/SKILL.md
@@ -7,7 +7,7 @@ description: Shared post-implementation review fanout — dispatches 5 advisory 
 
 ## Overview
 
-5 reviewer agents fire in PARALLEL inside a single assistant turn; their findings are aggregated into a single non-blocking summary returned to the caller. The reviewers are advisory — at this layer the caller continues regardless of `REVISIONS_REQUIRED` verdicts. This keeps wall-clock cost low (one round-trip for five perspectives) while still applying multi-axis scrutiny to every wave's commit.
+5 reviewer agents fire in PARALLEL inside a single assistant turn; their findings are aggregated into a single non-blocking summary returned to the caller. The reviewers are advisory — at this layer the caller continues regardless of `REVISIONS_REQUIRED` verdicts. This keeps wall-clock cost low (one round-trip for five perspectives) while still applying multi-axis scrutiny to the consolidated end-of-issue diff (or a trivial/small single commit).
 
 **Announce at start:** "I'm using the post-impl-review skill to fan out the 5 reviewer agents."
 
@@ -114,7 +114,7 @@ Counting rules:
 
 Return a prose summary of the aggregation table above to the caller. Example:
 
-> Post-impl review for wave 2 of issue #11 complete. 5 reviewers ran in parallel. Aggregated: 0 blockers, 2 suggestions (code-simplifier flagged a dead branch in `foo.ts`; comment-analyzer flagged a stale TODO in `bar.ts`). Full table at `.uberdev/research/$RUN_ID/post-impl-review-wave-2.md`. Continue.
+> Post-impl review for issue #11 complete (end-of-issue). 5 reviewers ran in parallel. Aggregated: 0 blockers, 2 suggestions (code-simplifier flagged a dead branch in `foo.ts`; comment-analyzer flagged a stale TODO in `bar.ts`). Full table at `.uberdev/research/$RUN_ID/post-impl-review-wave-final.md`. Continue.
 
 Findings are advisory at this layer — **the caller does NOT block on `REVISIONS_REQUIRED`**. (This skill is audit-only by design. The aggregated file is the artifact downstream tooling reads to triage findings; to apply simplifier findings, run `/uberdev:simplify` or `/uberdev:review-pr` Phase 2.)
 

--- a/plugins/uberdev/skills/subagent-driven-dev/SKILL.md
+++ b/plugins/uberdev/skills/subagent-driven-dev/SKILL.md
@@ -51,7 +51,7 @@ digraph when_to_use {
 
 1. **Read plan once.** Extract every task's full text and the `## Execution Waves` summary.
 2. **Create TodoWrite** with one todo per task, labeled with its wave (e.g., `[wave-2] Task 4: ...`).
-3. **Verify clean baseline:** `git status` is clean; you're on the feature branch in the feature-branch worktree.
+3. **Verify clean baseline:** `git status` is clean; you're on the feature branch in the feature-branch worktree. Capture `BASELINE_SHA=$(git rev-parse HEAD)` — this anchors the consolidated post-impl-review's `commit_range` at end-of-issue (`<BASELINE_SHA>..HEAD`), and is robust to spec/quality fix-up commits that increment the on-branch commit count beyond raw task count.
 4. **For each wave (sequential):**
    a. Dispatch every implementer in the wave **in a single message** with multiple `Agent` tool calls. All run in the current worktree. Each implementer gets an explicit allowlist of files it owns and an explicit denylist of files owned by sibling tasks.
    b. **Implementers never run git.** They edit files, run their tests, and report `Status + changed file paths + test results`.
@@ -67,13 +67,16 @@ digraph when_to_use {
    g. Loop spec fix-up per task until all spec reviewers approve. Fix dispatches still don't run git — controller amends the task's commit (or creates a fix-up commit) using the implementer's reported new paths.
    h. Dispatch code quality reviewers (parallel). Same fix-loop pattern.
    i. Mark every task in the wave complete in TodoWrite.
-   j. **Invoke `uberdev:post-impl-review` skill** (Skill tool, NOT Task) with:
-      - `changed_paths`: union of all wave tasks' reported paths
-      - `commit_range`: the wave's commit range (e.g. `HEAD~$WAVE_TASK_COUNT..HEAD`)
-      - `tier`: passed through from the orchestrator (medium/large)
-      Skill returns the aggregate findings table from `post-impl-review/SKILL.md`. Findings are ADVISORY — do NOT block on `REVISIONS_REQUIRED` at this layer (the auto-fix loop is deferred per #11 Q1). Append findings to the running session log so finish-branch can compose the PR body's `## Reviewer findings summary`.
-5. After the final wave, the per-wave post-impl-review has already covered code quality; if the orchestrator dispatched this skill in large tier, expect Phase 5.5 (`pr-test-analyzer`) to run after this skill returns. No additional whole-implementation reviewer fanout from this skill — the per-wave reviewers already covered that surface.
-6. Hand off to `uberdev:finish-branch`. **If `--turbo` was in `$ARGUMENTS`, propagate it** — invoke as `uberdev:finish-branch --turbo` so the branch close-out auto-selects "Push and Create PR" instead of prompting.
+   j. **Accumulate end-of-issue inputs** (no skill dispatch — the consolidated post-impl-review now fires after the wave loop, see step 5):
+      - Append every reported path from this wave's implementers to the running set `ALL_CHANGED_PATHS` (deduplicate).
+      - The wave's commit count is implicit in `git log` since `BASELINE_SHA`; no manual counter required.
+5. **End-of-issue post-impl-review.** After the wave loop exits (every wave's tasks committed and reviewed), invoke `uberdev:post-impl-review` skill (Skill tool, NOT Task) **exactly once** with the accumulated state:
+   - `changed_paths`: `ALL_CHANGED_PATHS` (deduped union of every wave's reported paths)
+   - `commit_range`: `<BASELINE_SHA>..HEAD` (captured at start of step 3) — equivalently `HEAD~$(git rev-list --count <BASELINE_SHA>..HEAD)..HEAD`. The `git rev-list --count` form is robust to spec/quality fix-up commits that increment the on-branch commit count beyond raw task count.
+   - `tier`: passed through from the orchestrator (medium/large)
+   - `WAVE`: `final` — drives the output artifact filename `.uberdev/research/$RUN_ID/post-impl-review-wave-final.md`. The existing `finish-branch` glob `post-impl-review-wave-*.md` matches without any read-path change.
+   Skill returns the aggregate findings table. Findings are ADVISORY — do NOT block on `REVISIONS_REQUIRED` at this layer. Append findings to the running session log so `finish-branch` can compose the PR body's `## Reviewer findings summary`.
+6. Hand off to `uberdev:finish-branch`. **If `--turbo` was in `$ARGUMENTS`, propagate it** — invoke as `uberdev:finish-branch --turbo` so the branch close-out auto-selects "Push and Create PR" instead of prompting. For large tier, the orchestrator's Phase 5.5 (`pr-test-analyzer`) runs *after* this skill returns; no additional reviewer fanout from `subagent-driven-dev` itself beyond the consolidated step 5 above.
 
 ### Parallel Dispatch Pattern
 
@@ -89,13 +92,17 @@ digraph when_to_use {
                 ↓
             spec reviewers (parallel) → fix loop → re-reviews
             quality reviewers (parallel) → fix loop → re-reviews
-            ↓
-            uberdev:post-impl-review (5 agents, 1 message)
-            advisory — no blocking
+                ↓ accumulate ALL_CHANGED_PATHS; no advisory fanout between waves
                 ↓ no merge step — already on feature branch
 [wave-2] →  Agent(T4, edits files only)  ┐
             Agent(T5, edits files only)  ┘  (parallel, depend on wave-1 commits)
             ...
+[wave-N] →  ...  (last wave finishes)
+                ↓
+            uberdev:post-impl-review (5 agents, 1 message) — ONCE, end-of-issue
+            advisory — no blocking
+                ↓
+            hand off to uberdev:finish-branch
 ```
 
 ### File-Ownership Enforcement
@@ -259,9 +266,12 @@ Ownership map:
 
 === AFTER ALL WAVES ===
 
-[Per-wave uberdev:post-impl-review has already covered code quality across every wave]
+[Invoke uberdev:post-impl-review skill ONCE with changed_paths=ALL_CHANGED_PATHS,
+ commit_range=<BASELINE_SHA>..HEAD, tier passed through, WAVE=final]
+[5 advisory reviewer agents fan out in a single message; aggregate written to
+ .uberdev/research/$RUN_ID/post-impl-review-wave-final.md]
+[Findings are advisory — no blocking on REVISIONS_REQUIRED]
 [For large tier: orchestrator Phase 5.5 dispatches pr-test-analyzer pre-merge after this skill returns]
-[No additional whole-implementation reviewer fanout from this skill]
 
 [Hand off to uberdev:finish-branch]
 ```

--- a/plugins/uberdev/skills/subagent-driven-dev/SKILL.md
+++ b/plugins/uberdev/skills/subagent-driven-dev/SKILL.md
@@ -72,7 +72,7 @@ digraph when_to_use {
       - The wave's commit count is implicit in `git log` since `BASELINE_SHA`; no manual counter required.
 5. **End-of-issue post-impl-review.** After the wave loop exits (every wave's tasks committed and reviewed), invoke `uberdev:post-impl-review` skill (Skill tool, NOT Task) **exactly once** with the accumulated state:
    - `changed_paths`: `ALL_CHANGED_PATHS` (deduped union of every wave's reported paths)
-   - `commit_range`: `<BASELINE_SHA>..HEAD` (captured at start of step 3) — equivalently `HEAD~$(git rev-list --count <BASELINE_SHA>..HEAD)..HEAD`. The `git rev-list --count` form is robust to spec/quality fix-up commits that increment the on-branch commit count beyond raw task count.
+   - `commit_range`: `<BASELINE_SHA>..HEAD` (anchor captured at start of step 3 — see step 3 for the fix-up-commit robustness rationale; equivalent commit-count form: `HEAD~$(git rev-list --count <BASELINE_SHA>..HEAD)..HEAD`).
    - `tier`: passed through from the orchestrator (medium/large)
    - `WAVE`: `final` — drives the output artifact filename `.uberdev/research/$RUN_ID/post-impl-review-wave-final.md`. The existing `finish-branch` glob `post-impl-review-wave-*.md` matches without any read-path change.
    Skill returns the aggregate findings table. Findings are ADVISORY — do NOT block on `REVISIONS_REQUIRED` at this layer. Append findings to the running session log so `finish-branch` can compose the PR body's `## Reviewer findings summary`.
@@ -92,7 +92,7 @@ digraph when_to_use {
                 ↓
             spec reviewers (parallel) → fix loop → re-reviews
             quality reviewers (parallel) → fix loop → re-reviews
-                ↓ accumulate ALL_CHANGED_PATHS; no advisory fanout between waves
+                ↓ accumulate ALL_CHANGED_PATHS into running set
                 ↓ no merge step — already on feature branch
 [wave-2] →  Agent(T4, edits files only)  ┐
             Agent(T5, edits files only)  ┘  (parallel, depend on wave-1 commits)
@@ -266,11 +266,8 @@ Ownership map:
 
 === AFTER ALL WAVES ===
 
-[Invoke uberdev:post-impl-review skill ONCE with changed_paths=ALL_CHANGED_PATHS,
- commit_range=<BASELINE_SHA>..HEAD, tier passed through, WAVE=final]
-[5 advisory reviewer agents fan out in a single message; aggregate written to
- .uberdev/research/$RUN_ID/post-impl-review-wave-final.md]
-[Findings are advisory — no blocking on REVISIONS_REQUIRED]
+[Invoke uberdev:post-impl-review skill ONCE — see step 5 for inputs and artifact path]
+[5 advisory reviewer agents fan out in a single message; findings are advisory]
 [For large tier: orchestrator Phase 5.5 dispatches pr-test-analyzer pre-merge after this skill returns]
 
 [Hand off to uberdev:finish-branch]

--- a/tests/post-impl-review.test.sh
+++ b/tests/post-impl-review.test.sh
@@ -59,23 +59,40 @@ assert_grep "$SUBAGENT_DRIVEN" 'End-of-issue post-impl-review' \
 assert_grep "$SUBAGENT_DRIVEN" 'WAVE.*final|WAVE: .final.' \
   "subagent-driven-dev passes WAVE=final to post-impl-review (drives -wave-final.md filename)"
 assert_grep "$SUBAGENT_DRIVEN" 'BASELINE_SHA=.*git rev-parse HEAD' \
-  "subagent-driven-dev captures BASELINE_SHA at start of step 4 for robust commit_range"
+  "subagent-driven-dev captures BASELINE_SHA before the wave loop for robust commit_range"
+assert_grep "$SUBAGENT_DRIVEN" 'ALL_CHANGED_PATHS' \
+  "subagent-driven-dev declares the ALL_CHANGED_PATHS accumulator for the consolidated invocation"
+assert_grep "$SUBAGENT_DRIVEN" 'Accumulate end-of-issue inputs' \
+  "subagent-driven-dev step 4j codifies path accumulation across waves (no per-wave dispatch)"
 
 echo
 echo "== Anti-regression: per-wave post-impl-review wording is GONE from subagent-driven-dev wave-loop =="
-# Whole-file count of "per-wave" inside the wave-loop region must be 0. The line 311 Red Flag
-# uses "post-wave full-test-suite" (different phrase, about the full-test-suite run that stays
-# in the loop — unrelated to the relocation), so we anchor on the wave-loop section only.
-WAVE_LOOP_REGION=$(awk '/^### High-Level Flow/,/^### Parallel Dispatch Pattern/' "$SUBAGENT_DRIVEN")
-# `grep -c` always prints the count to stdout (even 0), but exits 1 on zero matches.
-# `|| true` keeps the count clean (avoids "0\n0" from `|| echo 0`) and tolerates the non-zero exit.
-WAVE_LOOP_HITS=$(grep -cE "per-wave|after each wave" <<<"$WAVE_LOOP_REGION" || true)
-if [[ "$WAVE_LOOP_HITS" -eq 0 ]]; then
-  echo "  PASS  per-wave / after-each-wave wording removed from wave-loop region"
-  PASS=$((PASS + 1))
-else
-  echo "  FAIL  per-wave / after-each-wave wording must be 0 in wave-loop region (got $WAVE_LOOP_HITS)"
+# Whole-file count of "per-wave" inside the wave-loop region must be 0. The Red Flag bullet
+# elsewhere in the file uses "post-wave full-test-suite" (different phrase, about the
+# full-test-suite run that stays in the loop — unrelated to the relocation), so we anchor on
+# the wave-loop section only via awk range. Anchor-existence guard added below: if either
+# range header is renamed (e.g. ### -> ##, or wording changes), awk silently returns empty
+# and grep would report 0 hits — a false PASS. Verify both anchors exist first.
+if ! grep -q '^### High-Level Flow' "$SUBAGENT_DRIVEN" || ! grep -q '^### Parallel Dispatch Pattern' "$SUBAGENT_DRIVEN"; then
+  echo "  FAIL  awk anchors '### High-Level Flow' / '### Parallel Dispatch Pattern' missing — wave-loop region cannot be extracted (rename detected?)"
   FAIL=$((FAIL + 1))
+else
+  WAVE_LOOP_REGION=$(awk '/^### High-Level Flow/,/^### Parallel Dispatch Pattern/' "$SUBAGENT_DRIVEN")
+  if [ -z "$WAVE_LOOP_REGION" ]; then
+    echo "  FAIL  awk extracted empty wave-loop region (anchors found but range did not match)"
+    FAIL=$((FAIL + 1))
+  else
+    # `grep -c` always prints the count to stdout (even 0), but exits 1 on zero matches.
+    # `|| true` keeps the count clean (avoids "0\n0" from `|| echo 0`) and tolerates the non-zero exit.
+    WAVE_LOOP_HITS=$(grep -cE "per-wave|after each wave" <<<"$WAVE_LOOP_REGION" || true)
+    if [[ "$WAVE_LOOP_HITS" -eq 0 ]]; then
+      echo "  PASS  per-wave / after-each-wave wording removed from wave-loop region"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL  per-wave / after-each-wave wording must be 0 in wave-loop region (got $WAVE_LOOP_HITS)"
+      FAIL=$((FAIL + 1))
+    fi
+  fi
 fi
 
 # Obsolete step 5 prose must be fully gone

--- a/tests/post-impl-review.test.sh
+++ b/tests/post-impl-review.test.sh
@@ -50,7 +50,99 @@ echo "== Skill referenced from both call sites =="
 assert_grep "$SOLVE_PIPELINE" 'post-impl-review|uberdev:post-impl-review' \
   "solve-pipeline skill references post-impl-review (trivial/small inline prompt; gated on AUTO_MODE=0)"
 assert_grep "$SUBAGENT_DRIVEN" 'post-impl-review|uberdev:post-impl-review' \
-  "subagent-driven-dev references post-impl-review (per-wave invocation)"
+  "subagent-driven-dev references post-impl-review (end-of-issue invocation)"
+
+echo
+echo "== End-of-issue post-impl-review wording is canonical in subagent-driven-dev =="
+assert_grep "$SUBAGENT_DRIVEN" 'End-of-issue post-impl-review' \
+  "subagent-driven-dev step 5 codifies the consolidated end-of-issue invocation"
+assert_grep "$SUBAGENT_DRIVEN" 'WAVE.*final|WAVE: .final.' \
+  "subagent-driven-dev passes WAVE=final to post-impl-review (drives -wave-final.md filename)"
+assert_grep "$SUBAGENT_DRIVEN" 'BASELINE_SHA=.*git rev-parse HEAD' \
+  "subagent-driven-dev captures BASELINE_SHA at start of step 4 for robust commit_range"
+
+echo
+echo "== Anti-regression: per-wave post-impl-review wording is GONE from subagent-driven-dev wave-loop =="
+# Whole-file count of "per-wave" inside the wave-loop region must be 0. The line 311 Red Flag
+# uses "post-wave full-test-suite" (different phrase, about the full-test-suite run that stays
+# in the loop — unrelated to the relocation), so we anchor on the wave-loop section only.
+WAVE_LOOP_REGION=$(awk '/^### High-Level Flow/,/^### Parallel Dispatch Pattern/' "$SUBAGENT_DRIVEN")
+# `grep -c` always prints the count to stdout (even 0), but exits 1 on zero matches.
+# `|| true` keeps the count clean (avoids "0\n0" from `|| echo 0`) and tolerates the non-zero exit.
+WAVE_LOOP_HITS=$(grep -cE "per-wave|after each wave" <<<"$WAVE_LOOP_REGION" || true)
+if [[ "$WAVE_LOOP_HITS" -eq 0 ]]; then
+  echo "  PASS  per-wave / after-each-wave wording removed from wave-loop region"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  per-wave / after-each-wave wording must be 0 in wave-loop region (got $WAVE_LOOP_HITS)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Obsolete step 5 prose must be fully gone
+if grep -qE "per-wave post-impl-review has already covered" "$SUBAGENT_DRIVEN"; then
+  echo "  FAIL  obsolete step 5 wording 'per-wave post-impl-review has already covered' must be removed"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  obsolete step 5 wording removed"
+  PASS=$((PASS + 1))
+fi
+
+echo
+echo "== post-impl-review/SKILL.md prose updated for end-of-issue invocation =="
+assert_grep "$POST_IMPL" 'end-of-issue from subagent-driven-dev' \
+  "frontmatter description names end-of-issue caller"
+assert_grep "$POST_IMPL" 'once after all waves complete' \
+  "When to invoke section names once-at-end-of-issue semantics"
+assert_grep "$POST_IMPL" 'post-impl-review-wave-final\.md' \
+  "output artifact docstring names the canonical -final.md filename"
+if grep -qE 'after each wave commits' "$POST_IMPL"; then
+  echo "  FAIL  obsolete 'after each wave commits' wording must be removed from post-impl-review When-to-invoke"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  obsolete 'after each wave commits' wording removed"
+  PASS=$((PASS + 1))
+fi
+
+echo
+echo "== orchestrator tier-profile table reflects end-of-issue (via SDD) for medium and large =="
+ORCHESTRATOR="$REPO_ROOT/plugins/uberdev/skills/orchestrator/SKILL.md"
+if [ ! -r "$ORCHESTRATOR" ]; then
+  echo "  FAIL  orchestrator SKILL.md missing or unreadable"
+  FAIL=$((FAIL + 1))
+else
+  # See note above: `|| true` (not `|| echo "0"`) to avoid "0\n0" when grep finds zero matches.
+  END_OF_ISSUE_CELLS=$(grep -cE 'end-of-issue \(via SDD\)' "$ORCHESTRATOR" || true)
+  if [[ "$END_OF_ISSUE_CELLS" -eq 2 ]]; then
+    echo "  PASS  tier-profile table has 2 end-of-issue (via SDD) cells (medium + large)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  tier-profile table must have 2 'end-of-issue (via SDD)' cells (got $END_OF_ISSUE_CELLS)"
+    FAIL=$((FAIL + 1))
+  fi
+  if grep -qE 'per-wave \(via SDD\)' "$ORCHESTRATOR"; then
+    echo "  FAIL  obsolete 'per-wave (via SDD)' cells must be removed from tier-profile table"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  obsolete 'per-wave (via SDD)' cells removed"
+    PASS=$((PASS + 1))
+  fi
+fi
+
+echo
+echo "== code-simplifier agent self-trigger guard drops 'post-wave' wording =="
+CODE_SIMPLIFIER="$REPO_ROOT/plugins/uberdev/agents/code-simplifier.md"
+if [ ! -r "$CODE_SIMPLIFIER" ]; then
+  echo "  FAIL  code-simplifier.md missing or unreadable"
+  FAIL=$((FAIL + 1))
+else
+  if grep -q "post-wave" "$CODE_SIMPLIFIER"; then
+    echo "  FAIL  'post-wave' must be removed from code-simplifier.md self-trigger guard"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  'post-wave' wording removed from code-simplifier.md"
+    PASS=$((PASS + 1))
+  fi
+fi
 
 echo
 echo "== Negative guard: turbo (AUTO_MODE==1) trivial+small heredoc BODIES omit post-impl-review (#15) =="

--- a/tests/turbo-flow.test.sh
+++ b/tests/turbo-flow.test.sh
@@ -284,9 +284,27 @@ assert_grep "$ORCHESTRATOR" 'pr-test-analyzer' \
   "pr-test-analyzer wired for large tier (Phase 5.5)"
 
 echo
-echo "== subagent-driven-dev invokes post-impl-review after each wave =="
+echo "== subagent-driven-dev invokes post-impl-review once at end-of-issue =="
 assert_grep "$SUBAGENT_DRIVEN" 'post-impl-review' \
   "post-impl-review skill referenced from subagent-driven-dev"
+assert_grep "$SUBAGENT_DRIVEN" 'End-of-issue post-impl-review' \
+  "subagent-driven-dev codifies end-of-issue invocation (not per-wave)"
+assert_grep "$SUBAGENT_DRIVEN" 'WAVE.*final|WAVE: .final.' \
+  "subagent-driven-dev passes WAVE=final to drive -wave-final.md filename"
+
+echo
+echo "== turbo medium/large parity: end-of-issue post-impl-review documented in turbo.md =="
+assert_grep "$TURBO_CMD" 'post-impl-review.* once at end-of-issue' \
+  "turbo.md documents end-of-issue post-impl-review for medium/large"
+assert_grep "$TURBO_CMD" 'consolidated across all waves' \
+  "turbo.md names the consolidated semantics (one fanout, all waves)"
+if grep -qE 'uberdev:post-impl-review. per wave' "$TURBO_CMD"; then
+  echo "  FAIL  obsolete 'per wave' wording in turbo.md medium/large bullet must be removed"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  turbo.md medium/large bullet drops 'per wave' wording"
+  PASS=$((PASS + 1))
+fi
 
 echo
 echo "== finish-branch composes new PR-body sections =="


### PR DESCRIPTION
## Summary

Relocates `uberdev:post-impl-review` from per-wave invocation (inside `subagent-driven-dev`'s wave loop, step 4j) to a single end-of-issue invocation between the wave loop and the `finish-branch` hand-off. Pure relocation — the skill's internals (5-agent fanout, 2000-line truncation, advisory non-blocking semantics) are untouched. A 4-wave issue now runs 5 reviewer agents instead of 20.

- 8 files updated across 8 commits + 1 fix-up: 6 skill/command/agent docs + 2 bash test scripts.
- Filename convention: `WAVE=final` drives `post-impl-review-wave-final.md`; existing `finish-branch` glob `post-impl-review-wave-*.md` matches without changes (zero migration cost; legacy per-wave artifacts from older runs still match).
- Mode parity: runs in both `/solve` and `/turbo` for medium and large tier (`orchestrator/SKILL.md` tier-profile column updated).

## Test Plan

- [x] `bash tests/post-impl-review.test.sh` → 23 passed / 0 failed
- [x] `bash tests/turbo-flow.test.sh` → 62 passed / 0 failed
- [x] Combined regression gate `bash tests/post-impl-review.test.sh && bash tests/turbo-flow.test.sh` → 85 passed / 0 failed
- [x] Anti-regression assertion: `awk '/^### High-Level Flow/,/^### Parallel Dispatch Pattern/' subagent-driven-dev/SKILL.md | grep -cE "per-wave|after each wave"` → 0
- [x] HARD INVARIANT verified: `post-impl-review/SKILL.md` `## Process` Step 1 (truncation), Step 2 (single-message fanout), Step 3 (parse), Step 4 (aggregation logic) byte-identical to pre-edit.
- [ ] Manual smoke test on a multi-wave medium issue once merged (no runtime test runner; skill behaviour cannot be unit-tested).

## Process metadata

- **Tier:** medium (Q&A-driven; 6-research-agent fanout; spec-reviewer always-on; plan-reviewer always-on)
- **Spec:** `docs/uberdev/specs/2026-05-03-post-impl-review-end-of-issue-design.md`
- **Plan:** `docs/uberdev/plans/2026-05-03-post-impl-review-end-of-issue.md`
- **Plan-reviewer verdict:** APPROVE (high confidence, zero findings)
- **Spec-reviewer verdict:** APPROVE (high confidence, zero findings)

## Q&A locked decisions (interactive Phase 2)

| Question | Choice | Rationale |
|----------|--------|-----------|
| How should the consolidated review handle diff size? | Keep existing 2000-line truncation | User: "we just need invoke post impl review of end on chain, no?" — pure relocation, not internal rework |
| Filename + finish-branch back-compat? | `post-impl-review-wave-final.md` (WAVE=final) | Zero migration; existing glob already matches |
| Run in /turbo? | Yes — both /solve and /turbo for medium and large | Parity with current per-wave behaviour |
| Cross-wave feed-forward? | Accepted as lost | Issue's stated trade-off; user's "end on chain" framing confirms |


## Reviewer findings summary

### post-impl-review-wave-final.md
---
phase: end-of-issue-post-impl-review
issue: 48
run_id: 20260503-232917-cbb2727
WAVE: final
commit_range: cbb2727..HEAD
tier: medium
changed_paths_count: 8
diff_lines: 322
test_gate: 85 passed / 0 failed
---

## Aggregation table

| Agent | Verdict | Top finding |
|-------|---------|-------------|
| code-reviewer | REVISIONS_REQUIRED | post-impl-review/SKILL.md:117 — Output example still names `wave 2 of issue #11` + `post-impl-review-wave-2.md`; with the WAVE=final-only contract this artifact path is no longer producible. (suggestion, confidence high) |
| code-simplifier | (audit-only) | Convergent on post-impl-review/SKILL.md:117 stale example AND :10 "every wave's commit"; also flagged BASELINE_SHA rationale duplication (subagent-driven-dev/SKILL.md:54 vs 75) and step-3-vs-step-4 disagreement in test:62 description. |
| silent-failure-hunter | (advisory; flagged 2 "BLOCKER"s) | AWK anchor brittleness in tests/post-impl-review.test.sh:69 (rename → silent false-pass); no documented error handling if post-impl-review skill itself fails (subagent-driven-dev/SKILL.md:73-78). |
| type-design-analyzer | (mostly green) | Same stale example at post-impl-review/SKILL.md:117 (corroborates). All bash typing + filename-glob convention checks PASS; the frontmatter "simplifier" naming nit is PRE-EXISTING (not introduced by this refactor). |
| comment-analyzer | (zero critical) | Praises consistent terminology across 6 files + anti-regression test design. Three suggestion-level prose-clarity polish opportunities; none load-bearing. |

**Aggregated: 0 true blockers, 5 suggestions. Continue.**

(Silent-failure-hunter labelled 2 findings as "BLOCKER" but per the skill contract these are advisory at this layer; both relate to defensive guards that are explicitly out-of-scope per the spec's pure-relocation invariant. Not blocked.)

## Convergent finding (3 of 5 reviewers caught the same line)

**post-impl-review/SKILL.md:117** — the `## Output` example narrates "wave 2 of issue #11" with artifact `post-impl-review-wave-2.md`. Under the new WAVE=final-only contract from this PR, that exact artifact path is no longer producible from the subagent-driven-dev call site. Three independent reviewers (code-reviewer suggestion, code-simplifier finding D, type-design-analyzer Finding 2) converged on this. **High signal — worth fixing in-pipeline before PR.**

Adjacent stale prose flagged by code-simplifier:
- **post-impl-review/SKILL.md:10** — Overview says "applying multi-axis scrutiny to **every wave's commit**" — also stale post-relocation.

## Out-of-scope (acknowledged, not actioned)

- **AWK anchor brittleness** (tests/post-impl-review.test.sh:69) — known residual risk per plan-writer's pre-implementation review (D5). Trade-off: a whole-file grep would false-positive on the unrelated `post-wave full-test-suite` Red Flag at line 321. The awk-scoped check is the agreed compromise.
- **No skill-failure error handling at the call site** (subagent-driven-dev/SKILL.md:73-78) — the `post-impl-review/SKILL.md` skill itself has a `## Failure modes` table (untouched by this PR per HARD INVARIANT). Adding redundant failure-mode prose at the call site is out of scope (pure relocation, not internal rework).
- **Frontmatter "simplifier" vs "code-simplifier" naming nit** at post-impl-review/SKILL.md:3 — pre-existing in the file, not introduced by this PR. Out of scope for #48; should be a separate cleanup issue.
- **Test-assertion duplication between T8 and T9** — intentional per plan decision D4 (each test file is a self-contained gate; cheap grep duplication preserves standalone signal).

## Findings detail (full reviewer output preserved for finish-branch / review-pr Phase 2)

### code-reviewer
- **post-impl-review/SKILL.md:117** (suggestion, high confidence) — Stale example artifact name `post-impl-review-wave-2.md` contradicts the new `WAVE=final`-only contract.

### code-simplifier (audit-only, all advisory)
- **subagent-driven-dev/SKILL.md:73-78, 100-105, 267-276** — End-of-issue dispatch contract stated 3x; condense Example Workflow block to a step-5 reference.
- **tests/post-impl-review.test.sh:57,59 + tests/turbo-flow.test.sh:290,292** — duplicate `End-of-issue` + `WAVE=final` assertions (cheap; keep both per plan D4 — defensible standalone-gate).
- **subagent-driven-dev/SKILL.md:54 vs 75** — fix-up-commit-robustness rationale appears twice; second mention adds nothing.
- **subagent-driven-dev/SKILL.md:75** — `commit_range` line offers two equivalent forms; over-engineering.
- **post-impl-review/SKILL.md:10** — Overview "every wave's commit" stale.
- **post-impl-review/SKILL.md:117** — Output example wave-2 stale (corroborates code-reviewer).
- **subagent-driven-dev/SKILL.md:75 + tests/post-impl-review.test.sh:62** — step-3-vs-step-4 description mismatch (BASELINE_SHA captured in step 3 per line 54; test description says step 4).
- **finish-branch/SKILL.md:115** — over-explained glob-breadth note; could condense to "(glob matches both new `-final.md` and any legacy `-wave-N.md` artifacts)".
- **agents/code-simplifier.md:4 vs 87** — pre-existing duplication (frontmatter + body); not introduced by this PR.

### silent-failure-hunter (advisory — labelled BLOCKER but out-of-scope here)
- **tests/post-impl-review.test.sh:69** — AWK anchor brittleness; section rename → false negative.
- **subagent-driven-dev/SKILL.md:73-78** — no documented error handling if post-impl-review skill fails.
- **subagent-driven-dev/SKILL.md:70-72** — ALL_CHANGED_PATHS edge cases undocumented (zero-paths, dedup overlap, empty-set guard).
- **tests/post-impl-review.test.sh:72** — `grep -c || true` masks genuine grep failures (exit 2+).
- **finish-branch/SKILL.md:137 area** — `ls 2>/dev/null` hides missing-directory case.

### type-design-analyzer
- All 4 audit dimensions pass (frontmatter YAML, soft-type contracts, bash variable typing, filename convention).
- 2 minor pre-existing issues (frontmatter "simplifier" name + line 117 stale example) — only the example is in-scope for this PR.

### comment-analyzer
- Zero critical issues. Three suggestion-level prose-clarity opportunities, all non-required.
- Positive findings: anti-regression test design, consistent terminology across 6 files, comment-to-code alignment all green.


Closes #48
