### PR TITLE
feat(orchestrator): invalidate research cache on codebase drift

### DIFF
--- a/plugins/uberdev/agents/research-codebase.md
+++ b/plugins/uberdev/agents/research-codebase.md
@@ -31,7 +31,44 @@ Read, Grep, Glob, Bash (for `find`, `wc`, content-hashing only)
    - Anything that contradicts the issue's stated assumptions
 4. Compute the content hash of your summary file: `shasum -a 256 <summary_dir>/codebase.md | awk '{print substr($1,1,8)}'`
 
+## Required artifact front-matter
+
+Your artifact MUST begin with this YAML front-matter (between two `---` fences):
+
+```yaml
+---
+topic: <name-of-this-research-topic>
+issue: <issue number>
+head_sha: <output of `git rev-parse HEAD` captured at write time>
+summary: <one-line summary>
+---
+```
+
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
+- Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
+
+## Required `## Files investigated` section
+
+Your artifact MUST include a `## Files investigated` section listing every path you read, grep'd, or otherwise consulted. Format:
+
+```markdown
+## Files investigated
+- path/to/file.ext — short description
+- path/to/file.ext:LINE-RANGE — short description
+- another/path.ext — short description
+```
+
+Rules:
+- One path per line.
+- Optional leading `- ` (Markdown list marker).
+- The first whitespace-separated token is the path. An optional `:LINE-RANGE` suffix is allowed and preserved verbatim in the artifact, but the orchestrator parser strips it before set-intersection.
+- Disallowed characters in the path token: `$`, `` ` ``, `;`, `\`, and embedded newlines. The orchestrator's parser rejects any line whose path token fails the regex `^[A-Za-z0-9_./-]+$` — failing lines are silently dropped from the set (artifact stays valid; only `head_sha` validation failure forces a fresh dispatch).
+- This section is REQUIRED. The orchestrator's freshness predicate intersects this set with `git diff --name-only <stored-sha>..HEAD`; if the intersection is non-empty, the artifact is invalidated and a fresh dispatch is forced (`reason=file-intersection`).
+
 ## Output (last lines of your reply)
+
+Your artifact at `artifact_path` MUST conform to the front-matter and `## Files investigated` contracts above before you emit the YAML below. The orchestrator's freshness predicate depends on both.
 
 ```yaml
 status: DONE | DONE_WITH_CONCERNS | BLOCKED

--- a/plugins/uberdev/agents/research-codebase.md
+++ b/plugins/uberdev/agents/research-codebase.md
@@ -44,7 +44,7 @@ summary: <one-line summary>
 ---
 ```
 
-- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time).
 - The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
 - Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
 

--- a/plugins/uberdev/agents/research-constraints.md
+++ b/plugins/uberdev/agents/research-constraints.md
@@ -42,6 +42,41 @@ For each source:
   - When in doubt, mark `[soft]`. Only `[hard]` for explicit must/shall/never.
 - Drop rules that are clearly irrelevant to this issue.
 
+## Required artifact front-matter
+
+Your artifact MUST begin with this YAML front-matter (between two `---` fences):
+
+```yaml
+---
+topic: <name-of-this-research-topic>
+issue: <issue number>
+head_sha: <output of `git rev-parse HEAD` captured at write time>
+summary: <one-line summary>
+---
+```
+
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
+- Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
+
+## Required `## Files investigated` section
+
+Your artifact MUST include a `## Files investigated` section listing every path you read, grep'd, or otherwise consulted. Format:
+
+```markdown
+## Files investigated
+- path/to/file.ext — short description
+- path/to/file.ext:LINE-RANGE — short description
+- another/path.ext — short description
+```
+
+Rules:
+- One path per line.
+- Optional leading `- ` (Markdown list marker).
+- The first whitespace-separated token is the path. An optional `:LINE-RANGE` suffix is allowed and preserved verbatim in the artifact, but the orchestrator parser strips it before set-intersection.
+- Disallowed characters in the path token: `$`, `` ` ``, `;`, `\`, and embedded newlines. The orchestrator's parser rejects any line whose path token fails the regex `^[A-Za-z0-9_./-]+$` — failing lines are silently dropped from the set (artifact stays valid; only `head_sha` validation failure forces a fresh dispatch).
+- This section is REQUIRED. The orchestrator's freshness predicate intersects this set with `git diff --name-only <stored-sha>..HEAD`; if the intersection is non-empty, the artifact is invalidated and a fresh dispatch is forced (`reason=file-intersection`).
+
 ## Output
 
 Write `<summary_dir>/constraints.md` with this structure:
@@ -67,6 +102,8 @@ Write `<summary_dir>/constraints.md` with this structure:
 ```
 
 Omit any source section entirely if no relevant constraints were found in that source.
+
+Your artifact at `artifact_path` MUST conform to the front-matter and `## Files investigated` contracts above before you emit the YAML below. The orchestrator's freshness predicate depends on both.
 
 After writing the file, emit the universal writer return block as the final lines of your reply:
 

--- a/plugins/uberdev/agents/research-constraints.md
+++ b/plugins/uberdev/agents/research-constraints.md
@@ -55,7 +55,7 @@ summary: <one-line summary>
 ---
 ```
 
-- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time).
 - The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
 - Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
 

--- a/plugins/uberdev/agents/research-patterns.md
+++ b/plugins/uberdev/agents/research-patterns.md
@@ -44,7 +44,7 @@ summary: <one-line summary>
 ---
 ```
 
-- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time).
 - The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
 - Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
 

--- a/plugins/uberdev/agents/research-patterns.md
+++ b/plugins/uberdev/agents/research-patterns.md
@@ -31,7 +31,44 @@ Read, Grep, Glob, Bash (for `git log`, `gh pr list`, `gh issue list`)
 4. For 3-5 most relevant results: read the PR body and primary commit's diff stat to identify the pattern.
 5. Write summary to `<summary_dir>/patterns.md`: top 3 precedents (with PR/commit refs), the pattern they demonstrate, and a one-line "applies here because…" or "doesn't apply here because…".
 
+## Required artifact front-matter
+
+Your artifact MUST begin with this YAML front-matter (between two `---` fences):
+
+```yaml
+---
+topic: <name-of-this-research-topic>
+issue: <issue number>
+head_sha: <output of `git rev-parse HEAD` captured at write time>
+summary: <one-line summary>
+---
+```
+
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
+- Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
+
+## Required `## Files investigated` section
+
+Your artifact MUST include a `## Files investigated` section listing every path you read, grep'd, or otherwise consulted. Format:
+
+```markdown
+## Files investigated
+- path/to/file.ext — short description
+- path/to/file.ext:LINE-RANGE — short description
+- another/path.ext — short description
+```
+
+Rules:
+- One path per line.
+- Optional leading `- ` (Markdown list marker).
+- The first whitespace-separated token is the path. An optional `:LINE-RANGE` suffix is allowed and preserved verbatim in the artifact, but the orchestrator parser strips it before set-intersection.
+- Disallowed characters in the path token: `$`, `` ` ``, `;`, `\`, and embedded newlines. The orchestrator's parser rejects any line whose path token fails the regex `^[A-Za-z0-9_./-]+$` — failing lines are silently dropped from the set (artifact stays valid; only `head_sha` validation failure forces a fresh dispatch).
+- This section is REQUIRED. The orchestrator's freshness predicate intersects this set with `git diff --name-only <stored-sha>..HEAD`; if the intersection is non-empty, the artifact is invalidated and a fresh dispatch is forced (`reason=file-intersection`).
+
 ## Output
+
+Your artifact at `artifact_path` MUST conform to the front-matter and `## Files investigated` contracts above before you emit the YAML below. The orchestrator's freshness predicate depends on both.
 
 Emit exactly this YAML block as the final lines of your reply:
 

