### PR TITLE
docs(orchestrator): add Phase 6 naming for finish-branch -> /review-pr cascade

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents as `claude --bg` background sessions (monitor with `claude agents`); /issue creates well-investigated, deduped issues.",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,4 +48,5 @@ jobs:
           bash tests/solve-effort-flag.test.sh && \
           zsh tests/solve-pipeline-zsh.test.sh && \
           bash tests/orchestrator-phase1-shortcircuit.test.sh && \
-          bash tests/config-override.test.sh
+          bash tests/config-override.test.sh && \
+          bash tests/orchestrator-phase-6-doc.test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.1] - 2026-05-13
+
+### Documentation
+
+- **`plugins/uberdev/skills/orchestrator/SKILL.md`**: Added `### Phase 6: PR creation + review chain` to make the `subagent-driven-dev → finish-branch → /uberdev:review-pr` cascade explicit inside the orchestrator skill. Deleted the misleading `## End-of-pipeline` section that previously read "the orchestrator's job is done" after Phase 5. Phase 6 names the two downstream `/uberdev:review-pr` phases (Phase 1: 6 advisory reviewers via `uberdev:post-impl-review`; Phase 2: 3 simplify lenses) and acknowledges the large-tier `Phase 5.5` ordering. Closes #94.
+
 ## [0.23.0] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.23.0-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.23.1-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via claude --bg background sessions (Agent View), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -284,6 +284,24 @@ Parse the analyzer's YAML return (`gaps[]`, `severity`, `confidence`). Append fi
 
 Why large-only: signal-to-noise on smaller changes is poor; medium tier may revisit after metrics. (Per spec Open question 2.)
 
+### Phase 6: PR creation + review chain
+
+The orchestrator's contract does NOT end at Phase 5 — it extends end-to-end through PR creation and review. Phase 6 is the final phase of every orchestrator run; agents reading this skill must treat the full cascade as the orchestrator's responsibility, not as optional downstream behaviour.
+
+After Phase 5 (`subagent-driven-dev`) returns control:
+
+1. **`uberdev:subagent-driven-dev`** hands off to `uberdev:finish-branch` (forwarding `--turbo` if the orchestrator was invoked with `--turbo`, per Phase 5 above).
+2. **`uberdev:finish-branch`** pushes the branch, creates the PR via `gh pr create`, then invokes `uberdev:review-pr` via the `Skill` tool with the captured PR URL. This is the "always-PR path" — default mode and `--turbo` both auto-select it; only the `--interactive` flag with Options 1/3/4 bypasses the chain.
+3. **`/uberdev:review-pr`** runs its two-phase pipeline:
+   - **Phase 1 — Review + Fix loop** (6 advisory reviewer agents dispatched in a single message via `uberdev:post-impl-review`, then `code-fixer` auto-apply loop on findings).
+   - **Phase 2 — Mandatory Simplify Pass** (3 `uberdev:code-simplifier` lenses — Reuse / Quality / Efficiency — dispatched in a single message, then `code-fixer` auto-apply on findings).
+
+   Findings are advisory at the `finish-branch` boundary — `finish-branch` does NOT block on `REVISIONS_REQUIRED`. `/uberdev:review-pr` writes the trust trail directly to the PR.
+
+**Large-tier note:** On large tier, `Phase 5.5` (`pr-test-analyzer`) runs after `subagent-driven-dev` returns and BEFORE `finish-branch` dispatches PR creation; the analyzer's findings flow into the PR body that `finish-branch` composes for `## Reviewer findings summary`. The small/medium cascade goes Phase 5 → finish-branch directly.
+
+This section names the chain explicitly so that a model reading only the orchestrator skill understands the full end-to-end pipeline. The orchestrator's job is complete when the trust trail from `/uberdev:review-pr` is written; not when Phase 5 returns.
+
 ## Tier profiles (summary)
 
 | Tier | Research fanout | Spec reviewer | Plan reviewer | Plan-writer internal research | Post-impl review | pr-test-analyzer |
