### PR TITLE
fix(merge): guard Step 1.1 against missing flock(1) on macOS

### DIFF
--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -99,7 +99,49 @@ Probe for `flock(1)` availability via `command -v flock` BEFORE invoking it. `fl
 
 - **`flock` available** (Linux, or macOS with Homebrew `flock`): use `flock` against `LOCK_FILE_PATH` (declared in `## Constants`). Default fail-fast on contention with message `"another /merge run in progress, PID <X>"`. `--wait` flag opt-in for queueing. Stale-lock cleanup: if PID dead, release.
 
-- **`flock` missing** (stock macOS, minimal container images, BSDs): fall back to a portable `mkdir`-based mutex at `${LOCK_FILE_PATH}.d/` (the directory sibling of the flock path). `mkdir` is POSIX-guaranteed atomic for exclusive creation, so two concurrent `/merge` runs cannot both succeed. On success, write `$$` to `${LOCK_FILE_PATH}.d/pid` so contention diagnostics carry the holder PID. On `mkdir` failure (directory already exists), read the PID file and probe liveness via `kill -0 <pid> 2>/dev/null`: if the holder is dead, the lock is stale — `rm -rf "${LOCK_FILE_PATH}.d"` and retry `mkdir` once; if still held, fail-fast with the same `"another /merge run in progress, PID <X>"` message.
+- **`flock` missing** (stock macOS, minimal container images, BSDs): fall back to a portable `mkdir`-based mutex at `${LOCK_FILE_PATH}.d/` (the directory sibling of the flock path). `mkdir` is POSIX-guaranteed atomic for exclusive creation, so two concurrent `/merge` runs cannot both succeed. Concrete acquisition + cleanup pattern:
+
+  ```bash
+  LOCK_DIR="${LOCK_FILE_PATH}.d"
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    # Acquired. Stamp PID then install cleanup trap before any other work.
+    if ! printf '%s\n' "$$" > "$LOCK_DIR/pid" 2>/dev/null; then
+      rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+      echo "error: cannot stamp PID into $LOCK_DIR/pid (filesystem error)" >&2
+      exit 1
+    fi
+    trap 'rm -rf "$LOCK_DIR"' EXIT INT TERM
+  else
+    # mkdir failed. Distinguish stale-holder vs live-contention vs filesystem error.
+    if [ ! -d "$LOCK_DIR" ]; then
+      # mkdir failed for a non-EEXIST reason (ENOSPC, EACCES, EROFS, parent missing).
+      echo "error: cannot create $LOCK_DIR (filesystem error — disk full / permission / read-only fs)" >&2
+      exit 1
+    fi
+    HOLDER_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || echo)"
+    if [ -n "$HOLDER_PID" ] && kill -0 "$HOLDER_PID" 2>/dev/null; then
+      echo "another /merge run in progress, PID $HOLDER_PID" >&2
+      exit 1
+    fi
+    # Stale (holder dead OR PID file empty / unreadable). Clean up and retry once.
+    rm -rf "$LOCK_DIR"
+    if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+      # Lost the race to another live /merge during cleanup, OR the FS broke between attempts.
+      echo "another /merge run in progress, PID $(cat "$LOCK_DIR/pid" 2>/dev/null || echo unknown)" >&2
+      exit 1
+    fi
+    printf '%s\n' "$$" > "$LOCK_DIR/pid"
+    trap 'rm -rf "$LOCK_DIR"' EXIT INT TERM
+  fi
+  ```
+
+  **Load-bearing failure-mode distinctions** (these silent-collapse cases were the reason issue #51 was misdiagnosed; do not let a future simplification re-collapse them):
+  - Missing-`flock` probe miss → silent fall-through to mkdir branch (**NOT contention**).
+  - `mkdir` EEXIST + holder alive → fail-fast `"another /merge run in progress, PID <X>"` (**true contention**).
+  - `mkdir` EEXIST + holder dead OR PID file empty → stale; clean up; retry `mkdir` once.
+  - `mkdir` non-EEXIST (ENOSPC, EACCES, EROFS, parent missing) → distinct `"filesystem error"` diagnostic (**NOT contention**).
+  - PID-file write failure (disk full immediately after `mkdir` succeeded) → release the lock dir; distinct `"cannot stamp PID"` diagnostic (**NOT contention**).
+  - `kill -0` exit 1 (process dead OR cross-UID permission denied) → treated as stale; safe under the run's own UID assumption (UberDev runs as the user, never cross-UID).
 
 The missing-`flock` case (`command -v flock` returns empty / exit 1) is **NOT contention** and MUST NOT emit the contention diagnostic — it is a tool-availability branch, taken silently as a fall-through to the portable mutex. Without this guard, every `/merge` invocation on a stock macOS install reports a false-positive "another /merge run in progress" before doing any work; that mis-classification was the root cause of issue #51.
 
@@ -421,7 +463,7 @@ For each stale branch, the agent decides (per-branch). Each decision emits one `
 
 ### Step 4.6 — Release the lock
 
-`flock` releases automatically on process exit; no explicit unlock required for the flock path. The `mkdir`-based fallback (Step 1.1, missing-`flock` branch) does NOT auto-release — the run MUST explicitly `rmdir "${LOCK_FILE_PATH}.d"` (or `rm -rf` to also drop the inner PID file) on every exit path, including signal-handler cleanup, so the next `/merge` does not encounter a stale-but-recently-held directory before its `kill -0` liveness probe runs.
+`flock` releases automatically on process exit; no explicit unlock required for the flock path. The `mkdir`-based fallback (Step 1.1, missing-`flock` branch) does NOT auto-release — cleanup is handled by the `trap 'rm -rf "$LOCK_DIR"' EXIT INT TERM` installed in Step 1.1 immediately after acquisition. That trap fires on normal exit, on Ctrl-C (SIGINT), and on SIGTERM. SIGKILL is uncatchable by definition; the safety net for a SIGKILL'd holder is the next `/merge` invocation's `kill -0` liveness probe, which detects the dead holder and triggers the stale-cleanup-and-retry path. Step 4.6 therefore has no explicit work to do for the fallback path beyond letting the trap fire — but the trap installation in Step 1.1 is non-negotiable.
 
 ## Quick Reference
 

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -118,7 +118,7 @@ Probe for `flock(1)` availability via `command -v flock` BEFORE invoking it. `fl
       echo "error: cannot create $LOCK_DIR (filesystem error — disk full / permission / read-only fs)" >&2
       exit 1
     fi
-    HOLDER_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || echo)"
+    HOLDER_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || printf '')"
     if [ -n "$HOLDER_PID" ] && kill -0 "$HOLDER_PID" 2>/dev/null; then
       echo "another /merge run in progress, PID $HOLDER_PID" >&2
       exit 1

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -95,7 +95,13 @@ This is transparency for the autopilot contract — every blocking gate has been
 
 ### Step 1.1 — Acquire the single-instance lock
 
