### PR TITLE
docs(readme): document HARD-GATE rejection (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ## [Unreleased]
 
+### Documentation
+- **README — explicit "we rejected upstream's HARD-GATE" stance now documented (#61).** Adds a row to the `## Design decisions worth knowing` table plus a `<details>` block answering "why doesn't UberDev pause for approval?" and naming the three trust anchors (`spec-reviewer` always-on, `plan-reviewer` always-on, `post-impl-review` end-of-issue fanout) that replace user-approval gates.
+
 ## [0.18.2] - 2026-05-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Bundled upstream license texts in `plugins/uberdev/licenses/`.
 
 Upstream `obra/superpowers` gates implementation behind a user-approval HARD-GATE: brainstorm halts, asks "does this look right so far?", and waits for sign-off before any subagent runs. Per-section approval prompts and a 3-iteration review-loop cap follow the same pattern.
 
-UberDev rejects all of those. User gates trade quality for ceremony — every pause shifts review burden onto a non-expert reader (you) and adds wall-clock cost. Quality wins from **parallel research fanout** (six research agents in one shot, not sequential), **always-on reviewers** (`spec-reviewer` runs on medium/large tier per orchestrator Phase 3.5; `plan-reviewer` runs on every plan per Phase 4.5), and an **end-of-issue `post-impl-review` fanout** (5 advisory reviewers — code-reviewer, simplifier, silent-failure-hunter, type-design-analyzer, comment-analyzer — dispatched in one message after PR push via `/uberdev:review-pr`). Trust comes from review depth, not approval ceremony. Design provenance: internal design notes.
+UberDev rejects all of those. User gates trade quality for ceremony — every pause shifts review burden onto a non-expert reader (you) and adds wall-clock cost. Quality wins from **parallel research fanout** (six research agents in one shot), **always-on reviewers** (`spec-reviewer` runs on medium/large tier per orchestrator Phase 3.5; `plan-reviewer` runs on every plan per Phase 4.5), and an **end-of-issue `post-impl-review` fanout** (5 advisory reviewers — code-reviewer, code-simplifier, silent-failure-hunter, type-design-analyzer, comment-analyzer — dispatched in one message after PR push via `/uberdev:review-pr`).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,16 @@ Bundled upstream license texts in `plugins/uberdev/licenses/`.
 | **`/merge` autopilot has no author gate** | Trust anchor is `reviewDecision == "APPROVED"` + GitHub branch protections. Bot vs. human vs. external contributor — same eligibility. |
 | **No `Co-Authored-By: Claude` trailer** | Commits and PR bodies use the user's authorship only. |
 | **Wave-based parallel execution** | Plans declare task dependencies + file ownership; `subagent-driven-dev` fires every wave's tasks concurrently in one shared worktree. Controller-only git eliminates index races without per-task worktree ceremony. |
+| **No HARD-GATE approval checkpoints** | Upstream's brainstorm pauses for user sign-off before implementation. UberDev replaces user gates with parallel research fanout and always-on agent reviewers (`spec-reviewer`, `plan-reviewer`, end-of-issue `post-impl-review`). Quality wins from review depth, not approval ceremony. |
+
+<details>
+<summary><strong>Why doesn't UberDev pause for me to approve the design?</strong></summary>
+
+Upstream `obra/superpowers` gates implementation behind a user-approval HARD-GATE: brainstorm halts, asks "does this look right so far?", and waits for sign-off before any subagent runs. Per-section approval prompts and a 3-iteration review-loop cap follow the same pattern.
+
+UberDev rejects all of those. User gates trade quality for ceremony — every pause shifts review burden onto a non-expert reader (you) and adds wall-clock cost. Quality wins from **parallel research fanout** (six research agents in one shot, not sequential), **always-on reviewers** (`spec-reviewer` runs on medium/large tier per orchestrator Phase 3.5; `plan-reviewer` runs on every plan per Phase 4.5), and an **end-of-issue `post-impl-review` fanout** (5 advisory reviewers — code-reviewer, simplifier, silent-failure-hunter, type-design-analyzer, comment-analyzer — dispatched in one message after PR push via `/uberdev:review-pr`). Trust comes from review depth, not approval ceremony. Design provenance: internal design notes.
+
+</details>
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a new "No HARD-GATE approval checkpoints" row to the existing `## Design decisions worth knowing` table in README.md plus a `<details>` collapsible block immediately after the table that answers the two acceptance-criteria questions ("why doesn't UberDev pause for me to approve the design?" and "if there are no gates, how do I trust the output?"). Names the three canonical trust anchors (`spec-reviewer`, `plan-reviewer`, `post-impl-review`) so a curious reader can grep the agent definitions.
- Adds a one-line CHANGELOG.md entry under `## [Unreleased]` under a new `### Documentation` subheading, back-linking the README change.
- Pure prose-only edit. No code paths, agent semantics, or skill dispatches change.

Closes #61

## Test Plan

- [x] All 11 bash test scripts under `tests/` pass post-wave (PASS=11 FAIL=0).
- [x] README structural verifications: design-decisions table row count = 10 (was 9, +1); `<details>` opens = `</details>` closes = 6 (5 pre-existing + 1 new); section divider preserved (`</details>`, blank, `---`, blank, `## Changelog`).
- [x] CHANGELOG structural verifications: `[Unreleased]` block contains exactly one `#61` reference and exactly one `### Documentation` subheading; release header `## [0.18.2] - 2026-05-04` byte-identical.
- [x] Acceptance-criteria self-check: AC #1 (rejection documented) — C1 row + C2 block both present. AC #2 (verbatim question + answer) — `<summary>` is the question; first paragraph answers it. AC #3 (named trust anchors) — `spec-reviewer`, `plan-reviewer`, `post-impl-review` all present and backticked. AC #4 (~150 words) — combined ~170 words, within "brief" framing.
- [ ] Visual sanity-check on the GitHub PR diff that the `<details>` block collapses/expands and the table row aligns with the existing nine rows.

## Open questions answered by /turbo

The following questions were answered automatically — please review:

| Question | Choice | Confidence |
|----------|--------|------------|
| Where in README should the rejection be documented — new top-level "Design philosophy" section, an extension of "Design decisions worth knowing", or a separate DESIGN.md? | Add a 10th row to the existing `## Design decisions worth knowing` table plus a `<details>` collapsible block immediately after the table containing the ~120-word prose answer to the two acceptance-criteria questions. | high |
| Should the README reference the MEMORY.md provenance files by path (`feedback_brainstorm_no_gates.md`, `feedback_quality_over_speed.md`)? | No. Refer to them in prose as "internal design notes" or omit the pointer entirely; do not include absolute paths. | high |
| Should CHANGELOG.md also be updated with a one-line entry? | Yes — add a single line under `## [Unreleased]` under a `### Documentation` heading. | medium |
| Voice — match the blunt declarative style of the existing "Bundled" upstream-divergence callout, or a softer explanatory tone? | Match the existing blunt declarative voice. Direct contrasts ("Upstream gates X. UberDev does Y because…") with no hedging. | high |
| How explicit should the new section be about which agents enforce quality in lieu of user gates? | Name them concretely — `spec-reviewer` (always-on for medium/large per Phase 3.5), `plan-reviewer` (always-on per Phase 4.5), and the end-of-issue `post-impl-review` fanout. | high |

## Notes for reviewer

- Spec: `docs/uberdev/specs/2026-05-04-readme-hard-gate-rejection-design.md`. Plan: `docs/uberdev/plans/2026-05-04-readme-hard-gate-rejection.md`.
- Spec compliance reviewers and code quality reviewers both approved at end-of-wave (no Critical/Important issues; only optional Minor stylistic suggestions documented in the orchestrator log).
- Spec-reviewer for T2 surfaced a non-blocking bug in the plan's prescribed awk verification commands for the `[Unreleased]` block (`NR>1` exit guard fires on the matched header line itself — `NR` is global file line number, not a within-range counter). File content is correct; the spec's verification commands need a follow-up fix outside this PR's allowed paths.
- Word-count overage (~170 vs ~150 soft target in AC #4) is acknowledged in the spec; trim is straightforward if the maintainer pushes back.
- CHANGELOG uses a new `### Documentation` subheading; D3 in the spec authorised either this or `### Changed` (Keep-a-Changelog enum). One-token swap on review if `### Changed` is preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated project documentation to include a new design decisions entry explaining the project's approach to approval workflows and how quality assurance standards are maintained across the development process
* Added a frequently asked questions section detailing the alternative methodology to code review, researcher collaboration, and quality verification that replaces traditional approval checkpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->