--- a/plugins/uberdev/agents/research-prior-art.md
+++ b/plugins/uberdev/agents/research-prior-art.md
@@ -70,7 +70,44 @@ Rules:
    - Lead each bullet with the **takeaway**, not the source — source goes in parentheses at the end.
    - If a topic yielded no useful results, write: `> No relevant prior art found for this topic.`
 
+## Required artifact front-matter
+
+Your artifact MUST begin with this YAML front-matter (between two `---` fences):
+
+```yaml
+---
+topic: <name-of-this-research-topic>
+issue: <issue number>
+head_sha: <output of `git rev-parse HEAD` captured at write time>
+summary: <one-line summary>
+---
+```
+
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
+- Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
+
+## Required `## Files investigated` section
+
+Your artifact MUST include a `## Files investigated` section listing every path you read, grep'd, or otherwise consulted. Format:
+
+```markdown
+## Files investigated
+- path/to/file.ext — short description
+- path/to/file.ext:LINE-RANGE — short description
+- another/path.ext — short description
+```
+
+Rules:
+- One path per line.
+- Optional leading `- ` (Markdown list marker).
+- The first whitespace-separated token is the path. An optional `:LINE-RANGE` suffix is allowed and preserved verbatim in the artifact, but the orchestrator parser strips it before set-intersection.
+- Disallowed characters in the path token: `$`, `` ` ``, `;`, `\`, and embedded newlines. The orchestrator's parser rejects any line whose path token fails the regex `^[A-Za-z0-9_./-]+$` — failing lines are silently dropped from the set (artifact stays valid; only `head_sha` validation failure forces a fresh dispatch).
+- This section is REQUIRED. The orchestrator's freshness predicate intersects this set with `git diff --name-only <stored-sha>..HEAD`; if the intersection is non-empty, the artifact is invalidated and a fresh dispatch is forced (`reason=file-intersection`).
+
 ## Output
+
+Your artifact at `artifact_path` MUST conform to the front-matter and `## Files investigated` contracts above before you emit the YAML below. The orchestrator's freshness predicate depends on both.
 
 Emit the following YAML block as the **final lines** of your reply, inside a fenced `yaml` block:
 

--- a/plugins/uberdev/agents/research-prior-art.md
+++ b/plugins/uberdev/agents/research-prior-art.md
@@ -83,7 +83,7 @@ summary: <one-line summary>
 ---
 ```
 
-- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time).
 - The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
 - Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
 

--- a/plugins/uberdev/agents/research-security.md
+++ b/plugins/uberdev/agents/research-security.md
@@ -56,7 +56,44 @@ Read, Grep, Glob, Bash, mcp__plugin_semgrep_semgrep__semgrep_scan, mcp__plugin_s
    - Secure-defaults libraries already adopted vs gaps for the detected stack
    - Compute the content hash: `shasum -a 256 <summary_dir>/security.md | awk '{print substr($1,1,8)}'`
 
+## Required artifact front-matter
+
+Your artifact MUST begin with this YAML front-matter (between two `---` fences):
+
+```yaml
+---
+topic: <name-of-this-research-topic>
+issue: <issue number>
+head_sha: <output of `git rev-parse HEAD` captured at write time>
+summary: <one-line summary>
+---
+```
+
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
+- Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
+
+## Required `## Files investigated` section
+
+Your artifact MUST include a `## Files investigated` section listing every path you read, grep'd, or otherwise consulted. Format:
+
+```markdown
+## Files investigated
+- path/to/file.ext — short description
+- path/to/file.ext:LINE-RANGE — short description
+- another/path.ext — short description
+```
+
+Rules:
+- One path per line.
+- Optional leading `- ` (Markdown list marker).
+- The first whitespace-separated token is the path. An optional `:LINE-RANGE` suffix is allowed and preserved verbatim in the artifact, but the orchestrator parser strips it before set-intersection.
+- Disallowed characters in the path token: `$`, `` ` ``, `;`, `\`, and embedded newlines. The orchestrator's parser rejects any line whose path token fails the regex `^[A-Za-z0-9_./-]+$` — failing lines are silently dropped from the set (artifact stays valid; only `head_sha` validation failure forces a fresh dispatch).
+- This section is REQUIRED. The orchestrator's freshness predicate intersects this set with `git diff --name-only <stored-sha>..HEAD`; if the intersection is non-empty, the artifact is invalidated and a fresh dispatch is forced (`reason=file-intersection`).
+
 ## Output (last lines of your reply)
+
+Your artifact at `artifact_path` MUST conform to the front-matter and `## Files investigated` contracts above before you emit the YAML below. The orchestrator's freshness predicate depends on both.
 
 ```yaml
 status: DONE | DONE_WITH_CONCERNS | BLOCKED

--- a/plugins/uberdev/agents/research-security.md
+++ b/plugins/uberdev/agents/research-security.md
@@ -69,7 +69,7 @@ summary: <one-line summary>
 ---
 ```
 
-- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time).
 - The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
 - Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
 

--- a/plugins/uberdev/agents/research-test-coverage.md
+++ b/plugins/uberdev/agents/research-test-coverage.md
@@ -41,7 +41,44 @@ Read, Grep, Glob, Bash (for `find`, `wc`, content-hashing only)
    - Top uncovered files relevant to the issue topic.
    Then compute the content hash: `shasum -a 256 <summary_dir>/test-coverage.md | awk '{print substr($1,1,8)}'`.
 
+## Required artifact front-matter
+
+Your artifact MUST begin with this YAML front-matter (between two `---` fences):
+
+```yaml
+---
+topic: <name-of-this-research-topic>
+issue: <issue number>
+head_sha: <output of `git rev-parse HEAD` captured at write time>
+summary: <one-line summary>
+---
+```
+
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
+- Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
+
+## Required `## Files investigated` section
+
+Your artifact MUST include a `## Files investigated` section listing every path you read, grep'd, or otherwise consulted. Format:
+
+```markdown
+## Files investigated
+- path/to/file.ext — short description
+- path/to/file.ext:LINE-RANGE — short description
+- another/path.ext — short description
+```
+
+Rules:
+- One path per line.
+- Optional leading `- ` (Markdown list marker).
+- The first whitespace-separated token is the path. An optional `:LINE-RANGE` suffix is allowed and preserved verbatim in the artifact, but the orchestrator parser strips it before set-intersection.
+- Disallowed characters in the path token: `$`, `` ` ``, `;`, `\`, and embedded newlines. The orchestrator's parser rejects any line whose path token fails the regex `^[A-Za-z0-9_./-]+$` — failing lines are silently dropped from the set (artifact stays valid; only `head_sha` validation failure forces a fresh dispatch).
+- This section is REQUIRED. The orchestrator's freshness predicate intersects this set with `git diff --name-only <stored-sha>..HEAD`; if the intersection is non-empty, the artifact is invalidated and a fresh dispatch is forced (`reason=file-intersection`).
+
 ## Output (last lines of your reply)
+
+Your artifact at `artifact_path` MUST conform to the front-matter and `## Files investigated` contracts above before you emit the YAML below. The orchestrator's freshness predicate depends on both.
 
 ```yaml
 status: DONE | DONE_WITH_CONCERNS | BLOCKED

--- a/plugins/uberdev/agents/research-test-coverage.md
+++ b/plugins/uberdev/agents/research-test-coverage.md
@@ -54,7 +54,7 @@ summary: <one-line summary>
 ---
 ```
 
-- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time). The orchestrator may pass `head_sha_at_dispatch` as a hint, but your own `git rev-parse HEAD` is authoritative.
+- Capture `head_sha` by running `git rev-parse HEAD` at the moment you write the artifact (NOT at dispatch time).
 - The `head_sha` value MUST match `^[0-9a-f]{7,40}$`. The orchestrator's reuse-time validator will reject any other format and force a fresh dispatch on the next run (`reason=missing-head-sha`).
 - Do NOT embed shell metacharacters in the `head_sha` value. The orchestrator treats malformed values as missing.
 

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -63,9 +63,48 @@ emit_topic_log() {  # args: <topic> <status> <note>
 
 # Global pre-gate: evaluated once before the per-topic loop. If it fires,
 # ALL six topics get the same `reason=` — never mixed with per-topic reasons.
+GLOBAL_FALLBACK_REASON=""
+
+# Defense-in-depth: regex-validate $ISSUE_NUM before interpolation
+# (solve-pipeline already validates upstream; this is the second gate).
+if ! [[ "${ISSUE_NUM:-}" =~ ^[0-9]+$ ]]; then
+  echo "warning: ISSUE_NUM not a positive integer; falling back to fresh for all topics" >&2
+  GLOBAL_FALLBACK_REASON="invalid-timestamp"
+fi
+
+# Read divergence threshold via existing config helper.
+if [ -r "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
+  CACHE_DIVERGENCE_THRESHOLD="$(uberdev_read_int_in_range \
+    cache.divergence_threshold UBERDEV_CACHE_DIVERGENCE_THRESHOLD 1 100000 50)"
+else
+  CACHE_DIVERGENCE_THRESHOLD=50
+fi
+
+# Global pre-gate: gh pr list. Fail-open per Q4 — non-zero exit means
+# we cannot determine closure, so we do NOT invalidate (treat as no
+# closing PR). Intentional security trade-off: this is a freshness
+# signal, not an authentication boundary; the security research
+# accepted fail-open here because cached artifacts remain untrusted
+# on reuse regardless. Single call per orchestrator run, cached for the run.
+if [ -z "$GLOBAL_FALLBACK_REASON" ]; then
+  PR_CLOSED_COUNT="$(gh pr list \
+    --state merged \
+    --search "closes #${ISSUE_NUM}" \
+    --json number \
+    --jq '. | length' 2>/dev/null || echo 0)"
+  if [ "${PR_CLOSED_COUNT:-0}" -gt 0 ]; then
+    GLOBAL_FALLBACK_REASON="pr-closed"
+  fi
+fi
+
 if [ ! -d "$RESEARCH_DIR" ]; then
   for TOPIC in codebase patterns prior-art constraints security test-coverage; do
     emit_topic_log "$TOPIC" dispatched "fresh-run,reason=no-cache"
+  done
+elif [ -n "$GLOBAL_FALLBACK_REASON" ]; then
+  for TOPIC in codebase patterns prior-art constraints security test-coverage; do
+    emit_topic_log "$TOPIC" dispatched "fresh-run,reason=${GLOBAL_FALLBACK_REASON}"
   done
 else
   ISSUE_UPDATED_ISO=$(gh issue view "$ISSUE_NUM" --json updatedAt --jq .updatedAt 2>/dev/null)
@@ -103,6 +142,48 @@ else
         emit_topic_log "$TOPIC" dispatched "fresh-run,reason=stale-mtime"
         continue
       fi
+
+      # NEW: head_sha presence + reachability check.
+      STORED_SHA="$(awk '/^head_sha:/{print $2; exit}' "$F" 2>/dev/null)"
+      if [ -z "$STORED_SHA" ] || ! [[ "$STORED_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+        emit_topic_log "$TOPIC" dispatched "fresh-run,reason=missing-head-sha"
+        continue
+      fi
+      # Reachability probe MUST run before any git diff invocation so
+      # that an unreachable SHA never leaks into a git diff command line
+      # (per security research: never let raw git diff exit code drive
+      # control flow).
+      if ! git cat-file -e "${STORED_SHA}^{commit}" 2>/dev/null; then
+        emit_topic_log "$TOPIC" dispatched "fresh-run,reason=missing-head-sha"
+        continue
+      fi
+
+      # NEW: divergence check.
+      DIVERGENCE="$(git rev-list --count "${STORED_SHA}..HEAD" 2>/dev/null || echo 0)"
+      if [ "${DIVERGENCE:-0}" -gt "${CACHE_DIVERGENCE_THRESHOLD}" ]; then
+        emit_topic_log "$TOPIC" dispatched "fresh-run,reason=head-divergence"
+        continue
+      fi
+
+      # NEW: file-intersection check.
+      FILES_INVESTIGATED="$(awk '
+        /^## Files investigated/ { capture=1; next }
+        /^## / { capture=0 }
+        capture && NF {
+          sub(/^- /, "")
+          split($1, p, ":")
+          if (p[1] ~ /^[A-Za-z0-9_.\/-]+$/) print p[1]
+        }
+      ' "$F")"
+      if [ -n "$FILES_INVESTIGATED" ]; then
+        FILES_TOUCHED="$(git diff --name-only "${STORED_SHA}..HEAD" 2>/dev/null)"
+        if [ -n "$FILES_TOUCHED" ] && \
+           echo "$FILES_TOUCHED" | grep -Fxq -f <(echo "$FILES_INVESTIGATED"); then
+          emit_topic_log "$TOPIC" dispatched "fresh-run,reason=file-intersection"
+          continue
+        fi
+      fi
+
       VAR="SHORTCIRCUIT_$(echo "$TOPIC" | tr '[:lower:]-' '[:upper:]_')"
       declare "$VAR=1"  # was: eval "$VAR=1" — safer indirection, no shell-injection risk if VAR ever becomes attacker-controlled
       emit_topic_log "$TOPIC" reused "cache-hit,mtime=$F_MTIME_EPOCH,issue_updated_at=$ISSUE_UPDATED_EPOCH"
@@ -119,30 +200,64 @@ After the short-circuit pass, dispatch Phase 1 fanout (below) but gate each `Tas
 
 **Invalidation key.** `(file_mtime, summary_field_present)` per artifact at `.uberdev/research/issue-<N>/<topic>.md`. Topic_slug is not part of the key.
 
-**Freshness predicate.** `fresh(F) := exists(F) AND grep -q '^summary:' F AND mtime(F) >= updatedAt(issue)`.
+**Freshness predicate.**
+
+```
+fresh(F) :=
+    exists(F)
+  AND grep -q '^summary:' F
+  AND grep -q '^head_sha:' F
+  AND mtime(F) >= updatedAt(issue)
+  AND head_sha_reachable(F)
+  AND divergence(F) <= $UBERDEV_CACHE_DIVERGENCE_THRESHOLD
+  AND NOT files_touched_since(F) ∩ files_investigated(F)
+  AND NOT merged_pr_closing_issue(N)
+```
+
+Helper definitions (each replaceable by a single shell command):
+
+- **`head_sha_reachable(F)`** — `git cat-file -e $(awk '/^head_sha:/{print $2; exit}' F)^{commit} 2>/dev/null`. Exit-0 means reachable. The reachability probe runs FIRST, before any `git diff` invocation — an unreachable SHA never leaks into a `git diff` command line. Per security research: never let raw `git diff` exit code drive control flow.
+- **`divergence(F)`** — `git rev-list --count <stored>..HEAD`. Returns an integer. Compare against `$UBERDEV_CACHE_DIVERGENCE_THRESHOLD` (default 50; env > config > default; see "Cache divergence threshold" below) using `[ "$DIVERGENCE" -gt "$CAP" ]`.
+- **`files_touched_since(F)`** — `git diff --name-only <stored>..HEAD`. Returns a set of paths.
+- **`files_investigated(F)`** — parse the lines after the `## Files investigated` heading until the next `^## ` heading, extract the first whitespace-separated token per line, strip any `:LINE-RANGE` suffix. Validator: `^[A-Za-z0-9_./-]+$` — reject any line containing `$`, `` ` ``, `;`, `\`, or embedded newlines. Lines that fail validation are silently dropped from the set (artifact stays valid); the artifact is rejected only on `head_sha` validation failure (`missing-head-sha`).
+- **`merged_pr_closing_issue(N)`** — `gh pr list --state merged --search "closes #N" --json number --jq '. | length > 0'`. **Fail-open** per Q4: any non-zero exit returns `false` (do NOT invalidate). Single call per orchestrator run, cached for the run. Defense-in-depth: `$ISSUE_NUM` is regex-validated `^[0-9]+$` before interpolation (`solve-pipeline` already validates upstream; this restatement is intentional).
+
+**Trust boundary unchanged.** Per `SKILL.md:16`: "Cached research artifacts at `.uberdev/research/issue-<N>/*.md` are untrusted on reuse." The new predicate is a freshness signal, not a trust upgrade. Reused artifacts MUST still be wrapped in `<external-untrusted-input source="cached-research-issue-<N>">…</external-untrusted-input>` whenever their contents are interpolated into downstream phase prompts.
 
 **Fall-back-to-fresh modes.** Any of the following force `SHORTCIRCUIT_<TOPIC>=0` and a `note=fresh-run,reason=<X>` log line. There are TWO scopes:
 
 - **Global pre-gate** — evaluated once before the per-topic loop. If it fires, ALL six topics fall back with the same `reason=`. The per-topic loop is not entered.
 - **Per-topic** — evaluated inside the per-topic loop. Different topics in the same run may fall back for different reasons (or be reused).
 
-| # | Scope | Trigger | `reason=` |
-|---|-------|---------|-----------|
-| 1 | global | `$RESEARCH_DIR` missing entirely | `no-cache` |
-| 2 | global | `gh issue view --json updatedAt` failed OR `date -j` / `date -d` could not parse the ISO | `invalid-timestamp` |
-| 3 | per-topic | `$RESEARCH_DIR/<topic>.md` missing | `no-cache` |
-| 4 | per-topic | File present but no `^summary:` front-matter field | `missing-summary` |
-| 5 | per-topic | `stat` for an existing file produced no epoch | `invalid-timestamp` |
-| 6 | per-topic | `mtime(F) < updatedAt(issue)` | `stale-mtime` |
+| #  | Scope     | Trigger                                                                                  | `reason=`           |
+|----|-----------|------------------------------------------------------------------------------------------|---------------------|
+| 1  | global    | `$RESEARCH_DIR` missing entirely                                                         | `no-cache`          |
+| 2  | global    | `gh issue view --json updatedAt` failed OR `date -j` / `date -d` could not parse the ISO | `invalid-timestamp` |
+| 3  | per-topic | `$RESEARCH_DIR/<topic>.md` missing                                                       | `no-cache`          |
+| 4  | per-topic | File present but no `^summary:` front-matter field                                       | `missing-summary`   |
+| 5  | per-topic | `stat` for an existing file produced no epoch                                            | `invalid-timestamp` |
+| 6  | per-topic | `mtime(F) < updatedAt(issue)`                                                            | `stale-mtime`       |
+| 7  | per-topic | `head_sha:` field missing, invalid (`^[0-9a-f]{7,40}$` fails), or unreachable (`git cat-file -e <sha>^{commit}` non-zero) | `missing-head-sha`  |
+| 8  | per-topic | `git rev-list --count <stored>..HEAD` > `UBERDEV_CACHE_DIVERGENCE_THRESHOLD` (default 50) | `head-divergence`   |
+| 9  | per-topic | `git diff --name-only <stored>..HEAD` ∩ `files_investigated(F)` ≠ ∅                      | `file-intersection` |
+| 10 | global    | `gh pr list --state merged --search "closes #<N>"` returns ≥1 PR                         | `pr-closed`         |
 
-`invalid-timestamp` may surface globally (row 2) or per-topic (row 5) but never mixed in the same run — if a global pre-gate fires the per-topic loop is skipped entirely.
+`invalid-timestamp` may surface globally (row 2) or per-topic (row 5) but never mixed in the same run — if a global pre-gate fires the per-topic loop is skipped entirely. Likewise `pr-closed` (row 10) fires globally — when set, all six topics fall back with `reason=pr-closed` and the per-topic loop is skipped.
+
+**Cache divergence threshold (`UBERDEV_CACHE_DIVERGENCE_THRESHOLD`).** The divergence cap for the `head-divergence` check (row 8 above).
+
+- **Name:** `UBERDEV_CACHE_DIVERGENCE_THRESHOLD`
+- **Range:** `[1, 100000]` (any positive integer; the 100000 upper bound is a sanity cap to keep `uberdev_read_int_in_range`'s validator happy and is effectively unbounded for the actual use case)
+- **Default:** 50
+- **Precedence:** env > config > default, matching the existing `UBERDEV_FANOUT_RESEARCH` pattern.
+- **Read via:** `${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh` with `CAP=$(uberdev_read_int_in_range cache.divergence_threshold UBERDEV_CACHE_DIVERGENCE_THRESHOLD 1 100000 50)`. Mirror the existing call site for `UBERDEV_FANOUT_RESEARCH` at the bottom of this Phase-1 section.
 
 **Reuse path.** When `fresh(F)`, `cp` immediately to `$RESEARCH_DIR_ABS/<topic>.md`, set `SHORTCIRCUIT_<TOPIC>=1`, emit `status=reused note=cache-hit,mtime=<e>,issue_updated_at=<e>`. `cp`-first-then-evaluate-downstream is the recommended TOCTOU sequence; single-writer-per-issue is assumed.
 
 **Per-topic observability.** On every Phase 1 entry, emit one log line per topic to `$RESEARCH_DIR_ABS/orchestrator.log`:
 
 - **Reused:** `[<ts>] phase=phase1-fanout agent=research-<topic> status=reused note=cache-hit,mtime=<epoch>,issue_updated_at=<epoch>`
-- **Dispatched:** `[<ts>] phase=phase1-fanout agent=research-<topic> status=dispatched note=fresh-run,reason=<no-cache|stale-mtime|missing-summary|invalid-timestamp>`
+- **Dispatched:** `[<ts>] phase=phase1-fanout agent=research-<topic> status=dispatched note=fresh-run,reason=<no-cache|stale-mtime|missing-summary|invalid-timestamp|missing-head-sha|head-divergence|file-intersection|pr-closed>`
 
 Six lines per medium/large run (one per topic). The global-schema `attempt=<n>` field is omitted (gate decision is one-shot).
 

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -54,6 +54,11 @@ SHORTCIRCUIT_CONSTRAINTS=0
 SHORTCIRCUIT_SECURITY=0
 SHORTCIRCUIT_TEST_COVERAGE=0
 
+# Canonical topic list — single source of truth for every Phase 1 loop
+# below. Iterate via "${TOPICS[@]}" so the six-topic enumeration cannot
+# drift between the four pre/per-topic loops.
+TOPICS=(codebase patterns prior-art constraints security test-coverage)
+
 # Helper: emit one per-topic observability line. Six lines per medium/large
 # run regardless of cache state — see "Per-topic observability" below for
 # the schema. `declare` is bash-only; LLM-as-executor accepts it.
@@ -81,136 +86,136 @@ else
   CACHE_DIVERGENCE_THRESHOLD=50
 fi
 
-# Global pre-gate: gh pr list. Fail-open per Q4 — non-zero exit means
-# we cannot determine closure, so we do NOT invalidate (treat as no
-# closing PR). Intentional security trade-off: this is a freshness
-# signal, not an authentication boundary; the security research
-# accepted fail-open here because cached artifacts remain untrusted
-# on reuse regardless. Single call per orchestrator run, cached for the run.
-if [ -z "$GLOBAL_FALLBACK_REASON" ]; then
-  # Capture stderr alongside stdout so a non-zero exit surfaces an
-  # operator-triage warning (auth/rate-limit/network failure mode).
-  # Fail-open semantic preserved: on non-zero exit PR_CLOSED_COUNT
-  # defaults to 0 and the pr-closed gate does NOT fire — see Q4.
-  PR_CLOSED_RAW="$(gh pr list \
-    --state merged \
-    --search "closes #${ISSUE_NUM}" \
-    --json number \
-    --jq '. | length' 2>&1)"
-  GH_RC=$?
-  if [ "$GH_RC" -eq 0 ]; then
-    PR_CLOSED_COUNT="$PR_CLOSED_RAW"
-  else
-    echo "warning: gh pr list failed (rc=$GH_RC) for issue #${ISSUE_NUM}; failing open (no pr-closed gate fired): $PR_CLOSED_RAW" >&2
-    PR_CLOSED_COUNT=0
-  fi
-  if [ "${PR_CLOSED_COUNT:-0}" -gt 0 ]; then
-    GLOBAL_FALLBACK_REASON="pr-closed"
-  fi
-fi
+# Fail-open policy: the gh pr list probe below and the two per-topic git
+# probes (git rev-list divergence, git diff file-intersection) ALL fail
+# open on non-zero exit — failures are treated as "no gate fired" so the
+# cache is reused. Trade-off per Q4 in the design spec: this is a freshness
+# signal, not a trust upgrade; cached artifacts remain
+# <external-untrusted-input> wrapped on reuse regardless. See
+# merged_pr_closing_issue / divergence / files_touched_since helpers in
+# the Freshness predicate section for the per-probe rationale.
 
+# Cheap short-circuit: if the cache directory is missing, every topic is
+# a fresh-run with reason=no-cache. Skip the gh pr list network call
+# (and the per-topic loop) entirely — first-run-per-issue would otherwise
+# pay a gh API round-trip just to discard the result.
 if [ ! -d "$RESEARCH_DIR" ]; then
-  for TOPIC in codebase patterns prior-art constraints security test-coverage; do
+  for TOPIC in "${TOPICS[@]}"; do
     emit_topic_log "$TOPIC" dispatched "fresh-run,reason=no-cache"
   done
-elif [ -n "$GLOBAL_FALLBACK_REASON" ]; then
-  for TOPIC in codebase patterns prior-art constraints security test-coverage; do
-    emit_topic_log "$TOPIC" dispatched "fresh-run,reason=${GLOBAL_FALLBACK_REASON}"
-  done
 else
-  ISSUE_UPDATED_ISO=$(gh issue view "$ISSUE_NUM" --json updatedAt --jq .updatedAt 2>/dev/null)
-  ISSUE_UPDATED_EPOCH=""
-  if [ -n "$ISSUE_UPDATED_ISO" ]; then
-    ISSUE_UPDATED_EPOCH=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ISSUE_UPDATED_ISO" +%s 2>/dev/null \
-                        || date -d "$ISSUE_UPDATED_ISO" +%s 2>/dev/null)
+  # Cache directory exists; the cache may be reusable. Probe gh pr list
+  # (global pre-gate — fail-open per policy above).
+  if [ -z "$GLOBAL_FALLBACK_REASON" ]; then
+    # Capture stderr alongside stdout so a non-zero exit surfaces an
+    # operator-triage warning (auth/rate-limit/network failure mode).
+    PR_CLOSED_RAW="$(gh pr list \
+      --state merged \
+      --search "closes #${ISSUE_NUM}" \
+      --json number \
+      --jq '. | length' 2>&1)"
+    GH_RC=$?
+    if [ "$GH_RC" -eq 0 ]; then
+      PR_CLOSED_COUNT="$PR_CLOSED_RAW"
+    else
+      echo "warning: gh pr list failed (rc=$GH_RC) for issue #${ISSUE_NUM}; failing open (no pr-closed gate fired): $PR_CLOSED_RAW" >&2
+      PR_CLOSED_COUNT=0
+    fi
+    if [ "${PR_CLOSED_COUNT:-0}" -gt 0 ]; then
+      GLOBAL_FALLBACK_REASON="pr-closed"
+    fi
   fi
-  if [ -z "$ISSUE_UPDATED_EPOCH" ]; then
-    echo "warning: failed to fetch or parse issue #$ISSUE_NUM updatedAt; using full parallel dispatch" >&2
-    for TOPIC in codebase patterns prior-art constraints security test-coverage; do
-      emit_topic_log "$TOPIC" dispatched "fresh-run,reason=invalid-timestamp"
+
+  if [ -n "$GLOBAL_FALLBACK_REASON" ]; then
+    for TOPIC in "${TOPICS[@]}"; do
+      emit_topic_log "$TOPIC" dispatched "fresh-run,reason=${GLOBAL_FALLBACK_REASON}"
     done
   else
-    # Per-topic loop: each topic is evaluated independently. Different topics
-    # in the same run may fall back for different reasons or be reused.
-    for TOPIC in codebase patterns prior-art constraints security test-coverage; do
-      F="$RESEARCH_DIR/${TOPIC}.md"
-      if [ ! -f "$F" ]; then
-        emit_topic_log "$TOPIC" dispatched "fresh-run,reason=no-cache"
-        continue
-      fi
-      if ! grep -q '^summary:' "$F"; then
-        echo "warning: $F missing 'summary:' field; using full parallel dispatch for $TOPIC" >&2
-        emit_topic_log "$TOPIC" dispatched "fresh-run,reason=missing-summary"
-        continue
-      fi
-      F_MTIME_EPOCH=$(stat -f %m "$F" 2>/dev/null || stat -c %Y "$F" 2>/dev/null)
-      if [ -z "$F_MTIME_EPOCH" ]; then
-        echo "warning: failed to read $F mtime; using full parallel dispatch for $TOPIC" >&2
+    ISSUE_UPDATED_ISO=$(gh issue view "$ISSUE_NUM" --json updatedAt --jq .updatedAt 2>/dev/null)
+    ISSUE_UPDATED_EPOCH=""
+    if [ -n "$ISSUE_UPDATED_ISO" ]; then
+      ISSUE_UPDATED_EPOCH=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ISSUE_UPDATED_ISO" +%s 2>/dev/null \
+                          || date -d "$ISSUE_UPDATED_ISO" +%s 2>/dev/null)
+    fi
+    if [ -z "$ISSUE_UPDATED_EPOCH" ]; then
+      echo "warning: failed to fetch or parse issue #$ISSUE_NUM updatedAt; using full parallel dispatch" >&2
+      for TOPIC in "${TOPICS[@]}"; do
         emit_topic_log "$TOPIC" dispatched "fresh-run,reason=invalid-timestamp"
-        continue
-      fi
-      if [ "$F_MTIME_EPOCH" -lt "$ISSUE_UPDATED_EPOCH" ]; then
-        emit_topic_log "$TOPIC" dispatched "fresh-run,reason=stale-mtime"
-        continue
-      fi
-
-      # head_sha presence + reachability check.
-      STORED_SHA="$(awk '/^head_sha:/{print $2; exit}' "$F" 2>/dev/null)"
-      if [ -z "$STORED_SHA" ] || ! [[ "$STORED_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
-        emit_topic_log "$TOPIC" dispatched "fresh-run,reason=missing-head-sha"
-        continue
-      fi
-      # Reachability probe MUST run before any git diff invocation so
-      # that an unreachable SHA never leaks into a git diff command line
-      # (per security research: never let raw git diff exit code drive
-      # control flow).
-      if ! git cat-file -e "${STORED_SHA}^{commit}" 2>/dev/null; then
-        emit_topic_log "$TOPIC" dispatched "fresh-run,reason=missing-head-sha"
-        continue
-      fi
-
-      # divergence check.
-      # Fail-open: any git failure (corrupted repo, unreachable SHA somehow
-      # slipping past the cat-file gate, OOM) treated as zero divergence so
-      # the per-topic loop proceeds. Symmetric with the gh pr list fail-open
-      # above. Trade-off: silent on transient git errors; the trust-boundary
-      # contract makes this acceptable (cached artifacts remain
-      # <external-untrusted-input> wrapped regardless).
-      DIVERGENCE="$(git rev-list --count "${STORED_SHA}..HEAD" 2>/dev/null || echo 0)"
-      if [ "${DIVERGENCE:-0}" -gt "${CACHE_DIVERGENCE_THRESHOLD}" ]; then
-        emit_topic_log "$TOPIC" dispatched "fresh-run,reason=head-divergence"
-        continue
-      fi
-
-      # file-intersection check.
-      FILES_INVESTIGATED="$(awk '
-        /^## Files investigated/ { capture=1; next }
-        /^## / { capture=0 }
-        capture && NF {
-          sub(/^- /, "")
-          split($1, p, ":")
-          if (p[1] ~ /^[A-Za-z0-9_.\/-]+$/) print p[1]
-        }
-      ' "$F")"
-      if [ -n "$FILES_INVESTIGATED" ]; then
-        # Fail-open: empty $FILES_TOUCHED on git error short-circuits the
-        # intersection check to false → cache is reused. Symmetric with the
-        # divergence fail-open and the gh pr list fail-open. Trade-off:
-        # silent on transient git errors; the trust-boundary contract makes
-        # this acceptable (cached artifacts remain <external-untrusted-input>
-        # wrapped regardless).
-        FILES_TOUCHED="$(git diff --name-only "${STORED_SHA}..HEAD" 2>/dev/null)"
-        if [ -n "$FILES_TOUCHED" ] && \
-           echo "$FILES_TOUCHED" | grep -Fxq -f <(echo "$FILES_INVESTIGATED"); then
-          emit_topic_log "$TOPIC" dispatched "fresh-run,reason=file-intersection"
+      done
+    else
+      # Per-topic loop: each topic is evaluated independently. Different topics
+      # in the same run may fall back for different reasons or be reused.
+      for TOPIC in "${TOPICS[@]}"; do
+        F="$RESEARCH_DIR/${TOPIC}.md"
+        if [ ! -f "$F" ]; then
+          emit_topic_log "$TOPIC" dispatched "fresh-run,reason=no-cache"
           continue
         fi
-      fi
+        if ! grep -q '^summary:' "$F"; then
+          echo "warning: $F missing 'summary:' field; using full parallel dispatch for $TOPIC" >&2
+          emit_topic_log "$TOPIC" dispatched "fresh-run,reason=missing-summary"
+          continue
+        fi
+        F_MTIME_EPOCH=$(stat -f %m "$F" 2>/dev/null || stat -c %Y "$F" 2>/dev/null)
+        if [ -z "$F_MTIME_EPOCH" ]; then
+          echo "warning: failed to read $F mtime; using full parallel dispatch for $TOPIC" >&2
+          emit_topic_log "$TOPIC" dispatched "fresh-run,reason=invalid-timestamp"
+          continue
+        fi
+        if [ "$F_MTIME_EPOCH" -lt "$ISSUE_UPDATED_EPOCH" ]; then
+          emit_topic_log "$TOPIC" dispatched "fresh-run,reason=stale-mtime"
+          continue
+        fi
 
-      VAR="SHORTCIRCUIT_$(echo "$TOPIC" | tr '[:lower:]-' '[:upper:]_')"
-      declare "$VAR=1"  # was: eval "$VAR=1" — safer indirection, no shell-injection risk if VAR ever becomes attacker-controlled
-      emit_topic_log "$TOPIC" reused "cache-hit,mtime=$F_MTIME_EPOCH,issue_updated_at=$ISSUE_UPDATED_EPOCH"
-    done
+        # head_sha presence + reachability check.
+        STORED_SHA="$(awk '/^head_sha:/{print $2; exit}' "$F" 2>/dev/null)"
+        if [ -z "$STORED_SHA" ] || ! [[ "$STORED_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+          emit_topic_log "$TOPIC" dispatched "fresh-run,reason=missing-head-sha"
+          continue
+        fi
+        # Reachability probe MUST run before any git diff invocation so
+        # that an unreachable SHA never leaks into a git diff command line
+        # (per security research: never let raw git diff exit code drive
+        # control flow).
+        if ! git cat-file -e "${STORED_SHA}^{commit}" 2>/dev/null; then
+          emit_topic_log "$TOPIC" dispatched "fresh-run,reason=missing-head-sha"
+          continue
+        fi
+
+        # divergence check (fail-open per policy above).
+        DIVERGENCE="$(git rev-list --count "${STORED_SHA}..HEAD" 2>/dev/null || echo 0)"
+        if [ "${DIVERGENCE:-0}" -gt "${CACHE_DIVERGENCE_THRESHOLD}" ]; then
+          emit_topic_log "$TOPIC" dispatched "fresh-run,reason=head-divergence"
+          continue
+        fi
+
+        # file-intersection check (fail-open per policy above).
+        FILES_INVESTIGATED="$(awk '
+          /^## Files investigated/ { capture=1; next }
+          /^## / { capture=0 }
+          capture && NF {
+            sub(/^- /, "")
+            split($1, p, ":")
+            if (p[1] ~ /^[A-Za-z0-9_.\/-]+$/) print p[1]
+          }
+        ' "$F")"
+        if [ -n "$FILES_INVESTIGATED" ]; then
+          # When FILES_TOUCHED is empty (git error or no diff), the -n guard
+          # short-circuits BEFORE grep, so the cache is reused. The grep here
+          # is whole-line exact match (grep -Fxq), never substring.
+          FILES_TOUCHED="$(git diff --name-only "${STORED_SHA}..HEAD" 2>/dev/null)"
+          if [ -n "$FILES_TOUCHED" ] && \
+             echo "$FILES_TOUCHED" | grep -Fxq -f <(echo "$FILES_INVESTIGATED"); then
+            emit_topic_log "$TOPIC" dispatched "fresh-run,reason=file-intersection"
+            continue
+          fi
+        fi
+
+        VAR="SHORTCIRCUIT_$(echo "$TOPIC" | tr '[:lower:]-' '[:upper:]_')"
+        declare "$VAR=1"  # was: eval "$VAR=1" — safer indirection, no shell-injection risk if VAR ever becomes attacker-controlled
+        emit_topic_log "$TOPIC" reused "cache-hit,mtime=$F_MTIME_EPOCH,issue_updated_at=$ISSUE_UPDATED_EPOCH"
+      done
+    fi
   fi
 fi
 ```
@@ -256,18 +261,18 @@ Helper definitions (each replaceable by a single shell command):
 |----|-----------|------------------------------------------------------------------------------------------|---------------------|
 | 1  | global    | `$RESEARCH_DIR` missing entirely                                                         | `no-cache`          |
 | 2  | global    | `gh issue view --json updatedAt` failed OR `date -j` / `date -d` could not parse the ISO | `invalid-timestamp` |
-| 3  | per-topic | `$RESEARCH_DIR/<topic>.md` missing                                                       | `no-cache`          |
-| 4  | per-topic | File present but no `^summary:` front-matter field                                       | `missing-summary`   |
-| 5  | per-topic | `stat` for an existing file produced no epoch                                            | `invalid-timestamp` |
-| 6  | per-topic | `mtime(F) < updatedAt(issue)`                                                            | `stale-mtime`       |
-| 7  | per-topic | `head_sha:` field missing, invalid (`^[0-9a-f]{7,40}$` fails), or unreachable (`git cat-file -e <sha>^{commit}` non-zero) | `missing-head-sha`  |
-| 8  | per-topic | `git rev-list --count <stored>..HEAD` > `UBERDEV_CACHE_DIVERGENCE_THRESHOLD` (default 50) | `head-divergence`   |
-| 9  | per-topic | `git diff --name-only <stored>..HEAD` ∩ `files_investigated(F)` ≠ ∅                      | `file-intersection` |
-| 10 | global    | `gh pr list --state merged --search "closes #<N>"` returns ≥1 PR                         | `pr-closed`         |
+| 3  | global    | `gh pr list --state merged --search "closes #<N>"` returns ≥1 PR                         | `pr-closed`         |
+| 4  | per-topic | `$RESEARCH_DIR/<topic>.md` missing                                                       | `no-cache`          |
+| 5  | per-topic | File present but no `^summary:` front-matter field                                       | `missing-summary`   |
+| 6  | per-topic | `stat` for an existing file produced no epoch                                            | `invalid-timestamp` |
+| 7  | per-topic | `mtime(F) < updatedAt(issue)`                                                            | `stale-mtime`       |
+| 8  | per-topic | `head_sha:` field missing, invalid (`^[0-9a-f]{7,40}$` fails), or unreachable (`git cat-file -e <sha>^{commit}` non-zero) | `missing-head-sha`  |
+| 9  | per-topic | `git rev-list --count <stored>..HEAD` > `UBERDEV_CACHE_DIVERGENCE_THRESHOLD` (default 50) | `head-divergence`   |
+| 10 | per-topic | `git diff --name-only <stored>..HEAD` ∩ `files_investigated(F)` ≠ ∅                      | `file-intersection` |
 
-`invalid-timestamp` may surface globally (row 2) or per-topic (row 5) but never mixed in the same run — if a global pre-gate fires the per-topic loop is skipped entirely. Likewise `pr-closed` (row 10) fires globally — when set, all six topics fall back with `reason=pr-closed` and the per-topic loop is skipped.
+`invalid-timestamp` may surface globally (row 2) or per-topic (row 6) but never mixed in the same run — if a global pre-gate fires the per-topic loop is skipped entirely. Likewise `pr-closed` (row 3) fires globally — when set, all six topics fall back with `reason=pr-closed` and the per-topic loop is skipped.
 
-**Cache divergence threshold (`UBERDEV_CACHE_DIVERGENCE_THRESHOLD`).** The divergence cap for the `head-divergence` check (row 8 above).
+**Cache divergence threshold (`UBERDEV_CACHE_DIVERGENCE_THRESHOLD`).** The divergence cap for the `head-divergence` check (row 9 above).
 
 - **Name:** `UBERDEV_CACHE_DIVERGENCE_THRESHOLD`
 - **Range:** `[1, 100000]` (any positive integer; the 100000 upper bound is a sanity cap to keep `uberdev_read_int_in_range`'s validator happy and is effectively unbounded for the actual use case)

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -154,7 +154,7 @@ else
         continue
       fi
 
-      # NEW: head_sha presence + reachability check.
+      # head_sha presence + reachability check.
       STORED_SHA="$(awk '/^head_sha:/{print $2; exit}' "$F" 2>/dev/null)"
       if [ -z "$STORED_SHA" ] || ! [[ "$STORED_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
         emit_topic_log "$TOPIC" dispatched "fresh-run,reason=missing-head-sha"
@@ -169,7 +169,7 @@ else
         continue
       fi
 
-      # NEW: divergence check.
+      # divergence check.
       # Fail-open: any git failure (corrupted repo, unreachable SHA somehow
       # slipping past the cat-file gate, OOM) treated as zero divergence so
       # the per-topic loop proceeds. Symmetric with the gh pr list fail-open
@@ -182,7 +182,7 @@ else
         continue
       fi
 
-      # NEW: file-intersection check.
+      # file-intersection check.
       FILES_INVESTIGATED="$(awk '
         /^## Files investigated/ { capture=1; next }
         /^## / { capture=0 }
@@ -240,7 +240,7 @@ fresh(F) :=
 Helper definitions (each replaceable by a single shell command):
 
 - **`head_sha_reachable(F)`** — `git cat-file -e $(awk '/^head_sha:/{print $2; exit}' F)^{commit} 2>/dev/null`. Exit-0 means reachable. The reachability probe runs FIRST, before any `git diff` invocation — an unreachable SHA never leaks into a `git diff` command line. Per security research: never let raw `git diff` exit code drive control flow.
-- **`divergence(F)`** — `git rev-list --count <stored>..HEAD`. Returns an integer. Compare against `$UBERDEV_CACHE_DIVERGENCE_THRESHOLD` (default 50; env > config > default; see "Cache divergence threshold" below) using `[ "$DIVERGENCE" -gt "$CAP" ]`.
+- **`divergence(F)`** — `git rev-list --count <stored>..HEAD`. Returns an integer. Compare against `$UBERDEV_CACHE_DIVERGENCE_THRESHOLD` (default 50; env > config > default; see "Cache divergence threshold" below) using `[ "$DIVERGENCE" -gt "$UBERDEV_CACHE_DIVERGENCE_THRESHOLD" ]`.
 - **`files_touched_since(F)`** — `git diff --name-only <stored>..HEAD`. Returns a set of paths.
 - **`files_investigated(F)`** — parse the lines after the `## Files investigated` heading until the next `^## ` heading, extract the first whitespace-separated token per line, strip any `:LINE-RANGE` suffix. Validator: `^[A-Za-z0-9_./-]+$` — reject any line containing `$`, `` ` ``, `;`, `\`, or embedded newlines. Lines that fail validation are silently dropped from the set (artifact stays valid); the artifact is rejected only on `head_sha` validation failure (`missing-head-sha`).
 - **`merged_pr_closing_issue(N)`** — `gh pr list --state merged --search "closes #N" --json number --jq '. | length > 0'`. **Fail-open** per Q4: any non-zero exit returns `false` (do NOT invalidate). Single call per orchestrator run, cached for the run. Defense-in-depth: `$ISSUE_NUM` is regex-validated `^[0-9]+$` before interpolation (`solve-pipeline` already validates upstream; this restatement is intentional).

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -88,11 +88,22 @@ fi
 # accepted fail-open here because cached artifacts remain untrusted
 # on reuse regardless. Single call per orchestrator run, cached for the run.
 if [ -z "$GLOBAL_FALLBACK_REASON" ]; then
-  PR_CLOSED_COUNT="$(gh pr list \
+  # Capture stderr alongside stdout so a non-zero exit surfaces an
+  # operator-triage warning (auth/rate-limit/network failure mode).
+  # Fail-open semantic preserved: on non-zero exit PR_CLOSED_COUNT
+  # defaults to 0 and the pr-closed gate does NOT fire — see Q4.
+  PR_CLOSED_RAW="$(gh pr list \
     --state merged \
     --search "closes #${ISSUE_NUM}" \
     --json number \
-    --jq '. | length' 2>/dev/null || echo 0)"
+    --jq '. | length' 2>&1)"
+  GH_RC=$?
+  if [ "$GH_RC" -eq 0 ]; then
+    PR_CLOSED_COUNT="$PR_CLOSED_RAW"
+  else
+    echo "warning: gh pr list failed (rc=$GH_RC) for issue #${ISSUE_NUM}; failing open (no pr-closed gate fired): $PR_CLOSED_RAW" >&2
+    PR_CLOSED_COUNT=0
+  fi
   if [ "${PR_CLOSED_COUNT:-0}" -gt 0 ]; then
     GLOBAL_FALLBACK_REASON="pr-closed"
   fi
@@ -159,6 +170,12 @@ else
       fi
 
       # NEW: divergence check.
+      # Fail-open: any git failure (corrupted repo, unreachable SHA somehow
+      # slipping past the cat-file gate, OOM) treated as zero divergence so
+      # the per-topic loop proceeds. Symmetric with the gh pr list fail-open
+      # above. Trade-off: silent on transient git errors; the trust-boundary
+      # contract makes this acceptable (cached artifacts remain
+      # <external-untrusted-input> wrapped regardless).
       DIVERGENCE="$(git rev-list --count "${STORED_SHA}..HEAD" 2>/dev/null || echo 0)"
       if [ "${DIVERGENCE:-0}" -gt "${CACHE_DIVERGENCE_THRESHOLD}" ]; then
         emit_topic_log "$TOPIC" dispatched "fresh-run,reason=head-divergence"
@@ -176,6 +193,12 @@ else
         }
       ' "$F")"
       if [ -n "$FILES_INVESTIGATED" ]; then
+        # Fail-open: empty $FILES_TOUCHED on git error short-circuits the
+        # intersection check to false → cache is reused. Symmetric with the
+        # divergence fail-open and the gh pr list fail-open. Trade-off:
+        # silent on transient git errors; the trust-boundary contract makes
+        # this acceptable (cached artifacts remain <external-untrusted-input>
+        # wrapped regardless).
         FILES_TOUCHED="$(git diff --name-only "${STORED_SHA}..HEAD" 2>/dev/null)"
         if [ -n "$FILES_TOUCHED" ] && \
            echo "$FILES_TOUCHED" | grep -Fxq -f <(echo "$FILES_INVESTIGATED"); then

--- a/tests/orchestrator-phase1-shortcircuit.test.sh
+++ b/tests/orchestrator-phase1-shortcircuit.test.sh
@@ -70,6 +70,18 @@ assert_grep "$SKILL" \
 assert_grep "$SKILL" \
   'invalid-timestamp' \
   'invalid-timestamp reason discriminator listed'
+assert_grep "$SKILL" \
+  'missing-head-sha' \
+  'missing-head-sha reason discriminator listed'
+assert_grep "$SKILL" \
+  'head-divergence' \
+  'head-divergence reason discriminator listed'
+assert_grep "$SKILL" \
+  'file-intersection' \
+  'file-intersection reason discriminator listed'
+assert_grep "$SKILL" \
+  'pr-closed' \
+  'pr-closed reason discriminator listed'
 
 echo
 echo "== All six topics enumerated =="
@@ -86,11 +98,32 @@ assert_grep "$SKILL" \
   'status=dispatched' \
   'status=dispatched log line present'
 assert_grep "$SKILL" \
-  'note=fresh-run,reason=<no-cache\|stale-mtime\|missing-summary\|invalid-timestamp>' \
-  'dispatched-line bullet enumerates all four reasons'
+  'note=fresh-run,reason=<no-cache\|stale-mtime\|missing-summary\|invalid-timestamp\|missing-head-sha\|head-divergence\|file-intersection\|pr-closed>' \
+  'dispatched-line bullet enumerates all eight reasons'
 assert_grep "$SKILL" \
   'note=cache-hit,mtime=' \
   'reused-line bullet present with mtime'
+
+echo
+echo "== New front-matter and env-var contract present =="
+assert_grep "$SKILL" \
+  'head_sha:' \
+  'head_sha front-matter field documented'
+assert_grep "$SKILL" \
+  'UBERDEV_CACHE_DIVERGENCE_THRESHOLD' \
+  'divergence threshold env var documented'
+assert_grep "$SKILL" \
+  'git cat-file -e' \
+  'git cat-file -e reachability probe documented'
+assert_grep "$SKILL" \
+  'git rev-list --count' \
+  'divergence count primitive documented'
+assert_grep "$SKILL" \
+  'gh pr list --state merged --search' \
+  'gh pr list closing-PR primitive documented'
+assert_grep "$SKILL" \
+  'Files investigated' \
+  'Files investigated section reference documented'
 
 echo
 echo "== Stale brainstorm cross-reference removed =="

--- a/tests/orchestrator-phase1-shortcircuit.test.sh
+++ b/tests/orchestrator-phase1-shortcircuit.test.sh
@@ -85,9 +85,16 @@ assert_grep "$SKILL" \
 
 echo
 echo "== All six topics enumerated =="
+# Behavior assertion: the canonical six-topic list is declared exactly once
+# as a TOPICS array, and every Phase 1 loop iterates via "${TOPICS[@]}".
+# Pins the topic enumeration without pinning the literal `for TOPIC in ...; do`
+# string (which used to appear 4x and drifted easily).
 assert_grep "$SKILL" \
-  'for TOPIC in codebase patterns prior-art constraints security test-coverage' \
-  'six-topic loop literal preserved'
+  'TOPICS=\(codebase patterns prior-art constraints security test-coverage\)' \
+  'six-topic TOPICS array declaration present'
+assert_grep "$SKILL" \
+  'for TOPIC in "\$\{TOPICS\[@\]\}"; do' \
+  'Phase 1 loops iterate via "${TOPICS[@]}"'
 
 echo
 echo "== Per-topic log emission documented =="


### PR DESCRIPTION
## Summary

Replaces the orchestrator Phase 1 cache-freshness predicate at `plugins/uberdev/skills/orchestrator/SKILL.md` (previously mtime-only) with a multi-signal predicate that invalidates the research cache on codebase drift, not just issue body / title / comment edits.

- **4 new fall-back-to-fresh discriminators**: `missing-head-sha` (per-topic), `head-divergence` (per-topic), `file-intersection` (per-topic), `pr-closed` (global). Table rows 7–10.
- **`UBERDEV_CACHE_DIVERGENCE_THRESHOLD` env var** (default 50, range [1, 100000], precedence env > config > default) read through the existing `uberdev_read_int_in_range` helper.
- **`head_sha:` front-matter contract** + standardised `## Files investigated` section in all 6 research agents (`plugins/uberdev/agents/research-*.md`) — byte-identical insertion.
- **Defense-in-depth**: `^[0-9a-f]{7,40}$` SHA validator, `^[A-Za-z0-9_./-]+$` path validator (silently drops bad lines), `git cat-file -e` reachability probe BEFORE any `git diff` invocation, fail-open on `gh pr list` failure per Q4.
- **Trust boundary unchanged**: freshness ≠ trust; reused artifacts remain `<external-untrusted-input>`-wrapped.

## Test Plan

- [x] `bash tests/orchestrator-phase1-shortcircuit.test.sh` — 24/24 PASS, exit 0
- [x] Full shape-check suite (17 tests): all green
- [x] Spec compliance + code-quality reviewers per Wave-1 task: ✅ compliant, zero findings at confidence ≥80

## Open questions answered by /turbo

The following design choices were auto-picked during /turbo Phase 2 — please review, especially the `medium`-confidence rows.

| Question | Choice | Confidence |
|----------|--------|------------|
| How should the "N commits diverged" invalidation trigger be implemented? | Add an `UBERDEV_CACHE_DIVERGENCE_THRESHOLD` env var (default 50), evaluated as `(git rev-list --count <stored-sha>..HEAD) > N`; emit `reason=head-divergence` when it fires. | medium |
| What additional content fingerprint beyond HEAD SHA should we stamp? | HEAD SHA only. Do NOT add a content-hash of `files_investigated` or a `head_tree:` field in this PR. | high |
| Backward compatibility for artifacts without `head_sha:` front-matter? | Treat missing `head_sha:` as fall-back-to-fresh with new `reason=missing-head-sha`. Add as per-topic row #7 in the fall-back table, parallel to existing `missing-summary` row #4. | high |
| gh rate-limit guard for `gh pr list --search "closes #N"`? | No guard — single call per orchestrator run, consistent with the existing un-guarded `gh issue view --json updatedAt` Phase 1 call. | medium |

## Deferred (follow-up issues)

- Force-pushed branch hardening (e.g. pair `head_sha` with `head_tree`). Stale-but-trusted window is real but narrow; tracked in spec Open Questions.
- Content-hash of `files_investigated` (industry-standard from prior-art research). Out of scope for #98.
- Phase-1-wide `gh` rate-limit guard. Consistent-with-current-state choice for one-shot call.
- Integration-level test fixtures with live `git`/`gh` mocks.

## Artifacts

- Spec: `docs/uberdev/specs/2026-05-13-research-cache-drift-invalidation-design.md`
- Plan: `docs/uberdev/plans/2026-05-13-research-cache-drift-invalidation.md`

Closes #98


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced validation contracts for research agents to ensure stricter output consistency and format compliance
  * Improved cache freshness detection with enhanced commit tracking and divergence checks
  * Added strict validation for artifact metadata and investigation file references
  * Expanded orchestration logic to detect stale cached results more reliably

* **Tests**
  * Added comprehensive test coverage for artifact-reuse validation and freshness predicate behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->