-Use `flock` against `LOCK_FILE_PATH` (declared in `## Constants`). Default fail-fast on contention with message `"another /merge run in progress, PID <X>"`. `--wait` flag opt-in for queueing. Stale-lock cleanup: if PID dead, release.
+Probe for `flock(1)` availability via `command -v flock` BEFORE invoking it. `flock` is not part of the macOS base system, so the unguarded invocation path must not be the only one. Branch on the probe:
+
+- **`flock` available** (Linux, or macOS with Homebrew `flock`): use `flock` against `LOCK_FILE_PATH` (declared in `## Constants`). Default fail-fast on contention with message `"another /merge run in progress, PID <X>"`. `--wait` flag opt-in for queueing. Stale-lock cleanup: if PID dead, release.
+
+- **`flock` missing** (stock macOS, minimal container images, BSDs): fall back to a portable `mkdir`-based mutex at `${LOCK_FILE_PATH}.d/` (the directory sibling of the flock path). `mkdir` is POSIX-guaranteed atomic for exclusive creation, so two concurrent `/merge` runs cannot both succeed. On success, write `$$` to `${LOCK_FILE_PATH}.d/pid` so contention diagnostics carry the holder PID. On `mkdir` failure (directory already exists), read the PID file and probe liveness via `kill -0 <pid> 2>/dev/null`: if the holder is dead, the lock is stale — `rm -rf "${LOCK_FILE_PATH}.d"` and retry `mkdir` once; if still held, fail-fast with the same `"another /merge run in progress, PID <X>"` message.
+
+The missing-`flock` case (`command -v flock` returns empty / exit 1) is **NOT contention** and MUST NOT emit the contention diagnostic — it is a tool-availability branch, taken silently as a fall-through to the portable mutex. Without this guard, every `/merge` invocation on a stock macOS install reports a false-positive "another /merge run in progress" before doing any work; that mis-classification was the root cause of issue #51.
 
 ### Step 1.2 — Read integration_branch via the four-tier precedence chain (D8)
 
