### PR TITLE
docs(orchestrator): retire missing-spec citation; mark SKILL.md authoritative (#99)

### DIFF
--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -7,7 +7,7 @@ description: "Writer-subagent orchestrator for /solve and /turbo medium/large ti
 
 You are the orchestrator. You drive the design+plan+execute pipeline by dispatching dedicated subagents and parsing their structured returns. You hold pointers — paths, shas, summaries — never the raw artifacts.
 
-**Spec:** see `docs/uberdev/specs/2026-04-28-writer-subagent-orchestrator-design.md` for the full design including return contracts and tier profiles.
+**Spec:** this SKILL.md is the authoritative reference for return contracts, tier profiles, and the Phase 5.5 / 6 boundary. The prior design doc at `docs/uberdev/specs/2026-04-28-writer-subagent-orchestrator-design.md` was never committed; this file supersedes it.
 
 ## Trust boundary
 

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -7,7 +7,7 @@ description: "Writer-subagent orchestrator for /solve and /turbo medium/large ti
 
 You are the orchestrator. You drive the design+plan+execute pipeline by dispatching dedicated subagents and parsing their structured returns. You hold pointers — paths, shas, summaries — never the raw artifacts.
 
-**Spec:** this SKILL.md is the authoritative reference for return contracts, tier profiles, and the Phase 5.5 / 6 boundary. The prior design doc at `docs/uberdev/specs/2026-04-28-writer-subagent-orchestrator-design.md` was never committed; this file supersedes it.
+**Spec:** this SKILL.md is the authoritative reference for return contracts, tier profiles, and the Phase 5.5 / 6 boundary (historical note: an external design doc was drafted at `docs/uberdev/specs/2026-04-28-writer-subagent-orchestrator-design.md` but never landed in-repo — grep traffic to that path correctly lands here).
 
 ## Trust boundary
 


### PR DESCRIPTION
## Summary

- Issue #99 reported the orchestrator SKILL.md cited a design spec (`docs/uberdev/specs/2026-04-28-writer-subagent-orchestrator-design.md`) suspected of drift from the SKILL.
- Investigation: the cited spec file has no git history in this repo and the `docs/uberdev/specs/` directory contains no committed spec files. The spec was never written, so drift is impossible — SKILL.md is the de-facto authoritative source.
- Fix: replace the stale citation on plugins/uberdev/skills/orchestrator/SKILL.md:10 with a one-liner declaring SKILL.md authoritative and noting the prior path was never committed.

## Test Plan

- [x] `bash tests/orchestrator-phase-6-doc.test.sh` — 9/9 pass (Phase 6 cascade doc invariants intact)
- [x] `bash tests/orchestrator-phase1-shortcircuit.test.sh` — 14/14 pass (Phase 1 short-circuit invariants intact)
- [x] No new tests added — citation prose is not covered by any existing test, per the trivial-fix scope rule.

Closes #99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the SKILL documentation is the authoritative reference for return contracts and tier/phase boundaries.
  * Noted that the previously referenced design doc was never committed and is superseded by this SKILL documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/106)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->