@@ -313,10 +331,6 @@ For every phase, write a one-line log to `$RESEARCH_DIR_ABS/orchestrator.log`:
 ```
 
 This is the trail for the issue's "telemetry/measurement" acceptance criterion.
-
-## End-of-pipeline
-
-After Phase 5 completes (subagent-driven-dev returns control), the orchestrator's job is done. The downstream skill handles PR creation per its own flow.
 
 ## Standalone invocation (no /solve or /turbo)
 

--- a/tests/orchestrator-phase-6-doc.test.sh
+++ b/tests/orchestrator-phase-6-doc.test.sh
@@ -39,6 +39,18 @@ assert_ge() {
 
 echo "[orchestrator-phase-6-doc] checking $SKILL"
 
+# Guard: source-of-truth files must exist. Without this, the AC3 negated-grep
+# below (and any future bare-grep tests) would silently treat a missing/unreadable
+# file as "string absent" and mark the assertion PASS. Fail fast instead.
+if [ ! -f "$SKILL" ]; then
+  echo "  FAIL precondition: SKILL file not found at $SKILL"
+  exit 1
+fi
+if [ ! -f "$CHANGELOG" ]; then
+  echo "  FAIL precondition: CHANGELOG not found at $CHANGELOG"
+  exit 1
+fi
+
 # AC1 — new heading present, exact form
 n=$(grep -cE '^### Phase 6: PR creation \+ review chain$' "$SKILL" || true)
 assert_eq "AC1 Phase 6 heading present"          "1" "$n"
@@ -65,9 +77,14 @@ order=$(awk '
 ' "$SKILL")
 assert_eq "AC4 Phase 5.5 -> Phase 6 -> Logging order" "ok" "$order"
 
-# AC5 — Phase 6 prose names the canonical skill ids
-n=$(grep -cE 'uberdev:subagent-driven-dev|uberdev:finish-branch|uberdev:review-pr' "$SKILL" || true)
-assert_ge "AC5 canonical skill ids appear >= 3 times" 3 "$n"
+# AC5 — Phase 6 prose names the canonical skill ids.
+# Scope the search to the Phase 6 section body (### Phase 6: ... up to the next
+# `## ` heading) so the assertion regresses if Phase 6 is deleted but ids remain
+# in earlier phases. Count individual matches (grep -o) rather than matching
+# lines (grep -c), so multi-mention lines aren't under-counted.
+phase6_body=$(awk '/^### Phase 6:/{f=1} f; /^## /{if(f && !/^### Phase 6:/) exit}' "$SKILL")
+n=$(printf '%s\n' "$phase6_body" | grep -oE 'uberdev:subagent-driven-dev|uberdev:finish-branch|uberdev:review-pr' | wc -l | tr -d ' ')
+assert_ge "AC5 canonical skill ids appear >= 3 times in Phase 6" 3 "$n"
 
 # AC6 — reviewer-count signals
 six=$(grep -cE '6 advisory reviewer agents' "$SKILL" || true)

