### PR TITLE
chore(gitignore): ignore stale editor backup and conflict files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,14 @@
 .AppleDouble
 .LSOverride
 
-# Editor / IDE noise
+# Editor / tool noise
 .vscode/
 .idea/
 *.swp
 *.swo
 *~
+# Enumerate *.bak / *.bak[0-9] / *.bak[0-9][0-9] explicitly — *.bak* would
+# over-match real files like backup-config.txt or backups/.
 *.bak
 *.bak[0-9]
 *.bak[0-9][0-9]

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 *.bak[0-9]
 *.bak[0-9][0-9]
 *.fix
+
+# Merge conflict artifacts
 *.orig
 *.rej
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@
 *.swp
 *.swo
 *~
+*.bak
+*.bak[0-9]
+*.bak[0-9][0-9]
+*.fix
+*.orig
+*.rej
 
 # OS-level temp
 Thumbs.db


### PR DESCRIPTION
## Summary
- Add `*.bak`, `*.bak[0-9]`, `*.bak[0-9][0-9]`, `*.fix`, `*.orig`, `*.rej` to `.gitignore` under "Editor / IDE noise" so stray editor backups and merge-conflict leftovers stop polluting `git status` between sessions.
- The two stale files cited in the issue (`plugins/uberdev/skills/solve-pipeline/SKILL.md.bak2`, `SKILL.md.fix`) are now ignored automatically — users can leave them on disk or `rm` at leisure without `git status` noise.
- `docs/rfc/` policy is unchanged: the existing whitelist at `.gitignore:17-19` already documents RFCs as public/tracked. No edit needed there.

## Test Plan
- [x] `git ls-files | grep -E '\.(bak|bak[0-9]+|fix|orig|rej)$'` returns empty (no tracked files match new patterns).
- [x] `git check-ignore -v` confirms `SKILL.md.bak2`, `SKILL.md.fix`, `*.bak`, `*.bak2`, `*.bak10`, `*.fix`, `*.orig`, `*.rej` all match the intended rules.
- [x] No test/lint surface for `.gitignore` in this repo; nothing to run.

Closes #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded repository ignore rules to cover a broader set of backup and recovery artifacts and reduce recovery/editor noise, helping keep commits and diffs cleaner and preventing accidental inclusion of transient files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/107)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->