### PR TITLE
fix(solve): probe gtimeout fallback so /solve wall-clock kill engages on macOS (v0.21.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve spawns autonomous agents in cmux/Ghostty/iTerm; /issue creates well-investigated, deduped issues.",
-      "version": "0.21.5",
+      "version": "0.21.6",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "cmux", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.6] - 2026-05-12
+
+### Fixed
+- **`/solve` wall-clock kill never engaged on macOS.** `plugins/uberdev/skills/solve-pipeline/SKILL.md` Step 5b's heredoc-template launcher probed `command -v timeout` only — but macOS does **not** ship GNU `timeout(1)`. The only supported install path (`brew install coreutils`) places the binary at `gtimeout` (Homebrew's `g`-prefix avoids masking BSD utilities), so the wrap branch was dead code for the entire macOS audience: stock boxes hit the fail-open warning, and `brew install coreutils` did nothing to fix it. The user-facing symptom was `warning: timeout(1) not on PATH; /solve will run unwrapped (no wall-clock kill)` firing on every `/solve` and `/turbo` launch, with `command_timeouts.solve` (default 3600s) silently unenforced. /turbo, which runs unattended, was the most exposed: a stuck Opus-4.7 1M-context agent could burn tokens until the user manually noticed.
+  - **Fix.** The launcher template now probes `timeout` then `gtimeout` and binds the resolved path to `TIMEOUT_BIN`; the wrap branch becomes `"$TIMEOUT_BIN" "${SOLVE_TIMEOUT}" CLAUDE_BIN …`. The quoted-`"$TIMEOUT_BIN"` form keeps it as a single `argv[0]` token under zsh `SH_WORD_SPLIT=off` (mirrors the inline-`timeout` zsh-safety precedent from #63/#72). Comment block updated to call out the `gtimeout` rationale explicitly.
+  - **Misleading prose corrected.** The Step 5b narration previously called the missing-timeout case "rare on bare macOS without coreutils". It was actually the **default** behaviour on every macOS box (with or without coreutils). Rewritten to state that macOS does not ship GNU `timeout(1)`, that `brew install coreutils` installs it as `gtimeout`, and that fail-open fires only when **neither** binary is on PATH.
+  - **Remediation pointer in the warning.** The fail-open stderr line previously read `warning: timeout(1) not on PATH; /solve will run unwrapped (no wall-clock kill)` — mystery, not action. Now: `warning: neither timeout(1) nor gtimeout on PATH; /solve will run unwrapped (no wall-clock kill). Fix: brew install coreutils`.
+  - **Sibling doc synced.** `plugins/uberdev/skills/using-uberdev/SKILL.md` "Enforcement scope" paragraph (lines 193-196) now mentions the `gtimeout` fallback so the user-facing config reference matches the launcher behaviour.
+  - **Tests.** `tests/config-override.test.sh` I2 block extended: I2c now asserts `command -v gtimeout` appears in the SKILL.md heredoc, I2d asserts the new `"$TIMEOUT_BIN" "${SOLVE_TIMEOUT}" CLAUDE_BIN` wrap form (replaces the old I2c `timeout "${SOLVE_TIMEOUT}" CLAUDE_BIN` literal regex which no longer matches), I2e asserts the warning contains the `brew install coreutils` remediation pointer. Pre-fix run: I2c/I2d/I2e fail. Post-fix run: all five I2 assertions pass; full suite remains green (77/77 config-override, 1080/1080 across 18 test scripts).
+  - **Backward compatibility.** Linux and any macOS box with `timeout` shimmed onto PATH (e.g. via `brew install coreutils --with-default-names` on Intel, or manual symlink) continue down the original probe-and-wrap branch unchanged — `command -v timeout` still matches first.
+
 ## [0.21.5] - 2026-05-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.21.5-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.21.6-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution, brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -351,15 +351,19 @@ The launcher `cd`s to repo root, cleans stale worktree, logs errors, keeps termi
 **Wall-clock timeout.** The launcher reads
 `command_timeouts.solve` from `.claude/uberdev.local.md` (env override:
 `UBERDEV_SOLVE_TIMEOUT`; default 3600s; range [60, 86400]) and wraps the
-`claude` invocation in `timeout(1)` when the binary is on PATH. If
-`timeout(1)` is unavailable (rare on bare macOS without coreutils) the
-launcher emits one stderr warning and runs unwrapped — fail-open per
-the `aliases-sync.sh:14-23` jq-absent precedent. `/merge` and
-`/review-pr` parse `command_timeouts.{merge, review_pr}` but only
-surface the values in the run audit log; v1 does NOT enforce wall-clock
-kill on those commands (the orchestrator turn loop runs inside an
-existing Claude session and would need deeper changes to honour a
-kill). v2 issue can extend.
+`claude` invocation in `timeout(1)` when the binary is on PATH. macOS
+does **not** ship GNU `timeout(1)`; `brew install coreutils` installs
+it as `gtimeout` (Homebrew's `g`-prefix avoids masking BSD utilities),
+so the launcher probes `timeout` first and falls back to `gtimeout`. If
+neither is on PATH (stock macOS without coreutils) the launcher emits
+one stderr warning (with a `brew install coreutils` remediation
+pointer) and runs unwrapped — fail-open per the `aliases-sync.sh:14-23`
+jq-absent precedent. `/merge` and `/review-pr` parse
+`command_timeouts.{merge, review_pr}` but only surface the values in
+the run audit log; v1 does NOT enforce wall-clock kill on those
+commands (the orchestrator turn loop runs inside an existing Claude
+session and would need deeper changes to honour a kill). v2 issue can
+extend.
 
 ```bash
 cat > /tmp/solve-$ISSUE_NUM.sh << 'SCRIPT_EOF'
@@ -406,15 +410,21 @@ else
   SOLVE_TIMEOUT=3600
 fi
 
-# Wrap claude in timeout(1) when the binary is on PATH; fail-open otherwise
-# (graceful degradation when required tooling is unavailable). The if/else form
-# is mandatory: zsh's default SH_WORD_SPLIT=off would treat a scalar
-# `$PREFIX="timeout 3600"` at command position as ONE token and abort with
-# "command not found: timeout 3600" under set -e.
-if command -v timeout >/dev/null 2>&1; then
-  timeout "${SOLVE_TIMEOUT}" CLAUDE_BIN --model 'claude-opus-4-7[1m]' --effort max --worktree solve-issue-ISSUE_NUM $PERM_FLAG "$PROMPT"
+# Wrap claude in timeout(1)/gtimeout when one is on PATH; fail-open otherwise
+# (graceful degradation when required tooling is unavailable). macOS does NOT
+# ship GNU timeout; `brew install coreutils` installs it as `gtimeout` (Homebrew
+# `g`-prefix), so we probe both. The if/elif/else form is mandatory: zsh's
+# default SH_WORD_SPLIT=off would treat a scalar `$PREFIX="timeout 3600"` at
+# command position as ONE token and abort with "command not found: timeout 3600"
+# under set -e. Quoting "$TIMEOUT_BIN" keeps it as a single argv[0] token.
+TIMEOUT_BIN=""
+if   command -v timeout  >/dev/null 2>&1; then TIMEOUT_BIN=timeout
+elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN=gtimeout
+fi
+if [[ -n "$TIMEOUT_BIN" ]]; then
+  "$TIMEOUT_BIN" "${SOLVE_TIMEOUT}" CLAUDE_BIN --model 'claude-opus-4-7[1m]' --effort max --worktree solve-issue-ISSUE_NUM $PERM_FLAG "$PROMPT"
 else
-  echo "warning: timeout(1) not on PATH; /solve will run unwrapped (no wall-clock kill)" >&2
+  echo "warning: neither timeout(1) nor gtimeout on PATH; /solve will run unwrapped (no wall-clock kill). Fix: brew install coreutils" >&2
   CLAUDE_BIN --model 'claude-opus-4-7[1m]' --effort max --worktree solve-issue-ISSUE_NUM $PERM_FLAG "$PROMPT"
 fi
 SCRIPT_EOF

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -357,7 +357,7 @@ it as `gtimeout` (Homebrew's `g`-prefix avoids masking BSD utilities),
 so the launcher probes `timeout` first and falls back to `gtimeout`. If
 neither is on PATH (stock macOS without coreutils) the launcher emits
 one stderr warning (with a `brew install coreutils` remediation
-pointer) and runs unwrapped — fail-open per the `aliases-sync.sh:14-23`
+pointer) and runs unwrapped — fail-open per the `aliases-sync.sh:105`
 jq-absent precedent. `/merge` and `/review-pr` parse
 `command_timeouts.{merge, review_pr}` but only surface the values in
 the run audit log; v1 does NOT enforce wall-clock kill on those

--- a/plugins/uberdev/skills/using-uberdev/SKILL.md
+++ b/plugins/uberdev/skills/using-uberdev/SKILL.md
@@ -191,8 +191,10 @@ change; matches the `merge_strategy` chunking precedent).
 **`command_timeouts.{solve, review_pr, merge}`:** per-command
 wall-clock timeout in seconds, range `[60, 86400]` (1m–24h).
 **Enforcement scope:** only `command_timeouts.solve` is enforced — the
-`/solve` launcher wraps the `claude` invocation in `timeout(1)` (and
-fails-open with one stderr warning if `timeout(1)` is not on PATH).
+`/solve` launcher wraps the `claude` invocation in `timeout(1)` (probing
+`gtimeout` as a fallback, since `brew install coreutils` on macOS
+installs the GNU binary under that name; fails-open with one stderr
+warning if neither is on PATH).
 `command_timeouts.{merge, review_pr}` are **ADVISORY-ONLY in v1**:
 they are parsed and recorded in the audit log under
 `uberdev_config_read` but NOT enforced as wall-clock kills, because

--- a/plugins/uberdev/skills/using-uberdev/SKILL.md
+++ b/plugins/uberdev/skills/using-uberdev/SKILL.md
@@ -148,7 +148,7 @@ fanout_concurrency:
 # --- per-command wall-clock timeouts ---
 # dot-path refs: command_timeouts.solve, command_timeouts.review_pr, command_timeouts.merge
 command_timeouts:
-  solve: 3600                    # int seconds [60, 86400]; ENFORCED via /solve launcher timeout(1) wrap; default 3600 (1h); env: UBERDEV_SOLVE_TIMEOUT
+  solve: 3600                    # int seconds [60, 86400]; ENFORCED via /solve launcher timeout(1)/gtimeout wrap; default 3600 (1h); env: UBERDEV_SOLVE_TIMEOUT
   review_pr: 900                 # int seconds [60, 86400]; ADVISORY-ONLY in v1 (parsed + audit-logged; no kill); default 900 (15m); env: UBERDEV_REVIEW_PR_TIMEOUT
   merge: 600                     # int seconds [60, 86400]; ADVISORY-ONLY in v1 (parsed + audit-logged; no kill); default 600 (10m); env: UBERDEV_MERGE_TIMEOUT
 ---

--- a/tests/config-override.test.sh
+++ b/tests/config-override.test.sh
@@ -362,8 +362,14 @@ assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
   'command -v timeout' \
   "I2b: launcher checks timeout(1) availability"
 assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
-  'timeout "\$\{SOLVE_TIMEOUT\}" CLAUDE_BIN' \
-  "I2c: launcher inlines timeout(1) call directly (zsh-safe; no scalar prefix)"
+  'command -v gtimeout' \
+  "I2c: launcher probes gtimeout fallback (Homebrew coreutils installs the macOS binary as gtimeout, not timeout)"
+assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
+  '"\$TIMEOUT_BIN" "\$\{SOLVE_TIMEOUT\}" CLAUDE_BIN' \
+  "I2d: launcher inlines resolved-binary wrap call (zsh-safe; no scalar prefix)"
+assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
+  'brew install coreutils' \
+  "I2e: missing-timeout warning includes remediation pointer"
 
 echo
 echo "== I3: orchestrator research fanout cap (Task 3) =="

--- a/tests/config-override.test.sh
+++ b/tests/config-override.test.sh
@@ -370,6 +370,9 @@ assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
 assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
   'brew install coreutils' \
   "I2e: missing-timeout warning includes remediation pointer"
+assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
+  'if \[\[ -n "\$TIMEOUT_BIN" \]\]; then' \
+  "I2f: launcher guards wrap branch with -n TIMEOUT_BIN check (prevents silent regression on guard inversion/removal)"
 
 echo
 echo "== I3: orchestrator research fanout cap (Task 3) =="


### PR DESCRIPTION
## Summary
- **Bug:** `/solve`'s wall-clock kill (`command_timeouts.solve`, default 3600s) never engaged on macOS. `solve-pipeline/SKILL.md` Step 5b probed `command -v timeout` only; macOS does **not** ship GNU `timeout(1)`, and `brew install coreutils` installs it as `gtimeout` (Homebrew's `g`-prefix). So the wrap branch was dead code for every macOS box — stock or brew-coreutils — and `/solve` always fell through to the fail-open warning. `/turbo` (unattended) was the most exposed: a stuck Opus-4.7 1M agent could burn tokens until the user manually noticed.
- **Fix:** Probe `timeout` then `gtimeout`, bind the resolved path to `TIMEOUT_BIN`, wrap as `"$TIMEOUT_BIN" "${SOLVE_TIMEOUT}" CLAUDE_BIN …` (quoted form keeps it as a single `argv[0]` token under zsh `SH_WORD_SPLIT=off` — mirrors the inline-`timeout` zsh-safety precedent from #63/#72). Corrects the misleading "rare on bare macOS without coreutils" prose (it was the default, not rare), adds a `brew install coreutils` remediation pointer to the warning, and syncs the `using-uberdev` Enforcement-scope paragraph.
- **Patch bump:** `0.21.5` → `0.21.6` synced across plugin.json, marketplace.json, README badge, CHANGELOG.

## Test plan
- [x] `tests/config-override.test.sh` I2 block extended: I2c (`command -v gtimeout`), I2d (new `"$TIMEOUT_BIN" "${SOLVE_TIMEOUT}" CLAUDE_BIN` wrap form replacing the old `timeout "${SOLVE_TIMEOUT}" CLAUDE_BIN` literal), I2e (`brew install coreutils` remediation pointer)
- [x] Pre-fix: I2c/I2d/I2e fail. Post-fix: all 5 I2 assertions pass
- [x] Full suite green: 77/77 config-override, 1080/1080 across 18 test scripts
- [x] Manual: `command -v timeout` returns nothing on this macOS box (Darwin 25.4.0, arm64); the new probe will fall through to gtimeout once coreutils is installed, or to the warning otherwise

## Backward compatibility
Linux and any macOS box with `timeout` symlinked onto PATH (e.g. brew coreutils Intel `--with-default-names`, or manual symlink) continue down the original probe-and-wrap branch unchanged — `command -v timeout` still matches first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `/solve` timeout enforcement on macOS by supporting both standard and Homebrew-installed timeout variants.
  * Enhanced fallback behavior with clearer guidance when timeout tools are unavailable.

* **Documentation**
  * Updated enforcement scope documentation for improved timeout handling guidance.

* **Tests**
  * Expanded test coverage for timeout tool detection and validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/84)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->