--- a/tests/orchestrator-phase-6-doc.test.sh
+++ b/tests/orchestrator-phase-6-doc.test.sh
@@ -77,28 +77,38 @@ order=$(awk '
 ' "$SKILL")
 assert_eq "AC4 Phase 5.5 -> Phase 6 -> Logging order" "ok" "$order"
 
-# AC5 — Phase 6 prose names the canonical skill ids.
-# Scope the search to the Phase 6 section body (### Phase 6: ... up to the next
-# `## ` heading) so the assertion regresses if Phase 6 is deleted but ids remain
-# in earlier phases. Count individual matches (grep -o) rather than matching
-# lines (grep -c), so multi-mention lines aren't under-counted.
-phase6_body=$(awk '/^### Phase 6:/{f=1} f; /^## /{if(f && !/^### Phase 6:/) exit}' "$SKILL")
-n=$(printf '%s\n' "$phase6_body" | grep -oE 'uberdev:subagent-driven-dev|uberdev:finish-branch|uberdev:review-pr' | wc -l | tr -d ' ')
+# Extract the Phase 6 section body (### Phase 6: ... up to the next `## ` heading)
+# once so AC5/AC6/AC7 can all scope their searches to it. Scoping is what makes
+# these assertions regress when Phase 6 itself is deleted; otherwise bare-grep
+# matches in other phases would mask the regression.
+phase6_body=$(awk '/^### Phase 6:/{f=1; next} /^## /{f=0} f' "$SKILL")
+
+# AC5 — Phase 6 prose names the canonical skill ids. Count individual matches
+# (grep -o) rather than matching lines (grep -c), so multi-mention lines aren't
+# under-counted. The brace-grouped `|| true` keeps a zero-match grep from
+# aborting the script under `set -euo pipefail` (pipefail would otherwise
+# propagate grep's exit-1 through the command substitution).
+n=$(printf '%s\n' "$phase6_body" | { grep -oE 'uberdev:subagent-driven-dev|uberdev:finish-branch|uberdev:review-pr' || true; } | wc -l | tr -d ' ')
 assert_ge "AC5 canonical skill ids appear >= 3 times in Phase 6" 3 "$n"
 
-# AC6 — reviewer-count signals
-six=$(grep -cE '6 advisory reviewer agents' "$SKILL" || true)
-three=$(grep -cE '3 .*code-simplifier.*lenses' "$SKILL" || true)
+# AC6 — reviewer-count signals (scoped to Phase 6 body, see AC5 comment)
+six=$(printf '%s\n' "$phase6_body" | grep -cE '6 advisory reviewer agents' || true)
+three=$(printf '%s\n' "$phase6_body" | grep -cE '3 .*code-simplifier.*lenses' || true)
 assert_ge "AC6a 6 advisory reviewer agents mentioned"  1 "$six"
 assert_ge "AC6b 3 simplify lenses mentioned"           1 "$three"
 
-# AC7 — large-tier Phase 5.5 ordering acknowledged in Phase 6 prose
-n=$(grep -ciE 'Phase 5\.5.*pr-test-analyzer.*before' "$SKILL" || true)
+# AC7 — large-tier Phase 5.5 ordering acknowledged in Phase 6 prose (scoped;
+# the same phrasing exists in the Phase 5.5 section so an unscoped grep would
+# false-pass even after Phase 6 was deleted).
+n=$(printf '%s\n' "$phase6_body" | grep -ciE 'Phase 5\.5.*pr-test-analyzer.*before' || true)
 assert_ge "AC7 Phase 5.5 ordering note present"        1 "$n"
 
-# AC8 — CHANGELOG entry naming the issue
-n=$(grep -cF 'Closes #94' "$CHANGELOG" || true)
-assert_ge "AC8 CHANGELOG references #94"               1 "$n"
+# AC8 — CHANGELOG entry naming the issue. Scope to the `## [0.23.1]` block via
+# the same awk pattern so an old "Closes #94" in an unrelated future release
+# doesn't mask deletion of the 0.23.1 entry.
+v0231_body=$(awk '/^## \[0\.23\.1\]/{f=1; next} /^## /{f=0} f' "$CHANGELOG")
+n=$(printf '%s\n' "$v0231_body" | grep -cF 'Closes #94' || true)
+assert_ge "AC8 CHANGELOG references #94 in 0.23.1"     1 "$n"
 
 echo ""
 echo "[orchestrator-phase-6-doc] PASS=$PASS FAIL=$FAIL"

--- a/tests/orchestrator-phase-6-doc.test.sh
+++ b/tests/orchestrator-phase-6-doc.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# tests/orchestrator-phase-6-doc.test.sh
+#
+# Validates the orchestrator/SKILL.md Phase 6 cascade doc (issue #94, PR-time fix).
+# Mirrors the anchored-grep style of tests/dispatch-claude-bg.test.sh.
+#
+# Each assertion echoes pass/fail and increments PASS / FAIL counters.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL="$ROOT/plugins/uberdev/skills/orchestrator/SKILL.md"
+CHANGELOG="$ROOT/CHANGELOG.md"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  ok   $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL $name (expected=$expected actual=$actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_ge() {
+  local name="$1" min="$2" actual="$3"
+  if (( actual >= min )); then
+    echo "  ok   $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL $name (expected>=$min actual=$actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "[orchestrator-phase-6-doc] checking $SKILL"
+
+# AC1 — new heading present, exact form
+n=$(grep -cE '^### Phase 6: PR creation \+ review chain$' "$SKILL" || true)
+assert_eq "AC1 Phase 6 heading present"          "1" "$n"
+
+# AC2 — deleted heading is gone
+n=$(grep -cE '^## End-of-pipeline' "$SKILL" || true)
+assert_eq "AC2 ## End-of-pipeline removed"       "0" "$n"
+
+# AC3 — deleted prose is gone
+if grep -qF "the orchestrator's job is done. The downstream skill handles PR creation per its own flow." "$SKILL"; then
+  echo "  FAIL AC3 misleading one-liner still present"
+  FAIL=$((FAIL + 1))
+else
+  echo "  ok   AC3 misleading one-liner removed"
+  PASS=$((PASS + 1))
+fi
+
+# AC4 — structural ordering: Phase 5.5 -> Phase 6 -> Logging
+order=$(awk '
+  /^### Phase 5\.5:/ { f = 1 }
+  /^### Phase 6:/    { if (f) p = 1 }
+  /^## Logging/      { l = 1; exit }
+  END                { print (p && l) ? "ok" : "fail" }
+' "$SKILL")
+assert_eq "AC4 Phase 5.5 -> Phase 6 -> Logging order" "ok" "$order"
+
+# AC5 — Phase 6 prose names the canonical skill ids
+n=$(grep -cE 'uberdev:subagent-driven-dev|uberdev:finish-branch|uberdev:review-pr' "$SKILL" || true)
+assert_ge "AC5 canonical skill ids appear >= 3 times" 3 "$n"
+
+# AC6 — reviewer-count signals
+six=$(grep -cE '6 advisory reviewer agents' "$SKILL" || true)
+three=$(grep -cE '3 .*code-simplifier.*lenses' "$SKILL" || true)
+assert_ge "AC6a 6 advisory reviewer agents mentioned"  1 "$six"
+assert_ge "AC6b 3 simplify lenses mentioned"           1 "$three"
+
+# AC7 — large-tier Phase 5.5 ordering acknowledged in Phase 6 prose
+n=$(grep -ciE 'Phase 5\.5.*pr-test-analyzer.*before' "$SKILL" || true)
+assert_ge "AC7 Phase 5.5 ordering note present"        1 "$n"
+
+# AC8 — CHANGELOG entry naming the issue
+n=$(grep -cF 'Closes #94' "$CHANGELOG" || true)
+assert_ge "AC8 CHANGELOG references #94"               1 "$n"
+
+echo ""
+echo "[orchestrator-phase-6-doc] PASS=$PASS FAIL=$FAIL"
+
+if (( FAIL > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Replaces the misleading `## End-of-pipeline` section in `plugins/uberdev/skills/orchestrator/SKILL.md` with an explicit `### Phase 6: PR creation + review chain` inside `## Phase pipeline` (after Phase 5.5), naming the full cascade `subagent-driven-dev → finish-branch → /uberdev:review-pr (Phase 1 reviewer fanout + Phase 2 simplify lenses)` and quantifying the reviewer counts (6 advisory reviewers in Phase 1; 3 simplify lenses in Phase 2).
- Reframes the orchestrator's contract to extend end-to-end through the trust-trail write, so a model reading only the orchestrator skill cannot conclude its contract ends at Phase 5.
- Acknowledges the large-tier Phase 5.5 (`pr-test-analyzer`) ordering — runs after SDD returns and BEFORE `finish-branch` dispatches PR creation.
- Patch-version bump (0.23.0 → 0.23.1) per the bump-everywhere rule: `marketplace.json`, `plugin.json`, and the `README.md` version badge synchronized. (README addition keeps `tests/merge-discovery-resilience.test.sh` A11b green.)
- New anchored-grep test `tests/orchestrator-phase-6-doc.test.sh` (9 assertions) wired into `.github/workflows/test.yml`. Full suite green (21/21 scripts plus the new one).

## Test Plan

- [x] `bash tests/orchestrator-phase-6-doc.test.sh` → `PASS=9 FAIL=0` (exit 0)
- [x] `for t in tests/*.test.sh; do bash "$t" || ...; done` and `zsh tests/solve-pipeline-zsh.test.sh` → all green (22 scripts total)
- [x] Spec ACs 1–8 re-greped directly: AC1=1, AC2=0, AC3=0, AC4=ok, AC5=7, AC6=2, AC7=1, AC8=1
- [x] Repo-wide `grep -r "End-of-pipeline\|orchestrator's job is done"` returns only intentional matches (CHANGELOG history + test script anti-grep assertions)
- [x] Version markers consistent: all 4 surfaces (`marketplace.json`, `plugin.json`, `README.md` badge, `CHANGELOG.md` heading) at 0.23.1

## Open questions answered by /turbo

The following clarifying questions were answered automatically by `/turbo` mode — please review (especially any `medium`/`low` confidence rows):

## Q1: Should `### Phase 6: PR creation + review chain` REPLACE the existing `## End-of-pipeline` block, or be ADDED as a subsection under it?
**Auto-pick:** Replace the `## End-of-pipeline` block — move Phase 6 into the `## Phase pipeline` section (after `### Phase 5.5`) where every other phase lives, and remove the now-redundant `## End-of-pipeline` heading and one-liner prose. Fold the "after Phase 5 returns control" framing into the new Phase 6 prose.
**Rationale:** The current `## End-of-pipeline` text is exactly the source of confusion the issue cites ("orchestrator's job is done"). Patching around it with a subsection leaves the misleading sentence intact above the fix. Restructuring it as the final phase of `## Phase pipeline` matches the convention of every other phase header and removes the misleading framing in one move. Adding a subsection under `## End-of-pipeline` would leave a structural orphan (one `###` under a `##` outside the Phase pipeline block) and contradict the heading-hierarchy convention research-codebase confirmed.
**Confidence:** high

## Q2: Should the new Phase 6 wording quantify the reviewer count inside `/uberdev:review-pr` (e.g. "6 advisory reviewer agents") or just use the phase names?
**Auto-pick:** Use the phase names with a parenthetical count ("Phase 1 — Review + Fix loop (6 advisory reviewer agents dispatched in a single message)" and "Phase 2 — Mandatory Simplify Pass (3 `uberdev:code-simplifier` lenses)"). Both are factual at HEAD per research-codebase's reading of `review-pr.md`.
**Rationale:** Phase names alone read fine but lose the "this is a big fanout, not a single agent" signal. Counts add that, and the research agent flagged that `review-pr.md` is the source of truth at 6 agents (SDD's stale ASCII diagram says 5). Locking the new prose to the source-of-truth numbers avoids propagating the stale count and gives readers a quick mental model of the cascade's size.
**Confidence:** medium

## Q3: Should Phase 6 acknowledge the Phase 5.5 ordering (large-tier-only, runs BEFORE finish-branch dispatches PR creation), or stay silent on it?
**Auto-pick:** Acknowledge it in one sentence — note that on large tier, Phase 5.5 runs after SDD returns and before finish-branch dispatches the PR push; the pr-test-analyzer's findings flow into the PR body that finish-branch composes.
**Rationale:** Research-codebase flagged this as a documentation risk: a reader of the new Phase 6 could assume the cascade is uniform across tiers and miss the large-tier insertion. One short sentence prevents the same kind of gap this issue is fixing.
**Confidence:** high

## Q4: Should we make a parallel edit to any other doc (README tier table, finish-branch SKILL.md, /solve.md, /turbo.md, CHANGELOG.md) in this PR?
**Auto-pick:** No parallel doc edits. Only the orchestrator SKILL.md change. Add a CHANGELOG.md entry under the upcoming version's `### Documentation` (or equivalent) heading describing the docs fix.
**Rationale:** Research-codebase verified that README, finish-branch, and SDD already document the cascade correctly elsewhere. The gap is specific to orchestrator/SKILL.md. Touching unrelated files would expand blast radius. CHANGELOG is the one exception because this repo records every shipped change there.
**Confidence:** high

## Q5: Should the new Phase 6 prose reframe the orchestrator's contract (i.e. "orchestrator's contract is to ensure the chain runs end-to-end") or stay neutrally descriptive ("here is what happens downstream")?
**Auto-pick:** Reframe — explicitly state that the orchestrator's contract includes ensuring the cascade reaches `/uberdev:review-pr`, and that Phase 6 is the final phase of the run, not optional documentation.
**Rationale:** The issue diagnoses the root cause as "agent reading orchestrator can conclude its contract ends at Phase 5". Reframing the contract is the fix, not just describing what happens downstream. Neutral description would risk leaving the same takeaway intact ("the orchestrator hands off and is done — the chain happens, but it's not really my problem").
**Confidence:** high

---

Closes #94


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added explicit Phase 6 (PR creation + review chain) to the orchestrator docs, removed the outdated “End-of-pipeline” section, and clarified reviewer/PR flow; closes issue #94.

* **Chores**
  * Bumped project version to 0.23.1 and updated changelog and README badges.

* **Tests**
  * Added a regression test validating the Phase 6 docs and changelog; CI updated to run this check.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/101)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->