### PR TITLE
fix(merge): root-fix gh+jq spinner-leak via in-process --jq + lib extraction (R1+R2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve spawns autonomous agents in cmux/Ghostty/iTerm; /issue creates well-investigated, deduped issues.",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "cmux", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-05-05
+
+### Fixed
+- **R1 (in-process filter):** All three `gh … --json` discovery sites in `/merge` (Steps 1.0.5, 1.2.5, 1.4) now use `gh … --jq '<filter>'` so jq runs inside the gh process on the parsed Go object before serializing stdout. No external pipe = no FD-pollution surface for the spinner-leak bug class fixed for `/solve` in `21ad417`.
+- **R2 (lib extraction):** Discovery logic factored into `plugins/uberdev/skills/merge/lib/discover.sh` (`discover_bare_fast_path` / `discover_multi` / `pr_view_projection` + `emit_gate_fail` helper). SKILL.md Steps 1.0.5 / 1.2.5 / 1.4 now source the lib via `${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/discover.sh` (mirroring the existing `lib/config-read.sh` precedent — `BASH_SOURCE`/`$0` does not resolve in Claude's skill-eval context) and call the functions instead of inlining bash blocks. Eliminates the model-improv surface that re-introduced `2>&1` despite the pattern being absent from the spec text.
+- New audit event `discovery_gh_failed` (members: `reason`, `step`, `exit_code`, `gh_stderr`, `pr_number?`) and new gate_fail reason `pr_view_unreachable` (Step 1.4 infrastructure failure). `gh_stderr` is raw-truncated to ≤512 bytes pre-JSON-escaping (escaped form may expand to ≤2048 bytes for adversarial backslash-heavy stderr).
+- **JSON-injection defense in audit emit.** Numeric inputs (`exit_code`, `pr_number`) are sanitised to integers before bare-numeric `printf` substitution — non-numeric inputs are normalised (`exit_code` → `-1`, `pr_number` → `0` or omitted) so a caller bug or future field-source change cannot produce malformed JSON or inject extra fields into the audit log.
+- New test suite `tests/merge-discovery-resilience.test.sh` (67 assertions; 14/14 test files pass) with a fake-gh fixture that simulates the spinner-leak shape (ANSI on stderr while gh succeeds on stdout). Locks: no `gh … 2>&1`, no `gh … | jq`, lib uses `--jq '<filter>'` at ≥3 sites, SKILL.md sources via `${CLAUDE_PLUGIN_ROOT}` (not `BASH_SOURCE`), audit-log path configurable via `UBERDEV_AUDIT_LOG_PATH`. Pre-processes file contents (folds backslash-continuations, strips comments) so multi-line bug-shape regressions cannot hide. Includes a canary on `solve-pipeline/SKILL.md` Step 4 detecting any revert of `21ad417`.
+
 ## [0.19.2] - 2026-05-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.19.2-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.19.3-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution, brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/skills/merge/SKILL.md
+++ b/plugins/uberdev/skills/merge/SKILL.md
@@ -27,7 +27,7 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `LOCK_FILE_PATH` | `.git/uberdev-merge.lock` | D14 |
 | `AUDIT_LOG_DIR_PATTERN` | `.uberdev/runs/<run-id>/` | D15 |
 | `AUDIT_LOG_FILENAME` | `audit.jsonl` | D15 |
-| `AUDIT_EVENT_ENUM` | `gate_pass`, `gate_fail`, `order_proposed`, `order_confirmed`, `strategy_chosen`, `probe_clean`, `probe_conflict`, `agent_dispatched`, `agent_returned`, `patch_applied`, `test_pass`, `test_fail`, `push_resolution`, `merge_executed`, `local_sync`, `branch_deleted`, `worktree_removed`, `admin_bypass`, `waiver_recorded`, `error`, `pr_parked`, `stale_branch_rebase_decision`, `deprecated_flag_used`, `agent_strategy_switch`, `test_fail_agent_decision`, `trust_trail_agent_decision`, `merge_strategy_agent_decision`, `merge_strategy_fanout_wave_started` | D15. Field-level extensions: gate_pass.data.trust_anchor ∈ TRUST_ANCHOR_ENUM; gate_fail.data.reason ∈ GATE_FAIL_REASON_ENUM (see Phase 1.4). **Deprecated (never emitted post-v0.17.0):** `admin_bypass`, `waiver_recorded` |
+| `AUDIT_EVENT_ENUM` | `gate_pass`, `gate_fail`, `order_proposed`, `order_confirmed`, `strategy_chosen`, `probe_clean`, `probe_conflict`, `agent_dispatched`, `agent_returned`, `patch_applied`, `test_pass`, `test_fail`, `push_resolution`, `merge_executed`, `local_sync`, `branch_deleted`, `worktree_removed`, `admin_bypass`, `waiver_recorded`, `error`, `pr_parked`, `stale_branch_rebase_decision`, `deprecated_flag_used`, `agent_strategy_switch`, `test_fail_agent_decision`, `trust_trail_agent_decision`, `merge_strategy_agent_decision`, `merge_strategy_fanout_wave_started`, `discovery_gh_failed` | D15. Field-level extensions: gate_pass.data.trust_anchor ∈ TRUST_ANCHOR_ENUM; gate_fail.data.reason ∈ GATE_FAIL_REASON_ENUM (see Phase 1.4); discovery_gh_failed.data.reason ∈ {`gh_failed`, `jq_failed`}, .data.step ∈ {`1.0.5`, `1.2.5`, `1.4`}, .data.exit_code (int), .data.gh_stderr (string, raw stderr ≤512 bytes pre-truncation; JSON-escaping may expand to ≤2048 bytes for adversarial backslash-heavy payloads), .data.pr_number (int, optional — only set when step="1.4"). **Deprecated (never emitted post-v0.17.0):** `admin_bypass`, `waiver_recorded` |
 | `SCRATCH_WORKTREE_PATTERN` | `.claude/worktrees/merge-<run-id>/` | D10 |
 | `BRANCH_NAME_REGEX` | `^[A-Za-z0-9._/-]{1,255}$` | D8 (validation before shell argv use) |
 | `MERGE_STRATEGY_LABEL_PREFIX` | `merge-strategy:` | D-LABEL |
@@ -53,12 +53,12 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `REVIEW_PR_TRAILER_PREFIX` | `Reviewed-by: uberdev/review-pr@` | Phase 1.4 (PATH_2 trailer extraction); regex form `^Reviewed-by: uberdev/review-pr@([a-f0-9]{40})$` |
 | `RUN_ID_REGEX` | `^[0-9]{8}-[0-9]{6}-[a-f0-9]+$` | Phase 1.4 (PATH_2 audit-JSON path validation); also enforced producer-side in `commands/review-pr.md` |
 | `TRUST_ANCHOR_ENUM` | `reviewDecision_approved`, `uberdev_review_trail`, `bypass_with_waiver` (deprecated; never emitted post-v0.17.0) | Phase 1.4 (audit-log `gate_pass.data.trust_anchor`) |
-| `GATE_FAIL_REASON_ENUM` | **trust-resolution reasons** (PATH_1 / PATH_2): `review_decision_not_approved`, `trust_trail_missing`, `trust_trail_stale_sha`, `trust_trail_label_missing`, `trust_trail_trailer_missing`, `trust_trail_json_missing`, `trust_trail_agent_invalid_input`, `trust_trail_json_sha_mismatch`. **Pre-condition gate reasons** (Step 1.4 pre-flight, evaluated before trust resolution): `pr_state_not_open`, `is_draft`, `ci_red`, `merge_state_blocked`. Total 12 members — the eight trust-resolution reasons are subject to M37's enum-row count assertion; the four pre-condition reasons are emitted by Step 1.4 pre-flight gates that fire regardless of trust path. | Phase 1.4 (audit-log `gate_fail.data.reason`) |
+| `GATE_FAIL_REASON_ENUM` | **trust-resolution reasons** (PATH_1 / PATH_2): `review_decision_not_approved`, `trust_trail_missing`, `trust_trail_stale_sha`, `trust_trail_label_missing`, `trust_trail_trailer_missing`, `trust_trail_json_missing`, `trust_trail_agent_invalid_input`, `trust_trail_json_sha_mismatch`. **Pre-condition gate reasons** (Step 1.4 pre-flight, evaluated before trust resolution): `pr_state_not_open`, `is_draft`, `ci_red`, `merge_state_blocked`. **Infrastructure failure reasons** (Step 1.4 lib-call failure): `pr_view_unreachable` — emitted when the pr-view projection lib call exits non-zero; the PR is skipped, the queue continues, and a discovery-gh-failed audit event is emitted alongside. Total 13 members — the eight trust-resolution reasons are subject to M37's enum-row count assertion; the four pre-condition reasons are emitted by Step 1.4 pre-flight gates that fire regardless of trust path; the one infrastructure failure reason is emitted when the lib call itself fails. | Phase 1.4 (audit-log `gate_fail.data.reason`) |
 | `GATE_FAIL_REASON_TRUST_TRAIL_JSON_SHA_MISMATCH` | `trust_trail_json_sha_mismatch` (8th member of `GATE_FAIL_REASON_ENUM`) | Phase 1.4 PATH_2 sub-condition (d) caller mapping for JSON-present-but-SHA-mismatch (or shape-malformed) cases; audit-log `gate_fail.data.reason` |
 | `TRUST_TRAIL_VERDICT_INVALID_SUBREASON_ENUM` | `input_malformed` (immediate gate_fail; no retry), `trailer_sha_not_in_local_clone` (one bounded `git fetch --prune` + re-dispatch with `data.retry_attempt=1`; second INVALID is terminal) | Phase 1.4 PATH_2 sub-condition (c); audit-log `trust_trail_agent_decision.data.subreason` when `data.choice="INVALID"` |
 | `TRUST_TRAIL_AGENT_DECISION_RETRY_ATTEMPT_RANGE` | integer enum `{0, 1}` (0 = first dispatch; 1 = bounded retry on `trailer_sha_not_in_local_clone`; never recursive) | Phase 1.4 PATH_2 sub-condition (c); audit-log `trust_trail_agent_decision.data.retry_attempt` |
-| `BARE_MODE_FAST_PATH_QUERY` | `gh pr list --head "$current_branch" --state open --search "draft:false" --json number,headRefOid` | Step 1.0.5 (bare-mode current-branch detection — does NOT consume `$integration_branch`; the cardinality of the result drives the three-way branch) |
-| `DISCOVERY_FILTER` | `gh pr list --base "$integration_branch" --state open --search "draft:false" --json number,title,headRefOid,headRefName,baseRefName,isDraft,createdAt,reviewDecision,labels,body,author,headRepositoryOwner` followed by `jq '.[] \| select(.isDraft==false)'` (belt-and-suspenders) | Step 1.2.5 (multi-discover dispatch — runs after Step 1.2 integration_branch resolution); also referenced by `--all` for one canonical filter shared by both modes (Q4) |
+| `BARE_MODE_FAST_PATH_QUERY` | `discover_bare_fast_path` in `lib/discover.sh` (R1 in-process filter — `gh pr list --head "$current_branch" --state open --search 'draft:false' --json number,headRefOid --jq 'length'`; eliminates the external-jq pipe-pollution surface) | Step 1.0.5 (bare-mode current-branch detection — does NOT consume `$integration_branch`; the cardinality of the result drives the three-way branch). Sourced by SKILL.md, never invoked inline. |
+| `DISCOVERY_FILTER` | `discover_multi` in `lib/discover.sh` (R1 in-process filter — `gh pr list --base "$integration_branch" --state open --search 'draft:false' --json number,title,headRefOid,headRefName,baseRefName,isDraft,createdAt,reviewDecision,labels,body,author,headRepositoryOwner --jq '[.[] \| select(.isDraft==false)]'`; the belt-and-suspenders `isDraft==false` filter runs inside gh's process so no external jq pipe is ever created) | Step 1.2.5 (multi-discover dispatch — runs after Step 1.2 integration_branch resolution); also referenced by `--all` for one canonical filter shared by both modes (Q4). Sourced by SKILL.md, never invoked inline. |
 | `PREFLIGHT_SUMMARY_FORMAT` | `"merging %d PR%s in order: %s"` (literal printf-style format). When the rendered line exceeds 80 chars, fold at PR-number boundaries with a continuation indent of 2 spaces (80-char wrap convention). | Step 2.2 entry pre-flight stderr line (multi-discover mode only); the line lists the FULL ordered set regardless of `MAX_PARALLEL_AGENTS` chunking (Q5) |
 
 ## Inputs
@@ -127,13 +127,19 @@ When `/merge` is invoked with no positional `<PR#>` and no `--all` flag (the bar
 Procedure:
 
 1. Resolve `current_branch := git symbolic-ref --short HEAD 2>/dev/null`. On failure (detached HEAD), set `current_branch=""`, **skip step 2 entirely**, and treat `N := 0` (multi-discover fall-through). Do not invoke `BARE_MODE_FAST_PATH_QUERY` with an empty `--head` value — `gh pr list --head ""` is undefined behaviour.
-2. Run the canonical `BARE_MODE_FAST_PATH_QUERY` (declared in `## Constants`):
+2. Source `lib/discover.sh` (resolved via `${CLAUDE_PLUGIN_ROOT}` — the canonical plugin-root variable Claude Code injects at skill-evaluation time, mirroring the same SKILL.md's `lib/config-read.sh` precedent at line 113) and call `discover_bare_fast_path` — the canonical entry point for `BARE_MODE_FAST_PATH_QUERY` (declared in `## Constants`):
 
    ```bash
-   gh pr list --head "$current_branch" --state open --search "draft:false" --json number,headRefOid
+   if [ -r "${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/discover.sh" ]; then
+     . "${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/discover.sh"
+   else
+     echo "error: lib/discover.sh not found at ${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/" >&2
+     exit 1
+   fi
+   N=$(discover_bare_fast_path "$current_branch") || N=0
    ```
 
-   The result is a JSON array; let `N := len(result)`. **`gh` failure-mode handling** (network, auth, rate limit, 5xx) is a cross-cutting concern across all `gh pr list` invocations in the skill (`--all` discovery has the same shape); follow-up issue tracks unified hardening across both bare-discover Step 1.0.5 / Step 1.2.5 and the existing `--all` path. Until then: a `gh` failure producing empty stdout will be observed as `N=0`, falling through to multi-discover; surface the breadcrumb at step 3 unchanged.
+   The function runs `gh pr list ... --jq 'length'` in-process (R1 root fix — no external `jq` pipe, so gh's spinner / progress bytes cannot pollute stdout and break a downstream `jq` parse). On gh-or-jq failure the function emits a `discovery_gh_failed` audit event with `data.step="1.0.5"`, prints a `warning:` breadcrumb to stderr, returns exit 1 — the caller's `|| N=0` clause normalises to `N=0` so the pipeline continues into multi-discover fall-through (step 3 below). The function contract is documented in `lib/discover.sh`; this lib extraction is the canonical hardening for the bug class previously tracked as a follow-up issue (R2 — eliminates the model-improv surface that re-introduced `2>&1` despite the spec text never asking for it).
 
 3. Branch on `N` (three-way):
 
@@ -222,19 +228,23 @@ Validate the resolved name against `BRANCH_NAME_REGEX` BEFORE any shell argv use
 
 ### Step 1.2.5 — Multi-discover dispatch (deferred from Step 1.0.5)
 
-If Step 1.0.5 set the bare-mode discriminator to `multi-discover` (or `--all` was given on the command line), apply the canonical `DISCOVERY_FILTER` (declared in `## Constants`) against the `$integration_branch` resolved by Step 1.2, and seed the Phase 1.4 candidate set with the result. Otherwise this step is a no-op.
+If Step 1.0.5 set the bare-mode discriminator to `multi-discover` (or `--all` was given on the command line), source `lib/discover.sh` and call `discover_multi` against the `$integration_branch` resolved by Step 1.2 to seed the Phase 1.4 candidate set. Otherwise this step is a no-op.
 
 Concretely:
 
 ```bash
-candidates=$(gh pr list --base "$integration_branch" --state open --search "draft:false" \
-  --json number,title,headRefOid,headRefName,baseRefName,isDraft,createdAt,reviewDecision,labels,body,author,headRepositoryOwner \
-  | jq '[.[] | select(.isDraft==false)]')
+if [ -r "${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/discover.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/discover.sh"
+else
+  echo "error: lib/discover.sh not found at ${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/" >&2
+  exit 1
+fi
+candidates=$(discover_multi "$integration_branch")  # always exits 0; '[]' on failure
 ```
 
-The `jq '.[] | select(.isDraft==false)'` filter is belt-and-suspenders against any future `gh` API change that might surface drafts despite the `--search "draft:false"` flag. The candidate array is the input set for Phase 1.4 (per-PR trust gate fanout). **This is the only place `DISCOVERY_FILTER` is invoked**; both bare-mode (multi-discover) and `--all` route through this single dispatch point so the two modes share one canonical filter (Q4). **`gh` and `jq` failure-mode handling** is a cross-cutting concern shared with Step 1.0.5 (see that step's note); a transient `gh` failure or `jq` parse error producing an empty pipeline output is currently observed as a legitimate empty candidate set (Step 1.7 clean-exit-0 applies). Follow-up issue tracks unified hardening across bare-discover and the existing `--all` path; until then, post-hoc forensics rely on `gh` CLI's own stderr emission rather than a structured audit event.
+The function runs `gh pr list ... --jq '[.[] | select(.isDraft==false)]'` in-process (R1 — the belt-and-suspenders `isDraft==false` filter executes inside gh's Go process on the parsed object before serialising stdout, so no external `jq` pipe is ever created and gh's spinner / progress bytes cannot break a downstream parse). The candidate array is the input set for Phase 1.4 (per-PR trust gate fanout). **The only call site of `discover_multi`** is this step — both bare-mode (multi-discover) and `--all` route through this single dispatch point so the two modes share one canonical filter (Q4). On gh-or-jq failure, the function emits a `discovery_gh_failed` audit event with `data.step="1.2.5"`, prints a `warning:` breadcrumb to stderr, and returns the literal `'[]'` to stdout — Step 1.7's clean-exit-0 contract still applies (the empty candidate set produces a clean-exit-0 run-summary block).
 
-If the `gh` invocation returns an empty array (all PRs are drafts, or no open PRs exist on `$integration_branch`), the candidate set is empty — Step 1.7's clean-exit-0 contract applies (see Step 1.7's bare-mode cross-reference).
+If `discover_multi` returns an empty array (all PRs are drafts, no open PRs exist on `$integration_branch`, or a gh-or-jq failure occurred), the candidate set is empty — Step 1.7's clean-exit-0 contract applies (see Step 1.7's bare-mode cross-reference).
 
 This step is the `$integration_branch`-dependent half of the split detection introduced in Step 1.0.5; the two steps are intentionally separate (see Step 1.0.5 for the rationale) and collapsing them would invert the dependency on `$integration_branch`. Do not collapse.
 
@@ -258,7 +268,26 @@ This is the only Phase-1 path where /merge declines to run for a config reason. 
 
 ### Step 1.4 — Per-PR pre-flight gate (trust resolution)
 
-For each PR in the candidate set (per-PR fanout — the gate is dispatched once per discovered PR; bare-discover does not relax this dispatch shape), project the JSON: `gh pr view <N> --json state,isDraft,reviewDecision,statusCheckRollup,headRepository,maintainerCanModify,isCrossRepository,headRefName,headRefOid,baseRefName,body,commits,labels,createdAt,author`.
+For each PR in the candidate set (per-PR fanout — the gate is dispatched once per discovered PR; bare-discover does not relax this dispatch shape), project the JSON via the canonical `pr_view_projection` lib function:
+
+```bash
+if [ -r "${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/discover.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/discover.sh"
+else
+  echo "error: lib/discover.sh not found at ${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/" >&2
+  exit 1
+fi
+PR_JSON=$(pr_view_projection "$PR_NUMBER") || {
+  emit_gate_fail "$PR_NUMBER" "pr_view_unreachable"
+  continue
+}
+PR_STATE=$(jq -r .state <<<"$PR_JSON")
+# … other fields extracted via `jq <<<"$PR_JSON"` — safe because PR_JSON
+# is byte-clean from the lib (the projection ran through gh's in-process
+# `--jq '.'` identity filter; no external pipe = no FD-pollution surface).
+```
+
+The `pr_view_projection` function wraps `gh pr view <N> --json state,isDraft,reviewDecision,statusCheckRollup,headRepository,maintainerCanModify,isCrossRepository,headRefName,headRefOid,baseRefName,body,commits,labels,createdAt,author --jq '.'` (R1 — the identity `--jq '.'` filter routes the projection through gh's in-process JSON parser before the bytes ever reach stdout, so subsequent `jq <<<"$PR_JSON"` calls cannot crash on spinner / progress pollution). On gh-or-jq failure the lib emits a `discovery_gh_failed` audit event with `data.step="1.4"` and `data.pr_number=$PR_NUMBER`, prints a `warning:` breadcrumb to stderr, and returns exit 1; the caller's `|| { … }` block then emits `gate_fail` with `data.reason="pr_view_unreachable"` (∈ `GATE_FAIL_REASON_ENUM`) via `emit_gate_fail`, skips this PR, and the queue continues. This is the only Phase-1 path where a non-trust-related infrastructure failure can park a PR.
 
 Pre-conditions that ALL must pass regardless of trust path (real blockers):
 
@@ -509,6 +538,7 @@ viii. **Tear down the scratch worktree** per `using-git-worktrees` protocol: `gi
 | local pull non-FF (Phase 4.2) | auto-rebase local onto origin; on rebase conflict, abort rebase and surface in summary | continues |
 | `trust_trail_agent_decision` returns `INVALID / input_malformed` (Phase 1.4 PATH_2 (c)) | `gate_fail` with `data.reason="trust_trail_agent_invalid_input"`; PR excluded from merge set | continues |
 | `trust_trail_agent_decision` returns `INVALID / trailer_sha_not_in_local_clone` (Phase 1.4 PATH_2 (c)) | One bounded `git fetch --prune origin <branch>` + re-dispatch (max retry=1); persistent INVALID → `gate_fail` with `data.reason="trust_trail_agent_invalid_input"`; PR excluded from merge set | continues |
+| `pr_view_projection` lib call failure (Step 1.4 — gh-or-jq exit non-zero, e.g., network / auth / rate-limit) | emit `discovery_gh_failed` (step="1.4") + `gate_fail` with `data.reason="pr_view_unreachable"`; PR excluded from merge set | continues |
 
 **No halt conditions remain.** Already-merged PRs stay merged. Every event hits `audit.jsonl`. Every parked PR appears in the run-summary block with its `PARK_REASON_ENUM` value and the structured handoff (where applicable).
 

--- a/plugins/uberdev/skills/merge/lib/discover.sh
+++ b/plugins/uberdev/skills/merge/lib/discover.sh
@@ -27,24 +27,17 @@ _uberdev_discover_iso_ts() {
   date -u +%Y-%m-%dT%H:%M:%SZ
 }
 
-# _uberdev_discover_truncate FILE
-# Echo the first 512 bytes of FILE, JSON-escaped (backslashes, quotes, and
-# control bytes \n \r \t are escaped; other C0/C1 + DEL dropped via tr).
-# Bash 3.2 + POSIX tools only (no GNU-sed multiline-label extensions —
-# BSD sed on macOS rejects `:a;N;$!ba`, which would silently produce
-# unescaped raw newlines and corrupt the JSONL audit log).
-_uberdev_discover_truncate() {
-  local file="$1"
-  if [ ! -r "$file" ]; then
-    printf ''
-    return 0
-  fi
-  # Read first 512 bytes, then escape JSON-meaningful characters in awk.
-  # awk reads byte-by-byte via getc-style RS="" emulation; using the
-  # "feed each character" pattern keeps the scan portable across BSD
-  # awk (macOS) and gawk. Drop C0/C1 + DEL except \n \r \t, then escape.
-  head -c 512 "$file" 2>/dev/null \
-    | LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' \
+# _uberdev_discover_json_escape_stream
+# Read stdin and emit JSON-escaped output (backslash, quote, \n \r \t
+# escaped; other C0/C1 + DEL dropped via tr). Shared body of
+# _uberdev_discover_truncate and _uberdev_discover_json_escape_str — keeps
+# the escape rules in one place so a future fix (e.g. \b / \f handling)
+# cannot drift between the two paths. Bash 3.2 + POSIX tools only
+# (no GNU-sed multiline-label extensions — BSD sed on macOS rejects
+# `:a;N;$!ba`, which would silently produce unescaped raw newlines and
+# corrupt the JSONL audit log).
+_uberdev_discover_json_escape_stream() {
+  LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' \
     | LC_ALL=C awk '
         BEGIN { ORS = ""; out = "" }
         {
@@ -59,31 +52,27 @@ _uberdev_discover_truncate() {
       '
 }
 
+# _uberdev_discover_truncate FILE
+# Echo the first 512 bytes of FILE, JSON-escaped via the shared escape
+# stream. Empty string when FILE is unreadable (best-effort).
+_uberdev_discover_truncate() {
+  local file="$1"
+  if [ ! -r "$file" ]; then
+    printf ''
+    return 0
+  fi
+  head -c 512 "$file" 2>/dev/null | _uberdev_discover_json_escape_stream
+}
+
 # _uberdev_discover_json_escape_str STRING
-# Emit STRING JSON-escaped (backslash, quote, \n \r \t escaped; other
-# C0/C1 + DEL dropped via tr). Defense-in-depth for enum-shaped fields
-# (reason, step) interpolated into audit-log JSON via bare-string printf.
-# Today every call site passes a static enum literal, so this is unreachable
-# given current callers — but the function signatures do not enforce that
-# discipline, and a future caller passing a dynamic string would otherwise
-# corrupt the audit log. Mirrors the awk shape used by
-# _uberdev_discover_truncate so behaviour is identical for any input the
-# truncate path would also accept.
+# Emit STRING JSON-escaped via the shared escape stream. Defense-in-depth
+# for enum-shaped fields (reason, step) interpolated into audit-log JSON
+# via bare-string printf. Today every call site passes a static enum
+# literal, so this is unreachable given current callers — but the function
+# signatures do not enforce that discipline, and a future caller passing a
+# dynamic string would otherwise corrupt the audit log.
 _uberdev_discover_json_escape_str() {
-  printf '%s' "$1" \
-    | LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' \
-    | LC_ALL=C awk '
-        BEGIN { ORS = ""; out = "" }
-        {
-          line = $0
-          gsub(/\\/, "\\\\", line)
-          gsub(/"/, "\\\"", line)
-          gsub(/\r/, "\\r", line)
-          gsub(/\t/, "\\t", line)
-          out = out (NR > 1 ? "\\n" : "") line
-        }
-        END { print out }
-      '
+  printf '%s' "$1" | _uberdev_discover_json_escape_stream
 }
 
 # _uberdev_discover_emit_audit REASON STEP EXIT_CODE STDERR_FILE [PR_NUMBER]

--- a/plugins/uberdev/skills/merge/lib/discover.sh
+++ b/plugins/uberdev/skills/merge/lib/discover.sh
@@ -59,6 +59,33 @@ _uberdev_discover_truncate() {
       '
 }
 
+# _uberdev_discover_json_escape_str STRING
+# Emit STRING JSON-escaped (backslash, quote, \n \r \t escaped; other
+# C0/C1 + DEL dropped via tr). Defense-in-depth for enum-shaped fields
+# (reason, step) interpolated into audit-log JSON via bare-string printf.
+# Today every call site passes a static enum literal, so this is unreachable
+# given current callers — but the function signatures do not enforce that
+# discipline, and a future caller passing a dynamic string would otherwise
+# corrupt the audit log. Mirrors the awk shape used by
+# _uberdev_discover_truncate so behaviour is identical for any input the
+# truncate path would also accept.
+_uberdev_discover_json_escape_str() {
+  printf '%s' "$1" \
+    | LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' \
+    | LC_ALL=C awk '
+        BEGIN { ORS = ""; out = "" }
+        {
+          line = $0
+          gsub(/\\/, "\\\\", line)
+          gsub(/"/, "\\\"", line)
+          gsub(/\r/, "\\r", line)
+          gsub(/\t/, "\\t", line)
+          out = out (NR > 1 ? "\\n" : "") line
+        }
+        END { print out }
+      '
+}
+
 # _uberdev_discover_emit_audit REASON STEP EXIT_CODE STDERR_FILE [PR_NUMBER]
 # Best-effort append of one discovery_gh_failed event to the audit log.
 # Pre-lock context — no run_id required (mirrors Step 1.0a's
@@ -84,15 +111,23 @@ _uberdev_discover_emit_audit() {
   # bare-numeric in the JSON shape per the AUDIT_EVENT_ENUM doc).
   case "$exit_code" in ''|*[!0-9-]*) exit_code=-1 ;; esac
   case "$pr_number" in ''|*[!0-9]*) pr_number="" ;; esac
+  # JSON-escape string fields. Today's callers pass static enum literals
+  # (reason ∈ {gh_failed, jq_failed}; step ∈ {1.0.5, 1.2.5, 1.4}), so these
+  # escapes are no-ops in practice — the helper is here so the function
+  # contract no longer relies on caller discipline. stderr_truncated is
+  # already escaped by _uberdev_discover_truncate above.
+  local reason_escaped step_escaped
+  reason_escaped="$(_uberdev_discover_json_escape_str "$reason")"
+  step_escaped="$(_uberdev_discover_json_escape_str "$step")"
   # Ensure parent dir exists (best-effort).
   mkdir -p "$audit_dir" 2>/dev/null || true
   if [ -n "$pr_number" ]; then
     printf '{"ts":"%s","event":"discovery_gh_failed","data":{"reason":"%s","step":"%s","exit_code":%s,"gh_stderr":"%s","pr_number":%s}}\n' \
-      "$ts" "$reason" "$step" "$exit_code" "$stderr_truncated" "$pr_number" \
+      "$ts" "$reason_escaped" "$step_escaped" "$exit_code" "$stderr_truncated" "$pr_number" \
       >> "$audit_path" 2>/dev/null || true
   else
     printf '{"ts":"%s","event":"discovery_gh_failed","data":{"reason":"%s","step":"%s","exit_code":%s,"gh_stderr":"%s"}}\n' \
-      "$ts" "$reason" "$step" "$exit_code" "$stderr_truncated" \
+      "$ts" "$reason_escaped" "$step_escaped" "$exit_code" "$stderr_truncated" \
       >> "$audit_path" 2>/dev/null || true
   fi
 }
@@ -255,6 +290,12 @@ emit_gate_fail() {
   # Bare-numeric pr_number in JSON; sanitise non-integer input to 0 so the
   # emitted line stays valid JSON regardless of caller bugs.
   case "$pr_number" in ''|*[!0-9]*) pr_number=0 ;; esac
+  # JSON-escape reason. Today's only caller passes the static enum
+  # GATE_FAIL_REASON_ENUM literal "pr_view_unreachable" — escape is a no-op
+  # there. Defense-in-depth so the function contract no longer relies on
+  # caller discipline (mirrors _uberdev_discover_emit_audit).
+  local reason_escaped
+  reason_escaped="$(_uberdev_discover_json_escape_str "$reason")"
   local audit_path
   audit_path="$(_uberdev_discover_audit_path)"
   local audit_dir
@@ -263,7 +304,7 @@ emit_gate_fail() {
   ts="$(_uberdev_discover_iso_ts)"
   mkdir -p "$audit_dir" 2>/dev/null || true
   printf '{"ts":"%s","event":"gate_fail","pr":%s,"data":{"reason":"%s"}}\n' \
-    "$ts" "$pr_number" "$reason" \
+    "$ts" "$pr_number" "$reason_escaped" \
     >> "$audit_path" 2>/dev/null || true
   printf 'gate_fail: PR #%s reason=%s\n' "$pr_number" "$reason" >&2
 }

--- a/plugins/uberdev/skills/merge/lib/discover.sh
+++ b/plugins/uberdev/skills/merge/lib/discover.sh
@@ -1,0 +1,269 @@
+# shellcheck shell=bash
+# Generated under R1+R2 root fix (see CHANGELOG v0.19.3)
+#
+# Why this exists: gh's spinner / progress bytes leak into stdout when /merge
+# pipes `gh ... --json` into an external `jq`, which crashes the pipeline with
+# "Invalid string: control characters from U+0000 through U+001F must be
+# escaped". R1 collapses every gh|jq pipeline into `gh ... --jq '<filter>'`
+# (in-process; no FD pollution). R2 lifts the three discovery sites out of
+# SKILL.md prose into this real lib so the model cannot improvise a `2>&1`
+# back in. Each function emits a `discovery_gh_failed` audit event on failure.
+
+if [ "${_UBERDEV_MERGE_DISCOVER_LOADED:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+_UBERDEV_MERGE_DISCOVER_LOADED=1
+
+# _uberdev_discover_audit_path
+# Resolve the audit-log path. Tests redirect via UBERDEV_AUDIT_LOG_PATH;
+# production defaults to .uberdev/audit.jsonl (best-effort, pre-lock context).
+_uberdev_discover_audit_path() {
+  printf '%s' "${UBERDEV_AUDIT_LOG_PATH:-.uberdev/audit.jsonl}"
+}
+
+# _uberdev_discover_iso_ts
+# Emit a UTC ISO8601 timestamp. POSIX-portable on macOS bash 3.2 (BSD date).
+_uberdev_discover_iso_ts() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# _uberdev_discover_truncate FILE
+# Echo the first 512 bytes of FILE, JSON-escaped (backslashes, quotes, and
+# control bytes \n \r \t are escaped; other C0/C1 + DEL dropped via tr).
+# Bash 3.2 + POSIX tools only (no GNU-sed multiline-label extensions —
+# BSD sed on macOS rejects `:a;N;$!ba`, which would silently produce
+# unescaped raw newlines and corrupt the JSONL audit log).
+_uberdev_discover_truncate() {
+  local file="$1"
+  if [ ! -r "$file" ]; then
+    printf ''
+    return 0
+  fi
+  # Read first 512 bytes, then escape JSON-meaningful characters in awk.
+  # awk reads byte-by-byte via getc-style RS="" emulation; using the
+  # "feed each character" pattern keeps the scan portable across BSD
+  # awk (macOS) and gawk. Drop C0/C1 + DEL except \n \r \t, then escape.
+  head -c 512 "$file" 2>/dev/null \
+    | LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' \
+    | LC_ALL=C awk '
+        BEGIN { ORS = ""; out = "" }
+        {
+          line = $0
+          gsub(/\\/, "\\\\", line)
+          gsub(/"/, "\\\"", line)
+          gsub(/\r/, "\\r", line)
+          gsub(/\t/, "\\t", line)
+          out = out (NR > 1 ? "\\n" : "") line
+        }
+        END { print out }
+      '
+}
+
+# _uberdev_discover_emit_audit REASON STEP EXIT_CODE STDERR_FILE [PR_NUMBER]
+# Best-effort append of one discovery_gh_failed event to the audit log.
+# Pre-lock context — no run_id required (mirrors Step 1.0a's
+# uberdev_config_read precedent of writing to .uberdev/audit.jsonl directly).
+# Never fails the caller if the log write fails (`|| true`).
+_uberdev_discover_emit_audit() {
+  local reason="$1"
+  local step="$2"
+  local exit_code="$3"
+  local stderr_file="$4"
+  local pr_number="${5:-}"
+  local audit_path
+  audit_path="$(_uberdev_discover_audit_path)"
+  local audit_dir
+  audit_dir="$(dirname "$audit_path")"
+  local stderr_truncated
+  stderr_truncated="$(_uberdev_discover_truncate "$stderr_file")"
+  local ts
+  ts="$(_uberdev_discover_iso_ts)"
+  # Sanitise numerics so a non-integer exit_code / pr_number cannot inject
+  # malformed-or-attacker-shaped JSON into the audit log (defense in depth —
+  # both fields come from gh-validated sources today, but the contract is
+  # bare-numeric in the JSON shape per the AUDIT_EVENT_ENUM doc).
+  case "$exit_code" in ''|*[!0-9-]*) exit_code=-1 ;; esac
+  case "$pr_number" in ''|*[!0-9]*) pr_number="" ;; esac
+  # Ensure parent dir exists (best-effort).
+  mkdir -p "$audit_dir" 2>/dev/null || true
+  if [ -n "$pr_number" ]; then
+    printf '{"ts":"%s","event":"discovery_gh_failed","data":{"reason":"%s","step":"%s","exit_code":%s,"gh_stderr":"%s","pr_number":%s}}\n' \
+      "$ts" "$reason" "$step" "$exit_code" "$stderr_truncated" "$pr_number" \
+      >> "$audit_path" 2>/dev/null || true
+  else
+    printf '{"ts":"%s","event":"discovery_gh_failed","data":{"reason":"%s","step":"%s","exit_code":%s,"gh_stderr":"%s"}}\n' \
+      "$ts" "$reason" "$step" "$exit_code" "$stderr_truncated" \
+      >> "$audit_path" 2>/dev/null || true
+  fi
+}
+
+# _uberdev_discover_warn STEP_LABEL EXIT_CODE STDERR_FILE
+# Emit one stderr breadcrumb (truncated to 512 bytes of stderr).
+_uberdev_discover_warn() {
+  local label="$1"
+  local exit_code="$2"
+  local stderr_file="$3"
+  local truncated
+  if [ -r "$stderr_file" ]; then
+    truncated="$(head -c 512 "$stderr_file" 2>/dev/null \
+                 | LC_ALL=C tr -d '\000-\010\013\014\016-\037\177')"
+  else
+    truncated=""
+  fi
+  printf 'warning: %s (gh exit %s): %s\n' "$label" "$exit_code" "$truncated" >&2
+}
+
+# discover_bare_fast_path CURRENT_BRANCH
+# Stdout: integer N (count of open non-draft PRs whose HEAD = current_branch).
+# Exit:   0 on success (incl. N=0); 1 on gh-or-jq failure.
+# Stderr: warning on failure (see _uberdev_discover_warn).
+# Audit:  discovery_gh_failed with step="1.0.5" on failure.
+# Implementation: in-process `gh ... --jq 'length'` (R1 root fix — no
+# external jq pipe, eliminating FD-pollution surface).
+discover_bare_fast_path() {
+  local current_branch="$1"
+  local gh_err
+  gh_err="$(mktemp)"
+  # Function-scoped trap; bash 3.2 supports RETURN trap idiom.
+  # shellcheck disable=SC2064  # intentional immediate expansion of $gh_err
+  trap "rm -f \"$gh_err\"" RETURN
+
+  local result
+  result="$(gh pr list \
+    --head "$current_branch" \
+    --state open \
+    --search 'draft:false' \
+    --json number,headRefOid \
+    --jq 'length' \
+    2>"$gh_err")"
+  local gh_exit=$?
+
+  if [ "$gh_exit" -ne 0 ]; then
+    _uberdev_discover_warn "bare-mode discovery failed" "$gh_exit" "$gh_err"
+    _uberdev_discover_emit_audit "gh_failed" "1.0.5" "$gh_exit" "$gh_err"
+    return 1
+  fi
+
+  # Validate result is an integer (jq 'length' on a non-array → would have
+  # exited non-zero above; defensive numeric check guards against future
+  # gh-CLI changes that emit informational stdout text alongside JSON).
+  case "$result" in
+    ''|*[!0-9]*)
+      _uberdev_discover_warn "bare-mode discovery returned non-integer" "$gh_exit" "$gh_err"
+      _uberdev_discover_emit_audit "jq_failed" "1.0.5" "$gh_exit" "$gh_err"
+      return 1
+      ;;
+  esac
+
+  printf '%s\n' "$result"
+  return 0
+}
+
+# discover_multi INTEGRATION_BRANCH
+# Stdout: JSON array of candidate PRs (or '[]' on failure — Step 1.7's
+#         clean-exit-0 contract still applies).
+# Exit:   0 always (gh-or-jq failure → '[]' + audit event).
+# Stderr: warning on failure.
+# Audit:  discovery_gh_failed with step="1.2.5" on failure.
+# Implementation: gh's in-process --jq filter does the isDraft==false
+# belt-and-suspenders filter; no external jq pipe.
+discover_multi() {
+  local integration_branch="$1"
+  local gh_err
+  gh_err="$(mktemp)"
+  # shellcheck disable=SC2064
+  trap "rm -f \"$gh_err\"" RETURN
+
+  local result
+  result="$(gh pr list \
+    --base "$integration_branch" \
+    --state open \
+    --search 'draft:false' \
+    --json number,title,headRefOid,headRefName,baseRefName,isDraft,createdAt,reviewDecision,labels,body,author,headRepositoryOwner \
+    --jq '[.[] | select(.isDraft==false)]' \
+    2>"$gh_err")"
+  local gh_exit=$?
+
+  if [ "$gh_exit" -ne 0 ]; then
+    _uberdev_discover_warn "multi-discover failed" "$gh_exit" "$gh_err"
+    _uberdev_discover_emit_audit "gh_failed" "1.2.5" "$gh_exit" "$gh_err"
+    printf '[]\n'
+    return 0
+  fi
+
+  # Empty stdout on a 0-exit gh is unexpected (jq identity on empty would
+  # have errored); treat as jq_failed and fall back to '[]'.
+  if [ -z "$result" ]; then
+    _uberdev_discover_warn "multi-discover returned empty stdout" "$gh_exit" "$gh_err"
+    _uberdev_discover_emit_audit "jq_failed" "1.2.5" "$gh_exit" "$gh_err"
+    printf '[]\n'
+    return 0
+  fi
+
+  printf '%s\n' "$result"
+  return 0
+}
+
+# pr_view_projection PR_NUMBER
+# Stdout: JSON object with the 15 fields Step 1.4 trust gate consumes.
+# Exit:   0 on success; 1 on gh-or-jq failure.
+# Stderr: warning on failure.
+# Audit:  discovery_gh_failed with step="1.4" and pr_number=<N> on failure.
+# Implementation: identity --jq '.' filter routes the projection through
+# gh's in-process JSON parser before reaching stdout (R1 root fix —
+# downstream callers can safely use `<<<"$PR_JSON"` herestrings because
+# the bytes are clean by construction).
+pr_view_projection() {
+  local pr_number="$1"
+  local gh_err
+  gh_err="$(mktemp)"
+  # shellcheck disable=SC2064
+  trap "rm -f \"$gh_err\"" RETURN
+
+  local result
+  result="$(gh pr view "$pr_number" \
+    --json state,isDraft,reviewDecision,statusCheckRollup,headRepository,maintainerCanModify,isCrossRepository,headRefName,headRefOid,baseRefName,body,commits,labels,createdAt,author \
+    --jq '.' \
+    2>"$gh_err")"
+  local gh_exit=$?
+
+  if [ "$gh_exit" -ne 0 ]; then
+    _uberdev_discover_warn "pr_view_projection #$pr_number failed" "$gh_exit" "$gh_err"
+    _uberdev_discover_emit_audit "gh_failed" "1.4" "$gh_exit" "$gh_err" "$pr_number"
+    return 1
+  fi
+
+  if [ -z "$result" ]; then
+    _uberdev_discover_warn "pr_view_projection #$pr_number returned empty stdout" "$gh_exit" "$gh_err"
+    _uberdev_discover_emit_audit "jq_failed" "1.4" "$gh_exit" "$gh_err" "$pr_number"
+    return 1
+  fi
+
+  printf '%s\n' "$result"
+  return 0
+}
+
+# emit_gate_fail PR_NUMBER REASON
+# Discovery-adjacent helper. Appends one gate_fail event to the audit log
+# with {event:"gate_fail",pr:<N>,data:{reason:"<reason>"}} and writes a
+# stderr breadcrumb. Mirrors the inline gate_fail pattern used elsewhere
+# in /merge so Step 1.4's `pr_view_projection` failure path can short-
+# circuit cleanly when the projection lib call fails.
+emit_gate_fail() {
+  local pr_number="$1"
+  local reason="$2"
+  # Bare-numeric pr_number in JSON; sanitise non-integer input to 0 so the
+  # emitted line stays valid JSON regardless of caller bugs.
+  case "$pr_number" in ''|*[!0-9]*) pr_number=0 ;; esac
+  local audit_path
+  audit_path="$(_uberdev_discover_audit_path)"
+  local audit_dir
+  audit_dir="$(dirname "$audit_path")"
+  local ts
+  ts="$(_uberdev_discover_iso_ts)"
+  mkdir -p "$audit_dir" 2>/dev/null || true
+  printf '{"ts":"%s","event":"gate_fail","pr":%s,"data":{"reason":"%s"}}\n' \
+    "$ts" "$pr_number" "$reason" \
+    >> "$audit_path" 2>/dev/null || true
+  printf 'gate_fail: PR #%s reason=%s\n' "$pr_number" "$reason" >&2
+}

--- a/tests/_fixtures/fake-gh/gh
+++ b/tests/_fixtures/fake-gh/gh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Test fixture: a fake `gh` binary for tests/merge-discovery-resilience.test.sh.
+#
+# The real `gh` is unavailable in CI sandboxes (and we don't want network calls
+# in unit tests), so this stub simulates it. Behaviour is selected by the
+# $FAKE_GH_MODE environment variable so each test in Layer B can prepend this
+# directory to PATH and dial in the exact (stdout, stderr, exit-code) shape
+# the function-under-test should encounter.
+#
+# Modes:
+#   success-bare       : honour gh ... --jq '<filter>' for length-of-array;
+#                        simulates a non-empty bare-discovery result. stdout=2.
+#   success-multi      : emits a JSON array with two non-draft PR objects
+#                        carrying the fields downstream code reads.
+#   success-pr-view    : emits a JSON object with all 15 fields
+#                        (state, isDraft, reviewDecision, ...).
+#   fail-net           : simulates a network-unreachable failure. exit 1,
+#                        stderr "network unreachable" (truncatable to 512B).
+#   fail-malformed     : exit 1 with malformed JSON on stdout — used to
+#                        simulate gh's --jq filter aborting because the
+#                        upstream JSON wouldn't parse (gh prints the parser
+#                        error on stderr and exits non-zero).
+#   spinner-leak       : the R1 regression we are guarding against — fake gh
+#                        emits a valid JSON array on stdout AND ANSI cursor
+#                        escapes on stderr. With the OLD `gh ... 2>&1 | jq …`
+#                        shape this would crash jq; with the NEW `gh … --jq`
+#                        in-process filter it must NOT crash because stderr
+#                        never reaches the function's stdout.
+#   fail-pr-view       : exit 2 — used by B6 to verify pr_view_projection's
+#                        failure path captures the right exit code.
+#
+# A side-effect log of the call (argv) is written to $FAKE_GH_CALL_LOG when
+# that variable is set; tests can inspect it to verify call shape (e.g. that
+# the function actually used `gh ... --jq '<filter>'` and not a piped jq).
+# This is opt-in so the default test path stays simple.
+
+set -u
+
+if [ -n "${FAKE_GH_CALL_LOG:-}" ]; then
+  printf '%s\n' "$*" >> "$FAKE_GH_CALL_LOG"
+fi
+
+mode="${FAKE_GH_MODE:-}"
+
+case "$mode" in
+  success-bare)
+    # gh ... --jq 'length' over a 2-element array would print 2 on stdout.
+    # We don't actually parse the args; we trust the caller passed --jq.
+    printf '2\n'
+    exit 0
+    ;;
+
+  success-multi)
+    # Valid JSON array of two non-draft candidate PRs. Field set is the
+    # minimum the discover_multi caller is documented to read.
+    cat <<'JSON'
+[
+  {
+    "number": 101,
+    "headRefName": "feat/branch-a",
+    "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "baseRefName": "main",
+    "isDraft": false,
+    "state": "OPEN",
+    "author": {"login": "alice"},
+    "createdAt": "2026-05-01T00:00:00Z"
+  },
+  {
+    "number": 102,
+    "headRefName": "feat/branch-b",
+    "headRefOid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "baseRefName": "main",
+    "isDraft": false,
+    "state": "OPEN",
+    "author": {"login": "bob"},
+    "createdAt": "2026-05-02T00:00:00Z"
+  }
+]
+JSON
+    exit 0
+    ;;
+
+  success-pr-view)
+    # The 15 fields documented in the contract for pr_view_projection.
+    cat <<'JSON'
+{
+  "state": "OPEN",
+  "isDraft": false,
+  "reviewDecision": "APPROVED",
+  "statusCheckRollup": [],
+  "headRepository": {"name": "uberdev", "owner": {"login": "TheFJK"}},
+  "maintainerCanModify": true,
+  "isCrossRepository": false,
+  "headRefName": "feat/discover",
+  "headRefOid": "cccccccccccccccccccccccccccccccccccccccc",
+  "baseRefName": "main",
+  "body": "Closes #42",
+  "commits": [],
+  "labels": [],
+  "createdAt": "2026-05-03T00:00:00Z",
+  "author": {"login": "alice"}
+}
+JSON
+    exit 0
+    ;;
+
+  fail-net)
+    # B2: simulate a transient network failure. The "network unreachable"
+    # token must end up in the audit log's gh_stderr field (truncated to
+    # 512B by the lib).
+    printf 'network unreachable\n' >&2
+    exit 1
+    ;;
+
+  fail-malformed)
+    # B4: gh's --jq filter could not parse upstream JSON. Real gh exits
+    # non-zero in this case; the lib treats that as jq_failed.
+    printf '{"truncated\n'
+    printf 'gh: --jq parse error: unexpected end of JSON\n' >&2
+    exit 1
+    ;;
+
+  spinner-leak)
+    # B3: the headline R1 regression — valid JSON on stdout, ANSI cursor
+    # escapes on stderr. The OLD `gh ... 2>&1 | jq …` shape merged stderr
+    # into the jq input and crashed; the NEW `gh ... --jq '<filter>'`
+    # shape filters in-process so stderr can't pollute stdout.
+    # The escape sequences here mirror what spinner libraries emit
+    # (\x1b[?25l = hide cursor, \x1b[?25h = show cursor).
+    printf '\x1b[?25l' >&2
+    cat <<'JSON'
+[
+  {
+    "number": 101,
+    "headRefName": "feat/branch-a",
+    "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "baseRefName": "main",
+    "isDraft": false,
+    "state": "OPEN",
+    "author": {"login": "alice"},
+    "createdAt": "2026-05-01T00:00:00Z"
+  }
+]
+JSON
+    printf '\x1b[?25h' >&2
+    exit 0
+    ;;
+
+  fail-pr-view)
+    printf 'pr view failure\n' >&2
+    exit 2
+    ;;
+
+  *)
+    printf 'fake-gh: unknown FAKE_GH_MODE=%s\n' "${mode}" >&2
+    exit 99
+    ;;
+esac

--- a/tests/merge-discovery-resilience.test.sh
+++ b/tests/merge-discovery-resilience.test.sh
@@ -1,0 +1,587 @@
+#!/usr/bin/env bash
+# Tests for the R1+R2 root fix to /merge's discovery logic (issue/PR for v0.19.3).
+#
+# The bug class being guarded against: `gh pr list ... 2>&1 | jq ...` and
+# `gh pr view ... | jq ...` shapes inside the merge skill body. Two failure
+# modes flow from those shapes:
+#   R1 — spinner / progress indicators leak from gh's stderr into the jq
+#        pipeline and crash the parse, masquerading as "no PRs found"
+#        (the original 21ad417 fix in solve-pipeline; the merge skill had
+#        the same bug pattern in three sites).
+#   R2 — when gh itself fails (network, auth, malformed response), `2>&1`
+#        merges its diagnostics with the JSON output and the inline jq
+#        either crashes or silently swallows an empty result; the run can
+#        then proceed past a failure that should have aborted with audit.
+#
+# The fix introduces a new bash library at
+#   plugins/uberdev/skills/merge/lib/discover.sh
+# exposing four functions that move filtering into gh's `--jq '<filter>'`
+# (in-process) and capture stderr separately via mktemp so the gh exit code
+# can be inspected and propagated to a structured audit event:
+#   discover_bare_fast_path   (Step 1.0.5)
+#   discover_multi            (Step 1.2.5)
+#   pr_view_projection        (Step 1.4)
+#   emit_gate_fail            (gate-fail audit-emit helper)
+#
+# This test file has two layers:
+#   Layer A — file-content greps that lock the implementation shape so a
+#             future regression can't reintroduce the bug (no live gh).
+#   Layer B — functional tests that source the library and exercise it
+#             against the fake-gh fixture in tests/_fixtures/fake-gh.
+#
+# Layer B sources lib/discover.sh from REPO_ROOT. In the test author's
+# isolated worktree the file does not exist yet — Layer B will FAIL until
+# the implementation worktree is merged in. That is the expected and
+# intended state during parallel development.
+#
+# Bash 3.2 compatible. No associative arrays.
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="$REPO_ROOT/plugins/uberdev/skills/merge/lib/discover.sh"
+SKILL="$REPO_ROOT/plugins/uberdev/skills/merge/SKILL.md"
+SOLVE_PIPELINE="$REPO_ROOT/plugins/uberdev/skills/solve-pipeline/SKILL.md"
+PLUGIN_JSON="$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json"
+MARKETPLACE_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
+README="$REPO_ROOT/README.md"
+FAKE_GH_DIR="$REPO_ROOT/tests/_fixtures/fake-gh"
+
+# Pre-flight: refuse to run if any input file is missing. This test file
+# focuses on lib/discover.sh and the merge SKILL.md; if those are absent
+# (e.g. before the implementation agent merges in their work) we still
+# want clear failures rather than confusing "pattern not found" errors.
+# We only HARD-FAIL on files that should always exist; lib/discover.sh
+# may be absent in the test author's worktree and will surface as
+# specific Layer A failures instead.
+for f in "$SKILL" "$SOLVE_PIPELINE" "$PLUGIN_JSON" "$MARKETPLACE_JSON" "$README"; do
+  if [ ! -r "$f" ]; then
+    echo "FATAL: required file missing or unreadable: $f" >&2
+    exit 2
+  fi
+done
+
+if [ ! -x "$FAKE_GH_DIR/gh" ]; then
+  echo "FATAL: fake-gh fixture not executable: $FAKE_GH_DIR/gh" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# --- Helpers ----------------------------------------------------------------
+
+assert_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file" 2>/dev/null; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        file:    $file"
+    echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_no_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file" 2>/dev/null; then
+    echo "  FAIL  $desc"
+    echo "        file:    $file"
+    echo "        pattern (must NOT appear): $pattern"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_eq() {
+  local actual="$1" expected="$2" desc="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        expected: $expected"
+    echo "        actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_count_at_least() {
+  local file="$1" pattern="$2" min="$3" desc="$4"
+  local count
+  # `grep -cE` always prints an integer (even 0), but exits 1 when count=0
+  # and 2 on real errors (unreadable file, bad regex). `|| true` handles
+  # the count=0 path; we still want to surface zero counts as failures via
+  # the comparison below rather than silently skipping the assertion.
+  count=$(grep -cE -e "$pattern" "$file" 2>/dev/null || true)
+  # If count is empty (file unreadable, etc.), default to 0 so the
+  # comparison below fails loud.
+  count="${count:-0}"
+  if [ "$count" -ge "$min" ] 2>/dev/null; then
+    echo "  PASS  $desc (count=$count, min=$min)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        file:     $file"
+    echo "        pattern:  $pattern"
+    echo "        expected: count >= $min"
+    echo "        actual:   $count"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_count_eq() {
+  local file="$1" pattern="$2" expected="$3" desc="$4"
+  local count
+  count=$(grep -cE -e "$pattern" "$file" 2>/dev/null || true)
+  count="${count:-0}"
+  if [ "$count" = "$expected" ]; then
+    echo "  PASS  $desc (count=$count)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        file:     $file"
+    echo "        pattern:  $pattern"
+    echo "        expected: count == $expected"
+    echo "        actual:   $count"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Layer-B helpers — wrap a function call against the fake-gh fixture in a
+# clean PATH/env subshell. Captures stdout, stderr, exit; exposes via
+# globals _LB_STDOUT / _LB_STDERR / _LB_EXIT for the caller to assert on.
+_run_lib_call() {
+  local mode="$1" call="$2" extra_env="${3:-}"
+  local out err rc
+  out="$(mktemp)"
+  err="$(mktemp)"
+  # shellcheck disable=SC2030,SC2031
+  (
+    PATH="$FAKE_GH_DIR:$PATH"
+    export FAKE_GH_MODE="$mode"
+    if [ -n "$extra_env" ]; then
+      eval "$extra_env"
+    fi
+    # shellcheck source=/dev/null
+    if [ ! -r "$LIB" ]; then
+      echo "lib/discover.sh missing — Layer B cannot source it" >&2
+      exit 127
+    fi
+    . "$LIB"
+    eval "$call"
+  ) >"$out" 2>"$err"
+  rc=$?
+  _LB_STDOUT="$(cat "$out")"
+  _LB_STDERR="$(cat "$err")"
+  _LB_EXIT="$rc"
+  rm -f "$out" "$err"
+}
+
+# --- Layer A — Source-discipline assertions --------------------------------
+
+echo "== A1: lib/discover.sh exists and is non-empty =="
+if [ -s "$LIB" ]; then
+  echo "  PASS  lib/discover.sh exists and is non-empty"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  lib/discover.sh missing or empty: $LIB"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== A2: lib/discover.sh defines all four functions =="
+# Match either `funcname() {` (with optional whitespace) or `function funcname`.
+# We accept both POSIX-style and bash `function` keyword styles.
+for fn in discover_bare_fast_path discover_multi pr_view_projection emit_gate_fail; do
+  assert_grep "$LIB" \
+    "^${fn}[[:space:]]*\([[:space:]]*\)[[:space:]]*\{|^function[[:space:]]+${fn}([[:space:]]|\(|\{|$)" \
+    "A2: function ${fn} defined"
+done
+
+echo
+echo "== A3: lib/discover.sh uses --jq '<filter>' at >= 3 sites (real call sites only, no comments) =="
+# `gh ... --jq '<filter>'` is the canonical in-process filter shape. Real
+# implementation uses multi-line `gh \\` continuation so we fold continuations
+# AND strip comments before counting — closes the prose-only false-pass risk
+# flagged in code review (S5).
+LIB_NORMALISED="$(grep -v '^[[:space:]]*#' "$LIB" | awk 'BEGIN{RS=""} {gsub(/\\\n[[:space:]]*/," "); print}')"
+JQ_HITS=$(printf '%s\n' "$LIB_NORMALISED" | grep -cE "[-][-]jq '" || echo 0)
+JQ_HITS="${JQ_HITS//[^0-9]/}"
+if [ "$JQ_HITS" -ge 3 ]; then
+  echo "  PASS  A3: --jq '<filter>' appears in >= 3 real call sites (found $JQ_HITS)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  A3: --jq '<filter>' appears only $JQ_HITS times (expected >= 3, one per discovery fn)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== A4: lib/discover.sh does NOT contain bug shapes (continuations folded, comments stripped) =="
+# We pre-process to (a) strip comment-only lines (file docs what it avoids)
+# and (b) fold backslash-continuations into single logical lines (real impl
+# splits gh calls across 7+ lines). This catches bug-shapes that span
+# continuations — the false-negative class flagged in code review (S4).
+COUNT=$(printf '%s\n' "$LIB_NORMALISED" | grep -cE "gh[[:space:]]([^|]*[[:space:]])?2>&1" || echo 0)
+COUNT="${COUNT//[^0-9]/}"
+if [ "$COUNT" -eq 0 ]; then
+  echo "  PASS  A4a: no 'gh ... 2>&1' (stderr-merged) shape — closes R1 spinner-leak class"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  A4a: found $COUNT 'gh ... 2>&1' bug-shape occurrence(s)"
+  FAIL=$((FAIL + 1))
+fi
+COUNT=$(printf '%s\n' "$LIB_NORMALISED" | grep -cE "gh[[:space:]]([^|]*[[:space:]])?\| *jq([^.A-Za-z]|$)" || echo 0)
+COUNT="${COUNT//[^0-9]/}"
+if [ "$COUNT" -eq 0 ]; then
+  echo "  PASS  A4b: no 'gh ... | jq …' (piped-jq) shape — closes R2 retired pattern"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  A4b: found $COUNT 'gh ... | jq' bug-shape occurrence(s)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== A4c: SKILL.md sources lib via \${CLAUDE_PLUGIN_ROOT} (not BASH_SOURCE) — closes B1 blocker =="
+# B1 (code-review blocker): SKILL.md bash blocks run in Claude's eval context
+# where BASH_SOURCE is empty and \$0 is /bin/bash. The canonical path resolution
+# is \${CLAUDE_PLUGIN_ROOT} which Claude Code injects at skill-evaluation time.
+# This regression-locks the fix.
+assert_no_grep "$SKILL" 'BASH_SOURCE\[0\]:-\$0' \
+  "A4c: SKILL.md does NOT use BASH_SOURCE/\$0 (broken in Claude eval context)"
+assert_count_at_least "$SKILL" 'CLAUDE_PLUGIN_ROOT.*skills/merge/lib/discover\.sh' 3 \
+  "A4d: SKILL.md sources lib via \${CLAUDE_PLUGIN_ROOT} at all 3 hot spots"
+
+echo
+echo "== A5: lib/discover.sh uses mktemp + trap RETURN cleanup =="
+assert_grep "$LIB" 'mktemp' \
+  "A5a: mktemp present (stderr capture file)"
+assert_grep "$LIB" 'trap[[:space:]]+.*RETURN' \
+  "A5b: trap ... RETURN present (function-scoped cleanup)"
+
+echo
+echo "== A6: lib/discover.sh uses configurable audit-log path =="
+# Exact env-var fallback shape; locks the contract end-to-end so tests
+# that override UBERDEV_AUDIT_LOG_PATH actually take effect.
+assert_grep "$LIB" 'UBERDEV_AUDIT_LOG_PATH:-\.uberdev/audit\.jsonl' \
+  "A6: \${UBERDEV_AUDIT_LOG_PATH:-.uberdev/audit.jsonl} fallback present"
+
+echo
+echo "== A7: SKILL.md sources lib/discover.sh from each call site =="
+# One source line per discovery step (1.0.5, 1.2.5, 1.4). The skill must
+# `source ... lib/discover.sh` (or `. lib/discover.sh`) at >= 3 places.
+assert_count_at_least "$SKILL" 'source[^\n]*lib/discover\.sh|\. *[^\n]*lib/discover\.sh' 3 \
+  "A7: SKILL.md sources lib/discover.sh in >= 3 places"
+
+echo
+echo "== A8: SKILL.md no longer contains raw bug shapes =="
+assert_no_grep "$SKILL" 'gh pr list[^|]*\| *jq' \
+  "A8a: SKILL.md no inline 'gh pr list ... | jq ...' (R2 retired shape)"
+assert_no_grep "$SKILL" 'gh pr view[^|]*\| *jq' \
+  "A8b: SKILL.md no inline 'gh pr view ... | jq ...' (R2 retired shape)"
+
+echo
+echo "== A9: SKILL.md ## Constants block declares new audit/gate-fail names =="
+# Both names must appear *somewhere* in the file (the constants block lists
+# enum members inline). We anchor on the literal token; the implementing
+# agent writes them into the AUDIT_EVENT_ENUM and GATE_FAIL_REASON_ENUM rows.
+assert_grep "$SKILL" 'discovery_gh_failed' \
+  "A9a: SKILL.md mentions new audit event 'discovery_gh_failed'"
+assert_grep "$SKILL" 'pr_view_unreachable' \
+  "A9b: SKILL.md mentions new gate_fail reason 'pr_view_unreachable'"
+
+echo
+echo "== A10: solve-pipeline canary preserved (21ad417 fix intact) =="
+# This is the original mktemp-stderr-capture pattern; the merge fix is the
+# same pattern applied to a different skill. If this assertion fails, the
+# upstream fix has been undone and the new merge fix is also at risk.
+assert_grep "$SOLVE_PIPELINE" 'GH_ERR=\$\(mktemp\)' \
+  "A10: solve-pipeline Step 4 still has GH_ERR=\$(mktemp) (21ad417 fix intact)"
+
+echo
+echo "== A11: version bumped to 0.19.3 in three file-based locations =="
+assert_grep "$PLUGIN_JSON" '"version":[[:space:]]*"0\.19\.3"' \
+  "A11a: plugin.json version is 0.19.3"
+assert_grep "$MARKETPLACE_JSON" '"version":[[:space:]]*"0\.19\.3"' \
+  "A11b: marketplace.json version is 0.19.3"
+assert_grep "$README" 'version-0\.19\.3-blue' \
+  "A11c: README.md badge version is 0.19.3"
+
+# --- Layer B — Functional fake-gh tests ------------------------------------
+
+echo
+echo "== B1: discover_bare_fast_path happy path =="
+# Fake gh emits "2" on stdout (length-of-array via the in-process --jq
+# 'length' filter). Function should pass that through, exit 0, and write
+# nothing to the audit log.
+B1_AUDIT="$(mktemp)"
+rm -f "$B1_AUDIT"
+_run_lib_call "success-bare" \
+  'discover_bare_fast_path feat/my-branch' \
+  "export UBERDEV_AUDIT_LOG_PATH='$B1_AUDIT'"
+assert_eq "$_LB_STDOUT" "2" "B1a: stdout is the integer count '2'"
+assert_eq "$_LB_EXIT" "0" "B1b: exit code is 0 on success"
+if [ ! -s "$B1_AUDIT" ]; then
+  echo "  PASS  B1c: no audit event written on happy path"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  B1c: audit log unexpectedly non-empty: $(cat "$B1_AUDIT" 2>/dev/null)"
+  FAIL=$((FAIL + 1))
+fi
+rm -f "$B1_AUDIT"
+
+echo
+echo "== B2: discover_bare_fast_path gh-failure path =="
+# Fake gh exits 1 with stderr "network unreachable". Function must:
+#   - return exit 1
+#   - emit 'warning: bare-mode discovery failed' to stderr
+#   - append a discovery_gh_failed audit event with step=1.0.5,
+#     exit_code=1, reason=gh_failed, gh_stderr containing the original
+#     "network unreachable" diagnostic.
+B2_AUDIT="$(mktemp)"
+rm -f "$B2_AUDIT"
+_run_lib_call "fail-net" \
+  'discover_bare_fast_path feat/my-branch' \
+  "export UBERDEV_AUDIT_LOG_PATH='$B2_AUDIT'"
+assert_eq "$_LB_EXIT" "1" "B2a: exit code is 1 on gh failure"
+case "$_LB_STDERR" in
+  *"warning: bare-mode discovery failed"*)
+    echo "  PASS  B2b: stderr contains 'warning: bare-mode discovery failed'"
+    PASS=$((PASS + 1))
+    ;;
+  *)
+    echo "  FAIL  B2b: stderr missing 'warning: bare-mode discovery failed'"
+    echo "        actual stderr: $_LB_STDERR"
+    FAIL=$((FAIL + 1))
+    ;;
+esac
+if [ -s "$B2_AUDIT" ]; then
+  assert_grep "$B2_AUDIT" '"event":"discovery_gh_failed"' \
+    "B2c: audit log contains discovery_gh_failed event"
+  assert_grep "$B2_AUDIT" '"step":"1\.0\.5"' \
+    "B2d: audit event has step=1.0.5"
+  assert_grep "$B2_AUDIT" '"reason":"gh_failed"' \
+    "B2e: audit event has reason=gh_failed"
+  assert_grep "$B2_AUDIT" '"exit_code":1' \
+    "B2f: audit event has exit_code=1"
+  assert_grep "$B2_AUDIT" 'network unreachable' \
+    "B2g: audit event gh_stderr contains 'network unreachable'"
+else
+  echo "  FAIL  B2c-g: audit log was not written (file empty: $B2_AUDIT)"
+  FAIL=$((FAIL + 5))
+fi
+rm -f "$B2_AUDIT"
+
+echo
+echo "== B3: discover_multi spinner-pollution defense (R1) =="
+# Headline anti-regression: fake gh emits valid JSON on stdout AND ANSI
+# cursor escapes on stderr. With the OLD `gh ... 2>&1 | jq …` shape, the
+# escapes would have crashed jq. With the NEW `gh --jq '<filter>'` shape,
+# stderr cannot reach the function's stdout — the call must succeed.
+B3_AUDIT="$(mktemp)"
+rm -f "$B3_AUDIT"
+_run_lib_call "spinner-leak" \
+  'discover_multi main' \
+  "export UBERDEV_AUDIT_LOG_PATH='$B3_AUDIT'"
+assert_eq "$_LB_EXIT" "0" "B3a: exit code 0 despite spinner-leaking gh stderr"
+case "$_LB_STDOUT" in
+  *'"number":'*'101'*)
+    echo "  PASS  B3b: stdout is valid JSON array (parseable by downstream code)"
+    PASS=$((PASS + 1))
+    ;;
+  *)
+    echo "  FAIL  B3b: stdout did not contain expected JSON content"
+    echo "        actual stdout: $_LB_STDOUT"
+    FAIL=$((FAIL + 1))
+    ;;
+esac
+# stdout must NOT contain ANSI escape sequences. The OLD shape merged
+# stderr into stdout via 2>&1; the NEW shape must keep them separate.
+case "$_LB_STDOUT" in
+  *$'\x1b'*)
+    echo "  FAIL  B3c: stdout was contaminated with ANSI escapes (R1 regression)"
+    FAIL=$((FAIL + 1))
+    ;;
+  *)
+    echo "  PASS  B3c: stdout is clean of ANSI escape sequences"
+    PASS=$((PASS + 1))
+    ;;
+esac
+if [ ! -s "$B3_AUDIT" ]; then
+  echo "  PASS  B3d: no audit event on happy spinner-leak path"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  B3d: audit log unexpectedly non-empty: $(cat "$B3_AUDIT" 2>/dev/null)"
+  FAIL=$((FAIL + 1))
+fi
+rm -f "$B3_AUDIT"
+
+echo
+echo "== B4: discover_multi gh/jq-failure path =="
+# Note: gh's internal --jq filter exits non-zero when the upstream JSON is
+# malformed. The fake-gh `fail-malformed` mode simulates that exact shape
+# (exit 1, malformed JSON on stdout, parser error on stderr). The lib
+# treats this as a discovery failure and:
+#   - returns '[]' on stdout (so callers get an empty candidate set
+#     rather than an aborted run — discovery is best-effort)
+#   - returns exit 0 (the contract says discover_multi never aborts the
+#     run; the failure is recorded in the audit log instead)
+#   - appends a discovery_gh_failed audit event with step=1.2.5
+#     and reason=jq_failed (or reason=gh_failed if the lib chooses to
+#     report based on gh's exit code rather than the filter outcome —
+#     both are acceptable; we accept either).
+B4_AUDIT="$(mktemp)"
+rm -f "$B4_AUDIT"
+_run_lib_call "fail-malformed" \
+  'discover_multi main' \
+  "export UBERDEV_AUDIT_LOG_PATH='$B4_AUDIT'"
+assert_eq "$_LB_STDOUT" "[]" "B4a: stdout is '[]' on jq/gh failure (best-effort discovery)"
+assert_eq "$_LB_EXIT" "0" "B4b: exit code 0 (failure recorded in audit, run continues)"
+case "$_LB_STDERR" in
+  *"warning: multi-discover failed"*)
+    echo "  PASS  B4c: stderr contains 'warning: multi-discover failed'"
+    PASS=$((PASS + 1))
+    ;;
+  *)
+    echo "  FAIL  B4c: stderr missing 'warning: multi-discover failed'"
+    echo "        actual stderr: $_LB_STDERR"
+    FAIL=$((FAIL + 1))
+    ;;
+esac
+if [ -s "$B4_AUDIT" ]; then
+  assert_grep "$B4_AUDIT" '"event":"discovery_gh_failed"' \
+    "B4d: audit log contains discovery_gh_failed event"
+  assert_grep "$B4_AUDIT" '"step":"1\.2\.5"' \
+    "B4e: audit event has step=1.2.5"
+  # Accept either reason — see comment above. The lib's choice depends on
+  # how it distinguishes a non-zero gh exit from a filter failure.
+  assert_grep "$B4_AUDIT" '"reason":"(jq_failed|gh_failed)"' \
+    "B4f: audit event reason is jq_failed or gh_failed"
+else
+  echo "  FAIL  B4d-f: audit log was not written (file empty: $B4_AUDIT)"
+  FAIL=$((FAIL + 3))
+fi
+rm -f "$B4_AUDIT"
+
+echo
+echo "== B5: pr_view_projection happy path =="
+B5_AUDIT="$(mktemp)"
+rm -f "$B5_AUDIT"
+_run_lib_call "success-pr-view" \
+  'pr_view_projection 42' \
+  "export UBERDEV_AUDIT_LOG_PATH='$B5_AUDIT'"
+assert_eq "$_LB_EXIT" "0" "B5a: exit code 0 on happy path"
+# Verify the 15 fields are all present in stdout (sanity — the fake-gh
+# fixture emits all 15, and the lib's --jq projection should preserve them).
+for field in state isDraft reviewDecision statusCheckRollup headRepository \
+             maintainerCanModify isCrossRepository headRefName headRefOid \
+             baseRefName body commits labels createdAt author; do
+  case "$_LB_STDOUT" in
+    *"\"$field\""*)
+      # one PASS per field → 15 assertions in this block
+      echo "  PASS  B5: stdout contains field '$field'"
+      PASS=$((PASS + 1))
+      ;;
+    *)
+      echo "  FAIL  B5: stdout missing field '$field'"
+      FAIL=$((FAIL + 1))
+      ;;
+  esac
+done
+if [ ! -s "$B5_AUDIT" ]; then
+  echo "  PASS  B5z: no audit event on happy pr_view_projection"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  B5z: audit log unexpectedly non-empty: $(cat "$B5_AUDIT" 2>/dev/null)"
+  FAIL=$((FAIL + 1))
+fi
+rm -f "$B5_AUDIT"
+
+echo
+echo "== B6: pr_view_projection gh-failure path =="
+B6_AUDIT="$(mktemp)"
+rm -f "$B6_AUDIT"
+_run_lib_call "fail-pr-view" \
+  'pr_view_projection 42' \
+  "export UBERDEV_AUDIT_LOG_PATH='$B6_AUDIT'"
+assert_eq "$_LB_EXIT" "1" "B6a: exit code 1 on gh failure"
+case "$_LB_STDERR" in
+  *"warning: pr_view_projection #42 failed"*)
+    echo "  PASS  B6b: stderr contains 'warning: pr_view_projection #42 failed'"
+    PASS=$((PASS + 1))
+    ;;
+  *)
+    echo "  FAIL  B6b: stderr missing 'warning: pr_view_projection #42 failed'"
+    echo "        actual stderr: $_LB_STDERR"
+    FAIL=$((FAIL + 1))
+    ;;
+esac
+if [ -s "$B6_AUDIT" ]; then
+  assert_grep "$B6_AUDIT" '"event":"discovery_gh_failed"' \
+    "B6c: audit log contains discovery_gh_failed event"
+  assert_grep "$B6_AUDIT" '"step":"1\.4"' \
+    "B6d: audit event has step=1.4"
+  assert_grep "$B6_AUDIT" '"pr_number":42' \
+    "B6e: audit event has pr_number=42"
+  assert_grep "$B6_AUDIT" '"exit_code":2' \
+    "B6f: audit event has exit_code=2 (fake-gh fail-pr-view exits 2)"
+else
+  echo "  FAIL  B6c-f: audit log was not written (file empty: $B6_AUDIT)"
+  FAIL=$((FAIL + 4))
+fi
+rm -f "$B6_AUDIT"
+
+echo
+echo "== B7: audit log path is configurable via UBERDEV_AUDIT_LOG_PATH =="
+# Verify the env-var override actually redirects audit lines away from the
+# default `.uberdev/audit.jsonl`. We use a unique-per-pid path under /tmp
+# (no collisions across parallel test runs) and assert it lands there.
+# We also assert the default path is NOT written to. To make that assertion
+# robust we run from a fresh PWD where `.uberdev/audit.jsonl` is guaranteed
+# absent at start.
+B7_SANDBOX="$(mktemp -d)"
+B7_AUDIT="/tmp/test-audit-$$"
+rm -f "$B7_AUDIT"
+# We deliberately use the failure path so an audit line is forced out.
+(
+  cd "$B7_SANDBOX"
+  PATH="$FAKE_GH_DIR:$PATH"
+  export FAKE_GH_MODE="fail-net"
+  export UBERDEV_AUDIT_LOG_PATH="$B7_AUDIT"
+  if [ ! -r "$LIB" ]; then
+    echo "lib/discover.sh missing — Layer B cannot source it" >&2
+    exit 127
+  fi
+  # shellcheck source=/dev/null
+  . "$LIB"
+  discover_bare_fast_path feat/branch >/dev/null 2>&1 || true
+)
+if [ -s "$B7_AUDIT" ]; then
+  echo "  PASS  B7a: audit line landed in UBERDEV_AUDIT_LOG_PATH override"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  B7a: audit line did not land in $B7_AUDIT (override ignored?)"
+  FAIL=$((FAIL + 1))
+fi
+if [ ! -s "$B7_SANDBOX/.uberdev/audit.jsonl" ]; then
+  echo "  PASS  B7b: default .uberdev/audit.jsonl was NOT written when override set"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  B7b: default .uberdev/audit.jsonl was written despite override"
+  echo "        contents: $(cat "$B7_SANDBOX/.uberdev/audit.jsonl" 2>/dev/null)"
+  FAIL=$((FAIL + 1))
+fi
+rm -f "$B7_AUDIT"
+rm -rf "$B7_SANDBOX"
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[[ $FAIL -eq 0 ]]

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -666,17 +666,19 @@ assert_grep "$SKILL_FILE" 'pr_state_not_open'                  "M37.precond1 —
 assert_grep "$SKILL_FILE" 'is_draft'                           "M37.precond2 — pre-condition reason is_draft"
 assert_grep "$SKILL_FILE" 'ci_red'                             "M37.precond3 — pre-condition reason ci_red"
 assert_grep "$SKILL_FILE" 'merge_state_blocked'                "M37.precond4 — pre-condition reason merge_state_blocked"
+assert_grep "$SKILL_FILE" 'pr_view_unreachable'                "M37.infra1 — infrastructure-failure reason pr_view_unreachable (R2 lib-call failure)"
 ENUM_ROW=$(grep -E '\| `GATE_FAIL_REASON_ENUM` \|' "$SKILL_FILE" || true)
 # `[a-z_]+` matches lowercase snake_case reason tokens only (not the
 # UPPERCASE enum-name `GATE_FAIL_REASON_ENUM` itself, and not dotted
 # tokens like `gate_fail.data.reason`), so the count equals exactly
-# the number of reasons backticked in the row: 8 trust-resolution + 4 pre-condition = 12.
+# the number of reasons backticked in the row: 8 trust-resolution + 4
+# pre-condition + 1 infrastructure-failure (R2; v0.19.3) = 13.
 REASON_COUNT=$(echo "$ENUM_ROW" | grep -oE '`[a-z_]+`' | wc -l | tr -d ' ')
-if [ "$REASON_COUNT" -eq 12 ]; then
-  echo "  PASS  M37.count — GATE_FAIL_REASON_ENUM row contains exactly 12 reasons (8 trust-resolution + 4 pre-condition)"
+if [ "$REASON_COUNT" -eq 13 ]; then
+  echo "  PASS  M37.count — GATE_FAIL_REASON_ENUM row contains exactly 13 reasons (8 trust-resolution + 4 pre-condition + 1 infrastructure-failure)"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL  M37.count — GATE_FAIL_REASON_ENUM row contains $REASON_COUNT reasons; expected exactly 12"
+  echo "  FAIL  M37.count — GATE_FAIL_REASON_ENUM row contains $REASON_COUNT reasons; expected exactly 13"
   FAIL=$((FAIL + 1))
 fi
 
@@ -1314,10 +1316,10 @@ if [ -n "$STEP_125_BLOCK" ]; then
 else
   fail "M69.exists — Step 1.2.5 (multi-discover dispatch) section MUST exist between Step 1.2 and Step 1.3 (spec Components § SKILL.md item 4)"
 fi
-if echo "$STEP_125_BLOCK" | grep -qE 'DISCOVERY_FILTER'; then
-  pass "M69.discovery-filter-cited — Step 1.2.5 cites DISCOVERY_FILTER"
+if echo "$STEP_125_BLOCK" | grep -qE 'DISCOVERY_FILTER|discover_multi'; then
+  pass "M69.discovery-filter-cited — Step 1.2.5 cites DISCOVERY_FILTER or discover_multi (R2 canonical alias)"
 else
-  fail "M69.discovery-filter-cited — Step 1.2.5 MUST cite DISCOVERY_FILTER (spec Components § SKILL.md item 4)"
+  fail "M69.discovery-filter-cited — Step 1.2.5 MUST cite DISCOVERY_FILTER or discover_multi (spec Components § SKILL.md item 4; R2 v0.19.3 introduces lib-function alias)"
 fi
 if echo "$STEP_125_BLOCK" | grep -qE '\$integration_branch|integration_branch'; then
   pass "M69.integration-branch-cited — Step 1.2.5 cites \$integration_branch"


### PR DESCRIPTION
## Summary

Root fix (not patch) for the recurring `/merge` jq parse-error:

> `jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 35, column 1`

Same bug class as `solve-pipeline` 21ad417 — gh's spinner emits raw `ESC` (0x1B) to stderr; when stderr leaks into the stdout that pipes into `jq`, `jq` aborts with the message above. Fix shipped here is architectural, not symptomatic:

- **R1 — in-process filter.** All three discovery sites (`/merge` Steps 1.0.5, 1.2.5, 1.4) now use `gh … --jq '<filter>'`. gh runs jq inside its own process on the parsed object before serializing stdout. No external pipe = no FD-pollution surface. The bug class is eliminated for Steps 1.0.5 and 1.2.5 even if a future improv reintroduces `2>&1`.
- **R2 — lib extraction.** Discovery logic moves out of inline-bash-blocks-in-natural-language-SKILL.md into a real, sourceable, testable shell library at `plugins/uberdev/skills/merge/lib/discover.sh`. SKILL.md sources via `${CLAUDE_PLUGIN_ROOT}/skills/merge/lib/discover.sh` (mirroring the file's existing `lib/config-read.sh` precedent — `BASH_SOURCE`/`$0` does NOT resolve in Claude's skill-eval context, caught in code review).

Plus, observable instead of silent:
- New `discovery_gh_failed` audit event (data: `reason`, `step`, `exit_code`, `gh_stderr`, `pr_number?`) emitted when discovery fails. Until now a transient gh failure → empty candidate set → `Merged: 0 / Skipped: 0 / Parked: 0, exit 0` was indistinguishable from "no eligible PRs" — the audit log now distinguishes them.
- New `pr_view_unreachable` gate_fail reason for Step 1.4 lib-call failures.
- JSON-injection defense in audit emit: bare-numeric `printf` substitutions for `exit_code` / `pr_number` are sanitized to integers (defense in depth — current sources are gh-validated, but the contract is bare-numeric and a caller bug must not produce malformed JSON).

## Why root fix, not patch

5-Whys analysis:

1. jq sees control chars → because gh's stderr is in the input
2. gh's stderr is in the input → because the pipeline merges FDs (improv `2>&1` or implicit FD layering)
3. Why does the model add `2>&1` → because SKILL.md gives an example bash block and the model improvises around it
4. Why does the model improvise → because SKILL.md is a natural-language spec, not an executable script
5. Why is the discovery logic in natural-language → architectural choice; bash blocks are illustrative

The patch (mktemp stderr capture) addresses layers 1–2 only. R1+R2 addresses 4–5.

## What changed

| File | Status | Δ |
|------|--------|---|
| `plugins/uberdev/skills/merge/lib/discover.sh` | NEW | +268 |
| `plugins/uberdev/skills/merge/SKILL.md` | modified | +43/-23 |
| `tests/merge-discovery-resilience.test.sh` | NEW | +571 |
| `tests/_fixtures/fake-gh/gh` | NEW | +159 |
| `tests/merge.test.sh` | modified | +9/-7 (M37 13-reasons + M69 alias accept) |
| `plugins/uberdev/.claude-plugin/plugin.json` | version | +1/-1 |
| `.claude-plugin/marketplace.json` | version | +1/-1 |
| `README.md` | version badge | +1/-1 |
| `CHANGELOG.md` | new section | +5/-0 |

Net: 1079 insertions / 24 deletions across 9 files.

Version: 0.19.2 → **0.19.3** (`fix:` per SemVer; six-location bump per CLAUDE.md release rule).

## Test plan

- [x] `bash tests/merge-discovery-resilience.test.sh` — 67 assertions pass (Layer A: 18 source-discipline; Layer B: 49 functional fake-gh including the headline B3 spinner-pollution defense)
- [x] `bash tests/merge.test.sh` — 260 assertions pass (M37 13-reasons + new `pr_view_unreachable` lock; M69 accepts both `DISCOVERY_FILTER` and `discover_multi`)
- [x] All 14 test files pass (`for t in tests/*.test.sh; do bash "$t"; done`)
- [x] Empirical JSON-injection probe: `_uberdev_discover_emit_audit "..." "..." "abc; rm -rf /" "$tmp" '0,"injected":"yes"'` produces valid JSON with `exit_code:-1` and no injected field
- [ ] Live `/merge` invocation post-merge (smoke; no PRs eligible right now so nothing to land)

## Next steps after merge

- `git tag v0.19.3` on the merge commit
- `gh release create v0.19.3 --notes-file <changelog-section>`
- Follow-up issue if desired: extract `lib/discover.sh` pattern to `solve-pipeline` (currently uses inline mktemp from 21ad417 — could be unified with the same lib shape).

Closes the recurring jq-parse-error reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.19.3

* **Bug Fixes**
  * Fixed `/merge` discovery issues affecting PR detection and merge operations
  * Improved resilience when GitHub API calls fail, with better error handling and logging
  * Enhanced robustness of PR view operations against infrastructure failures
  * Improved audit logging with better error tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->