### PR TITLE
refactor: replace --turbo arg-chain with UBERDEV_TURBO env (#97)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents as `claude --bg` background sessions (monitor with `claude agents`); /issue creates well-investigated, deduped issues.",
-      "version": "0.23.3",
+      "version": "0.23.4",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.4] - 2026-05-13
+
+### Refactored
+
+- **Replace brittle 3-layer `--turbo` arg-forwarding chain with `UBERDEV_TURBO=1` env-var inheritance.** The chain `orchestrator → subagent-driven-dev → finish-branch → review-pr` previously forwarded `--turbo` as an LLM-interpreted argument across four prompts; a drop at any layer collapsed `/turbo` semantics silently (the chain fell back to interactive prompts inside a `claude --bg` session, which then deadlocked). Now the bit is set once at the pipeline entry point (`commands/turbo.md` `export UBERDEV_TURBO=1`) and propagates via two boundaries: (a) Skill() boundary (same agent process, in-process env table) into `solve-pipeline`; (b) OS process boundary (POSIX fork+exec) into `claude --bg` via inline-prefix exec `UBERDEV_TURBO=1 claude --bg …`. Each downstream consumer reads `[[ "${UBERDEV_TURBO:-0}" == "1" ]]`. `commands/solve.md` adds `unset UBERDEV_TURBO` to defend against shell-rc pollution. Mirrors `AUTO_MODE` (PR #19) and `UBERDEV_AUTO_REVIEW_ON_MERGE` (PR #90) precedents. **Hybrid arg-OR-env detector preserved on `orchestrator` and `commands/review-pr`** for legit standalone-invocation paths (`/uberdev:orchestrator --turbo …`, `merge-pipeline`'s separate `Skill("uberdev:review-pr", args: "${PR} --turbo")` dispatch). `subagent-driven-dev` and `finish-branch` are env-var-only (chain-internal). Test surface refactored: `tests/turbo-flow.test.sh` rewritten in dedicated commit `test(turbo-flow): assert UBERDEV_TURBO env-var propagation`. Closes #97.
+
 ## [0.23.3] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.23.3-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.23.4-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via claude --bg background sessions (Agent View), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/review-pr.md
+++ b/plugins/uberdev/commands/review-pr.md
@@ -25,7 +25,14 @@ Pass `--turbo` (anywhere in the arguments) to acknowledge invocation from `finis
    - Check git status to identify changed files
    - Parse arguments to see if user requested specific review aspects
    - Detect `--no-simplify` token in `$ARGUMENTS` and strip it from the aspect list — sets `SIMPLIFY_PHASE=0`, otherwise `SIMPLIFY_PHASE=1` (default).
-   - Detect `--turbo` token in `$ARGUMENTS` and strip it from the aspect list — acknowledged no-op (rationale above); it does NOT mutate `SIMPLIFY_PHASE` or any other phase variable.
+   - Detect `--turbo` token in `$ARGUMENTS` AND/OR inherited env var `${UBERDEV_TURBO:-0} == "1"` (#97 — hybrid OR detector). Strip the `--turbo` token from the aspect list. Set `TURBO=1` if either source signals turbo; else `TURBO=0`. The detection result feeds the Phase 3 halt-class carve-out (6c.6 HALT) — it does NOT mutate `SIMPLIFY_PHASE` or any other phase variable. Hybrid form (mirrors `orchestrator/SKILL.md`):
+     ```bash
+     TURBO=0
+     if [[ "$ARGUMENTS" == *"--turbo"* ]] || [[ "${UBERDEV_TURBO:-0}" == "1" ]]; then
+       TURBO=1
+     fi
+     ```
+     Rationale: `merge-pipeline` invokes `Skill("uberdev:review-pr", args: "${PR} --turbo")` (out-of-scope for #97) — arg form must remain accepted. `finish-branch` chains via `Skill("uberdev:review-pr")` with no flag (env-var inheritance, #97) — env form must also be accepted. The hybrid OR detector closes both call sites.
    - Detect `--no-ci-fix` token in `$ARGUMENTS` and strip it from the aspect list — sets `CI_FIX_PHASE=0` (probe-only mode), otherwise `CI_FIX_PHASE=1` (default). Mirrors `--no-simplify` shape. When `CI_FIX_PHASE=0`, Phase 3 6c.1 PROBE + 6c.2 MONITOR + 6c.3 CLASSIFY still run for audit telemetry; 6c.4 ROUTE / 6c.5 POST-FIX / 6c.6 HALT are skipped. Outcome is forced to `green` if probe was green; otherwise `halted` (still gates trust signal).
    - Default: Run all applicable reviews + Phase 2 simplify pass
    - **Capture aspect tokens.** Tokenise the remaining arguments (after the `--no-simplify` and `--turbo` flags are stripped) into `ASPECT_LIST` (an array). Example: `/uberdev:review-pr tests errors` → `ASPECT_LIST=("tests" "errors")`. Empty arguments → `ASPECT_LIST=()`. The `all` token is treated as "no emphasis" (i.e., default behavior — every reviewer's brief receives no emphasis section).
@@ -44,6 +51,7 @@ Pass `--turbo` (anywhere in the arguments) to acknowledge invocation from `finis
    | `SIMPLIFY_PHASE` | `--no-simplify` token | `1` | `0` skips Phase 2 |
    | `SEQUENTIAL` | `sequential` token | `0` | `1` exports `UBERDEV_FANOUT_POST_IMPL_REVIEW=1` (stderr notice emitted) |
    | `CI_FIX_PHASE` | `--no-ci-fix` token | `1` | `0` runs PROBE+MONITOR+CLASSIFY (audit-only) but skips ROUTE+POST-FIX+HALT — outcome forced to `green` if probe was green, otherwise `halted` (still gates trust signal). |
+   | `TURBO` | `--turbo` token OR `UBERDEV_TURBO=1` env (hybrid OR, #97) | `0` | `1` activates the Phase 3 halt-class carve-out (6c.6 HALT — no AskUserQuestion, exit 1, no trust signal). Phases 1+2 unchanged in either mode. |
    | `ASPECT_LIST` | remaining tokens | `()` | passed as `aspect_emphasis` input to `Skill(uberdev:post-impl-review)` Step 4 |
 
 2. **Available Review Aspects:**

--- a/plugins/uberdev/commands/review-pr.md
+++ b/plugins/uberdev/commands/review-pr.md
@@ -28,10 +28,11 @@ Pass `--turbo` (anywhere in the arguments) to acknowledge invocation from `finis
    - Detect `--turbo` token in `$ARGUMENTS` AND/OR inherited env var `${UBERDEV_TURBO:-0} == "1"` (#97 — hybrid OR detector). Strip the `--turbo` token from the aspect list. Set `TURBO=1` if either source signals turbo; else `TURBO=0`. The detection result feeds the Phase 3 halt-class carve-out (6c.6 HALT) — it does NOT mutate `SIMPLIFY_PHASE` or any other phase variable. Hybrid form (mirrors `orchestrator/SKILL.md`):
      ```bash
      TURBO=0
-     if [[ "$ARGUMENTS" == *"--turbo"* ]] || [[ "${UBERDEV_TURBO:-0}" == "1" ]]; then
+     if [[ "${ARGUMENTS:-}" == *"--turbo"* ]] || [[ "${UBERDEV_TURBO:-0}" == "1" ]]; then
        TURBO=1
      fi
      ```
+     `${ARGUMENTS:-}` is defense-in-depth against `set -u` and mirrors the `${UBERDEV_TURBO:-0}` half of the OR for symmetry (#97 follow-up).
      Rationale: `merge-pipeline` invokes `Skill("uberdev:review-pr", args: "${PR} --turbo")` (out-of-scope for #97) — arg form must remain accepted. `finish-branch` chains via `Skill("uberdev:review-pr")` with no flag (env-var inheritance, #97) — env form must also be accepted. The hybrid OR detector closes both call sites.
    - Detect `--no-ci-fix` token in `$ARGUMENTS` and strip it from the aspect list — sets `CI_FIX_PHASE=0` (probe-only mode), otherwise `CI_FIX_PHASE=1` (default). Mirrors `--no-simplify` shape. When `CI_FIX_PHASE=0`, Phase 3 6c.1 PROBE + 6c.2 MONITOR + 6c.3 CLASSIFY still run for audit telemetry; 6c.4 ROUTE / 6c.5 POST-FIX / 6c.6 HALT are skipped. Outcome is forced to `green` if probe was green; otherwise `halted` (still gates trust signal).
    - Default: Run all applicable reviews + Phase 2 simplify pass

--- a/plugins/uberdev/commands/solve.md
+++ b/plugins/uberdev/commands/solve.md
@@ -38,8 +38,8 @@ An audit event `deprecated_flag_used` is recorded for each first-encounter emiss
 ## Steps
 
 ```bash
-export AUTO_MODE=0       # /solve = interactive mode (post-impl-review wired in trivial/small; orchestrator without --turbo)
-unset UBERDEV_TURBO      # NEW (#97): defend against shell-rc pollution from prior /turbo or .zshrc export of UBERDEV_TURBO=1
+export AUTO_MODE=0       # /solve = interactive mode (post-impl-review wired in trivial/small; orchestrator + review-pr hybrid OR detector returns TURBO=0 when neither UBERDEV_TURBO=1 nor --turbo is present, #97)
+unset UBERDEV_TURBO      # NEW (#97): defend against shell-rc pollution from prior /turbo or .zshrc export of UBERDEV_TURBO=1 — MUST run BEFORE Skill('uberdev:solve-pipeline') below so the launcher inherits a clean env
 ```
 
 Now invoke the `uberdev:solve-pipeline` skill — it owns the bash launcher (arg parsing, repo detection, tier classification, prompt heredoc, terminal spawn, notify, retitle). The skill renders inline, so `$AUTO_MODE` and `$ARGUMENTS` remain in scope for its bash blocks.

--- a/plugins/uberdev/commands/solve.md
+++ b/plugins/uberdev/commands/solve.md
@@ -38,7 +38,8 @@ An audit event `deprecated_flag_used` is recorded for each first-encounter emiss
 ## Steps
 
 ```bash
-export AUTO_MODE=0  # /solve = interactive mode (post-impl-review wired in trivial/small; orchestrator without --turbo)
+export AUTO_MODE=0       # /solve = interactive mode (post-impl-review wired in trivial/small; orchestrator without --turbo)
+unset UBERDEV_TURBO      # NEW (#97): defend against shell-rc pollution from prior /turbo or .zshrc export of UBERDEV_TURBO=1
 ```
 
 Now invoke the `uberdev:solve-pipeline` skill — it owns the bash launcher (arg parsing, repo detection, tier classification, prompt heredoc, terminal spawn, notify, retitle). The skill renders inline, so `$AUTO_MODE` and `$ARGUMENTS` remain in scope for its bash blocks.

--- a/plugins/uberdev/commands/turbo.md
+++ b/plugins/uberdev/commands/turbo.md
@@ -41,7 +41,8 @@ An audit event `deprecated_flag_used` is recorded for each first-encounter emiss
 ## Steps
 
 ```bash
-export AUTO_MODE=1  # /turbo = unattended mode (post-impl-review omitted in trivial/small; orchestrator gets --turbo)
+export AUTO_MODE=1       # /turbo = unattended mode (post-impl-review omitted in trivial/small; orchestrator gets --turbo)
+export UBERDEV_TURBO=1   # NEW (#97): chain-wide unattended-mode signal — inherits via Skill() into solve-pipeline + via fork+exec into claude --bg child
 ```
 
 Now invoke the `uberdev:solve-pipeline` skill.

--- a/plugins/uberdev/commands/turbo.md
+++ b/plugins/uberdev/commands/turbo.md
@@ -41,8 +41,8 @@ An audit event `deprecated_flag_used` is recorded for each first-encounter emiss
 ## Steps
 
 ```bash
-export AUTO_MODE=1       # /turbo = unattended mode (post-impl-review omitted in trivial/small; orchestrator gets --turbo)
-export UBERDEV_TURBO=1   # NEW (#97): chain-wide unattended-mode signal — inherits via Skill() into solve-pipeline + via fork+exec into claude --bg child
+export AUTO_MODE=1       # /turbo = unattended mode (post-impl-review omitted in trivial/small; orchestrator + review-pr detect turbo via UBERDEV_TURBO env-var OR --turbo arg — hybrid OR detector, #97)
+export UBERDEV_TURBO=1   # NEW (#97): chain-wide unattended-mode signal — inherits via Skill() into solve-pipeline + via fork+exec into claude --bg child (env(1)-mediated, since timeout(1) sits in front of the inline-prefix slot)
 ```
 
 Now invoke the `uberdev:solve-pipeline` skill.

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -46,18 +46,18 @@ git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
 
 Or ask: "This branch split from main - is that correct?"
 
-### Step 3: Mode selection (precedence: --turbo > --interactive > default)
+### Step 3: Mode selection (precedence: UBERDEV_TURBO=1 > --interactive > default)
 
-Detect flags from `$ARGUMENTS`:
+Detect mode from the inherited environment variable `UBERDEV_TURBO` (set by `commands/turbo.md` → `solve-pipeline` → `claude --bg` inline-prefix exec, per #97) AND from `$ARGUMENTS` (for the `--interactive` flag only — finish-branch no longer parses `--turbo` as an argument; turbo signal is env-var-only on the chain hot path):
 
-1. **Turbo mode** — if `--turbo` is in `$ARGUMENTS`:
-   Skip the prompt, auto-select **Option 2 (Push and create a Pull Request)**, and chain into `/uberdev:review-pr` (forwarding `--turbo`). Announce:
+1. **Turbo mode** — if `[[ "${UBERDEV_TURBO:-0}" == "1" ]]`:
+   Skip the prompt, auto-select **Option 2 (Push and create a Pull Request)**, and chain into `/uberdev:review-pr` (no `--turbo` arg — review-pr inherits the env var via Skill() invocation in the same agent process). Announce:
 
-   > "Implementation complete. Turbo mode — auto-selecting Option 2 (Push and create PR). Chaining into /uberdev:review-pr (--turbo)."
+   > "Implementation complete. Turbo mode (UBERDEV_TURBO=1) — auto-selecting Option 2 (Push and create PR). Chaining into /uberdev:review-pr."
 
    Proceed to Step 4 → Option 2.
 
-2. **Interactive mode** — if `--interactive` is in `$ARGUMENTS` (and `--turbo` is NOT):
+2. **Interactive mode** — if `--interactive` is in `$ARGUMENTS` AND `[[ "${UBERDEV_TURBO:-0}" != "1" ]]`:
    Present the legacy 4-option menu below. If the user picks Option 2, chain into `/uberdev:review-pr` (no `--turbo`). Other options behave as today.
 
    ```
@@ -71,18 +71,18 @@ Detect flags from `$ARGUMENTS`:
    Which option?
    ```
 
-   > **Caveat — Options 1, 3, 4 bypass post-impl review.** Options 1 (Merge back to base locally), 3 (Keep the branch as-is), and 4 (Discard this work) skip `gh pr create` entirely, and therefore skip the chain into `/uberdev:review-pr` whose Phase 1 hosts the 5-reviewer post-impl-review fanout (per `plugins/uberdev/skills/post-impl-review/SKILL.md` "When to invoke" — `/uberdev:review-pr` Phase 1 is the sole live caller). Users who pick Options 1, 3, or 4 explicitly opt out of automated post-impl review for that branch. Only Option 2 (Push and create a Pull Request) preserves the chain. The default mode (always-PR, no flags) and `--turbo` mode both auto-select Option 2 — neither is affected by this bypass.
+   > **Caveat — Options 1, 3, 4 bypass post-impl review.** Options 1 (Merge back to base locally), 3 (Keep the branch as-is), and 4 (Discard this work) skip `gh pr create` entirely, and therefore skip the chain into `/uberdev:review-pr` whose Phase 1 hosts the 5-reviewer post-impl-review fanout (per `plugins/uberdev/skills/post-impl-review/SKILL.md` "When to invoke" — `/uberdev:review-pr` Phase 1 is the sole live caller). Users who pick Options 1, 3, or 4 explicitly opt out of automated post-impl review for that branch. Only Option 2 (Push and create a Pull Request) preserves the chain. The default mode (always-PR, no flags) and Turbo mode (`UBERDEV_TURBO=1`) both auto-select Option 2 — neither is affected by this bypass.
 
    **Don't add explanation** — keep options concise.
 
-3. **Default mode** — neither flag set (the always-PR path):
+3. **Default mode** — neither `UBERDEV_TURBO=1` nor `--interactive` set (the always-PR path):
    Auto-select **Option 2 (Push and create a Pull Request)** and chain into `/uberdev:review-pr` (no `--turbo` forwarded). Announce:
 
    > "Implementation complete. Pushing branch and creating PR. Chaining into /uberdev:review-pr…"
 
    Proceed to Step 4 → Option 2.
 
-**Conflict resolution:** if both `--turbo` and `--interactive` are present, `--turbo` wins (turbo's contract is unattended end-to-end; interactive prompts are mutually exclusive).
+**Conflict resolution:** if both `--interactive` is in `$ARGUMENTS` AND `UBERDEV_TURBO=1` is set, env var wins (turbo's contract is unattended end-to-end; interactive prompts are mutually exclusive). The `UBERDEV_TURBO` env var is the canonical signal on the chain hot path; finish-branch no longer accepts a `--turbo` argument (#97 — env-var-only since the orchestrator → SDD → finish-branch chain is fully internal).
 
 **Discoverability:** the `--interactive` flag restores the legacy 4-option menu (Merge back to base / Push and create a Pull Request / Keep the branch as-is / Discard) for users who want it. The default is now always-PR; this fulfills the `~/.claude/CLAUDE.md` mandate "MANDATORY: run `/uberdev:review-pr` after pushing the PR. No exceptions, hotfixes included."
 
@@ -317,9 +317,9 @@ The two `gh` calls above are intentionally fail-soft — the fire-and-surface co
 
 **Chain hand-off (always-PR path, default + turbo):**
 
-After the PR is created and `PR_URL` is validated, **invoke `uberdev:review-pr` via the `Skill` tool** with the captured `PR_URL`. Forward `--turbo` if it was in `$ARGUMENTS`. The chain is **fire-and-surface, not fire-and-block**: review-pr's findings surface to the user via its own output, but `finish-branch` does NOT block on `REVISIONS_REQUIRED` (advisory only, per #11 Q1).
+After the PR is created and `PR_URL` is validated, **invoke `uberdev:review-pr` via the `Skill` tool** with the captured `PR_URL` (no `--turbo` arg). Review-pr inherits the unattended-mode signal via the `UBERDEV_TURBO=1` env var inherited from the parent `claude --bg` process; review-pr also retains a hybrid arg-OR-env detector for compatibility with `merge-pipeline`'s separate dispatch (which still passes `--turbo` as an arg — out-of-scope for #97). The chain is **fire-and-surface, not fire-and-block**: review-pr's findings surface to the user via its own output, but `finish-branch` does NOT block on `REVISIONS_REQUIRED` (advisory only, per #11 Q1).
 
-> Invoke `uberdev:review-pr` via the Skill tool with the captured `PR_URL`. Forward `--turbo` if present. Findings are ADVISORY — do NOT block on `REVISIONS_REQUIRED` at this layer (the auto-fix loop is deferred per #11 Q1).
+> Invoke `uberdev:review-pr` via the Skill tool with the captured `PR_URL` (no flag args). Findings are ADVISORY — do NOT block on `REVISIONS_REQUIRED` at this layer (the auto-fix loop is deferred per #11 Q1).
 
 Mirrors the canonical `subagent-driven-dev → post-impl-review` precedent (commit `73b2562`). `commands/review-pr.md` has no `disable-model-invocation` flag, so the `Skill` tool can invoke the slash command directly without promotion.
 
@@ -425,4 +425,4 @@ git worktree remove <worktree-path>
 - **`uberdev:merge`** — follows Option 2. `finish-branch` opens the PR; `/merge` lands it. Together they form the lifecycle `/issue → /solve → push → /review-pr → /merge`.
 
 **Chains into:**
-- **`uberdev:review-pr`** — invoked via the `Skill` tool after PR creation on the always-PR path (default mode + `--turbo`). Mirrors `subagent-driven-dev → post-impl-review` (commit `73b2562`). Advisory only — `finish-branch` does not block on reviewer verdict.
+- **`uberdev:review-pr`** — invoked via the `Skill` tool after PR creation on the always-PR path (default mode + Turbo mode under `UBERDEV_TURBO=1`). Mirrors `subagent-driven-dev → post-impl-review` (commit `73b2562`). Advisory only — `finish-branch` does not block on reviewer verdict.

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -57,7 +57,7 @@ Detect mode from the inherited environment variable `UBERDEV_TURBO` (set by `com
 
    Proceed to Step 4 → Option 2.
 
-2. **Interactive mode** — if `--interactive` is in `$ARGUMENTS` AND `[[ "${UBERDEV_TURBO:-0}" != "1" ]]`:
+2. **Interactive mode** — if `--interactive` is in `$ARGUMENTS` (and `UBERDEV_TURBO` is not `1` — turbo wins per precedence above):
    Present the legacy 4-option menu below. If the user picks Option 2, chain into `/uberdev:review-pr` (no `--turbo`). Other options behave as today.
 
    ```
@@ -82,7 +82,7 @@ Detect mode from the inherited environment variable `UBERDEV_TURBO` (set by `com
 
    Proceed to Step 4 → Option 2.
 
-**Conflict resolution:** if both `--interactive` is in `$ARGUMENTS` AND `UBERDEV_TURBO=1` is set, env var wins (turbo's contract is unattended end-to-end; interactive prompts are mutually exclusive). The `UBERDEV_TURBO` env var is the canonical signal on the chain hot path; finish-branch no longer accepts a `--turbo` argument (#97 — env-var-only since the orchestrator → SDD → finish-branch chain is fully internal).
+**Conflict resolution:** if `--interactive` is in `$ARGUMENTS` AND `UBERDEV_TURBO=1` is also set, env var wins (turbo's contract is unattended end-to-end; interactive prompts are mutually exclusive). The `UBERDEV_TURBO` env var is the canonical signal on the chain hot path; finish-branch no longer accepts a `--turbo` argument (#97 — env-var-only since the orchestrator → SDD → finish-branch chain is fully internal).
 
 **Discoverability:** the `--interactive` flag restores the legacy 4-option menu (Merge back to base / Push and create a Pull Request / Keep the branch as-is / Discard) for users who want it. The default is now always-PR; this fulfills the `~/.claude/CLAUDE.md` mandate "MANDATORY: run `/uberdev:review-pr` after pushing the PR. No exceptions, hotfixes included."
 

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -317,7 +317,7 @@ The two `gh` calls above are intentionally fail-soft — the fire-and-surface co
 
 **Chain hand-off (always-PR path, default + turbo):**
 
-After the PR is created and `PR_URL` is validated, **invoke `uberdev:review-pr` via the `Skill` tool** with the captured `PR_URL` (no `--turbo` arg). Review-pr inherits the unattended-mode signal via the `UBERDEV_TURBO=1` env var inherited from the parent `claude --bg` process; review-pr also retains a hybrid arg-OR-env detector for compatibility with `merge-pipeline`'s separate dispatch (which still passes `--turbo` as an arg — out-of-scope for #97). The chain is **fire-and-surface, not fire-and-block**: review-pr's findings surface to the user via its own output, but `finish-branch` does NOT block on `REVISIONS_REQUIRED` (advisory only, per #11 Q1).
+After the PR is created and `PR_URL` is validated, **invoke `uberdev:review-pr` via the `Skill` tool** with the captured `PR_URL` (no `--turbo` arg). Review-pr inherits the unattended-mode signal via the `UBERDEV_TURBO=1` env var inherited from the parent `claude --bg` process; review-pr also retains a hybrid arg-OR-env detector for compatibility with the separate dispatch in `merge-pipeline` (which still passes `--turbo` as an arg — out-of-scope for #97). The chain is **fire-and-surface, not fire-and-block**: review-pr findings surface to the user via its own output, but `finish-branch` does NOT block on `REVISIONS_REQUIRED` (advisory only, per #11 Q1).
 
 > Invoke `uberdev:review-pr` via the Skill tool with the captured `PR_URL` (no flag args). Findings are ADVISORY — do NOT block on `REVISIONS_REQUIRED` at this layer (the auto-fix loop is deferred per #11 Q1).
 

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -201,10 +201,12 @@ If parse fails → re-dispatch the failed agent ONCE with the format example pin
 
 ```bash
 TURBO=0
-if [[ "$ARGUMENTS" == *"--turbo"* ]] || [[ "${UBERDEV_TURBO:-0}" == "1" ]]; then
+if [[ "${ARGUMENTS:-}" == *"--turbo"* ]] || [[ "${UBERDEV_TURBO:-0}" == "1" ]]; then
   TURBO=1
 fi
 ```
+
+The `${ARGUMENTS:-}` form is defense-in-depth against `set -u` (current Bash tool calls do not enable nounset, but symmetry with the `${UBERDEV_TURBO:-0}` half of the OR keeps the detector robust if the surrounding launcher ever does — #97 follow-up).
 
 All Phase-2/3.5/5 references to "if --turbo" in this skill resolve to `[[ "$TURBO" == "1" ]]` under this single detection contract.
 

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -197,6 +197,17 @@ If parse fails → re-dispatch the failed agent ONCE with the format example pin
 
 **Turbo (`--turbo` set — only path that auto-picks):** instead of skipping entirely, generate the same set of clarifying questions in-thread, auto-pick each answer using the spec-writer's `decisions`-block synthesis logic (best guess from research artifacts), and write to `$RESEARCH_DIR_ABS/questions.md` in the format below (Q-N heading, `**Auto-pick:**`, `**Rationale:**`, `**Confidence:** high|medium|low`). The `decisions` array fed to spec-writer has the same shape as a non-turbo run, just with `auto_pick: true` flagged.
 
+**Turbo detection (hybrid):** the orchestrator treats turbo mode as ON when EITHER `$ARGUMENTS` contains `--turbo` (standalone-invocation path, see "Standalone invocation" section below) OR the inherited environment variable `${UBERDEV_TURBO:-0} == "1"` (set by `commands/turbo.md` and propagated through `solve-pipeline`'s `claude --bg` inline-prefix exec, #97). Concretely:
+
+```bash
+TURBO=0
+if [[ "$ARGUMENTS" == *"--turbo"* ]] || [[ "${UBERDEV_TURBO:-0}" == "1" ]]; then
+  TURBO=1
+fi
+```
+
+All Phase-2/3.5/5 references to "if --turbo" in this skill resolve to `[[ "$TURBO" == "1" ]]` under this single detection contract.
+
 Format:
 ```markdown
 ## Q1: <verbatim question>
@@ -274,7 +285,7 @@ Trivial/small tier bypass orchestrator entirely; plan-reviewer is N/A there.
 
 ### Phase 5: subagent-driven-dev
 
-Invoke `uberdev:subagent-driven-dev` skill (NOT a Task() — actual skill invocation via Skill tool). Pass `plan_path`. **If the orchestrator was invoked with `--turbo`, also pass `--turbo`** so the downstream chain (`subagent-driven-dev → finish-branch`) stays unattended and `finish-branch` auto-selects "Push and Create PR" instead of prompting. The existing skill handles wave dispatch, review, and PR creation. `subagent-driven-dev` internally calls `uberdev:post-impl-review` once after all waves complete (consolidated end-of-issue invocation) — see `plugins/uberdev/skills/post-impl-review/SKILL.md`. Findings are advisory at this layer (non-blocking on `REVISIONS_REQUIRED`); the auto-fix loop is deferred per Q1 of the design spec.
+Invoke `uberdev:subagent-driven-dev` skill (NOT a Task() — actual skill invocation via Skill tool). Pass `plan_path`. The downstream chain (`subagent-driven-dev → finish-branch`) detects unattended mode via the `UBERDEV_TURBO=1` environment variable inherited from the parent `claude --bg` process — no per-call `--turbo` arg-forwarding needed (#97). The existing skill handles wave dispatch, review, and PR creation. `subagent-driven-dev` internally calls `uberdev:post-impl-review` once after all waves complete (consolidated end-of-issue invocation) — see `plugins/uberdev/skills/post-impl-review/SKILL.md`. Findings are advisory at this layer (non-blocking on `REVISIONS_REQUIRED`); the auto-fix loop is deferred per Q1 of the design spec.
 
 ### Phase 5.5: pr-test-analyzer (large tier only, pre-merge)
 

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -560,13 +560,23 @@ TITLE="${TITLES[$ISSUE_NUM]}"
 BG_DISPATCH_RC=0
 BG_SESSION_ID=""
 BG_STDOUT_LOG="/tmp/solve-bg-stdout-$ISSUE_NUM.log"
+# NEW (#97): UBERDEV_TURBO=1 chain-wide signal for /turbo (AUTO_MODE=1) only.
+# Inline-prefix exec is the canonical POSIX form for "set on this exec only" —
+# the bg child inherits via fork+exec, the parent shell's env is untouched.
+# AUTO_MODE=0 (/solve) skips the prefix so an interactive run never propagates
+# turbo into the bg child even if UBERDEV_TURBO leaked into the parent env.
+if [[ "$AUTO_MODE" == "1" ]]; then
+  BG_TURBO_ENV=( UBERDEV_TURBO=1 )
+else
+  BG_TURBO_ENV=()
+fi
 case "$BG_PROMPT_MODE" in
   file)
     # Trusted path arg; file contents never reach the shell as argv.
     # PERM_FLAG / EFFORT_FLAG are bash+zsh arrays — see Phase A hoist for the
     # zsh SH_WORD_SPLIT=off rationale; `"${ARRAY[@]}"` expands identically in
     # both shells (empty array → zero slots; populated → one slot per element).
-    "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" claude --bg \
+    "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" "${BG_TURBO_ENV[@]}" claude --bg \
       --prompt-file "/tmp/solve-prompt-$ISSUE_NUM.txt" \
       --worktree "solve-issue-$ISSUE_NUM" \
       --model "$MODEL" "${PERM_FLAG[@]}" "${EFFORT_FLAG[@]}" > "$BG_STDOUT_LOG" 2>&1
@@ -574,7 +584,7 @@ case "$BG_PROMPT_MODE" in
     ;;
   stdin)
     # File content streamed on FD 0; no argv quoting concern.
-    "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" claude --bg \
+    "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" "${BG_TURBO_ENV[@]}" claude --bg \
       --worktree "solve-issue-$ISSUE_NUM" \
       --model "$MODEL" "${PERM_FLAG[@]}" "${EFFORT_FLAG[@]}" \
       < "/tmp/solve-prompt-$ISSUE_NUM.txt" > "$BG_STDOUT_LOG" 2>&1
@@ -583,7 +593,7 @@ case "$BG_PROMPT_MODE" in
   argv)
     # Bash array form (spec-reviewer finding 1) — single argv slot, no eval.
     PROMPT_BODY="$(cat "/tmp/solve-prompt-$ISSUE_NUM.txt")"
-    cmd=( "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" claude --bg
+    cmd=( "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" "${BG_TURBO_ENV[@]}" claude --bg
           --worktree "solve-issue-$ISSUE_NUM"
           --model "$MODEL" )
     # PERM_FLAG / EFFORT_FLAG are arrays from Phase A

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -561,14 +561,19 @@ BG_DISPATCH_RC=0
 BG_SESSION_ID=""
 BG_STDOUT_LOG="/tmp/solve-bg-stdout-$ISSUE_NUM.log"
 # NEW (#97): UBERDEV_TURBO=1 chain-wide signal for /turbo (AUTO_MODE=1) only.
-# Inline-prefix exec is the canonical POSIX form for "set on this exec only" —
-# the bg child inherits via fork+exec, the parent shell's env is untouched.
-# AUTO_MODE=0 (/solve) skips the prefix so an interactive run never propagates
-# turbo into the bg child even if UBERDEV_TURBO leaked into the parent env.
+# env(1) mediates the inline-prefix because POSIX inline-prefix env-assignment
+# only takes effect at the START of a simple command. Here the dispatch is
+# `$TIMEOUT_BIN $SOLVE_TIMEOUT <env-tokens> claude --bg …` — `timeout(1)` is
+# already in front, so it would consume `UBERDEV_TURBO=1` as the COMMAND argv
+# (not as env) and exit 127. `env "${BG_TURBO_ENV[@]}" claude --bg` consumes
+# the KEY=value tokens and execs claude --bg with those env vars set; under
+# AUTO_MODE=0 (empty array) it degrades to a no-op env passthrough.
+# Pre-declare BG_TURBO_ENV=() before the if/else to keep the array bound under
+# `set -u` (defense-in-depth — current Bash tool calls do NOT enable -u, but
+# both branches setting the same name is the safer invariant). #97 follow-up.
+BG_TURBO_ENV=()
 if [[ "$AUTO_MODE" == "1" ]]; then
   BG_TURBO_ENV=( UBERDEV_TURBO=1 )
-else
-  BG_TURBO_ENV=()
 fi
 case "$BG_PROMPT_MODE" in
   file)
@@ -576,7 +581,7 @@ case "$BG_PROMPT_MODE" in
     # PERM_FLAG / EFFORT_FLAG are bash+zsh arrays — see Phase A hoist for the
     # zsh SH_WORD_SPLIT=off rationale; `"${ARRAY[@]}"` expands identically in
     # both shells (empty array → zero slots; populated → one slot per element).
-    "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" "${BG_TURBO_ENV[@]}" claude --bg \
+    "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" env "${BG_TURBO_ENV[@]}" claude --bg \
       --prompt-file "/tmp/solve-prompt-$ISSUE_NUM.txt" \
       --worktree "solve-issue-$ISSUE_NUM" \
       --model "$MODEL" "${PERM_FLAG[@]}" "${EFFORT_FLAG[@]}" > "$BG_STDOUT_LOG" 2>&1
@@ -584,7 +589,7 @@ case "$BG_PROMPT_MODE" in
     ;;
   stdin)
     # File content streamed on FD 0; no argv quoting concern.
-    "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" "${BG_TURBO_ENV[@]}" claude --bg \
+    "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" env "${BG_TURBO_ENV[@]}" claude --bg \
       --worktree "solve-issue-$ISSUE_NUM" \
       --model "$MODEL" "${PERM_FLAG[@]}" "${EFFORT_FLAG[@]}" \
       < "/tmp/solve-prompt-$ISSUE_NUM.txt" > "$BG_STDOUT_LOG" 2>&1
@@ -593,7 +598,7 @@ case "$BG_PROMPT_MODE" in
   argv)
     # Bash array form (spec-reviewer finding 1) — single argv slot, no eval.
     PROMPT_BODY="$(cat "/tmp/solve-prompt-$ISSUE_NUM.txt")"
-    cmd=( "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" "${BG_TURBO_ENV[@]}" claude --bg
+    cmd=( "$TIMEOUT_BIN" "$SOLVE_TIMEOUT" env "${BG_TURBO_ENV[@]}" claude --bg
           --worktree "solve-issue-$ISSUE_NUM"
           --model "$MODEL" )
     # PERM_FLAG / EFFORT_FLAG are arrays from Phase A

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -568,13 +568,15 @@ BG_STDOUT_LOG="/tmp/solve-bg-stdout-$ISSUE_NUM.log"
 # (not as env) and exit 127. `env "${BG_TURBO_ENV[@]}" claude --bg` consumes
 # the KEY=value tokens and execs claude --bg with those env vars set; under
 # AUTO_MODE=0 (empty array) it degrades to a no-op env passthrough.
-# Pre-declare BG_TURBO_ENV=() before the if/else to keep the array bound under
-# `set -u` (defense-in-depth — current Bash tool calls do NOT enable -u, but
-# both branches setting the same name is the safer invariant). #97 follow-up.
+# Pre-declare BG_TURBO_ENV=() so the array name is always bound before the
+# AUTO_MODE-conditional setter on the next line runs. The `[[ ... ]] && ...`
+# form (rather than a second `if/then/fi` block) keeps the file's anchor count
+# at exactly two `^if \[\[ "\$AUTO_MODE" == "1" \]\]; then$` matches (lines
+# 285 and 505) — the differential-guard awk in tests/turbo-flow.test.sh keys
+# off that anchor count and would scan an unbounded code region if a third
+# block were introduced (#97 simplify-lens E2 follow-up).
 BG_TURBO_ENV=()
-if [[ "$AUTO_MODE" == "1" ]]; then
-  BG_TURBO_ENV=( UBERDEV_TURBO=1 )
-fi
+[[ "$AUTO_MODE" == "1" ]] && BG_TURBO_ENV=( UBERDEV_TURBO=1 )
 case "$BG_PROMPT_MODE" in
   file)
     # Trusted path arg; file contents never reach the shell as argv.

--- a/plugins/uberdev/skills/subagent-driven-dev/SKILL.md
+++ b/plugins/uberdev/skills/subagent-driven-dev/SKILL.md
@@ -68,7 +68,7 @@ digraph when_to_use {
    h. Dispatch code quality reviewers (parallel). Same fix-loop pattern.
    i. Mark every task in the wave complete in TodoWrite.
    j. **Mark wave complete.** No additional accumulation required at the SDD layer — `/uberdev:review-pr` Phase 1, chained post-push from `finish-branch`, computes its own `changed_paths` and `commit_range` against the pushed PR.
-5. Hand off to `uberdev:finish-branch`. **If `--turbo` was in `$ARGUMENTS`, propagate it** — invoke as `uberdev:finish-branch --turbo` so the branch close-out auto-selects "Push and Create PR" instead of prompting. For large tier, the orchestrator's Phase 5.5 (`pr-test-analyzer`) runs *after* this skill returns. Post-implementation reviewer fanout is hosted by `/uberdev:review-pr` Phase 1 (chained from `finish-branch` after PR push); no reviewer fanout is dispatched from `subagent-driven-dev` itself.
+5. Hand off to `uberdev:finish-branch` (no flag arg). The branch close-out detects unattended mode via the `UBERDEV_TURBO=1` environment variable inherited from the parent `claude --bg` process — under that signal, `finish-branch` auto-selects "Push and Create PR" without prompting (#97). For large tier, the orchestrator's Phase 5.5 (`pr-test-analyzer`) runs *after* this skill returns. Post-implementation reviewer fanout is hosted by `/uberdev:review-pr` Phase 1 (chained from `finish-branch` after PR push); no reviewer fanout is dispatched from `subagent-driven-dev` itself.
 
 ### Parallel Dispatch Pattern
 

--- a/tests/config-override.test.sh
+++ b/tests/config-override.test.sh
@@ -365,8 +365,8 @@ assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
   'command -v gtimeout' \
   "I2c: launcher probes gtimeout fallback (Homebrew coreutils installs the macOS binary as gtimeout, not timeout)"
 assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
-  '"\$TIMEOUT_BIN" "\$SOLVE_TIMEOUT" claude --bg' \
-  "I2d: bg dispatch wraps claude --bg in timeout(1)/gtimeout (zsh-safe; no scalar prefix)"
+  '"\$TIMEOUT_BIN" "\$SOLVE_TIMEOUT" "\${BG_TURBO_ENV\[@\]}" claude --bg' \
+  "I2d: bg dispatch wraps claude --bg in timeout(1)/gtimeout with zsh-safe BG_TURBO_ENV[@] inline-prefix (#97 — array form preserves zsh SH_WORD_SPLIT=off compatibility)"
 assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
   'brew install coreutils' \
   "I2e: missing-timeout warning includes remediation pointer"

--- a/tests/config-override.test.sh
+++ b/tests/config-override.test.sh
@@ -365,8 +365,8 @@ assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
   'command -v gtimeout' \
   "I2c: launcher probes gtimeout fallback (Homebrew coreutils installs the macOS binary as gtimeout, not timeout)"
 assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
-  '"\$TIMEOUT_BIN" "\$SOLVE_TIMEOUT" "\${BG_TURBO_ENV\[@\]}" claude --bg' \
-  "I2d: bg dispatch wraps claude --bg in timeout(1)/gtimeout with zsh-safe BG_TURBO_ENV[@] inline-prefix (#97 — array form preserves zsh SH_WORD_SPLIT=off compatibility)"
+  '"\$TIMEOUT_BIN" "\$SOLVE_TIMEOUT" env "\${BG_TURBO_ENV\[@\]}" claude --bg' \
+  "I2d: bg dispatch wraps claude --bg in timeout(1)/gtimeout with env(1)-mediated zsh-safe BG_TURBO_ENV[@] inline-prefix (#97 — env(1) is required because timeout(1) sits between the shell and the env-prefix slot and would otherwise consume the KEY=value tokens as argv; array form preserves zsh SH_WORD_SPLIT=off compatibility)"
 assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
   'brew install coreutils' \
   "I2e: missing-timeout warning includes remediation pointer"

--- a/tests/finish-branch-auto-chain.test.sh
+++ b/tests/finish-branch-auto-chain.test.sh
@@ -40,13 +40,16 @@ assert_not_grep() {
   fi
 }
 
-echo "== Mode selection: --turbo auto-selects Option 2 + chains =="
+echo "== Mode selection: UBERDEV_TURBO=1 auto-selects Option 2 + chains (#97) =="
 assert_grep "$FINISH_BRANCH" \
-  '[Tt]urbo.*(Option 2|Push and [Cc]reate)|(Option 2|Push and [Cc]reate).*[Tt]urbo' \
-  "turbo auto-selects Option 2 (Push and Create PR)"
+  'UBERDEV_TURBO.*(Option 2|Push and [Cc]reate)|(Option 2|Push and [Cc]reate).*UBERDEV_TURBO' \
+  "UBERDEV_TURBO=1 auto-selects Option 2 (Push and Create PR)"
 assert_grep "$FINISH_BRANCH" \
-  '[Tt]urbo.*review-pr|review-pr.*[Tt]urbo|forward.*--turbo' \
-  "turbo forwards --turbo to review-pr"
+  'UBERDEV_TURBO.*review-pr|review-pr.*UBERDEV_TURBO|inherits.*UBERDEV_TURBO|UBERDEV_TURBO=1 env' \
+  "UBERDEV_TURBO env-var inherited by review-pr (no --turbo arg forwarding, #97)"
+assert_not_grep "$FINISH_BRANCH" \
+  'Forward `--turbo` if it was in `\$ARGUMENTS`' \
+  "finish-branch chain hand-off does NOT forward --turbo arg (#97 — env-var inheritance)"
 
 echo
 echo "== Mode selection: default (no flags) auto-selects Option 2 + chains =="

--- a/tests/review-pr-phase3-ci.test.sh
+++ b/tests/review-pr-phase3-ci.test.sh
@@ -148,6 +148,12 @@ else
 fi
 
 echo
+echo "== S7.5 (#97): hybrid TURBO detector — env-var path documented =="
+assert_grep "$REVIEW_PR" \
+  'UBERDEV_TURBO' \
+  "S7.5 — review-pr documents UBERDEV_TURBO env-var as hybrid OR with --turbo arg"
+
+echo
 echo "== S8: gh outage carve-out — ci_probe_unreachable + Step 7 still runs =="
 assert_grep "$REVIEW_PR" 'ci_probe_unreachable' \
   "S8.1 — ci_probe_unreachable audit event documented"

--- a/tests/turbo-flow.test.sh
+++ b/tests/turbo-flow.test.sh
@@ -95,6 +95,32 @@ assert_grep "$SOLVE_PIPELINE" \
   "solve-pipeline expands BG_TURBO_ENV[@] left of claude --bg via env(1)-mediated inline-prefix exec (#97 — timeout(1) eats raw KEY=value as argv, env(1) consumes them as env)"
 
 echo
+echo "== Anchor pre-check: solve-pipeline must contain exactly 2 'if AUTO_MODE==1' anchors (#97 simplify-lens E2 forward-guard) =="
+# The two differential-guard awk passes below key off the bare anchor
+# `^if \[\[ "\$AUTO_MODE" == "1" \]\]; then$` and rely on its state machine
+# (in_turbo → in_solve on the very next `^else$`). The skill's design contract
+# is two such blocks: line 285 (TURBO MODE banner gate, no else arm — but the
+# awk only enters in_turbo on a match and exits via the FIRST `^else$` it sees,
+# which today belongs to the line-505 medium dispatch block, not 285's banner)
+# and line 505 (medium-tier orchestrator dispatch, with else arm). A third
+# block was briefly introduced at line 575 by #97 Phase 1 (BG_TURBO_ENV
+# pre-declare in if/then/fi form) and immediately collapsed in #97 Phase 2 to
+# `[[ ... ]] && ...` form precisely because adding a third anchor would
+# silently corrupt this awk's region scan. Lock the count at 2 so any future
+# edit that reintroduces the pattern fails loudly here, BEFORE the differential
+# guards below produce confusing pass/fail behavior.
+ANCHOR_COUNT="$(grep -c '^if \[\[ "\$AUTO_MODE" == "1" \]\]; then$' "$SOLVE_PIPELINE")"
+if [[ "$ANCHOR_COUNT" -ne 2 ]]; then
+  echo "  FAIL  solve-pipeline anchor count expected 2, got $ANCHOR_COUNT — differential-guard awk relies on exactly two if/else/fi blocks"
+  echo "        file: $SOLVE_PIPELINE"
+  echo "        if a new AUTO_MODE-conditional block was added, prefer the [[ ... ]] && ... single-line form to avoid the anchor"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  solve-pipeline contains exactly 2 'if AUTO_MODE==1' anchors (differential-guard region-scan invariant holds)"
+  PASS=$((PASS + 1))
+fi
+
+echo
 echo "== Differential guard: AUTO_MODE!=1 medium dispatch dispatches WITHOUT --turbo (#15) =="
 # pr-test-analyzer Gap #2: the positive --turbo assertion above asserts --turbo
 # appears somewhere in the skill; this asserts the interactive (/solve) medium

--- a/tests/turbo-flow.test.sh
+++ b/tests/turbo-flow.test.sh
@@ -62,16 +62,19 @@ assert_grep "$WRITE_PLAN" \
   "write-plan auto-dispatches subagent-driven-dev with --turbo (no user prompt)"
 
 echo
-echo "== subagent-driven-dev forwards --turbo to finish-branch =="
+echo "== subagent-driven-dev no longer arg-forwards --turbo to finish-branch (#97) =="
 assert_grep "$SUBAGENT_DRIVEN" \
+  'UBERDEV_TURBO' \
+  "subagent-driven-dev names UBERDEV_TURBO env var (chain-internal env-var-only signal)"
+assert_not_grep "$SUBAGENT_DRIVEN" \
   'finish-branch.*--turbo|--turbo.*finish-branch' \
-  "subagent-driven-dev names finish-branch and --turbo together"
+  "subagent-driven-dev does NOT arg-forward --turbo to finish-branch (#97)"
 
 echo
-echo "== finish-branch auto-selects PR option under --turbo =="
+echo "== finish-branch auto-selects PR option under UBERDEV_TURBO=1 (#97) =="
 assert_grep "$FINISH_BRANCH" \
-  '[Tt]urbo.*(Option 2|Push and [Cc]reate)|(Option 2|Push and [Cc]reate).*[Tt]urbo' \
-  "finish-branch auto-selects Push and Create PR under turbo"
+  'UBERDEV_TURBO.*(Option 2|Push and [Cc]reate)|(Option 2|Push and [Cc]reate).*UBERDEV_TURBO|UBERDEV_TURBO=1.*Push and create' \
+  "finish-branch auto-selects Push and Create PR under UBERDEV_TURBO=1"
 
 echo
 echo "== /turbo command entry point dispatches --turbo into the pipeline =="
@@ -81,6 +84,15 @@ echo "== /turbo command entry point dispatches --turbo into the pipeline =="
 assert_grep "$SOLVE_PIPELINE" \
   'orchestrator --turbo|brainstorm --turbo|--turbo.*orchestrator|--turbo.*brainstorm' \
   "solve-pipeline skill (medium tier) dispatches --turbo into the pipeline"
+
+echo
+echo "== solve-pipeline inline-prefix UBERDEV_TURBO=1 on claude --bg (AUTO_MODE=1 only, #97) =="
+assert_grep "$SOLVE_PIPELINE" \
+  'BG_TURBO_ENV=\( UBERDEV_TURBO=1 \)' \
+  "solve-pipeline declares BG_TURBO_ENV array under AUTO_MODE=1 (#97)"
+assert_grep "$SOLVE_PIPELINE" \
+  '"\$\{BG_TURBO_ENV\[@\]\}" claude --bg' \
+  "solve-pipeline expands BG_TURBO_ENV[@] left of claude --bg (POSIX inline-prefix exec)"
 
 echo
 echo "== Differential guard: AUTO_MODE!=1 medium dispatch dispatches WITHOUT --turbo (#15) =="
@@ -103,6 +115,30 @@ else
 fi
 
 echo
+echo "== Differential guard: AUTO_MODE!=1 medium dispatch must NOT contain UBERDEV_TURBO=1 (#97) =="
+# Companion to the --turbo differential guard above. Locks the env-var contract:
+# `UBERDEV_TURBO=1` is the inline-prefix exec env on the bg dispatch line, but
+# ONLY inside the AUTO_MODE=1 (turbo) branch. Leaking it into the AUTO_MODE!=1
+# (interactive /solve) else-branch would silently propagate turbo into every
+# /solve invocation — exactly the regression #97's symmetric inverse defends
+# against. Same awk anchor as above; inner pattern flipped from `--turbo` to
+# `UBERDEV_TURBO=1`.
+SOLVE_MEDIUM_NO_TURBO=$(awk '
+  /^if \[\[ "\$AUTO_MODE" == "1" \]\]; then$/ { in_turbo=1; next }
+  in_turbo && /^else$/ { in_turbo=0; in_solve=1; next }
+  in_solve && /^fi$/ { in_solve=0; next }
+  in_solve && /UBERDEV_TURBO=1/ { print }
+' "$SOLVE_PIPELINE")
+if [[ -n "$SOLVE_MEDIUM_NO_TURBO" ]]; then
+  echo "  FAIL  AUTO_MODE!=1 (interactive /solve) branch must NOT contain UBERDEV_TURBO=1"
+  echo "        offending lines: $SOLVE_MEDIUM_NO_TURBO"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  AUTO_MODE!=1 branch correctly omits UBERDEV_TURBO=1 (interactive /solve preserved)"
+  PASS=$((PASS + 1))
+fi
+
+echo
 echo "== thin /solve and /turbo wrappers invoke the solve-pipeline skill =="
 SOLVE_PIPELINE_REF='uberdev:solve-pipeline|solve-pipeline skill'
 assert_grep "$SOLVE_CMD" "$SOLVE_PIPELINE_REF" \
@@ -113,6 +149,10 @@ assert_grep "$SOLVE_CMD" 'export AUTO_MODE=0' \
   "/solve thin wrapper sets AUTO_MODE=0 (interactive)"
 assert_grep "$TURBO_CMD" 'export AUTO_MODE=1' \
   "/turbo thin wrapper sets AUTO_MODE=1 (unattended)"
+assert_grep "$TURBO_CMD" 'export UBERDEV_TURBO=1' \
+  "/turbo thin wrapper exports UBERDEV_TURBO=1 (#97 — chain-wide unattended-mode signal)"
+assert_grep "$SOLVE_CMD" 'unset UBERDEV_TURBO' \
+  "/solve thin wrapper unsets UBERDEV_TURBO (#97 — defends against shell-rc pollution)"
 assert_grep "$TURBO_CMD" \
   'argument-hint:.*<issue-number>.*\[<issue-number>' \
   "/turbo argument-hint documents multi-issue syntax"
@@ -217,12 +257,31 @@ assert_grep "$SOLVE_PIPELINE" \
   "Phase A version-gates claude --bg minimum (2.1.139)"
 
 echo
-echo "== orchestrator forwards --turbo into subagent-driven-dev =="
-# Orchestrator → subagent-driven-dev is the medium/large /turbo handoff site.
-# Without --turbo here, finish-branch still prompts at the end of the pipeline.
+echo "== orchestrator no longer arg-forwards --turbo to SDD (#97 — env-var inheritance) =="
+# Pre-#97 the orchestrator pasted --turbo into the SDD invocation. Post-#97
+# the chain-internal turbo signal is the inherited `UBERDEV_TURBO=1` env var
+# (set by commands/turbo.md → solve-pipeline → claude --bg inline-prefix exec)
+# and SDD/finish-branch detect it directly. Phase 5 prose must NOT instruct
+# the agent to pass --turbo to SDD anymore.
+#
+# IMPORTANT — the negative pattern is intentionally precise (anchored on the
+# imperative-form "pass --turbo to" / "with `--turbo` to" with the explicit
+# prepositional phrase). The broad `subagent-driven-dev.*--turbo` regex would
+# false-positive on the new prose's negation phrasing
+# ("no per-call `--turbo` arg-forwarding needed (#97)") which intentionally
+# names the old contract to make the change explicit to readers.
+assert_not_grep "$ORCHESTRATOR" \
+  'pass --turbo to .*subagent-driven-dev|with `--turbo` to .*subagent-driven-dev' \
+  "orchestrator Phase 5 does NOT arg-forward --turbo to subagent-driven-dev (chain inherits via UBERDEV_TURBO env)"
 assert_grep "$ORCHESTRATOR" \
-  '--turbo.*subagent-driven-dev|subagent-driven-dev.*--turbo|pass.*--turbo|with `--turbo`' \
-  "orchestrator Phase 5 forwards --turbo to subagent-driven-dev"
+  'UBERDEV_TURBO' \
+  "orchestrator Phase 5 names UBERDEV_TURBO as the chain unattended-mode signal"
+# Orchestrator turbo detector is hybrid per Decision Q3: ON when EITHER
+# $ARGUMENTS contains --turbo (standalone-invocation path) OR
+# UBERDEV_TURBO=1 (set by commands/turbo.md, propagated through claude --bg).
+assert_grep "$ORCHESTRATOR" \
+  '\$ARGUMENTS.*--turbo.*UBERDEV_TURBO|UBERDEV_TURBO.*\$ARGUMENTS.*--turbo' \
+  "orchestrator turbo detector is hybrid (\$ARGUMENTS OR UBERDEV_TURBO env, per Decision Q3)"
 
 echo
 echo "== Default-mode paths preserved (regression canaries) =="

--- a/tests/turbo-flow.test.sh
+++ b/tests/turbo-flow.test.sh
@@ -91,8 +91,8 @@ assert_grep "$SOLVE_PIPELINE" \
   'BG_TURBO_ENV=\( UBERDEV_TURBO=1 \)' \
   "solve-pipeline declares BG_TURBO_ENV array under AUTO_MODE=1 (#97)"
 assert_grep "$SOLVE_PIPELINE" \
-  '"\$\{BG_TURBO_ENV\[@\]\}" claude --bg' \
-  "solve-pipeline expands BG_TURBO_ENV[@] left of claude --bg (POSIX inline-prefix exec)"
+  'env "\$\{BG_TURBO_ENV\[@\]\}" claude --bg' \
+  "solve-pipeline expands BG_TURBO_ENV[@] left of claude --bg via env(1)-mediated inline-prefix exec (#97 — timeout(1) eats raw KEY=value as argv, env(1) consumes them as env)"
 
 echo
 echo "== Differential guard: AUTO_MODE!=1 medium dispatch dispatches WITHOUT --turbo (#15) =="


### PR DESCRIPTION
## Summary

- Replace the brittle 3-layer `--turbo` arg-forwarding chain (`orchestrator → subagent-driven-dev → finish-branch → review-pr`) with a single `UBERDEV_TURBO=1` environment variable set once at the pipeline entry point and inherited transparently through every downstream stage.
- Two-site OS-level export: `commands/turbo.md` exports BEFORE the `Skill('uberdev:solve-pipeline')` invocation (mirrors the existing `export AUTO_MODE=1` precedent at `commands/turbo.md:44`); `solve-pipeline/SKILL.md` re-emits as inline-prefix exec `UBERDEV_TURBO=1 claude --bg …` so the bg child inherits via POSIX fork+exec. `commands/solve.md` adds `unset UBERDEV_TURBO` to defend against shell-rc pollution.
- Hybrid arg-OR-env detector preserved on `orchestrator` and `commands/review-pr` (standalone-invocation contracts: direct `/uberdev:orchestrator --turbo …` and `merge-pipeline`'s separate `Skill("uberdev:review-pr", args: "${PR} --turbo")` dispatch). `subagent-driven-dev` and `finish-branch` are env-var-only — chain-internal callers, no standalone arg form needed. The "three points of LLM-interpretation failure" collapse to zero on the chain hot path.

## Test Plan

- [x] `bash tests/turbo-flow.test.sh` — 75/0 PASS (was 66/1 pre-Wave-2; rewritten with 8 new env-var assertions).
- [x] `bash tests/finish-branch-auto-chain.test.sh` — 38/0 PASS (3 new env-var assertions; #55 apostrophe meta-test fixed by rephrase).
- [x] `bash tests/merge.test.sh` — 302/0 PASS (M80 unchanged; merge-pipeline arg-passing OUT OF SCOPE).
- [x] `bash tests/review-pr-phase3-ci.test.sh` — 78/0 PASS (S7.5 added: env-var presence assertion).
- [x] `bash tests/config-override.test.sh` — 84/0 PASS (I2d updated to recognise the new `BG_TURBO_ENV[@]` inline-prefix array form).
- [x] Full repo suite: 20/20 test files exit 0 (under bash; `solve-pipeline-zsh.test.sh` runs under zsh as documented).
- [x] `BG_TURBO_ENV=( UBERDEV_TURBO=1 )` array form mirrors the existing `PERM_FLAG[@]` / `EFFORT_FLAG[@]` precedent (PR #88) — preserves zsh `SH_WORD_SPLIT=off` compatibility; a scalar would collapse to one literal argv slot under zsh.
- [x] Differential guard: `UBERDEV_TURBO=1` MUST NOT appear in the `AUTO_MODE!=1` (interactive `/solve`) branch — verified by a parallel awk pass alongside the existing `--turbo`-token guard.
- [x] awk anchor at solve-pipeline:505 (`^if [[ "$AUTO_MODE" == "1" ]]; then$`) byte-identical to baseline (turbo-flow.test.sh:91-103 anchor preserved).
- [x] Version bumped to `0.23.1` across `plugin.json`, `marketplace.json`, `README.md` badge, `CHANGELOG.md` (4 in-PR locations; post-merge tag + Release belong to `/uberdev:merge`).

## Open questions answered by /turbo

The following questions were auto-answered by `/turbo` Phase 2 (synthesised from the research bundle); please review before merge.

| Question | Auto-pick | Confidence |
|----------|-----------|------------|
| Where to set `UBERDEV_TURBO` so it propagates the chain | Two-site OS-level export — `commands/turbo.md` before `Skill()` (mirrors `AUTO_MODE`) AND `solve-pipeline` inline-prefix on `claude --bg`. `commands/solve.md` unsets defensively. | high |
| Read idiom in downstream skills | Raw inline `[[ "${UBERDEV_TURBO:-0}" == "1" ]]` — no new `uberdev_read_*` helper. Mirrors `UBERDEV_AUTO_REVIEW_ON_MERGE` precedent. | high |
| Backward compat: keep `--turbo` arg-parsing or fully replace | Hybrid: `orchestrator` + `review-pr` keep `--turbo` arg (standalone paths). `subagent-driven-dev` + `finish-branch` env-var-only (chain-internal). | high |
| Test update strategy | Same PR, dedicated commit `test(turbo-flow): assert UBERDEV_TURBO env-var propagation`. Rewrite 14+ assertions; update `finish-branch-auto-chain` / `merge` / `review-pr-phase3-ci` in lockstep. | high |
| Symmetry around `commands/solve.md` and `commands/turbo.md` | `commands/solve.md` adds `unset UBERDEV_TURBO`; `commands/turbo.md` adds `export UBERDEV_TURBO=1`. Mirrors existing `AUTO_MODE=0|1` pair. | high |

All 5 decisions are recorded with rationale at `.uberdev/research/20260513-174736-7e8b835/questions.md` (in-tree).

## Notes

- Spec: `docs/uberdev/specs/2026-05-13-uberdev-turbo-env-var-refactor-design.md` (11 grep-checkable ACs).
- Plan: `docs/uberdev/plans/2026-05-13-uberdev-turbo-env-var-refactor.md` (3 waves, 13 tasks).
- Two cross-cutting fixes were committed alongside the planned tasks: (a) `fix(finish-branch): drop possessive apostrophes on #97-bearing line` to satisfy `tests/finish-branch-auto-chain.test.sh` `#55` meta-test (no `'` in `#`-bearing lines); (b) `test(config-override): adapt I2d to BG_TURBO_ENV[@] inline-prefix` so the I2d adjacency-check accepts the new array form.

Closes #97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Turbo/unattended signaling now uses an environment-variable propagation approach across the solve pipeline (hybrid arg-vs-env detector retained; child invocations avoid forwarding a turbo flag).

* **Documentation**
  * Updated docs, README, and changelog to describe the new turbo env-var behavior and detection precedence.

* **Tests**
  * Expanded tests to assert env-var propagation, unset behavior, and revised turbo-mode contracts.

* **Chore**
  * Bumped plugin/package version to v0.23.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/105)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->