### PR TITLE
feat(finish-branch): review-pr:pending backstop (#95)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents as `claude --bg` background sessions (monitor with `claude agents`); /issue creates well-investigated, deduped issues.",
-      "version": "0.23.2",
+      "version": "0.23.3",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,11 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents as `claude --bg` background sessions (monitor with `claude agents`); /issue creates well-investigated, deduped issues.",
-<<<<<<< HEAD
       "version": "0.23.3",
-=======
-      "version": "0.23.1",
->>>>>>> 648b390 (chore(release): sync marketplace.json + README badge to v0.23.1 (#95))
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,11 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents as `claude --bg` background sessions (monitor with `claude agents`); /issue creates well-investigated, deduped issues.",
+<<<<<<< HEAD
       "version": "0.23.3",
+=======
+      "version": "0.23.1",
+>>>>>>> 648b390 (chore(release): sync marketplace.json + README badge to v0.23.1 (#95))
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.3] - 2026-05-13
+
+### Added
+
+- **`review-pr:pending` label backstop one layer upstream of `/merge`.** Mirrors the v0.23.0 `/merge` trust-trail backstop at the previous chain link. `plugins/uberdev/skills/finish-branch/SKILL.md` now adds the `review-pr:pending` GitHub PR label (via `gh label create --force` + `gh pr edit --add-label`, both fail-soft per the fire-and-surface contract) immediately before invoking `uberdev:review-pr` via the `Skill` tool. `plugins/uberdev/commands/review-pr.md` Trust-Signal Emission block clears the label on green outcome (fail-soft per spec D4 — the label may legitimately not exist when `/review-pr` is invoked directly). `plugins/uberdev/skills/merge-pipeline/SKILL.md` Step 1.4.5 gains a new positive-signal label-presence probe (gated by `AUTO_REVIEW_ON_MERGE`) that short-circuits trust-trail reason resolution by assigning `reason="trust_trail_label_missing"` directly. **No new `AUDIT_EVENT_ENUM` or `GATE_FAIL_REASON_ENUM` members** — D1 reuses the existing `trust_trail_label_missing` value. The label is the durable cross-process signal: it survives session boundaries and any tool with `gh` access can inspect it. New named constant `REVIEW_PR_PENDING_LABEL = "review-pr:pending"` in `merge-pipeline/SKILL.md` Constants table. The `AUTO_REVIEW_DISPATCH_CAP = 1` cap-ordering invariant from v0.23.0 is preserved (counter write still precedes `Skill()` dispatch). Tests added: `tests/finish-branch-auto-chain.test.sh` (#95.1–#95.5 — label-add presence, line-order guard, fail-soft contract), `tests/review-pr.test.sh` R21 (label-remove presence, prose-anchor, fail-soft tombstone, section-anchor), `tests/merge.test.sh` M86 (Constants row, probe presence, gate, reason-reuse, `AUDIT_EVENT_ENUM` set-equality, cap-ordering preservation, Common Mistakes anchor). Total 16 new assertions. Closes #95.
+  - **Why patch only.** Mirror of the v0.23.0 backstop one layer upstream; no new public CLI flags; default-off behaviour is bit-identical for users not opted into `AUTO_REVIEW_ON_MERGE`.
+
 ## [0.23.2] - 2026-05-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.23.2-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.23.3-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-<<<<<<< HEAD
 [![Version](https://img.shields.io/badge/version-0.23.3-blue)](./CHANGELOG.md)
-=======
-[![Version](https://img.shields.io/badge/version-0.23.1-blue)](./CHANGELOG.md)
->>>>>>> 648b390 (chore(release): sync marketplace.json + README badge to v0.23.1 (#95))
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
+<<<<<<< HEAD
 [![Version](https://img.shields.io/badge/version-0.23.3-blue)](./CHANGELOG.md)
+=======
+[![Version](https://img.shields.io/badge/version-0.23.1-blue)](./CHANGELOG.md)
+>>>>>>> 648b390 (chore(release): sync marketplace.json + README badge to v0.23.1 (#95))
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via claude --bg background sessions (Agent View), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/review-pr.md
+++ b/plugins/uberdev/commands/review-pr.md
@@ -578,6 +578,18 @@ On GREEN, emit three SHA-bound durable artifacts in lockstep (all reference the 
    fi
    ```
 
+   ```bash
+   # New (#95): clear the review-pr:pending backstop label on green outcome.
+   # Fail-soft per spec D4 — /uberdev:review-pr may be invoked directly outside
+   # a finish-branch chain, so the label may legitimately be absent; an exit-2
+   # guard would falsely fail green direct-invocation runs.
+   if ! gh pr edit <N> --remove-label review-pr:pending 2>/dev/null; then
+     echo "note: review-pr:pending label not present (either never set or already cleared)" >&2
+   fi
+   ```
+
+   **Pending-label clearance** — the `gh pr edit <N> --remove-label review-pr:pending` call pairs with the `--add-label uberdev-approved` above; together they form the green-outcome trust-signal handoff. See `REVIEW_PR_PENDING_LABEL` in `skills/merge-pipeline/SKILL.md` Constants. The label is set by `finish-branch/SKILL.md` immediately before this Skill is dispatched (issue #95). It is intentionally preserved on REVISIONS_REQUIRED, agent crash, or non-green exit so `/merge` Step 1.4.5's label-present probe can backstop the missed review on the next integration run.
+
 3. **Audit JSON** — write to `.uberdev/runs/<run-id>/review-pr-verdict.json`. The `"sha"` field MUST be `${ANCHOR_SHA}` from artifact 1 (the post-emission `headRefOid`, equal to the anchor commit's own SHA). It is NOT `${PARENT_SHA}` — the trailer payload references the pre-anchor parent, but the JSON `"sha"` references the anchor itself, matching what `gh pr view --json headRefOid` returns immediately after the push:
 
 ```json

--- a/plugins/uberdev/commands/review-pr.md
+++ b/plugins/uberdev/commands/review-pr.md
@@ -579,6 +579,10 @@ On GREEN, emit three SHA-bound durable artifacts in lockstep (all reference the 
    ```
 
    ```bash
+   # Note: kept as a SEPARATE gh pr edit call (not combined with the
+   # --add-label uberdev-approved call above) so that the differential
+   # error contract is preserved: --add-label is exit-2-on-failure
+   # (trust-signal artifact), while --remove-label is fail-soft per D4.
    # New (#95): clear the review-pr:pending backstop label on green outcome.
    # Fail-soft per spec D4 — /uberdev:review-pr may be invoked directly outside
    # a finish-branch chain, so the label may legitimately be absent; an exit-2

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -294,8 +294,26 @@ if [[ ! "$PR_URL" =~ $PR_URL_REGEX ]]; then
   exit 1
 fi
 echo "PR created: $PR_URL"
+# Extract PR number from PR_URL using a capture-group variant of PR_URL_REGEX
+# (the existing constant at line 289 has no capture group; this inline form
+# allows single-pass extraction via BASH_REMATCH). Both gh calls are fail-soft
+# per the fire-and-surface contract (issue #11 Q1): a transient gh failure
+# loud-logs to stderr but MUST NOT exit non-zero or roll back the PR.
+if [[ "$PR_URL" =~ ^https://github\.com/[^/]+/[^/]+/pull/([0-9]+)$ ]]; then
+  PR_NUM="${BASH_REMATCH[1]}"
+  if ! gh label create --force review-pr:pending \
+       --color FBCA04 \
+       --description "review-pr has not yet completed for this PR" 2>/dev/null; then
+    echo "warning: failed to create review-pr:pending label; backstop may not fire" >&2
+  fi
+  if ! gh pr edit "$PR_NUM" --add-label review-pr:pending 2>/dev/null; then
+    echo "warning: failed to add review-pr:pending label to PR #$PR_NUM; backstop will not fire if review-pr is missed" >&2
+  fi
+fi
 rm -f "$TITLE_FILE" "$PR_BODY_FILE"
 ```
+
+The two `gh` calls above are intentionally fail-soft — the fire-and-surface contract trumps backstop completeness, so a transient `gh` failure must not roll back PR creation. The literal label string `review-pr:pending` is declared as `REVIEW_PR_PENDING_LABEL` in `plugins/uberdev/skills/merge-pipeline/SKILL.md` Constants table; it is inlined here (mirroring how `UBERDEV_APPROVED_LABEL` is inlined in `commands/review-pr.md`) because shell heredoc constraints preclude variable substitution in this position.
 
 **Chain hand-off (always-PR path, default + turbo):**
 

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -313,7 +313,7 @@ fi
 rm -f "$TITLE_FILE" "$PR_BODY_FILE"
 ```
 
-The two `gh` calls above are intentionally fail-soft — the fire-and-surface contract trumps backstop completeness, so a transient `gh` failure must not roll back PR creation. The literal label string `review-pr:pending` is declared as `REVIEW_PR_PENDING_LABEL` in `plugins/uberdev/skills/merge-pipeline/SKILL.md` Constants table; it is inlined here (mirroring how `UBERDEV_APPROVED_LABEL` is inlined in `commands/review-pr.md`) because shell heredoc constraints preclude variable substitution in this position.
+The two `gh` calls above are intentionally fail-soft — the fire-and-surface contract trumps backstop completeness, so a transient `gh` failure must not roll back PR creation. The literal label string `review-pr:pending` is declared as `REVIEW_PR_PENDING_LABEL` in `plugins/uberdev/skills/merge-pipeline/SKILL.md` Constants table; it is inlined here (mirroring how `UBERDEV_APPROVED_LABEL` is inlined in `commands/review-pr.md`) because bash does not dereference markdown constants — the literal string is the only available form in this position.
 
 **Chain hand-off (always-PR path, default + turbo):**
 

--- a/plugins/uberdev/skills/merge-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/merge-pipeline/SKILL.md
@@ -50,7 +50,7 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `TEST_FAIL_DECISION_ENUM` | `re-resolve`, `strategy-switch`, `park` | Phase 3.3v (audit-log `data.choice` for `test_fail_agent_decision`) |
 | `DEPRECATED_FLAGS_NOTE` | `warning: --yes / -y / auto_confirm are deprecated; /merge is now fully unattended. The flag has no behavioural effect.` | Phase 1 (stderr emission), `commands/merge.md` (Deprecated Flags section), `using-uberdev/SKILL.md` |
 | `UBERDEV_APPROVED_LABEL` | `uberdev-approved` | Phase 1.4 (PATH_2 label presence check) |
-| `REVIEW_PR_PENDING_LABEL` | `"review-pr:pending"` | `finish-branch/SKILL.md` (add — C1), `commands/review-pr.md` (remove — C2), `merge-pipeline/SKILL.md` Step 1.4.5 probe (C3) |
+| `REVIEW_PR_PENDING_LABEL` | `review-pr:pending` | `finish-branch/SKILL.md` (add — C1), `commands/review-pr.md` (remove — C2), `merge-pipeline/SKILL.md` Step 1.4.5 probe (C3) |
 | `REVIEW_PR_TRAILER_PREFIX` | `Reviewed-by: uberdev/review-pr@` | Phase 1.4 (PATH_2 trailer extraction); regex form `^Reviewed-by: uberdev/review-pr@([a-f0-9]{40})$` |
 | `RUN_ID_REGEX` | `^[0-9]{8}-[0-9]{6}-[a-f0-9]+$` | Phase 1.4 (PATH_2 audit-JSON path validation); also enforced producer-side in `commands/review-pr.md` |
 | `TRUST_ANCHOR_ENUM` | `reviewDecision_approved`, `uberdev_review_trail`, `bypass_with_waiver` (deprecated; never emitted post-v0.17.0) | Phase 1.4 (audit-log `gate_pass.data.trust_anchor`) |
@@ -374,12 +374,15 @@ Honest fast-forward fixup commits added between `/review-pr` and `/merge` (e.g.,
 # Reuses reason_triggering=trust_trail_label_missing per D1; NO new
 # AUDIT_EVENT_ENUM member is introduced (Q5).
 if [[ "$AUTO_REVIEW_ON_MERGE" == "true" ]]; then
-  if LABELS_OUT=$(gh pr view "$PR" --json labels --jq '.labels[].name' 2>&1); then
+  # Reuse $PR_JSON populated by pr_view_projection in Step 1.4 (line ~309).
+  # The projection already requests --json labels (Step 1.4 line ~319), so
+  # this avoids a redundant gh round-trip per AUTO_REVIEW_ON_MERGE-eligible PR.
+  if LABELS_OUT=$(jq -r '.labels[].name' <<<"$PR_JSON" 2>&1); then
     if echo "$LABELS_OUT" | grep -qx review-pr:pending; then
       reason="trust_trail_label_missing"
     fi
   else
-    echo "warning: gh pr view --json labels failed for PR $PR ($LABELS_OUT); label-present probe skipped — existing trust-trail reason resolution stands" >&2
+    echo "warning: jq labels extraction from PR_JSON failed for PR $PR ($LABELS_OUT); label-present probe skipped — existing trust-trail reason resolution stands" >&2
   fi
 fi
 ```

--- a/plugins/uberdev/skills/merge-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/merge-pipeline/SKILL.md
@@ -366,6 +366,23 @@ Honest fast-forward fixup commits added between `/review-pr` and `/merge` (e.g.,
 
 **Default-off bit-identity contract.** When `AUTO_REVIEW_ON_MERGE` is `false` (the default), this step is a structural no-op: control falls through to the existing `gate_fail` emission described under the "Otherwise:" paragraph above. Zero new audit events fire. Zero new wall-clock is consumed. The `AUTO_REVIEW_DISPATCHED` associative array is declared but never written. This is the load-bearing safety contract (constraints.md §Summary #1).
 
+**Label-presence probe (#95).** Before evaluating the trigger guard, a positive-signal probe checks for the `review-pr:pending` label on the PR (set by `finish-branch/SKILL.md` immediately before its `Skill("uberdev:review-pr")` dispatch — see `REVIEW_PR_PENDING_LABEL` in the Constants table). When the label is present, the probe short-circuits trust-trail reason resolution by assigning `reason="trust_trail_label_missing"` directly. This reuses the existing `GATE_FAIL_REASON_ENUM` member (per D1 of `docs/uberdev/specs/2026-05-13-finish-branch-review-pr-pending-backstop-design.md`) and introduces NO new `AUDIT_EVENT_ENUM` value — the existing `auto_review_dispatched.data.reason_triggering` enum at line 30 is preserved. The probe is itself gated by `AUTO_REVIEW_ON_MERGE` so the default-off bit-identity contract above remains intact (the block is a structural no-op when the user has not opted in).
+
+```bash
+# NEW (#95): label-present probe -- short-circuits trust-trail reason resolution
+# when the review-pr:pending label is still present at integration time.
+# Reuses reason_triggering=trust_trail_label_missing per D1; NO new
+# AUDIT_EVENT_ENUM member is introduced (Q5).
+if [[ "$AUTO_REVIEW_ON_MERGE" == "true" ]]; then
+  if gh pr view "$PR" --json labels --jq '.labels[].name' 2>/dev/null \
+       | grep -qx review-pr:pending; then
+    reason="trust_trail_label_missing"
+  fi
+fi
+```
+
+The existing `AUTO_REVIEW_DISPATCH_CAP = 1` and `AUTO_REVIEW_DISPATCHED["${PR}:${RUN_ID}"]` counter (asserted in the dispatch sequence below) continue to enforce per-run de-dup downstream — re-entry via the new probe cannot bypass the cap because the counter is checked as the third trigger guard condition (line 373 in source order).
+
 **Trigger guard (positive whitelist; D10).** The intercept fires if and only if ALL THREE conditions hold:
 
 1. `AUTO_REVIEW_ON_MERGE == true` (config-opt-in)
@@ -767,6 +784,7 @@ For each stale branch, the agent decides (per-branch). Each decision emits one `
 - **Treating `--bypass-protections` as a live admin-bypass anchor.** It is deprecated as a no-op post-v0.17.0 — the trust-trail-evaluator agent subsumes its job; there is no PATH_3 admin-bypass anchor and no CI-red waiver. The flag is parsed without error indefinitely (Terraform / npm CLI deprecation precedent), emits `BYPASS_PROTECTIONS_DEPRECATED_NOTE` once per run on first encounter, and records a `deprecated_flag_used` audit event. `admin_bypass` and `waiver_recorded` events are declared in `AUDIT_EVENT_ENUM` for backward-compat with audit-log consumers but are NEVER emitted post-v0.17.0.
 - **Inlining strategy heuristics in Phase 2.2 instead of dispatching `merge-strategy-decider`.** The agent owns the decision; the skill normalises inputs (commit_count, conventional_commit_ratio, divergence_commits, wip_marker_present, label_hint, repo_convention) and surfaces the verdict to the audit log via `merge_strategy_agent_decision` and `strategy_chosen` (`data.reason="agent_decided"`). There is NO "Per-invocation flag always wins" clause — `--squash` / `--rebase` / `--merge` are no-ops post-v0.17.0.
 - **Don't trigger auto-review on `review_decision_not_approved` alone, on `trust_trail_stale_sha`, or on any other non-whitelisted gate-fail reason.** The Phase 1.4.5 auto-review intercept fires ONLY on the positive whitelist `reason ∈ {trust_trail_label_missing, trust_trail_trailer_missing}` (D10). The non-trigger `GATE_FAIL_REASON_ENUM` members are excluded as a defensive completeness measure (D11): `review_decision_not_approved` (auto-bypassing branch protection is a security regression — security.md §2), `trust_trail_stale_sha` (deferred to v2 — requires a pricier full re-anchor), `trust_trail_agent_invalid_input` (input-malformed agent input is a manual-investigation signal), `trust_trail_json_sha_mismatch` (indicates a corrupted run-local path post-#78 — manual investigation per Q6), `pr_state_not_open`, `is_draft`, `ci_red`, `merge_state_blocked` (pre-condition gates evaluated before trust resolution — not auto-recoverable), `pr_view_unreachable` (infrastructure failure — not auto-recoverable). The cap is `AUTO_REVIEW_DISPATCH_CAP = 1` per `(pr_number, run_id)`; the counter is set BEFORE the synchronous `Skill("uberdev:review-pr")` dispatch (Step 1.4.5 cap-ordering invariant) so re-entry cannot bypass the cap even on green re-eval.
+- **Extending the trigger set for #95.** The label-presence probe added in #95 (gated by `AUTO_REVIEW_ON_MERGE`) short-circuits reason resolution by setting `reason="trust_trail_label_missing"` directly. This reuses the existing whitelist member and does NOT extend the trigger set — `GATE_FAIL_REASON_ENUM` is unchanged, `AUDIT_EVENT_ENUM` is unchanged (Q5 / D1). Do not "fix" this by introducing a new `review_pr_pending_label_present` reason or audit event.
 
 ## Red Flags
 

--- a/plugins/uberdev/skills/merge-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/merge-pipeline/SKILL.md
@@ -374,14 +374,17 @@ Honest fast-forward fixup commits added between `/review-pr` and `/merge` (e.g.,
 # Reuses reason_triggering=trust_trail_label_missing per D1; NO new
 # AUDIT_EVENT_ENUM member is introduced (Q5).
 if [[ "$AUTO_REVIEW_ON_MERGE" == "true" ]]; then
-  if gh pr view "$PR" --json labels --jq '.labels[].name' 2>/dev/null \
-       | grep -qx review-pr:pending; then
-    reason="trust_trail_label_missing"
+  if LABELS_OUT=$(gh pr view "$PR" --json labels --jq '.labels[].name' 2>&1); then
+    if echo "$LABELS_OUT" | grep -qx review-pr:pending; then
+      reason="trust_trail_label_missing"
+    fi
+  else
+    echo "warning: gh pr view --json labels failed for PR $PR ($LABELS_OUT); label-present probe skipped — existing trust-trail reason resolution stands" >&2
   fi
 fi
 ```
 
-The existing `AUTO_REVIEW_DISPATCH_CAP = 1` and `AUTO_REVIEW_DISPATCHED["${PR}:${RUN_ID}"]` counter (asserted in the dispatch sequence below) continue to enforce per-run de-dup downstream — re-entry via the new probe cannot bypass the cap because the counter is checked as the third trigger guard condition (line 373 in source order).
+The existing `AUTO_REVIEW_DISPATCH_CAP = 1` and `AUTO_REVIEW_DISPATCHED["${PR}:${RUN_ID}"]` counter (asserted in the dispatch sequence below) continue to enforce per-run de-dup downstream — re-entry via the new probe cannot bypass the cap because the counter is checked as the third trigger guard condition (the third condition in the Trigger guard section immediately below).
 
 **Trigger guard (positive whitelist; D10).** The intercept fires if and only if ALL THREE conditions hold:
 

--- a/plugins/uberdev/skills/merge-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/merge-pipeline/SKILL.md
@@ -50,6 +50,7 @@ All magic strings/numbers used by this skill are declared here once. Later phase
 | `TEST_FAIL_DECISION_ENUM` | `re-resolve`, `strategy-switch`, `park` | Phase 3.3v (audit-log `data.choice` for `test_fail_agent_decision`) |
 | `DEPRECATED_FLAGS_NOTE` | `warning: --yes / -y / auto_confirm are deprecated; /merge is now fully unattended. The flag has no behavioural effect.` | Phase 1 (stderr emission), `commands/merge.md` (Deprecated Flags section), `using-uberdev/SKILL.md` |
 | `UBERDEV_APPROVED_LABEL` | `uberdev-approved` | Phase 1.4 (PATH_2 label presence check) |
+| `REVIEW_PR_PENDING_LABEL` | `"review-pr:pending"` | `finish-branch/SKILL.md` (add — C1), `commands/review-pr.md` (remove — C2), `merge-pipeline/SKILL.md` Step 1.4.5 probe (C3) |
 | `REVIEW_PR_TRAILER_PREFIX` | `Reviewed-by: uberdev/review-pr@` | Phase 1.4 (PATH_2 trailer extraction); regex form `^Reviewed-by: uberdev/review-pr@([a-f0-9]{40})$` |
 | `RUN_ID_REGEX` | `^[0-9]{8}-[0-9]{6}-[a-f0-9]+$` | Phase 1.4 (PATH_2 audit-JSON path validation); also enforced producer-side in `commands/review-pr.md` |
 | `TRUST_ANCHOR_ENUM` | `reviewDecision_approved`, `uberdev_review_trail`, `bypass_with_waiver` (deprecated; never emitted post-v0.17.0) | Phase 1.4 (audit-log `gate_pass.data.trust_anchor`) |

--- a/tests/finish-branch-auto-chain.test.sh
+++ b/tests/finish-branch-auto-chain.test.sh
@@ -249,6 +249,48 @@ assert_not_grep "$FINISH_BRANCH" \
   '#.*`(if|then|else|elif|fi|while|for|until|do|done|case|esac|function|select|time)([[:space:]!]|`)' \
   "no shell-keyword backticks inside #-comments in bash blocks (Claude permission-evaluator parse-error bug, #42/#55 family)"
 
+echo "== Issue #95: review-pr:pending backstop in finish-branch =="
+
+assert_grep "$FINISH_BRANCH" \
+  'gh label create --force review-pr:pending' \
+  "#95.1 — idempotent gh label create call present (spec C1; gh --add-label cannot auto-create labels)"
+
+assert_grep "$FINISH_BRANCH" \
+  'gh pr edit .*--add-label review-pr:pending' \
+  "#95.2 — gh pr edit --add-label review-pr:pending present (spec C1)"
+
+assert_grep "$FINISH_BRANCH" \
+  'REVIEW_PR_PENDING_LABEL' \
+  "#95.3 — prose paragraph references REVIEW_PR_PENDING_LABEL constant by name (spec C4)"
+
+# Line-order: label-add MUST precede the Skill(uberdev:review-pr) dispatch prose
+L_ADD=$(grep -n -- '--add-label review-pr:pending' "$FINISH_BRANCH" | head -1 | cut -d: -f1)
+L_SKILL=$(grep -n -E 'Invoke `uberdev:review-pr` via the Skill tool' "$FINISH_BRANCH" | head -1 | cut -d: -f1)
+if [[ -n "$L_ADD" && -n "$L_SKILL" && "$L_ADD" -lt "$L_SKILL" ]]; then
+  echo "  PASS  #95.4 — label-add precedes Skill(uberdev:review-pr) dispatch in source order (L_ADD=$L_ADD < L_SKILL=$L_SKILL)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  #95.4 — label-add MUST appear before Skill(uberdev:review-pr) dispatch (L_ADD=$L_ADD L_SKILL=$L_SKILL)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Fail-soft contract: no `exit` inside the new label-add block (sed-based; bounded range)
+LABEL_BLOCK_START=$(grep -n 'Extract PR number from PR_URL using a capture-group variant' "$FINISH_BRANCH" | head -1 | cut -d: -f1)
+LABEL_BLOCK_END=$(awk -v s="$LABEL_BLOCK_START" 'NR > s && /^fi$/ { print NR; exit }' "$FINISH_BRANCH")
+if [[ -n "$LABEL_BLOCK_START" && -n "$LABEL_BLOCK_END" ]]; then
+  EXIT_COUNT=$(sed -n "${LABEL_BLOCK_START},${LABEL_BLOCK_END}p" "$FINISH_BRANCH" | grep -cE '^[[:space:]]*exit')
+  if [[ "$EXIT_COUNT" -eq 0 ]]; then
+    echo "  PASS  #95.5 — label-add bash block is fail-soft (no exit inside; fire-and-surface contract)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  #95.5 — label-add bash block MUST be fail-soft; found $EXIT_COUNT exit statement(s)"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  FAIL  #95.5 — could not locate label-add block (LABEL_BLOCK_START=$LABEL_BLOCK_START LABEL_BLOCK_END=$LABEL_BLOCK_END)"
+  FAIL=$((FAIL + 1))
+fi
+
 echo
 echo "== Summary =="
 echo "  passed: $PASS"

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -1652,13 +1652,13 @@ echo "== M86: review-pr:pending label-present probe in Step 1.4.5 (#95) =="
 
 # M86.1 — Constants table declares REVIEW_PR_PENDING_LABEL (Task 1)
 assert_grep "$SKILL_FILE" \
-  '\| `REVIEW_PR_PENDING_LABEL` \| `"review-pr:pending"` \|' \
-  "M86.1 — Constants table declares REVIEW_PR_PENDING_LABEL = \"review-pr:pending\" (#95 spec C4 / T1)"
+  '\| `REVIEW_PR_PENDING_LABEL` \| `review-pr:pending` \|' \
+  "M86.1 — Constants table declares REVIEW_PR_PENDING_LABEL = review-pr:pending (#95 spec C4 / T1, R8.6 simplify drops inner quotes for table parity)"
 
-# M86.2 — Step 1.4.5 contains the gh pr view --json labels probe (Task 4)
+# M86.2 — Step 1.4.5 contains the probe reusing cached $PR_JSON (Task 4)
 assert_grep "$SKILL_FILE" \
-  'gh pr view "\$PR" --json labels --jq' \
-  "M86.2 — gh pr view --json labels probe present in Step 1.4.5 (#95 spec C3 / T4)"
+  'jq -r .\.labels\[\]\.name. <<<"\$PR_JSON"' \
+  "M86.2 — probe reuses cached \$PR_JSON via jq -r .labels[].name in Step 1.4.5 (#95 spec C3 / T4, R8.6 simplify)"
 
 # M86.3 — probe assigns reason="trust_trail_label_missing" (reuses existing enum; no new member)
 PROBE_START=$(grep -n 'NEW (#95): label-present probe' "$SKILL_FILE" | head -1 | cut -d: -f1)

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -1648,6 +1648,81 @@ for reason in trust_trail_stale_sha trust_trail_agent_invalid_input trust_trail_
   fi
 done
 
+echo "== M86: review-pr:pending label-present probe in Step 1.4.5 (#95) =="
+
+# M86.1 — Constants table declares REVIEW_PR_PENDING_LABEL (Task 1)
+assert_grep "$SKILL_FILE" \
+  '\| `REVIEW_PR_PENDING_LABEL` \| `"review-pr:pending"` \|' \
+  "M86.1 — Constants table declares REVIEW_PR_PENDING_LABEL = \"review-pr:pending\" (#95 spec C4 / T1)"
+
+# M86.2 — Step 1.4.5 contains the gh pr view --json labels probe (Task 4)
+assert_grep "$SKILL_FILE" \
+  'gh pr view "\$PR" --json labels --jq' \
+  "M86.2 — gh pr view --json labels probe present in Step 1.4.5 (#95 spec C3 / T4)"
+
+# M86.3 — probe assigns reason="trust_trail_label_missing" (reuses existing enum; no new member)
+PROBE_START=$(grep -n 'NEW (#95): label-present probe' "$SKILL_FILE" | head -1 | cut -d: -f1)
+PROBE_END=$(awk -v s="$PROBE_START" 'NR > s && /^fi$/ { print NR; exit }' "$SKILL_FILE")
+if [[ -n "$PROBE_START" && -n "$PROBE_END" ]]; then
+  PROBE_BLOCK=$(sed -n "${PROBE_START},${PROBE_END}p" "$SKILL_FILE")
+  if echo "$PROBE_BLOCK" | grep -qE 'reason="trust_trail_label_missing"'; then
+    pass "M86.3 — probe assigns reason=trust_trail_label_missing on label match (spec D1; no new AUDIT_EVENT_ENUM member)"
+  else
+    fail "M86.3 — probe MUST assign reason=\"trust_trail_label_missing\" on label match (spec D1)"
+  fi
+
+  # M86.4 — AUTO_REVIEW_ON_MERGE gate wraps the probe block
+  if echo "$PROBE_BLOCK" | grep -qE 'AUTO_REVIEW_ON_MERGE.*==.*"true"'; then
+    pass "M86.4 — probe gated by AUTO_REVIEW_ON_MERGE=true (spec C3; default-off bit-identity contract preserved)"
+  else
+    fail "M86.4 — probe MUST be gated by AUTO_REVIEW_ON_MERGE == \"true\" (spec C3)"
+  fi
+else
+  fail "M86.3 — could not locate probe block (PROBE_START=$PROBE_START PROBE_END=$PROBE_END)"
+  fail "M86.4 — could not locate probe block"
+fi
+
+# M86.5 — AUDIT_EVENT_ENUM declaration unchanged: only auto_review_dispatched and auto_review_returned
+# This is a set-equality check on the AUDIT_EVENT_ENUM table row at line ~30 specifically;
+# we extract only that row to avoid false matches from other lines that may legitimately
+# reference auto_review_on_merge (the config-key constant).
+AUDIT_ROW=$(grep -E '^\| `AUDIT_EVENT_ENUM`' "$SKILL_FILE")
+GOT=$(echo "$AUDIT_ROW" | grep -oE '`auto_review_[a-z_]+`' | sort -u | tr '\n' ' ')
+EXPECTED='`auto_review_dispatched` `auto_review_returned` '
+if [[ "$GOT" == "$EXPECTED" ]]; then
+  pass "M86.5 — AUDIT_EVENT_ENUM row unchanged (#95 Q5: no new audit events; D1 reuses trust_trail_label_missing)"
+else
+  fail "M86.5 — AUDIT_EVENT_ENUM row MUST contain ONLY auto_review_dispatched and auto_review_returned (got: $GOT)"
+fi
+
+# M86.6 — cap-ordering preserved: AUTO_REVIEW_DISPATCHED counter write still precedes
+# the Skill(uberdev:review-pr) dispatch in source order. The bash code dispatch is the
+# `Skill("uberdev:review-pr",` line inside the dispatch sequence (lines ~410), not the
+# AUDIT_EVENT_ENUM prose row.  We anchor on the bash code by requiring "args:" on the
+# same line.
+L_COUNTER=$(grep -n 'AUTO_REVIEW_DISPATCHED\["\${PR}:\${RUN_ID}"\]=1' "$SKILL_FILE" | head -1 | cut -d: -f1)
+L_DISPATCH=$(grep -n -E 'Skill\("uberdev:review-pr",[[:space:]]*args:' "$SKILL_FILE" | head -1 | cut -d: -f1)
+if [[ -n "$L_COUNTER" && -n "$L_DISPATCH" && "$L_COUNTER" -lt "$L_DISPATCH" ]]; then
+  pass "M86.6 — AUTO_REVIEW_DISPATCHED counter write precedes Skill() dispatch (#89 cap-ordering preserved after #95 probe insertion; L_COUNTER=$L_COUNTER < L_DISPATCH=$L_DISPATCH)"
+else
+  fail "M86.6 — AUTO_REVIEW_DISPATCHED counter MUST precede Skill() dispatch (L_COUNTER=$L_COUNTER L_DISPATCH=$L_DISPATCH)"
+fi
+
+# M86.7 — Common Mistakes section documents the #95 probe (defends against future
+# extensions that try to introduce review_pr_pending_label_present as a new enum value)
+CM_START=$(grep -n '^## Common Mistakes' "$SKILL_FILE" | head -1 | cut -d: -f1)
+CM_END=$(awk -v s="$CM_START" 'NR > s && /^## / { print NR; exit }' "$SKILL_FILE")
+if [[ -n "$CM_START" && -n "$CM_END" ]]; then
+  CM_BLOCK=$(sed -n "${CM_START},${CM_END}p" "$SKILL_FILE")
+  if echo "$CM_BLOCK" | grep -q '#95'; then
+    pass "M86.7 — Common Mistakes section documents the #95 probe (defends against review_pr_pending_label_present regression)"
+  else
+    fail "M86.7 — Common Mistakes section MUST mention #95 (spec C3 / T4 Edit B)"
+  fi
+else
+  fail "M86.7 — could not locate ## Common Mistakes section (CM_START=$CM_START CM_END=$CM_END)"
+fi
+
 echo
 echo "== Summary =="
 echo "  passed: $PASS"

--- a/tests/review-pr.test.sh
+++ b/tests/review-pr.test.sh
@@ -527,6 +527,51 @@ assert_grep "$MERGE_SKILL" '\| `RERUN_FLAKY_CAP` \|' \
 assert_grep "$MERGE_SKILL" '`code_bug`.*`billing_quota`.*`platform_outage`.*`flaky`.*`env_drift`.*`stale_base`' \
   "R20.6 — CI_FAILURE_CLASS_ENUM lists all 6 classes in canonical order"
 
+echo "== R21: review-pr Trust-Signal Emission clears review-pr:pending label (#95) =="
+
+# R21.1 — gh pr edit --remove-label review-pr:pending is present somewhere in review-pr.md
+assert_grep "$REVIEW_PR" \
+  'gh pr edit .*--remove-label review-pr:pending' \
+  "R21.1 — gh pr edit --remove-label review-pr:pending present in review-pr.md (#95 spec C2)"
+
+# R21.2 — prose paragraph references the named constant REVIEW_PR_PENDING_LABEL
+assert_grep "$REVIEW_PR" \
+  'REVIEW_PR_PENDING_LABEL' \
+  "R21.2 — prose paragraph references REVIEW_PR_PENDING_LABEL constant by name (#95 spec C4)"
+
+# R21.3 — the new remove-label block is fail-soft (no exit-2 guard around it)
+# This is intentional per D4 — /uberdev:review-pr may be invoked directly outside
+# a finish-branch chain, in which case the pending label legitimately does not exist.
+# Negative shape-lock: extract the new bash block via line-range and assert no `exit 2`.
+REMOVE_START=$(grep -n 'New (#95): clear the review-pr:pending backstop label' "$REVIEW_PR" | head -1 | cut -d: -f1)
+REMOVE_END=$(awk -v s="$REMOVE_START" 'NR > s && /^[[:space:]]*fi$/ { print NR; exit }' "$REVIEW_PR")
+if [[ -n "$REMOVE_START" && -n "$REMOVE_END" ]]; then
+  EXIT2_COUNT=$(sed -n "${REMOVE_START},${REMOVE_END}p" "$REVIEW_PR" | grep -cE '^[[:space:]]*exit[[:space:]]+2')
+  if [[ "$EXIT2_COUNT" -eq 0 ]]; then
+    echo "  PASS  R21.3 — --remove-label block is fail-soft (no exit-2 guard; intentional per D4)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  R21.3 — --remove-label block MUST NOT use exit 2; found $EXIT2_COUNT exit-2 statement(s)"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  FAIL  R21.3 — could not locate --remove-label block (REMOVE_START=$REMOVE_START REMOVE_END=$REMOVE_END)"
+  FAIL=$((FAIL + 1))
+fi
+
+# R21.4 — line order: the new --remove-label is in the Trust-Signal Emission section,
+# which is after line 525 (## Trust-Signal Emission) and before line ~621 (## Exit-Code Contract).
+L_REMOVE=$(grep -n -- '--remove-label review-pr:pending' "$REVIEW_PR" | head -1 | cut -d: -f1)
+L_TS_HEADING=$(grep -n -E '^## Trust-Signal Emission' "$REVIEW_PR" | head -1 | cut -d: -f1)
+L_EXIT_CODE_HEADING=$(grep -n -E '^## Exit-Code Contract' "$REVIEW_PR" | head -1 | cut -d: -f1)
+if [[ -n "$L_REMOVE" && -n "$L_TS_HEADING" && -n "$L_EXIT_CODE_HEADING" && "$L_REMOVE" -gt "$L_TS_HEADING" && "$L_REMOVE" -lt "$L_EXIT_CODE_HEADING" ]]; then
+  echo "  PASS  R21.4 — --remove-label is inside Trust-Signal Emission section (TS=$L_TS_HEADING < REMOVE=$L_REMOVE < ExitCode=$L_EXIT_CODE_HEADING)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  R21.4 — --remove-label MUST be inside Trust-Signal Emission section (TS=$L_TS_HEADING REMOVE=$L_REMOVE ExitCode=$L_EXIT_CODE_HEADING)"
+  FAIL=$((FAIL + 1))
+fi
+
 echo
 echo "== Summary =="
 echo "  passed: $PASS"


### PR DESCRIPTION
## Summary

- Adds a `review-pr:pending` GitHub PR label as a durable cross-process backstop for missed `/uberdev:review-pr` chains. `finish-branch` adds the label (fail-soft) immediately before its `Skill("uberdev:review-pr")` dispatch; `/uberdev:review-pr` removes it on green outcome (fail-soft per D4); `/uberdev:merge` Step 1.4.5 gains a positive-signal label-presence probe (gated by `AUTO_REVIEW_ON_MERGE`) that short-circuits trust-trail reason resolution by reusing the existing `trust_trail_label_missing` enum value.
- **Zero new audit/enum members.** D1 reuses the existing `trust_trail_label_missing` value rather than introducing `review_pr_pending_label_present`. `AUDIT_EVENT_ENUM` and `GATE_FAIL_REASON_ENUM` unchanged. The v0.23.0 `AUTO_REVIEW_DISPATCH_CAP = 1` cap-ordering invariant is preserved (counter write still precedes `Skill()` dispatch).
- **Default-off bit-identical.** The new `/merge` probe is gated by the same `AUTO_REVIEW_ON_MERGE` opt-in as PR #90 / v0.23.0. Users not opted in see no behavioural change.

Closes #95.

## Test Plan

- [x] `tests/finish-branch-auto-chain.test.sh` — 5 new assertions #95.1–#95.5 (label-add presence, line-order guard, fail-soft contract). 42/0 passing.
- [x] `tests/review-pr.test.sh` — new R21 section, 4 assertions (label-remove presence, prose-anchor, fail-soft tombstone, section-anchor). 116/0 passing.
- [x] `tests/merge.test.sh` — new M86 section, 7 assertions (Constants row, probe presence, gate, reason-reuse, AUDIT_EVENT_ENUM set-equality, cap-ordering preservation, Common Mistakes anchor). 309/0 passing.
- [x] Full suite — 20/20 test scripts green (including `solve-pipeline-zsh.test.sh` under zsh).
- [x] `tests/merge-discovery-resilience.test.sh` — version-sync A11a/A11b PASS (marketplace.json + README badge bumped alongside plugin.json).

## Architecture (spec)

See [`docs/uberdev/specs/2026-05-13-finish-branch-review-pr-pending-backstop-design.md`](./docs/uberdev/specs/2026-05-13-finish-branch-review-pr-pending-backstop-design.md) and the wave-decomposed [plan](./docs/uberdev/plans/2026-05-13-finish-branch-review-pr-pending-backstop.md).


## Open questions answered by /turbo

The following questions were answered automatically — please review:

| # | Question | Choice | Confidence |
|---|----------|--------|------------|
| Q1 | How should `review-pr:pending` label be created so `gh pr edit --add-label` doesn't fail? | `gh label create --force review-pr:pending --color FBCA04 --description "review-pr has not yet completed for this PR"` is called in `finish-branch/SKILL.md` immediately before the `gh pr edit --add... | high |
| Q2 | Where does `/uberdev:review-pr` remove the `review-pr:pending` label, and under what outcomes? | Remove the label in the "Trust-Signal Emission" section of `commands/review-pr.md` (alongside the existing `uberdev-approved` label-add at line 575), and ONLY on a successful trust-trail emission (... | high |
| Q3 | Should the backstop consumer be a new "session-start probe" or extend the existing `/merge` Step 1.4.5 auto-review intercept? | Extend `/merge` Step 1.4.5 only. Add `review_pr_pending_label_present` to the `AUTO_REVIEW_ON_MERGE` trigger whitelist (alongside `trust_trail_label_missing` and `trust_trail_trailer_missing`). Do ... | high |
| Q4 | If `gh pr edit --add-label review-pr:pending` fails in `finish-branch`, should the chain abort or continue? | Fail-soft. Log a `warning: failed to add review-pr:pending label; backstop will not fire if /review-pr is missed` line to stderr and continue to the `Skill("uberdev:review-pr")` call. The PR creati... | high |
| Q5 | Should new audit events (`review_pr_pending_added`, `review_pr_pending_removed`) be introduced, or piggyback on existing audit lines? | No new audit events for v1. The `/merge` probe path already emits `auto_review_dispatched` / `auto_review_returned` (PR #90), which is sufficient for the trigger case. The add/remove transitions in... | medium |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a review-pr:pending label applied to new PRs and cleared when a review is approved.
  * Auto-review pipeline now checks this label as a verification checkpoint when auto-review-on-merge is enabled.

* **Bug Fixes**
  * Label add/remove operations are fail-soft to avoid breaking workflows if labels are missing.

* **Documentation**
  * Changelog and README updated for v0.23.3.

* **Tests**
  * New tests cover label creation, removal, ordering, and pipeline label-probe behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/104)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->