### PR TITLE
fix(finish-branch): apostrophe in #-comment trips permission-evaluator (#55)

### DIFF
--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -277,7 +277,7 @@ fi
 
 # Capture PR URL from gh stdout AND its exit code together. gh returns the
 # created PR URL on stdout when successful; non-zero exit on auth/network/quota
-# errors. The `if !` branch surfaces gh failure from gh pr create explicitly (PR_URL captures
+# errors. The `if !` branch surfaces the gh failure explicitly (PR_URL captures
 # stderr via 2>&1 in the failure case to keep the diagnostic).
 if ! PR_URL=$(gh pr create --title "$PR_TITLE_VAR" --body-file "$PR_BODY_FILE" 2>&1); then
   echo "ERROR: gh pr create failed: $PR_URL" >&2

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -20,7 +20,7 @@ Guide completion of development work by presenting clear options and handling ch
 **Before presenting options, verify tests pass:**
 
 ```bash
-# Run project's test suite
+# Run the project test suite
 npm test / cargo test / pytest / go test ./...
 ```
 
@@ -119,8 +119,8 @@ Option 2 PR-body composition: in addition to the standard Summary + Test Plan, t
 Both sections are read-only dumps; finish-branch does not block on confidence threshold or reviewer verdict (per #11 Q1: advisory only, auto-fix deferred).
 
 ```bash
-# Read the orchestrator's questions.md (--turbo non-blocking Q&A log) if present.
-# Note: the file lives under the orchestrator's $RUN_ID working dir, NOT issue-$N.
+# Read the orchestrator questions.md (--turbo non-blocking Q&A log) if present.
+# Note: the file lives under the orchestrator $RUN_ID working dir, NOT issue-$N.
 QUESTIONS_FILE=""
 if [ -n "${RUN_ID:-}" ] && [ -f ".uberdev/research/$RUN_ID/questions.md" ]; then
   QUESTIONS_FILE=".uberdev/research/$RUN_ID/questions.md"
@@ -139,9 +139,9 @@ fi
 REVIEW_FILES=$(ls -t .uberdev/research/*/post-impl-review-*.md .uberdev/research/issue-*/post-impl-review.md .uberdev/research/*/pr-test-analyzer.md 2>/dev/null | tr '\n' ' ')
 
 # Compose PR body. Heredoc delimiter is unquoted (`<<EOF`, not the single-
-# quoted form) to avoid Claude's permission-pattern evaluator `unmatched '`
+# quoted form) to avoid the Claude permission-pattern evaluator `unmatched '`
 # bug (#42). The agent must compose the body free of `$`, backticks, and
-# backslash — unquoted heredocs don't shield these from shell expansion.
+# backslash — unquoted heredocs do not shield these from shell expansion.
 PR_BODY_FILE=$(mktemp)
 cat > "$PR_BODY_FILE" <<EOF_HEADER
 ## Summary
@@ -180,7 +180,7 @@ fi
 # Compose PR title via heredoc + read-back into a bash variable, then pass to
 # `gh --title "$PR_TITLE_VAR"` — double-quoted variable expansion is byte-
 # verbatim, no backtick/dollar re-evaluation. The heredoc delimiter is
-# unquoted (`<<PR_TITLE_EOF`, not the single-quoted form) to avoid Claude's
+# unquoted (`<<PR_TITLE_EOF`, not the single-quoted form) to avoid the Claude
 # permission-pattern evaluator `unmatched '` bug (#42); the agent must
 # compose the title free of `$`, backticks, and backslash. This closes the
 # title-injection vector without inventing a `--title-file` flag (which gh
@@ -192,7 +192,7 @@ PR_TITLE_EOF
 
 # Read title back into a quoted variable — bytes pass through verbatim, no shell
 # expansion. `IFS= read -r` reads the first line only; if the title file ever
-# contains multiple lines (shouldn't, per the heredoc above), subsequent lines
+# contains multiple lines (should not, per the heredoc above), subsequent lines
 # are silently dropped. Empty-title rejection happens implicitly via the
 # downstream `gh pr create` failure path.
 IFS= read -r PR_TITLE_VAR < "$TITLE_FILE" || { echo "ERROR: failed to read title file" >&2; rm -f "$TITLE_FILE" "$PR_BODY_FILE"; exit 1; }
@@ -208,7 +208,7 @@ run_secret_scan_stdin() {
   # errors. We use the exit code as the authoritative signal — output-text
   # filtering is unreliable because info messages like "no leaks found"
   # would false-positive a substring match. On non-zero exit, we surface
-  # the captured output so the caller's error message has detail.
+  # the captured output so the caller error message has detail.
   if command -v gitleaks >/dev/null 2>&1; then
     local out rc
     out=$(gitleaks stdin --no-banner --redact 2>&1) ; rc=$?
@@ -216,7 +216,7 @@ run_secret_scan_stdin() {
       return 0  # clean — no output, caller continues
     fi
     # Non-zero: leak found OR gitleaks crashed (fail-CLOSED on either).
-    # Emit captured output so caller's ERROR message names the offending rule.
+    # Emit captured output so the caller ERROR message names the offending rule.
     printf '%s\n' "$out"
     return 0  # signal via output, not exit code (caller checks [[ -n $SCAN_OUT ]])
   fi
@@ -224,7 +224,7 @@ run_secret_scan_stdin() {
   grep -E -o '(AKIA[0-9A-Z]{16}|gh[ps]_[A-Za-z0-9]{36,255}|-----BEGIN [A-Z ]*PRIVATE KEY-----)' || true
 }
 
-# Emit gitleaks-missing warning ONCE in the parent shell (subshell exports don't
+# Emit gitleaks-missing warning ONCE in the parent shell (subshell exports do not
 # propagate, so the warning must live outside run_secret_scan_stdin to avoid
 # printing twice).
 if ! command -v gitleaks >/dev/null 2>&1; then
@@ -246,8 +246,8 @@ abort_if_secret() {
 if PUSH_DIFF=$(git diff @{u}..HEAD 2>/dev/null) && [[ -n "$PUSH_DIFF" ]]; then
   SCAN_OUT=$(printf '%s' "$PUSH_DIFF" | run_secret_scan_stdin)
 else
-  # No upstream set or empty diff → scan from origin's default branch. Falls
-  # back to literal main/master, then to the branch's root commit (catches
+  # No upstream set or empty diff → scan from origin default branch. Falls
+  # back to literal main/master, then to the branch root commit (catches
   # everything since branch creation). Note: `git merge-base HEAD HEAD~1` is
   # degenerate (= HEAD~1) and was removed — it scanned only the last commit.
   BASE_REF=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/@@' \
@@ -277,7 +277,7 @@ fi
 
 # Capture PR URL from gh stdout AND its exit code together. gh returns the
 # created PR URL on stdout when successful; non-zero exit on auth/network/quota
-# errors. The `if !` branch surfaces gh's failure explicitly (PR_URL captures
+# errors. The `if !` branch surfaces gh failure from gh pr create explicitly (PR_URL captures
 # stderr via 2>&1 in the failure case to keep the diagnostic).
 if ! PR_URL=$(gh pr create --title "$PR_TITLE_VAR" --body-file "$PR_BODY_FILE" 2>&1); then
   echo "ERROR: gh pr create failed: $PR_URL" >&2

--- a/tests/finish-branch-auto-chain.test.sh
+++ b/tests/finish-branch-auto-chain.test.sh
@@ -215,6 +215,20 @@ assert_not_grep "$FINISH_BRANCH" \
   "no quoted heredoc delimiters (Claude permission-evaluator unmatched ' bug, #42)"
 
 echo
+echo "== Issue #55: no English possessives/contractions in bash-block #-comments =="
+# Apostrophes inside #-comments in fenced bash blocks trip the Claude
+# permission-pattern evaluator (same tokenizer bug as #42 — the evaluator
+# does not honor comment context; every ' toggles quote-state, pairing with
+# the next unrelated ' downstream and inverting quote-balance until a later
+# ' surfaces as `unmatched '`). Rephrase comment prose to drop possessives
+# and contractions (gh failure, the caller error, etc.). Backtick-quoted
+# documentation forms like `unmatched '` are unaffected — the regex below
+# matches only ' adjacent to letters, not ' next to backticks/spaces.
+assert_not_grep "$FINISH_BRANCH" \
+  "#.*[a-zA-Z]'[a-zA-Z]" \
+  "no apostrophes inside #-comments in bash blocks (Claude permission-evaluator unmatched ' bug, #55)"
+
+echo
 echo "== Summary =="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"

--- a/tests/finish-branch-auto-chain.test.sh
+++ b/tests/finish-branch-auto-chain.test.sh
@@ -222,9 +222,9 @@ echo "== Issue #55: no English possessives/contractions in bash-block #-comments
 # the next unrelated ' downstream and inverting quote-balance until a later
 # ' surfaces as `unmatched '`). Rephrase comment prose to drop possessives
 # and contractions (e.g. gh's → the gh, caller's → the caller, don't → do
-# not). Backtick-quoted
-# documentation forms like `unmatched '` are unaffected — the regex below
-# matches only ' adjacent to letters, not ' next to backticks/spaces.
+# not). Backtick-quoted documentation forms like `unmatched '` are unaffected —
+# the regex below matches only ' adjacent to letters, not ' next to backticks
+# or spaces.
 assert_not_grep "$FINISH_BRANCH" \
   "#.*[a-zA-Z]'[a-zA-Z]" \
   "no apostrophes inside #-comments in bash blocks (Claude permission-evaluator unmatched ' bug, #55)"

--- a/tests/finish-branch-auto-chain.test.sh
+++ b/tests/finish-branch-auto-chain.test.sh
@@ -221,7 +221,8 @@ echo "== Issue #55: no English possessives/contractions in bash-block #-comments
 # does not honor comment context; every ' toggles quote-state, pairing with
 # the next unrelated ' downstream and inverting quote-balance until a later
 # ' surfaces as `unmatched '`). Rephrase comment prose to drop possessives
-# and contractions (gh failure, the caller error, etc.). Backtick-quoted
+# and contractions (e.g. gh's → the gh, caller's → the caller, don't → do
+# not). Backtick-quoted
 # documentation forms like `unmatched '` are unaffected — the regex below
 # matches only ' adjacent to letters, not ' next to backticks/spaces.
 assert_not_grep "$FINISH_BRANCH" \


### PR DESCRIPTION
## Summary

- Closes #55 — narrower-trigger regression of #42's permission-evaluator tokenizer bug.
- Point fix: rephrase the `gh's` apostrophe in `plugins/uberdev/skills/finish-branch/SKILL.md:280` so the `'` no longer pairs with `PR_URL_REGEX`'s opening quote on line 288 to surface as `(eval):17: unmatched '` at skill-load time.
- Class fix: rephrase 12 other latent `[a-zA-Z]'[a-zA-Z]`-shape apostrophes in `#`-comments inside the same fenced bash block (and one in an inert block at line 23, matched by the whole-file canary). Pure prose; zero behavioural delta.
- Regression canary: new `assert_not_grep` block in `tests/finish-branch-auto-chain.test.sh` after the existing Issue #42 block, mirroring PR #45's format. Pattern `#.*[a-zA-Z]'[a-zA-Z]` catches contractions/possessives adjacent to letters but explicitly skips the safe backtick-quoted documentation form `` `unmatched '` `` preserved on lines 142/184.

## Why two commits

`16c7d87` rephrases SKILL.md (the live-trigger fix). `5d57068` adds the canary test that proves the fix landed and bars future reintroductions. Splitting them keeps each commit reviewable in isolation; the canary depends on the rephrases having committed first.

## Test plan

- [x] `bash tests/finish-branch-auto-chain.test.sh` — `passed: 36, failed: 0` (was 35 before; new Issue #55 PASS line co-located with the existing Issue #42 PASS line).
- [x] `grep -nE "#.*[a-zA-Z]'[a-zA-Z]" plugins/uberdev/skills/finish-branch/SKILL.md` — empty (canary regex returns zero hits against the patched file).
- [x] `grep -nE "\`unmatched '\`" plugins/uberdev/skills/finish-branch/SKILL.md` — 2 hits on lines 142 and 184 (backtick-quoted documentation forms preserved; load-bearing because they document the literal evaluator-error string).
- [x] `bash -n tests/finish-branch-auto-chain.test.sh` — clean parse.
- [x] `git diff --stat 6828cd1 HEAD` — only the two intended files changed (13/13 in SKILL.md, +14 in the test).
- [ ] **Human verification (post-merge):** in a fresh Claude Code session after the next plugin release loads the patched SKILL.md, invoke `Skill(uberdev:finish-branch)` and confirm no `(eval):17: unmatched '` error. CI cannot exercise this — the bug is in the harness's permission-pattern evaluator at skill-load time, which only re-tokenizes the cached SKILL.md after the user's plugin cache updates.

## Why manual `gh pr create` (not `uberdev:finish-branch`)

The very bug this PR fixes prevents `uberdev:finish-branch` from loading in any session whose plugin cache still holds the pre-patch SKILL.md (which is every existing session, including this one). The issue body explicitly documents `git push` + `gh pr create` as the workaround, so this PR uses it.

## Out of scope

- `plugins/uberdev/skills/solve-pipeline/SKILL.md` has 12+ similar latent apostrophes in bash-block `#`-comments (codebase research finding, decision Q5). Different skill, different evaluation context, not currently triggering — tracked separately as a follow-on issue rather than conflated with this fix.

## Open questions answered by /turbo

The orchestrator ran in `--turbo` mode and auto-picked 6 questions during Phase 2 — captured in `.uberdev/research/<run-id>/questions.md`. Summary of decisions:

- Q1: Apply both point + class fix (issue body recommends class-fix; production-grade vs. band-aid).
- Q2: Rephrase all 13 sites the canary regex flags (including 2 the spec table missed: lines 23, 144).
- Q3: Use regex `#.*[a-zA-Z]'[a-zA-Z]` — narrow enough to skip backtick-quoted documentation, broad enough to catch the bug class.
- Q4: Append the canary block after PR #45's Issue #42 block (co-locate by bug class).
- Q5: solve-pipeline cleanup is out of scope (file follow-on issue).
- Q6: Whole-file regex (mirrors PR #45's prior art; line-range parsing is fragile).

## Reviewer summary

- Spec compliance (T1): all 13 plan-prescribed rephrases applied with verbatim wording; backtick documentation forms preserved at lines 142/184; allowlist respected; technical meaning unchanged.
- Spec compliance (T2): block format byte-for-byte mirrors PR #45's Issue #42 prior art; regex correctly tight; description string unique to #55.
- Code quality (T1): approve. One minor prose nit (line 280's "gh failure from gh pr create" is faithful to the plan but slightly redundant given the surrounding context); sub-threshold, not actionable.
- Code quality (T2): approve. Zero issues. Regex mathematically correct for the bug shape; rationale comment self-documenting.