### PR TITLE
feat(merge): bare /merge auto-discovers open PRs (#56)

### DIFF
--- a/plugins/uberdev/commands/merge.md
+++ b/plugins/uberdev/commands/merge.md
@@ -1,6 +1,6 @@
 ---
 description: "After a PR is approved, lands it into the integration branch — ordering, strategy, conflict resolution, and local sync automated"
-argument-hint: "[<PR#> | --all] [--yes|-y (deprecated)] [--integration-branch=<name>]"
+argument-hint: "[<PR#> | --all] [--integration-branch=<name>]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 ---
 
@@ -10,9 +10,9 @@ Land approved PRs into the integration branch — ordering, strategy, conflict r
 
 **RULES:** Do NOT use the Task tool or internal subagents. The skill body owns all logic.
 
-**Usage:** `/merge [<PR#> | --all] [--yes|-y (deprecated)] [--integration-branch=<name>]`
+**Usage:** `/merge [<PR#> | --all] [--integration-branch=<name>]`
 
-- No args → land the PR for the current branch (errors if none).
+- No args → context-aware: single PR if on a PR branch, else discover and land all eligible open PRs against integration_branch.
 - `<PR#>` → land a specific PR.
 - `--all` → land every open APPROVED PR with passing CI.
 - `--yes` / `-y` → **(deprecated; no behavioural effect)** parsed for backward compat; `/merge` is fully unattended (autopilot) and skips all prompts unconditionally. First encounter per run emits a one-line stderr deprecation notice. See `## Deprecated Flags` below.

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -103,14 +103,14 @@ When `/merge` is invoked with no positional `<PR#>` and no `--all` flag (the bar
 
 Procedure:
 
-1. Resolve `current_branch := git symbolic-ref --short HEAD 2>/dev/null`. On failure (detached HEAD), set `current_branch=""` and treat the candidate count as 0 (multi-discover fall-through).
+1. Resolve `current_branch := git symbolic-ref --short HEAD 2>/dev/null`. On failure (detached HEAD), set `current_branch=""`, **skip step 2 entirely**, and treat `N := 0` (multi-discover fall-through). Do not invoke `BARE_MODE_FAST_PATH_QUERY` with an empty `--head` value — `gh pr list --head ""` is undefined behaviour.
 2. Run the canonical `BARE_MODE_FAST_PATH_QUERY` (declared in `## Constants`):
 
    ```bash
    gh pr list --head "$current_branch" --state open --search "draft:false" --json number,headRefOid
    ```
 
-   The result is a JSON array; let `N := len(result)`.
+   The result is a JSON array; let `N := len(result)`. **`gh` failure-mode handling** (network, auth, rate limit, 5xx) is a cross-cutting concern across all `gh pr list` invocations in the skill (`--all` discovery has the same shape); follow-up issue tracks unified hardening across both bare-discover Step 1.0.5 / Step 1.2.5 and the existing `--all` path. Until then: a `gh` failure producing empty stdout will be observed as `N=0`, falling through to multi-discover; surface the breadcrumb at step 3 unchanged.
 
 3. Branch on `N` (three-way):
 
@@ -130,7 +130,7 @@ Procedure:
 
      The pipeline proceeds to Step 1.1 (lock) and Step 1.2 (integration_branch resolution); Step 1.2.5 will apply the multi-discover dispatch filter and seed the candidate set.
 
-   - `N > 1` → **ambiguity hard error**. Emit one stderr line `error: current branch '<current_branch>' has multiple open PRs (#A #B); use --all or <PR#> to disambiguate.` and exit 1. (Rare; cross-fork edge case.)
+   - `N > 1` → **ambiguity hard error**. Emit one stderr line `error: current branch '<current_branch>' has multiple open PRs (#A #B); use --all or <PR#> to disambiguate.` and exit 1. (Rare; cross-fork edge case.) **No audit event is emitted by design** — the stderr line is the canonical surface (cardinality matches Phase 2.1's cycle-break stderr-only convention; `AUDIT_EVENT_ENUM` intentionally has no `bare_mode_ambiguous` member). The audit log is bound to a `run_id` allocated at Step 1.1 (lock acquisition), and Step 1.0.5 runs pre-lock — so there is no audit context yet. Implementers MUST NOT add an audit event here without spec-level changes.
 
 When `--all` was passed on the command line, **Step 1.0.5 is skipped entirely** — the multi-discover discriminator is set unconditionally, and the pipeline proceeds to Step 1.1.
 
@@ -209,7 +209,7 @@ candidates=$(gh pr list --base "$integration_branch" --state open --search "draf
   | jq '[.[] | select(.isDraft==false)]')
 ```
 
-The `jq '.[] | select(.isDraft==false)'` filter is belt-and-suspenders against any future `gh` API change that might surface drafts despite the `--search "draft:false"` flag. The candidate array is the input set for Phase 1.4 (per-PR trust gate fanout). **This is the only place `DISCOVERY_FILTER` is invoked**; both bare-mode (multi-discover) and `--all` route through this single dispatch point so the two modes share one canonical filter (Q4).
+The `jq '.[] | select(.isDraft==false)'` filter is belt-and-suspenders against any future `gh` API change that might surface drafts despite the `--search "draft:false"` flag. The candidate array is the input set for Phase 1.4 (per-PR trust gate fanout). **This is the only place `DISCOVERY_FILTER` is invoked**; both bare-mode (multi-discover) and `--all` route through this single dispatch point so the two modes share one canonical filter (Q4). **`gh` and `jq` failure-mode handling** is a cross-cutting concern shared with Step 1.0.5 (see that step's note); a transient `gh` failure or `jq` parse error producing an empty pipeline output is currently observed as a legitimate empty candidate set (Step 1.7 clean-exit-0 applies). Follow-up issue tracks unified hardening across bare-discover and the existing `--all` path; until then, post-hoc forensics rely on `gh` CLI's own stderr emission rather than a structured audit event.
 
 If the `gh` invocation returns an empty array (all PRs are drafts, or no open PRs exist on `$integration_branch`), the candidate set is empty — Step 1.7's clean-exit-0 contract applies (see Step 1.7's bare-mode cross-reference).
 

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -213,7 +213,7 @@ The `jq '.[] | select(.isDraft==false)'` filter is belt-and-suspenders against a
 
 If the `gh` invocation returns an empty array (all PRs are drafts, or no open PRs exist on `$integration_branch`), the candidate set is empty — Step 1.7's clean-exit-0 contract applies (see Step 1.7's bare-mode cross-reference).
 
-Step 1.2.5 does NOT re-run the bare-mode fast-path query (that lives in Step 1.0.5). The two steps are intentionally split because the bare-mode fast-path query has zero dependency on `$integration_branch` while `DISCOVERY_FILTER` requires it — collapsing them into a single Step 1.0.5 would invert the dependency on `$integration_branch` and break the pipeline.
+This step is the `$integration_branch`-dependent half of the split detection introduced in Step 1.0.5; the two steps are intentionally separate (see Step 1.0.5 for the rationale) and collapsing them would invert the dependency on `$integration_branch`. Do not collapse.
 
 ### Step 1.3 — Last-resort fallback when all four tiers are empty
 

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -57,12 +57,15 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `GATE_FAIL_REASON_TRUST_TRAIL_JSON_SHA_MISMATCH` | `trust_trail_json_sha_mismatch` (8th member of `GATE_FAIL_REASON_ENUM`) | Phase 1.4 PATH_2 sub-condition (d) caller mapping for JSON-present-but-SHA-mismatch (or shape-malformed) cases; audit-log `gate_fail.data.reason` |
 | `TRUST_TRAIL_VERDICT_INVALID_SUBREASON_ENUM` | `input_malformed` (immediate gate_fail; no retry), `trailer_sha_not_in_local_clone` (one bounded `git fetch --prune` + re-dispatch with `data.retry_attempt=1`; second INVALID is terminal) | Phase 1.4 PATH_2 sub-condition (c); audit-log `trust_trail_agent_decision.data.subreason` when `data.choice="INVALID"` |
 | `TRUST_TRAIL_AGENT_DECISION_RETRY_ATTEMPT_RANGE` | integer enum `{0, 1}` (0 = first dispatch; 1 = bounded retry on `trailer_sha_not_in_local_clone`; never recursive) | Phase 1.4 PATH_2 sub-condition (c); audit-log `trust_trail_agent_decision.data.retry_attempt` |
+| `BARE_MODE_FAST_PATH_QUERY` | `gh pr list --head "$current_branch" --state open --search "draft:false" --json number,headRefOid` | Step 1.0.5 (bare-mode current-branch detection — does NOT consume `$integration_branch`; the cardinality of the result drives the three-way branch) |
+| `DISCOVERY_FILTER` | `gh pr list --base "$integration_branch" --state open --search "draft:false" --json number,title,headRefOid,headRefName,baseRefName,isDraft,createdAt,reviewDecision,labels,body,author,headRepositoryOwner` followed by `jq '.[] \| select(.isDraft==false)'` (belt-and-suspenders) | Step 1.2.5 (multi-discover dispatch — runs after Step 1.2 integration_branch resolution); also referenced by `--all` for one canonical filter shared by both modes (Q4) |
+| `PREFLIGHT_SUMMARY_FORMAT` | `"merging %d PR%s in order: %s"` (literal printf-style format). When the rendered line exceeds 80 chars, fold at PR-number boundaries with a continuation indent of 2 spaces (80-char wrap convention). | Step 2.2 entry pre-flight stderr line (multi-discover mode only); the line lists the FULL ordered set regardless of `MAX_PARALLEL_AGENTS` chunking (Q5) |
 
 ## Inputs
 
 Argument parsing:
 
-- **No args** — use the current branch's PR if one exists. If the current branch has no open PR, error out with a clear message pointing to `finish-branch`.
+- **No args** — context-aware bare-discover. If the current branch has exactly one open non-draft PR (per `BARE_MODE_FAST_PATH_QUERY`), operate on that PR (single-PR mode — today's fast path is preserved). If the current branch has zero open PRs (or `current_branch` resolution fails — detached HEAD), fall through to the same discovery pipeline as `--all` (multi-discover mode; Step 1.2.5 applies `DISCOVERY_FILTER` against `$integration_branch`). Greater than one open current-branch PR is an unrecoverable ambiguity error pointing the user at `--all` or `<PR#>`.
 - **`<PR#>`** (single positional integer) — single-PR mode; operate on exactly that PR number.
 - **`--all`** — enumerate all open PRs that are APPROVED and have passing required CI checks; treat the result as the input set.
 - **`--squash` / `--rebase` / `--merge`** — accepted for backward compat **(deprecated; no behavioural effect — see `## Inputs` autopilot paragraph and `commands/merge.md` `## Deprecated Flags`)**. The `merge-strategy-decider` agent picks per-PR strategy from PR-shape signals; the CLI flag is parsed without error, emits `STRATEGY_FLAGS_DEPRECATED_NOTE` once per run on first encounter, and records a `deprecated_flag_used` audit event. The flag does NOT override the agent's choice for any PR.
@@ -93,6 +96,45 @@ At the very start of the run (before lock acquisition), emit a one-line banner t
 ```
 
 This is transparency for the autopilot contract — every blocking gate has been removed; only data-integrity edges (e.g. lock contention by another live `/merge`) can stop the run.
+
+### Step 1.0.5 — Bare-mode detection (mode-only, no dispatch)
+
+When `/merge` is invoked with no positional `<PR#>` and no `--all` flag (the bare-discover entry point), this step decides between the single-PR fast path and the multi-discover fall-through. **This step runs `BARE_MODE_FAST_PATH_QUERY` only; it does NOT consume `$integration_branch` (which is not yet resolved at this point in the pipeline). The multi-discover dispatch that depends on `$integration_branch` is deferred to Step 1.2.5.**
+
+Procedure:
+
+1. Resolve `current_branch := git symbolic-ref --short HEAD 2>/dev/null`. On failure (detached HEAD), set `current_branch=""` and treat the candidate count as 0 (multi-discover fall-through).
+2. Run the canonical `BARE_MODE_FAST_PATH_QUERY` (declared in `## Constants`):
+
+   ```bash
+   gh pr list --head "$current_branch" --state open --search "draft:false" --json number,headRefOid
+   ```
+
+   The result is a JSON array; let `N := len(result)`.
+
+3. Branch on `N` (three-way):
+
+   - `N == 1` → **single-PR fast path** (Branch (a) in the design). Set `pr_number := result[0].number`, set the bare-mode discriminator to `fast-path`, short-circuit subsequent steps so they treat this run as if `<PR#>` was passed positionally, and emit a stderr breadcrumb:
+
+     ```
+     bare-mode: detected 1 current-branch PR (#<N>); entering single-PR mode
+     ```
+
+     Today's pipeline (Step 1.1 lock → Step 1.2 integration_branch → Phase 1.4 trust gate → Phase 2.2 → Phase 3) runs unchanged. **No pre-flight summary line** is emitted (Q2: single-PR mode preserves today's UX).
+
+   - `N == 0` → **multi-discover fall-through** (Branch (b) in the design). Set the bare-mode discriminator to `multi-discover` and emit a stderr breadcrumb:
+
+     ```
+     bare-mode: detected 0 current-branch PRs; entering multi-discover mode
+     ```
+
+     The pipeline proceeds to Step 1.1 (lock) and Step 1.2 (integration_branch resolution); Step 1.2.5 will apply the multi-discover dispatch filter and seed the candidate set.
+
+   - `N > 1` → **ambiguity hard error**. Emit one stderr line `error: current branch '<current_branch>' has multiple open PRs (#A #B); use --all or <PR#> to disambiguate.` and exit 1. (Rare; cross-fork edge case.)
+
+When `--all` was passed on the command line, **Step 1.0.5 is skipped entirely** — the multi-discover discriminator is set unconditionally, and the pipeline proceeds to Step 1.1.
+
+No new `AUDIT_EVENT_ENUM` member is introduced for Step 1.0.5; the stderr breadcrumb is the canonical audit surface (cardinality matches Phase 2.1's cycle-break stderr-only convention). Subsequent per-PR `gate_pass` / `gate_fail` events make the downstream gating decisions auditable as today.
 
 ### Step 1.1 — Acquire the single-instance lock
 
@@ -155,6 +197,24 @@ The missing-`flock` case (`command -v flock` returns empty / exit 1) is **NOT co
 
 Validate the resolved name against `BRANCH_NAME_REGEX` BEFORE any shell argv use. Reject and abort on regex fail.
 
+### Step 1.2.5 — Multi-discover dispatch (deferred from Step 1.0.5)
+
+If Step 1.0.5 set the bare-mode discriminator to `multi-discover` (or `--all` was given on the command line), apply the canonical `DISCOVERY_FILTER` (declared in `## Constants`) against the `$integration_branch` resolved by Step 1.2, and seed the Phase 1.4 candidate set with the result. Otherwise this step is a no-op.
+
+Concretely:
+
+```bash
+candidates=$(gh pr list --base "$integration_branch" --state open --search "draft:false" \
+  --json number,title,headRefOid,headRefName,baseRefName,isDraft,createdAt,reviewDecision,labels,body,author,headRepositoryOwner \
+  | jq '[.[] | select(.isDraft==false)]')
+```
+
+The `jq '.[] | select(.isDraft==false)'` filter is belt-and-suspenders against any future `gh` API change that might surface drafts despite the `--search "draft:false"` flag. The candidate array is the input set for Phase 1.4 (per-PR trust gate fanout). **This is the only place `DISCOVERY_FILTER` is invoked**; both bare-mode (multi-discover) and `--all` route through this single dispatch point so the two modes share one canonical filter (Q4).
+
+If the `gh` invocation returns an empty array (all PRs are drafts, or no open PRs exist on `$integration_branch`), the candidate set is empty — Step 1.7's clean-exit-0 contract applies (see Step 1.7's bare-mode cross-reference).
+
+Step 1.2.5 does NOT re-run the bare-mode fast-path query (that lives in Step 1.0.5). The two steps are intentionally split because the bare-mode fast-path query has zero dependency on `$integration_branch` while `DISCOVERY_FILTER` requires it — collapsing them into a single Step 1.0.5 would invert the dependency on `$integration_branch` and break the pipeline.
+
 ### Step 1.3 — Last-resort fallback when all four tiers are empty
 
 If the four-tier chain returns nothing (network-detached clone, missing remote): use the literal `INTEGRATION_BRANCH_FALLBACK` (`main`) and emit one stderr line: `warning: integration_branch unresolved from CLI / env / config / gh; falling back to 'main'. Set integration_branch in .claude/uberdev.local.md to silence this.` Validate the fallback against `BRANCH_NAME_REGEX` (it passes by construction). **Never prompt the user.** No persist step — autopilot does not ask, it acts; if the user wants a different default, they edit the config file out-of-band.
@@ -175,7 +235,7 @@ This is the only Phase-1 path where /merge declines to run for a config reason. 
 
 ### Step 1.4 — Per-PR pre-flight gate (trust resolution)
 
-Project the JSON: `gh pr view <N> --json state,isDraft,reviewDecision,statusCheckRollup,headRepository,maintainerCanModify,isCrossRepository,headRefName,headRefOid,baseRefName,body,commits,labels,createdAt,author`.
+For each PR in the candidate set (per-PR fanout — the gate is dispatched once per discovered PR; bare-discover does not relax this dispatch shape), project the JSON: `gh pr view <N> --json state,isDraft,reviewDecision,statusCheckRollup,headRepository,maintainerCanModify,isCrossRepository,headRefName,headRefOid,baseRefName,body,commits,labels,createdAt,author`.
 
 Pre-conditions that ALL must pass regardless of trust path (real blockers):
 
@@ -248,7 +308,7 @@ For every cross-repository PR (`isCrossRepository == true`):
 
 ### Step 1.7 — Single-PR pre-flight fail edge case
 
-If only one PR is in scope and its pre-flight fails: emit the `gate_fail` event, render the run-summary block with that PR listed under `Skipped:` and an empty `Merged:` set, and exit cleanly. **Not an error, not a halt** — there is simply nothing to merge this run.
+If only one PR is in scope and its pre-flight fails: emit the `gate_fail` event, render the run-summary block with that PR listed under `Skipped:` and an empty `Merged:` set, and exit cleanly. **Not an error, not a halt** — there is simply nothing to merge this run. Bare-mode discovery (Step 1.2.5) returning an empty eligible set — whether because no open PRs exist against `$integration_branch` or because all candidates gated out at Phase 1.4 — follows this same clean-exit-0 contract; the run-summary block reports `Merged: 0 PRs / Skipped: M PRs / Parked: P PRs` and exit 0 (Q3 amends issue #56 AC #6 to align with this precedent).
 
 ## Phase 2 — Merge plan
 
@@ -265,6 +325,18 @@ Skip Step 2.1 if only 1 PR is in scope (no ordering decision to make).
 ### Step 2.2 — PER-PR STRATEGY (agent-decided)
 
 For each PR in the in-scope set, dispatch a `merge-strategy-decider` agent. Inputs per PR: `pr_number`, `commit_count` (from `git rev-list --count <integration_branch>..<head_ref_oid>`), `conventional_commit_ratio` (from a regex pass over `git log <integration_branch>..<head_ref_oid> --format=%s` matching `^(feat|fix|chore|refactor|test|docs)(\(.+\))?:`), `wip_marker_present` (from a regex pass over the same log matching `WIP_MESSAGE_REGEX`), `divergence_commits` (`git rev-list --count <merge-base>..<head_ref_oid>`), `label_hint` (suffix of any `merge-strategy:<name>` label on the PR, advisory; null otherwise; wrapped in `<external-untrusted-input source="github-pr-label">…</external-untrusted-input>` envelope), `repo_convention` (recorded preference from `.claude/uberdev.local.md` `merge_strategy:` key, null if absent), `working_dir`.
+
+**Pre-flight summary line (multi-discover mode only).** If the bare-mode discriminator is `multi-discover` (or `--all` was given on the command line), emit one stderr line just before the fanout dispatch, formatted via `PREFLIGHT_SUMMARY_FORMAT` (declared in `## Constants`):
+
+```
+merging N PRs in order: #A #B #C ... #W
+```
+
+(For the singular case, `merging 1 PR: #N`.) The line lists the **full ordered set** regardless of `MAX_PARALLEL_AGENTS` chunking — wave dispatch is an internal scheduling detail invisible to the user (per Q5). When the rendered line exceeds 80 chars, fold at PR-number boundaries with a continuation indent of 2 spaces.
+
+**The pre-flight line is informational stderr only.**
+
+It is NOT a `[y/N]` prompt and NOT abortable — the autopilot contract from Step 1.0 (no prompts, no halts) is unconditional. Single-PR mode (Q1 fast path from Step 1.0.5) does NOT emit this line — preserving today's single-PR UX.
 
 **Fanout dispatch.** Dispatch ALL `merge-strategy-decider` Task() calls for the in-scope PR set in ONE assistant turn — the single-message Task() invariant (mirrors `uberdev:post-impl-review` and the conflict-resolver fanout shape).
 

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -1336,13 +1336,8 @@ if grep -qE '^- No args.*errors if none' "$CMD_FILE"; then
 else
   pass "M72.no-old-usage — commands/merge.md Usage bullet 1 correctly omits the old 'errors if none' wording"
 fi
-# M2 length cap re-asserted — file must remain ≤ 50 lines.
-CMD_LINE_COUNT=$(wc -l < "$CMD_FILE" | tr -d ' ')
-if [ "$CMD_LINE_COUNT" -le 50 ]; then
-  pass "M72.length-cap — commands/merge.md is $CMD_LINE_COUNT lines (≤ 50 thin-dispatcher cap; M2 invariant)"
-else
-  fail "M72.length-cap — commands/merge.md MUST be ≤ 50 lines (got $CMD_LINE_COUNT; M2 thin-dispatcher cap)"
-fi
+# M72.length-cap dropped — duplicate of M2 (line 115). M2 already enforces the ≤50-line
+# thin-dispatcher cap on every run; re-asserting it inside M72 added no coverage.
 
 echo
 echo "== M73: SKILL.md Phase 1.4 'per discovered PR' fanout + Step 2.2 single-message invariant preserved =="

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -40,6 +40,16 @@
 #   M32 — SKILL.md Phase 3.3vi parks PR on push-non-FF (no halt).
 #   M33 — SKILL.md Phase 2.1 auto-breaks dependency cycles (no halt).
 #   M34 — SKILL.md Phase 3.4 failure-mode table contains no 'halt' actions.
+#   M64 — SKILL.md Inputs "No args" bullet documents bare-discover dual path (single-PR fast path OR multi-discover fall-through).
+#   M65 — SKILL.md Constants table declares DISCOVERY_FILTER exactly once with --base / --state open / draft:false.
+#   M66 — SKILL.md Constants table declares BARE_MODE_FAST_PATH_QUERY exactly once with --head / --state open / draft:false.
+#   M67 — SKILL.md Constants table declares PREFLIGHT_SUMMARY_FORMAT with literal "merging %d PR%s in order: %s" and 80-char wrap convention.
+#   M68 — SKILL.md Step 1.0.5 mode-detect cites BARE_MODE_FAST_PATH_QUERY and three-way branch; does NOT mention DISCOVERY_FILTER (split-detection invariant).
+#   M69 — SKILL.md Step 1.2.5 multi-discover dispatch cites DISCOVERY_FILTER and $integration_branch; does NOT mention BARE_MODE_FAST_PATH_QUERY (split-detection invariant).
+#   M70 — SKILL.md Step 2.2 entry mentions PREFLIGHT_SUMMARY_FORMAT pre-flight line emitted in multi-discover mode only; full ordered set, not per-wave.
+#   M71 — SKILL.md Step 1.7 cross-references bare-mode zero-eligible (clean exit 0); preserves "Not an error, not a halt" prose.
+#   M72 — commands/merge.md frontmatter argument-hint omits --yes|-y; Usage bullet 1 documents context-aware bare-mode dual path.
+#   M73 — SKILL.md Phase 1.4 prose preserves "for each" / "per discovered PR" fanout language; Step 2.2 preserves "ONE assistant turn" single-message invariant.
 
 set -u
 set -o pipefail
@@ -1085,6 +1095,264 @@ assert_grep "$SKILL_FILE" 'absence on a fresh clone is by design|fresh clone.*by
 
 assert_grep "$SKILL_FILE" 'short-circuit.*sub-condition.*d|d.*only.*checked.*c.*returned.*PASS' \
   "M63.short-circuit-preserved — (c) short-circuit-on-non-PASS clause still documented in PATH_2"
+
+echo
+echo "== M64: SKILL.md Inputs 'No args' bullet documents bare-discover dual path =="
+# Anchor scoping: extract the "No args" bullet from the Inputs list. The bullet
+# starts with "- **No args**" and ends at the next "- **`<PR#" bullet (which is
+# the next argument-parsing entry). M33's awk-range pattern.
+BARE_MODE_BULLET=$(awk '/^- \*\*No args\*\*/,/^- \*\*`<PR/' "$SKILL_FILE")
+
+if echo "$BARE_MODE_BULLET" | grep -qE 'single-PR mode|context-aware'; then
+  pass "M64.fast-path-described — Inputs 'No args' bullet describes the single-PR fast path (context-aware wording)"
+else
+  fail "M64.fast-path-described — Inputs 'No args' bullet MUST describe the single-PR fast path (single-PR mode / context-aware) per spec Components § SKILL.md item 2"
+fi
+
+if echo "$BARE_MODE_BULLET" | grep -qE 'fall through.*--all|same discovery pipeline as `--all`|multi-discover'; then
+  pass "M64.multi-discover-described — Inputs 'No args' bullet describes the multi-discover fall-through to the --all pipeline"
+else
+  fail "M64.multi-discover-described — Inputs 'No args' bullet MUST describe the multi-discover fall-through (fall through / same discovery pipeline as --all / multi-discover)"
+fi
+
+if echo "$BARE_MODE_BULLET" | grep -qE 'errors if none|error out.*finish-branch'; then
+  fail "M64.no-old-error — Inputs 'No args' bullet MUST NOT carry the old 'errors if none' / 'error out…finish-branch' prose (bare-discover replaces it)"
+else
+  pass "M64.no-old-error — Inputs 'No args' bullet correctly omits the old finish-branch error wording"
+fi
+
+echo
+echo "== M65: SKILL.md Constants declares DISCOVERY_FILTER exactly once =="
+# Count constant rows where the Name column literal is `DISCOVERY_FILTER`.
+# Constants table rows match `^| \`DISCOVERY_FILTER\` |`.
+DISCOVERY_FILTER_ROWS=$(grep -cE '^\| `DISCOVERY_FILTER` \|' "$SKILL_FILE" || true)
+if [ "$DISCOVERY_FILTER_ROWS" = "1" ]; then
+  pass "M65.unique — DISCOVERY_FILTER declared exactly once in Constants table"
+else
+  fail "M65.unique — DISCOVERY_FILTER MUST be declared exactly once in Constants table (got $DISCOVERY_FILTER_ROWS rows; spec Components § SKILL.md item 1 / Q4)"
+fi
+# Value-cell content checks — must reference --base, --state open, draft:false.
+DISCOVERY_FILTER_ROW=$(grep -E '^\| `DISCOVERY_FILTER` \|' "$SKILL_FILE" || true)
+if echo "$DISCOVERY_FILTER_ROW" | grep -qE 'gh pr list --base'; then
+  pass "M65.base-flag — DISCOVERY_FILTER value cites 'gh pr list --base'"
+else
+  fail "M65.base-flag — DISCOVERY_FILTER value MUST cite 'gh pr list --base' (canonical query; spec Q4)"
+fi
+if echo "$DISCOVERY_FILTER_ROW" | grep -qE -- '--state open'; then
+  pass "M65.state-open — DISCOVERY_FILTER value cites '--state open'"
+else
+  fail "M65.state-open — DISCOVERY_FILTER value MUST cite '--state open' (canonical query; spec Q4)"
+fi
+if echo "$DISCOVERY_FILTER_ROW" | grep -qE 'draft:false'; then
+  pass "M65.draft-filter — DISCOVERY_FILTER value cites 'draft:false'"
+else
+  fail "M65.draft-filter — DISCOVERY_FILTER value MUST cite 'draft:false' (canonical query; spec Q4)"
+fi
+
+echo
+echo "== M66: SKILL.md Constants declares BARE_MODE_FAST_PATH_QUERY exactly once =="
+BARE_FAST_PATH_ROWS=$(grep -cE '^\| `BARE_MODE_FAST_PATH_QUERY` \|' "$SKILL_FILE" || true)
+if [ "$BARE_FAST_PATH_ROWS" = "1" ]; then
+  pass "M66.unique — BARE_MODE_FAST_PATH_QUERY declared exactly once in Constants table"
+else
+  fail "M66.unique — BARE_MODE_FAST_PATH_QUERY MUST be declared exactly once in Constants table (got $BARE_FAST_PATH_ROWS rows; spec Components § SKILL.md item 1)"
+fi
+BARE_FAST_PATH_ROW=$(grep -E '^\| `BARE_MODE_FAST_PATH_QUERY` \|' "$SKILL_FILE" || true)
+if echo "$BARE_FAST_PATH_ROW" | grep -qE 'gh pr list --head'; then
+  pass "M66.head-flag — BARE_MODE_FAST_PATH_QUERY value cites 'gh pr list --head'"
+else
+  fail "M66.head-flag — BARE_MODE_FAST_PATH_QUERY value MUST cite 'gh pr list --head' (current-branch detection; spec Architecture § Branch (a))"
+fi
+if echo "$BARE_FAST_PATH_ROW" | grep -qE -- '--state open'; then
+  pass "M66.state-open — BARE_MODE_FAST_PATH_QUERY value cites '--state open'"
+else
+  fail "M66.state-open — BARE_MODE_FAST_PATH_QUERY value MUST cite '--state open'"
+fi
+if echo "$BARE_FAST_PATH_ROW" | grep -qE 'draft:false'; then
+  pass "M66.draft-filter — BARE_MODE_FAST_PATH_QUERY value cites 'draft:false'"
+else
+  fail "M66.draft-filter — BARE_MODE_FAST_PATH_QUERY value MUST cite 'draft:false'"
+fi
+
+echo
+echo "== M67: SKILL.md Constants declares PREFLIGHT_SUMMARY_FORMAT with literal format string =="
+PREFLIGHT_FORMAT_ROWS=$(grep -cE '^\| `PREFLIGHT_SUMMARY_FORMAT` \|' "$SKILL_FILE" || true)
+if [ "$PREFLIGHT_FORMAT_ROWS" = "1" ]; then
+  pass "M67.unique — PREFLIGHT_SUMMARY_FORMAT declared exactly once in Constants table"
+else
+  fail "M67.unique — PREFLIGHT_SUMMARY_FORMAT MUST be declared exactly once in Constants table (got $PREFLIGHT_FORMAT_ROWS rows; spec Q5)"
+fi
+if grep -qE 'merging %d PR%s in order: %s' "$SKILL_FILE"; then
+  pass "M67.format-literal — PREFLIGHT_SUMMARY_FORMAT contains the literal 'merging %d PR%s in order: %s'"
+else
+  fail "M67.format-literal — PREFLIGHT_SUMMARY_FORMAT MUST contain literal 'merging %d PR%s in order: %s' (spec Q5)"
+fi
+if grep -qE '80-char|80 char' "$SKILL_FILE"; then
+  pass "M67.wrap-convention — Constants prose mentions 80-char line-wrap convention"
+else
+  fail "M67.wrap-convention — Constants prose MUST mention the 80-char line-wrap convention for long PR-number lists (spec Q5)"
+fi
+
+echo
+echo "== M68: SKILL.md Step 1.0.5 mode-detect cites BARE_MODE_FAST_PATH_QUERY but NOT DISCOVERY_FILTER =="
+# Range-scope to Step 1.0.5 body: from "### Step 1.0.5" to next "### Step 1." heading.
+STEP_105_BLOCK=$(awk '/^### Step 1\.0\.5/,/^### Step 1\.1/' "$SKILL_FILE")
+if [ -n "$STEP_105_BLOCK" ]; then
+  pass "M68.exists — Step 1.0.5 section exists between Step 1.0 and Step 1.1"
+else
+  fail "M68.exists — Step 1.0.5 (mode-detect) section MUST exist between Step 1.0 and Step 1.1 (spec Components § SKILL.md item 3)"
+fi
+if echo "$STEP_105_BLOCK" | grep -qE 'BARE_MODE_FAST_PATH_QUERY'; then
+  pass "M68.fast-path-query-cited — Step 1.0.5 cites BARE_MODE_FAST_PATH_QUERY"
+else
+  fail "M68.fast-path-query-cited — Step 1.0.5 MUST cite BARE_MODE_FAST_PATH_QUERY (the constant for the detection query)"
+fi
+if echo "$STEP_105_BLOCK" | grep -qE 'three-way|1.*0.*>1|fast-path.*multi-discover.*ambiguous'; then
+  pass "M68.three-way-branch — Step 1.0.5 documents the three-way branch (1 / 0 / >1)"
+else
+  fail "M68.three-way-branch — Step 1.0.5 MUST document the three-way branch on candidate count (1 / 0 / >1; spec Components § SKILL.md item 3)"
+fi
+if echo "$STEP_105_BLOCK" | grep -qE 'NOT consume.*integration_branch|does not consume.*integration_branch|deferred to Step 1\.2\.5'; then
+  pass "M68.no-integration-branch-dep — Step 1.0.5 explicitly states it does NOT consume \$integration_branch"
+else
+  fail "M68.no-integration-branch-dep — Step 1.0.5 MUST explicitly state it does NOT consume \$integration_branch (sequencing invariant; spec Architecture § Sequencing)"
+fi
+# Negative regression — Step 1.0.5 must NOT mention DISCOVERY_FILTER (which lives in Step 1.2.5).
+if echo "$STEP_105_BLOCK" | grep -qE 'DISCOVERY_FILTER'; then
+  fail "M68.no-discovery-filter — Step 1.0.5 MUST NOT mention DISCOVERY_FILTER (split-detection invariant; DISCOVERY_FILTER lives in Step 1.2.5)"
+else
+  pass "M68.no-discovery-filter — Step 1.0.5 correctly omits DISCOVERY_FILTER (lives in Step 1.2.5)"
+fi
+
+echo
+echo "== M69: SKILL.md Step 1.2.5 multi-discover dispatch cites DISCOVERY_FILTER + integration_branch =="
+STEP_125_BLOCK=$(awk '/^### Step 1\.2\.5/,/^### Step 1\.3/' "$SKILL_FILE")
+if [ -n "$STEP_125_BLOCK" ]; then
+  pass "M69.exists — Step 1.2.5 section exists between Step 1.2 and Step 1.3"
+else
+  fail "M69.exists — Step 1.2.5 (multi-discover dispatch) section MUST exist between Step 1.2 and Step 1.3 (spec Components § SKILL.md item 4)"
+fi
+if echo "$STEP_125_BLOCK" | grep -qE 'DISCOVERY_FILTER'; then
+  pass "M69.discovery-filter-cited — Step 1.2.5 cites DISCOVERY_FILTER"
+else
+  fail "M69.discovery-filter-cited — Step 1.2.5 MUST cite DISCOVERY_FILTER (spec Components § SKILL.md item 4)"
+fi
+if echo "$STEP_125_BLOCK" | grep -qE '\$integration_branch|integration_branch'; then
+  pass "M69.integration-branch-cited — Step 1.2.5 cites \$integration_branch"
+else
+  fail "M69.integration-branch-cited — Step 1.2.5 MUST cite \$integration_branch (consumed by DISCOVERY_FILTER post-Step-1.2)"
+fi
+if echo "$STEP_125_BLOCK" | grep -qE 'multi-discover|--all'; then
+  pass "M69.triggers-cited — Step 1.2.5 mentions both bare-mode and --all as triggers"
+else
+  fail "M69.triggers-cited — Step 1.2.5 MUST mention both bare-mode (multi-discover) and --all as triggers (spec Components § SKILL.md item 4)"
+fi
+# Negative regression — Step 1.2.5 must NOT mention BARE_MODE_FAST_PATH_QUERY (which lives in Step 1.0.5).
+if echo "$STEP_125_BLOCK" | grep -qE 'BARE_MODE_FAST_PATH_QUERY'; then
+  fail "M69.no-fast-path-query — Step 1.2.5 MUST NOT mention BARE_MODE_FAST_PATH_QUERY (split-detection invariant; lives in Step 1.0.5)"
+else
+  pass "M69.no-fast-path-query — Step 1.2.5 correctly omits BARE_MODE_FAST_PATH_QUERY (lives in Step 1.0.5)"
+fi
+
+echo
+echo "== M70: SKILL.md Step 2.2 entry emits PREFLIGHT_SUMMARY_FORMAT pre-flight in multi-discover mode only =="
+STEP_22_BLOCK=$(awk '/^### Step 2\.2/,/^### Step 2\.3/' "$SKILL_FILE")
+if echo "$STEP_22_BLOCK" | grep -qE 'PREFLIGHT_SUMMARY_FORMAT'; then
+  pass "M70.format-cited — Step 2.2 entry cites PREFLIGHT_SUMMARY_FORMAT"
+else
+  fail "M70.format-cited — Step 2.2 entry MUST cite PREFLIGHT_SUMMARY_FORMAT (spec Components § SKILL.md item 7)"
+fi
+if echo "$STEP_22_BLOCK" | grep -qE 'multi-discover.*mode|mode.*multi-discover|in multi-discover mode'; then
+  pass "M70.mode-gated — Step 2.2 entry pre-flight line is emitted in multi-discover mode only"
+else
+  fail "M70.mode-gated — Step 2.2 entry pre-flight line MUST be mode-gated (multi-discover mode only; not single-PR fast path; spec Q2)"
+fi
+if echo "$STEP_22_BLOCK" | grep -qE 'full ordered set|full.*ordered'; then
+  pass "M70.full-set — Step 2.2 entry pre-flight enumerates the full ordered set (not per-wave)"
+else
+  fail "M70.full-set — Step 2.2 entry pre-flight MUST enumerate the full ordered set, not a per-wave subset (spec Q5)"
+fi
+# Negative regression — pre-flight is informational, NOT a [y/N] prompt or abortable.
+if echo "$STEP_22_BLOCK" | grep -qE 'pre-flight.*\[y/N\]|y/N.*pre-flight|prompt.*pre-flight|pre-flight.*prompt|pre-flight.*abort'; then
+  fail "M70.no-prompt — Step 2.2 entry pre-flight line MUST NOT be described as a [y/N] prompt or abortable (autopilot contract; spec Q2)"
+else
+  pass "M70.no-prompt — Step 2.2 entry pre-flight correctly avoids [y/N] / abort wording"
+fi
+
+echo
+echo "== M71: SKILL.md Step 1.7 cross-references bare-mode zero-eligible (clean exit 0) =="
+STEP_17_BLOCK=$(awk '/^### Step 1\.7/,/^## Phase 2/' "$SKILL_FILE")
+if echo "$STEP_17_BLOCK" | grep -qE 'Not an error, not a halt|nothing to merge'; then
+  pass "M71.contract-preserved — Step 1.7 preserves 'Not an error, not a halt' / 'nothing to merge' baseline prose"
+else
+  fail "M71.contract-preserved — Step 1.7 MUST preserve baseline prose ('Not an error, not a halt' / 'nothing to merge') — bare-mode is a documentation-only addition"
+fi
+if echo "$STEP_17_BLOCK" | grep -qE 'bare-mode|bare-discover|bare-mode discovery|empty eligible set'; then
+  pass "M71.bare-mode-xref — Step 1.7 cross-references bare-mode zero-eligible behaviour"
+else
+  fail "M71.bare-mode-xref — Step 1.7 MUST add a cross-reference to bare-mode zero-eligible (spec Components § SKILL.md item 6 / Q3)"
+fi
+# Negative regression — must NOT introduce a non-zero exit code on the same logical state.
+if echo "$STEP_17_BLOCK" | grep -qE 'exit 1|non-zero.*exit|exit code.*1'; then
+  fail "M71.no-nonzero-exit — Step 1.7 MUST NOT introduce a non-zero exit on zero-eligible (Q3 amends issue AC #6 to clean exit 0)"
+else
+  pass "M71.no-nonzero-exit — Step 1.7 correctly preserves exit 0 (no non-zero exit reference; spec Q3)"
+fi
+
+echo
+echo "== M72: commands/merge.md argument-hint omits --yes|-y; Usage bullet documents bare-discover dual path =="
+# Frontmatter argument-hint must NOT contain the deprecated --yes|-y string.
+if grep -qE '^argument-hint: .*--yes\|-y' "$CMD_FILE"; then
+  fail "M72.no-yes-flag-in-hint — commands/merge.md argument-hint MUST NOT contain '--yes|-y' (deprecated flag dropped from active hint surface; spec Components § commands/merge.md item 1 / Q3 fix #3)"
+else
+  pass "M72.no-yes-flag-in-hint — commands/merge.md argument-hint correctly omits '--yes|-y' (deprecated flag)"
+fi
+# Frontmatter argument-hint MUST still contain --integration-branch=<name>.
+if grep -qE '^argument-hint: .*--integration-branch=<name>' "$CMD_FILE"; then
+  pass "M72.integration-branch-in-hint — commands/merge.md argument-hint preserves --integration-branch=<name>"
+else
+  fail "M72.integration-branch-in-hint — commands/merge.md argument-hint MUST preserve --integration-branch=<name> (spec Components § commands/merge.md item 1)"
+fi
+# Usage bullet 1 must describe the bare-mode dual path.
+if grep -qE '^- No args.*context-aware|^- No args.*single PR if on a PR branch.*else discover' "$CMD_FILE"; then
+  pass "M72.usage-bullet-bare-discover — Usage bullet 1 describes context-aware bare-discover dual path"
+else
+  fail "M72.usage-bullet-bare-discover — Usage bullet 1 MUST describe context-aware bare-discover (single PR if on a PR branch, else discover; spec Components § commands/merge.md item 2)"
+fi
+# Negative regression — old Usage prose 'errors if none' must be gone.
+if grep -qE '^- No args.*errors if none' "$CMD_FILE"; then
+  fail "M72.no-old-usage — commands/merge.md Usage bullet 1 MUST NOT carry the old 'errors if none' wording"
+else
+  pass "M72.no-old-usage — commands/merge.md Usage bullet 1 correctly omits the old 'errors if none' wording"
+fi
+# M2 length cap re-asserted — file must remain ≤ 50 lines.
+CMD_LINE_COUNT=$(wc -l < "$CMD_FILE" | tr -d ' ')
+if [ "$CMD_LINE_COUNT" -le 50 ]; then
+  pass "M72.length-cap — commands/merge.md is $CMD_LINE_COUNT lines (≤ 50 thin-dispatcher cap; M2 invariant)"
+else
+  fail "M72.length-cap — commands/merge.md MUST be ≤ 50 lines (got $CMD_LINE_COUNT; M2 thin-dispatcher cap)"
+fi
+
+echo
+echo "== M73: SKILL.md Phase 1.4 'per discovered PR' fanout + Step 2.2 single-message invariant preserved =="
+PHASE_14_BLOCK=$(awk '/^### Step 1\.4/,/^### Step 1\.5/' "$SKILL_FILE")
+if echo "$PHASE_14_BLOCK" | grep -qE 'for each|per discovered PR|per-PR|every PR'; then
+  pass "M73.per-pr-fanout — Phase 1.4 prose preserves per-PR fanout language (one gate dispatch per discovered PR)"
+else
+  fail "M73.per-pr-fanout — Phase 1.4 MUST preserve 'for each' / 'per discovered PR' / 'per-PR' fanout language (AC#2: bare-discover does not relax dispatch shape)"
+fi
+STEP_22_FOR_M73=$(awk '/^### Step 2\.2/,/^### Step 2\.3/' "$SKILL_FILE")
+if echo "$STEP_22_FOR_M73" | grep -qE 'ONE assistant turn|single-message Task|single-message invariant'; then
+  pass "M73.single-message-preserved — Step 2.2 fanout preserves the single-message Task() invariant"
+else
+  fail "M73.single-message-preserved — Step 2.2 MUST preserve 'ONE assistant turn' / 'single-message Task()' invariant (AC#2/AC#4: bare-discover changes candidate set but not dispatch shape)"
+fi
+# Negative regression — Phase 1.4 must NOT hard-code single-PR-only language.
+if echo "$PHASE_14_BLOCK" | grep -qE 'only one PR can|single PR only|exactly one PR per gate|hard-coded.*single'; then
+  fail "M73.no-single-pr-hardcode — Phase 1.4 MUST NOT enumerate a fixed PR count or hard-code single-PR-only language (bare-discover supplies a multi-PR candidate set)"
+else
+  pass "M73.no-single-pr-hardcode — Phase 1.4 correctly avoids single-PR-only hard-coding"
+fi
 
 echo
 echo "== Summary =="

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -333,10 +333,21 @@ fi
 
 echo
 echo "== M20: commands/merge.md surfaces --yes / -y as DEPRECATED with stable user-facing notice =="
-assert_grep "$CMD_FILE" '^argument-hint:.*--yes\|-y' \
-  "M20.1 — argument-hint frontmatter still lists --yes|-y (parsed for backward compat)"
-assert_grep "$CMD_FILE" '^\*\*Usage:\*\*.*--yes\|-y' \
-  "M20.2 — Usage line still lists --yes|-y"
+# M20.1 / M20.2 retired in #56 (Q3 fix #3): --yes / -y dropped from the visible
+# argument-hint and Usage signature per the deprecation lifecycle. The flag is
+# still parsed at runtime, but the active-surface hint should reflect the
+# supported surface only. Negative regression guards replace the old positives;
+# the new M72.no-yes-flag-in-hint (issue #56) is the authoritative contract.
+if grep -qE '^argument-hint:.*--yes\|-y' "$CMD_FILE"; then
+  fail "M20.1 — argument-hint frontmatter MUST NOT list --yes|-y (deprecated; #56 Q3)"
+else
+  pass "M20.1 — argument-hint frontmatter correctly omits --yes|-y (deprecated; #56 Q3)"
+fi
+if grep -qE '^\*\*Usage:\*\*.*--yes\|-y' "$CMD_FILE"; then
+  fail "M20.2 — Usage signature MUST NOT list --yes|-y (deprecated; #56 Q3)"
+else
+  pass "M20.2 — Usage signature correctly omits --yes|-y (deprecated; #56 Q3)"
+fi
 assert_grep "$CMD_FILE" '## Deprecated Flags' \
   "M20.3 — '## Deprecated Flags' section present"
 assert_grep "$CMD_FILE" 'no behavioural effect' \

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -1193,12 +1193,15 @@ if [ "$PREFLIGHT_FORMAT_ROWS" = "1" ]; then
 else
   fail "M67.unique — PREFLIGHT_SUMMARY_FORMAT MUST be declared exactly once in Constants table (got $PREFLIGHT_FORMAT_ROWS rows; spec Q5)"
 fi
-if grep -qE 'merging %d PR%s in order: %s' "$SKILL_FILE"; then
+# Mirror M65/M66: scope sub-checks to the row literal so future Step 2.2 prose
+# additions that quote the format string don't accidentally satisfy these.
+PREFLIGHT_FORMAT_ROW=$(grep -E '^\| `PREFLIGHT_SUMMARY_FORMAT` \|' "$SKILL_FILE" || true)
+if echo "$PREFLIGHT_FORMAT_ROW" | grep -qE 'merging %d PR%s in order: %s'; then
   pass "M67.format-literal — PREFLIGHT_SUMMARY_FORMAT contains the literal 'merging %d PR%s in order: %s'"
 else
   fail "M67.format-literal — PREFLIGHT_SUMMARY_FORMAT MUST contain literal 'merging %d PR%s in order: %s' (spec Q5)"
 fi
-if grep -qE '80-char|80 char' "$SKILL_FILE"; then
+if echo "$PREFLIGHT_FORMAT_ROW" | grep -qE '80-char|80 char'; then
   pass "M67.wrap-convention — Constants prose mentions 80-char line-wrap convention"
 else
   fail "M67.wrap-convention — Constants prose MUST mention the 80-char line-wrap convention for long PR-number lists (spec Q5)"
@@ -1347,8 +1350,7 @@ if echo "$PHASE_14_BLOCK" | grep -qE 'for each|per discovered PR|per-PR|every PR
 else
   fail "M73.per-pr-fanout — Phase 1.4 MUST preserve 'for each' / 'per discovered PR' / 'per-PR' fanout language (AC#2: bare-discover does not relax dispatch shape)"
 fi
-STEP_22_FOR_M73=$(awk '/^### Step 2\.2/,/^### Step 2\.3/' "$SKILL_FILE")
-if echo "$STEP_22_FOR_M73" | grep -qE 'ONE assistant turn|single-message Task|single-message invariant'; then
+if echo "$STEP_22_BLOCK" | grep -qE 'ONE assistant turn|single-message Task|single-message invariant'; then
   pass "M73.single-message-preserved — Step 2.2 fanout preserves the single-message Task() invariant"
 else
   fail "M73.single-message-preserved — Step 2.2 MUST preserve 'ONE assistant turn' / 'single-message Task()' invariant (AC#2/AC#4: bare-discover changes candidate set but not dispatch shape)"


### PR DESCRIPTION
## Summary

- Bare `/merge` (no positional, no `--all`) now infers scope from ambient context: single-PR fast path when the current branch has 1 open PR; multi-PR auto-discovery against `integration_branch` otherwise.
- Adds three named SKILL.md constants (`BARE_MODE_FAST_PATH_QUERY`, `DISCOVERY_FILTER`, `PREFLIGHT_SUMMARY_FORMAT`); Step 1.0.5 (mode-detect, no `$integration_branch` dep) + Step 1.2.5 (multi-discover dispatch, post-Step-1.2) split is load-bearing per Q4. Step 2.2 emits a pre-flight stderr summary in multi-discover mode only.
- 10 new test blocks (M64–M73) lock the contract; M20.1/M20.2 retired (they asserted the now-flipped `--yes|-y`-in-hint contract). Suite: 248 PASS / 0 FAIL.

## Test plan

- [x] `bash tests/merge.test.sh` — 248 PASS / 0 FAIL (exit 0)
- [x] M64–M73 (33 sub-assertions across 10 blocks) all green
- [x] M44/M46 mirror-site regression guards green (5 trust-gate prose mirror sites unchanged)
- [x] M2 thin-dispatcher cap preserved (commands/merge.md = 49 lines)
- [ ] e2e smoke matrix (manual, 5 scenarios from spec Rollout § 4): bare `/merge` on `main` with 0 open PRs / on `main` with N open PRs / on a feature branch with 1 PR / on detached HEAD / with `--all` while on a PR branch.

## Design

- Spec: `docs/uberdev/specs/2026-05-04-bare-merge-auto-discover-design.md` (APPROVED by spec-reviewer cycle 2).
- Plan: `docs/uberdev/plans/2026-05-04-bare-merge-auto-discover.md` (APPROVED by plan-reviewer; 3 waves, 4 tasks).
- Q3 deliberately diverges from issue body's "non-zero distinct exit code" framing: clean exit 0 on no-eligible-PRs cites existing Step 1.7 precedent.

## Reviewer findings summary

### post-impl-review-wave-final.md
# Post-Implementation Review — Issue #56 (end-of-issue, WAVE=final)

- **commit_range:** `9878a0eb24cba1c4f58a0556a920dbf74b643bae..HEAD`
- **changed_paths:**
  - `plugins/uberdev/commands/merge.md`
  - `plugins/uberdev/skills/merge/SKILL.md`
  - `tests/merge.test.sh`
- **tier:** medium
- **commits-on-branch:** 4

## Reviewer aggregation

| Agent | Verdict | Top finding |
|-------|---------|-------------|
| code-reviewer         | APPROVE             | (no blockers; 2 suggestions: detached-HEAD wording polish; M73 prose-only coverage acknowledged at this layer) |
| code-simplifier       | REVISIONS_REQUIRED (advisory) | M72.length-cap duplicates M2 (tests/merge.test.sh:1339-1345) — drop redundant assertion |
| silent-failure-hunter | REVISIONS_REQUIRED (advisory) | Step 1.0.5 + Step 1.2.5 do not document `gh pr list` failure path — could silently mask API outage as "no current-branch PRs" / "no eligible PRs" |
| type-design-analyzer  | APPROVE             | (no blockers; 9 affirmative observations on closed enums, explicit JSON projections, two-value discriminator) |
| comment-analyzer      | APPROVE             | (no blockers; 9 affirmative observations on accuracy of new comments, M20 retirement justification, mirror-site forward-references) |

**Aggregated: 2 blockers (advisory), 16 suggestions. Continue.**

## Blocker-severity findings (advisory; non-blocking at this layer)

### B1 — silent-failure-hunter — Step 1.0.5 `gh pr list --head` failure path

`SKILL.md` Step 1.0.5 procedure says "Run the canonical `BARE_MODE_FAST_PATH_QUERY` … The result is a JSON array; let `N := len(result)`." There is no documented behaviour if `gh` itself fails (network, rate limit, auth). A failed `gh` call producing empty output would yield `N=0`, indistinguishable from a legitimate "no current-branch PR" → silent fall-through to multi-discover, masking an API outage as a routine fall-through.

**Fix surface (deferred — not landed in this PR):** add an explicit error branch to Step 1.0.5 prose that distinguishes `gh` failure (exit ≠ 0) from a legitimate empty result; emit a distinct stderr line and exit 1 on `gh` failure rather than fall through. Track as follow-up issue.

### B2 — silent-failure-hunter — Step 1.2.5 `gh pr list --base` + `jq` failure path

`SKILL.md` Step 1.2.5 has the same shape: a `gh pr list` piped into `jq`. If `gh` fails or `jq` errors, the candidate set is empty, indistinguishable from the legitimate "no open PRs against `$integration_branch`" case → Step 1.7 clean-exit-0 path silently masks the outage.

**Fix surface (deferred — not landed in this PR):** Step 1.2.5 prose should mandate explicit error guards on both the `gh` and `jq` invocations, with distinct stderr messages and non-zero exit on command failure (preserving the clean exit 0 only for genuine empty results). Track as follow-up issue.

### Triage rationale

Both findings concern runtime error handling that isn't covered by this issue's scope. Issue #56 is a documentation-contract change to enable bare-mode auto-discovery; the underlying `gh pr list` invocation safety is an existing surface that pre-dates this PR (the `--all` path has the same shape and the same gap). Tracking these as a separate follow-up issue is appropriate — fixing them inside #56 would expand scope and the existing `--all` codepath would still need the same fix.

## Suggestion-severity findings (selected)

| Source | File:Line | Summary |
|--------|-----------|---------|
| simplifier | tests/merge.test.sh:1339-1345 | M72.length-cap duplicates M2 ≤50-line check |
| simplifier | SKILL.md:216 | Step 1.2.5 closing paragraph repeats split-detection rationale 3× |
| simplifier | SKILL.md:337-339 | Step 2.2 pre-flight prose splits one contract across 3 short paragraphs |
| simplifier | tests/merge.test.sh:1145-1186 | M65/M66 share near-duplicate sub-assertion shape; helper opportunity |
| simplifier | SKILL.md:60-62 | Constants "Used by" cells re-narrate behaviour from step bodies |
| simplifier | SKILL.md:68 | "No args" Inputs bullet is one ~85-word sentence |
| code-reviewer | SKILL.md:106 | Detached-HEAD wording slightly ambiguous (skip query vs. run with empty --head) |
| code-reviewer | tests/merge.test.sh:1280 | M73 is prose-only; runtime e2e is in spec Rollout § 4 manual smoke |

These are all advisory; none rise to blocker. They are tracked in this artifact for `finish-branch` to surface in the PR body's `## Reviewer findings summary`.

## Frozen-contract preservation (all five upheld)

1. Five trust-gate mirror sites — unchanged (M44/M46 pass).
2. Audit JSON contract (#52) — unchanged.
3. Single-message Task() fanout invariant — unchanged (M73.single-message-preserved pass).
4. AUDIT_EVENT_ENUM closed set — unchanged (no new event for Step 1.0.5; stderr breadcrumb only).
5. Phase 1.4 per-PR fanout shape — unchanged (M73.per-pr-fanout pass).

## Test-suite state

- 248 PASS / 0 FAIL (M1–M73 + M20.1/M20.2 retirement).
- Exit code 0.
- M64–M73 (33 sub-assertions across 10 blocks) all green.
- M20.1/M20.2 negative regression guards active in place of obsolete positive assertions.

## Recommendation

`Continue.` Findings are advisory at this layer; the implementation is correct against the spec. The two silent-failure-hunter blockers are cross-cutting concerns (apply equally to existing `--all`) and are out of scope for this issue. They will be triaged as a follow-up issue at finish-branch time.


## Closing note

Closes #56
