### PR TITLE
docs(changelog): restore v0.25.0 section header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 - **Solo-dev workflow preservation.** For the personal-TODO-queue workflow ([[user_workflow_todo_queue]]), the design intentionally preserves the "land imperfect work + file TODOs" pattern for `important` / `major` findings (silent file, no halt). The halt path is reserved for `blocker` — by definition the findings the reviewer agents consider unshippable.
 - **Rollback procedure.** Pin the marketplace to `0.25.0` in `.claude-plugin/marketplace.json` via the user-side override path; no code rollback is required server-side.
 
-
+## [0.25.0] - 2026-05-14
 
 ### Added
 


### PR DESCRIPTION
## Summary

One-line fix: my v0.26.0 CHANGELOG edit in PR #115 used an Edit with `old_string="## [0.25.0] - 2026-05-14"` and replaced it with the v0.26.0 header — but I forgot to re-add the v0.25.0 marker, so the v0.25.0 (visual companion) section's content got orphaned under v0.26.0's heading.

This PR re-adds the `## [0.25.0] - 2026-05-14` marker at the correct location (line 34, between v0.26.0's `### Notes` and v0.25.0's `### Added`).

## Test plan

- [ ] `grep -c "^## \[0\.25\.0\]" CHANGELOG.md` → 1 (was 0 after the bug)
- [ ] Visual inspection confirms v0.25.0 content (visual companion) is now under its own header

Discovered during the post-merge GH-release-notes extraction for v0.26.0 — `awk` couldn't find the v0.25.0 marker to bound the release-notes section. No behavior change; CHANGELOG-only.