@@ -415,7 +421,7 @@ For each stale branch, the agent decides (per-branch). Each decision emits one `
 
 ### Step 4.6 — Release the lock
 
-`flock` releases automatically on process exit. Explicit unlock not required.
+`flock` releases automatically on process exit; no explicit unlock required for the flock path. The `mkdir`-based fallback (Step 1.1, missing-`flock` branch) does NOT auto-release — the run MUST explicitly `rmdir "${LOCK_FILE_PATH}.d"` (or `rm -rf` to also drop the inner PID file) on every exit path, including signal-handler cleanup, so the next `/merge` does not encounter a stale-but-recently-held directory before its `kill -0` liveness probe runs.
 
 ## Quick Reference
 

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -1035,10 +1035,26 @@ else
   fi
   # Phase 4.6 must clean up the mkdir fallback explicitly (flock auto-releases; mkdir does not).
   PHASE_4_6_BLOCK=$(awk '/^### Step 4\.6/,/^## Quick Reference/' "$SKILL_FILE")
-  if echo "$PHASE_4_6_BLOCK" | grep -qE '\brmdir\b|remove.*lock dir|cleanup.*fallback'; then
+  if echo "$PHASE_4_6_BLOCK" | grep -qE '\brmdir\b|rm -rf.*LOCK_DIR|remove.*lock dir|cleanup.*fallback|trap.*EXIT'; then
     pass "M62.4 — Step 4.6 documents explicit cleanup for the mkdir fallback"
   else
-    fail "M62.4 — Step 4.6 must document explicit cleanup (rmdir) for the mkdir fallback path"
+    fail "M62.4 — Step 4.6 must document explicit cleanup (rmdir / trap EXIT) for the mkdir fallback path"
+  fi
+  # M62.5 — Step 1.1 must distinguish mkdir filesystem errors from contention so users see the
+  # right diagnostic. Without this, ENOSPC / EACCES / EROFS get mis-reported as "another /merge
+  # run in progress" — the same silent-failure family as the original issue #51 mis-classification.
+  if echo "$PHASE_1_1_BLOCK" | grep -qE 'filesystem error|ENOSPC|EACCES|EROFS|non-EEXIST'; then
+    pass "M62.5 — Step 1.1 distinguishes mkdir filesystem errors from lock contention"
+  else
+    fail "M62.5 — Step 1.1 must distinguish mkdir filesystem errors (ENOSPC / EACCES / EROFS) from lock contention so the diagnostic does not mis-fire"
+  fi
+  # M62.6 — Step 1.1 must prescribe a concrete trap so cleanup-on-exit is consistent across
+  # every codegen pass. "MUST install a trap" without the literal trap line is hopeful prose;
+  # the literal `trap ... EXIT INT TERM` syntax pins the contract.
+  if echo "$PHASE_1_1_BLOCK" | grep -qE 'trap.*EXIT[ ]+INT[ ]+TERM|trap.*EXIT.*TERM'; then
+    pass "M62.6 — Step 1.1 prescribes concrete trap syntax (trap ... EXIT INT TERM) for fallback cleanup"
+  else
+    fail "M62.6 — Step 1.1 must prescribe concrete trap syntax (trap 'rm -rf \$LOCK_DIR' EXIT INT TERM) so cleanup-on-exit is generated consistently"
   fi
 fi
 

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -1004,6 +1004,45 @@ else
 fi
 
 echo
+echo "== M62: SKILL.md Step 1.1 guards against missing flock(1) (issue #51) =="
+# Motivating case: macOS ships without flock(1), so the unguarded `flock` invocation
+# in Step 1.1 exits 127 ("command not found") and the prior prose mis-classified
+# every non-zero exit from the lock invocation as genuine contention. Result:
+# stock-macOS users see "another /merge run in progress" with no actual contender.
+# This test pins the contract that Step 1.1 (a) detects flock availability before
+# invoking it, (b) provides a portable fallback (mkdir-based mutex is the natural
+# POSIX-atomic choice) so /merge works out-of-the-box, and (c) explicitly
+# distinguishes the missing-binary path from real contention so the diagnostic
+# never mis-fires again.
+PHASE_1_1_BLOCK=$(awk '/^### Step 1\.1/,/^### Step 1\.2/' "$SKILL_FILE")
+if [ -z "$PHASE_1_1_BLOCK" ]; then
+  fail "M62 — could not slice Step 1.1 block; heading layout changed"
+else
+  if echo "$PHASE_1_1_BLOCK" | grep -qE 'command -v flock'; then
+    pass "M62.1 — Step 1.1 probes flock availability via 'command -v flock' before invoking it"
+  else
+    fail "M62.1 — Step 1.1 must probe flock availability via 'command -v flock' before invoking it"
+  fi
+  if echo "$PHASE_1_1_BLOCK" | grep -qE '\bmkdir\b'; then
+    pass "M62.2 — Step 1.1 specifies a portable mkdir-based mutex fallback"
+  else
+    fail "M62.2 — Step 1.1 must specify a portable mkdir-based mutex fallback (POSIX-atomic, no flock dep)"
+  fi
+  if echo "$PHASE_1_1_BLOCK" | grep -qE '(MUST NOT|must not|never).*(contention|contended)|missing.*flock.*not.*contention|not.*lock.*contention'; then
+    pass "M62.3 — Step 1.1 explicitly forbids classifying missing-flock as contention"
+  else
+    fail "M62.3 — Step 1.1 must explicitly state that the missing-flock case is NOT contention (the issue-#51 mis-classification regression guard)"
+  fi
+  # Phase 4.6 must clean up the mkdir fallback explicitly (flock auto-releases; mkdir does not).
+  PHASE_4_6_BLOCK=$(awk '/^### Step 4\.6/,/^## Quick Reference/' "$SKILL_FILE")
+  if echo "$PHASE_4_6_BLOCK" | grep -qE '\brmdir\b|remove.*lock dir|cleanup.*fallback'; then
+    pass "M62.4 — Step 4.6 documents explicit cleanup for the mkdir fallback"
+  else
+    fail "M62.4 — Step 4.6 must document explicit cleanup (rmdir) for the mkdir fallback path"
+  fi
+fi
+
+echo
 echo "== Summary =="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"


### PR DESCRIPTION
## Summary

- Step 1.1 now probes `command -v flock` before invoking it; missing-flock falls back to a POSIX-atomic `mkdir`-based mutex at `${LOCK_FILE_PATH}.d/` so `/merge` works out-of-the-box on stock macOS.
- The missing-flock branch is explicitly **NOT contention** in the prose, so the false-positive `"another /merge run in progress"` diagnostic on macOS (issue #51) cannot regress.
- Step 4.6 spells out the explicit `rmdir` cleanup the fallback requires (flock auto-releases on exit; mkdir does not).

## Why

`flock(1)` is not part of the macOS base system. The unguarded `flock` invocation in Step 1.1 exited 127 (`command not found: flock`), and the prior error-translation classified every non-zero exit as genuine contention. Result: every `/merge` invocation on a stock macOS install reported a held lock with no actual contender — `/merge` was unusable on macOS without a separate `brew install flock`.

## Test plan

- [x] New shape-check test M62 (4 sub-assertions in `tests/merge.test.sh`) pins the contract: flock-availability probe, mkdir fallback, no contention mis-classification, explicit Step 4.6 cleanup. RED before the SKILL.md edit; GREEN after.
- [x] Full `tests/merge.test.sh` suite: 201 / 0 (M62 added without disturbing M1–M61).
- [x] All 11 `tests/*.test.sh` files green (no cross-test regressions).
- [ ] Manual verification: invoke `/merge` on a stock macOS shell (no Homebrew flock) and confirm the run reaches Step 1.2 without the false-positive contention error.

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced merge skill's lock acquisition to detect `flock` availability and fallback to atomic `mkdir`-based mutex on unsupported systems, eliminating false-positive contention reports.
  * Clarified explicit lock cleanup requirements for robust stale-lock prevention.

* **Tests**
  * Added macOS portability validation for merge skill's lock handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->