### PR TITLE
feat(aliases): reliable alias provisioning on install (v0.29.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents as `claude --bg` background sessions (monitor with `claude agents`); /issue creates well-investigated, deduped issues.",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0] - 2026-05-19
+
+### Fixed
+
+- **Alias auto-install no longer silently depends on `jq`.** The `SessionStart` hook (`plugins/uberdev/hooks/session-start`) hard-requires `jq` to JSON-encode its context injection and `exit 0`s early when `jq` is absent — previously *before* the auto-alias-sync block ever ran, so a new user on a machine without `jq` got zero short-form aliases (`/issue`, `/solve`, `/turbo`, …) and no warning. The alias-sync block now runs **before** the `jq` guard, and `lib/aliases-sync.sh` no longer calls `jq` at all: its one use (`jq -r .version` on `plugin.json`) is replaced by a jq-free `_aliases_read_version()` `sed` parse of the plugin's own manifest. Forwarders now install regardless of `jq`. See `docs/rfc/0004-alias-install-reliability.md`.
+
+### Added
+
+- **Alias-install outcomes are surfaced in the session context.** `aliases_sync_main` now composes a `UBERDEV_ALIAS_NOTICE` that the `SessionStart` hook injects as an `<important-reminder>`: a first-run summary, a collision notice naming any alias skipped because a non-uberdev file already occupies its short name (with the resolution steps), or a write-failure notice. Previously this went only to `stderr` and only on first run, so a skipped `/turbo` was invisible. The notice is conditional — empty in steady state, so post-first-run sessions stay silent.
+- **When `jq` is absent the hook now emits a fixed notice** (`uberdev: jq not found …`) instead of a silently-empty context, making the jq-missing degradation visible.
+- **`tests/aliases.test.sh` — new cases S10–S14:** `_aliases_read_version` parity with `jq -r .version`, `aliases_sync_main` notice composition, jq-masked install (all seven forwarders install with `jq` off `PATH`), and collision / first-run notices reaching the context injection.
+
+### Why
+
+`README.md` already promised the seven aliases are "auto-installed on first session" — but the auto-sync was fail-open and silent, so on a jq-less machine or a short-name collision the user got less than promised with no signal. This release closes that reliability gap against the stated contract: aliases install unconditionally, and any skip or failure is reported. Claude Code has no install-time plugin hook (feature request anthropics/claude-code#11240, closed unshipped), so the `SessionStart` hook remains the provisioning mechanism — it is hardened, not replaced. Deliberately out of scope and deferred: content-hash idempotency, retry of a previously-skipped alias, and `install.sh`-side provisioning.
+
 ## [0.28.0] - 2026-05-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.28.0-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.29.0-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)
@@ -63,7 +63,7 @@ Then in Claude Code:
 /uberdev:issue trivial typo in README install step   # smoke-test
 ```
 
-The seven short-form aliases (`/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr`, `/merge`, `/dev`) are auto-installed on first session and refreshed on plugin upgrade. Opt out with `auto_install_aliases: false` in `.claude/uberdev.local.md` or `UBERDEV_NO_AUTO_ALIAS=1`.
+The seven short-form aliases (`/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr`, `/merge`, `/dev`) are auto-installed on first session and refreshed on plugin upgrade — `jq` is not required, and if a short name collides with an existing file the session context reports which alias was skipped. Opt out with `auto_install_aliases: false` in `.claude/uberdev.local.md` or `UBERDEV_NO_AUTO_ALIAS=1`.
 
 > **Why a bootstrap script?** Upstream Claude Code has a bug ([anthropics/claude-code#20661](https://github.com/anthropics/claude-code/issues/20661)) where `/plugin install` populates the cache but does not write `enabledPlugins` in `~/.claude/settings.json` — so `/uberdev:*` commands silently 404. `install.sh` does the install **and** jq-patches `enabledPlugins`. Idempotent. Requires `jq`.
 

--- a/docs/rfc/0004-alias-install-reliability.md
+++ b/docs/rfc/0004-alias-install-reliability.md
@@ -74,7 +74,7 @@ The `stderr` summary is retained for backward compatibility (the `/uberdev:insta
 | State                       | Notice text                                                                                                                                              |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | First run, all installed    | `uberdev: installed N short-form aliases (/issue, /solve, …). Opt out with UBERDEV_NO_AUTO_ALIAS=1.`                                                      |
-| Collision skip              | `uberdev: /turbo not installed — ~/.claude/commands/turbo.md exists and isn't uberdev-managed. Use /uberdev:turbo, or rename that file and run /uberdev:install-aliases.` |
+| Collision skip              | One aggregated line naming every skipped alias: `uberdev: these short-form aliases were not installed because a non-uberdev file already exists at ~/.claude/commands/<name>.md: /turbo /merge — use /uberdev:<name>, or rename the existing file and run /uberdev:install-aliases.` |
 | Write failure               | `uberdev: failed to install alias(es): <names>. Re-run /uberdev:install-aliases.`                                                                        |
 | Steady state (all in sync)  | *(empty — nothing is injected)*                                                                                                                          |
 

--- a/docs/rfc/0004-alias-install-reliability.md
+++ b/docs/rfc/0004-alias-install-reliability.md
@@ -1,0 +1,165 @@
+# RFC 0004 — Alias-Install Reliability
+
+| Field          | Value                                                                                                                                                                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status**     | Draft (2026-05-19 — awaiting implementation)                                                                                                                                                                                                 |
+| **Author**     | TheFJK                                                                                                                                                                                                                                       |
+| **Created**    | 2026-05-19                                                                                                                                                                                                                                   |
+| **Targets**    | NEW: `docs/rfc/0004-alias-install-reliability.md`. MODIFIED: `plugins/uberdev/lib/aliases-sync.sh`, `plugins/uberdev/hooks/session-start`, `tests/aliases.test.sh`, `tests/solve-claim.test.sh`, `README.md`, `CHANGELOG.md`, `.claude-plugin/marketplace.json`, `plugins/uberdev/.claude-plugin/plugin.json` |
+| **Supersedes** | —                                                                                                                                                                                                                                            |
+| **Builds on**  | Issue #21 (auto-alias sync via the `SessionStart` hook) — this RFC hardens that mechanism, it does not replace it.                                                                                                                            |
+| **Tracking**   | none — ad-hoc design (reliability hardening, not an issue resolution)                                                                                                                                                                        |
+| **Tier**       | Small–Medium (two behaviour files, no new command, no contract change to existing commands; a removed dependency plus an additive notice channel)                                                                                            |
+
+---
+
+## 1. Summary
+
+The seven short-form alias forwarders — `/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr`, `/merge`, `/dev` — are auto-installed into `~/.claude/commands/` on first session by the `SessionStart` hook (issue #21). Today that path is **fail-open and silent**: it installs *nothing* when `jq` is absent, and it skips an individual alias on collision — in both cases with no signal to the user. A new user can finish installation, expect `/turbo`, find it missing, and have no way to know why.
+
+This RFC makes alias provisioning:
+
+1. **jq-independent** — the forwarders install regardless of whether `jq` is on `PATH`; and
+2. **observable** — any skipped or failed alias, and the first-run result, are surfaced in the session context instead of disappearing onto `stderr`.
+
+The `SessionStart` hook stays the provisioning lever — Claude Code has no install-time hook (see §2.3). It is *hardened*, not relocated.
+
+## 2. Motivation
+
+### 2.1 A reliability gap against a stated promise
+
+`README.md:66` already tells users: *"The seven short-form aliases … are auto-installed on first session and refreshed on plugin upgrade."* This is not a missing feature — it is a **reliability gap against a contract the project already advertises**. When the gap trips, the user silently gets less than the README promised.
+
+### 2.2 Two silent failure modes
+
+A codebase investigation (2026-05-19) isolated two root causes.
+
+**(a) Incidental `jq` coupling.** `hooks/session-start:14-23` hard-requires `jq` — it needs it to JSON-encode the session-context injection safely — and `exit 0`s immediately if `jq` is missing, *before* control ever reaches the alias-sync block at `session-start:52`. Independently, `aliases_sync_main` re-checks `jq` itself (`aliases-sync.sh:106`, `command -v jq … || return 0`). Yet across the whole alias path `jq` is used for **exactly one thing**: `jq -r .version` against `plugin.json` (`aliases-sync.sh:118`) to drive the version-marker idempotency check. The dependency is incidental, not structural — but its effect is total: a new user on a machine without `jq` gets **zero aliases and zero alias-specific warning**.
+
+**(b) Invisible skips.** `aliases_sync_main` already computes `SKIPPED_LIST` and `FAILED_LIST`, but it emits a one-line summary only to **`stderr`**, and only on first run (`aliases-sync.sh:173-183`). The collision case is *correct* behaviour — a pre-existing, un-managed `~/.claude/commands/turbo.md` must not be clobbered, so `/turbo` is rightly skipped — but the user is never told that `/turbo` is missing *because* their own file won, nor what to do about it.
+
+### 2.3 No install-time hook exists — the hook is the right lever
+
+Research against the Claude Code plugin documentation (early 2026) confirms: there is **no PostInstall / install-time plugin hook**. A lifecycle-hook feature request (anthropics/claude-code#11240) was closed unshipped. The plugin manifest has **no field for un-prefixed (top-level) command aliases** — plugin commands are always `/<plugin>:<command>`. Dropping forwarder files into `~/.claude/commands/` genuinely requires plugin-authored code, and the earliest such code can run is a `SessionStart` hook. UberDev's existing `matcher: "startup|clear|compact"` hook is therefore the *idiomatic* mechanism. The correct fix hardens it; it does not move the work elsewhere (see §6.2).
+
+## 3. Design
+
+### 3.1 jq-independent version read
+
+`aliases-sync.sh` gains a small helper, `_aliases_read_version <plugin_json_path>`, that extracts the `version` value from the plugin's **own** `.claude-plugin/plugin.json` with `sed`:
+
+```sh
+sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$file" | head -n1
+```
+
+This reads a file the plugin **ships and controls**, in which `"version": "x.y.z"` is a single normal line. An empty result is treated exactly as a bad `jq -r .version` read is treated today — the caller fails open (`return 0`, a no-op). The `command -v jq … || return 0` gate at `aliases-sync.sh:106` is removed. After this change `aliases-sync.sh` has **no `jq` dependency at all**.
+
+A test (§4) asserts `_aliases_read_version` returns the same string as `jq -r .version` on the real manifest, so any future reformatting of `plugin.json` that breaks the parse is caught in CI.
+
+### 3.2 `SessionStart` runs alias-sync unconditionally
+
+The alias-sync block (`session-start:52-56`) moves to immediately **after** `PLUGIN_ROOT` resolution (`session-start:8`) and **before** the `jq` guard. `jq` remains required only for the context-injection JSON encoding — its original, legitimate purpose. The forwarders are written before the hook can possibly `exit` on a missing `jq`.
+
+### 3.3 The notice channel
+
+`aliases_sync_main` composes a single human-readable notice from first-run / `SKIPPED_LIST` / `FAILED_LIST` state and assigns it to an exported global, `UBERDEV_ALIAS_NOTICE` (the empty string when there is nothing to report — i.e. steady state). The hook already `source`s the library, so it reads that variable directly after the `aliases_sync_main` call:
+
+- **`jq` present** — a non-empty notice is wrapped as an `<important-reminder>…</important-reminder>` block and concatenated into `session_context` alongside the existing `warning_message` and `gh_warning`. `jq` then encodes the whole string in one pass; the encoding path is **unchanged** and stays the single safe-encoding choke point.
+- **`jq` absent** — the alias forwarders are *already installed* by this point. The hook's existing jq-missing branch hand-builds JSON and cannot safely encode arbitrary text, so it emits one **constant** notice — `uberdev: jq not found — install jq for the full session context` — which is safe to hand-encode precisely because it contains no interpolation and no user-derived data. As a bonus this finally makes the *previously silent* jq-missing degradation of the whole hook visible.
+
+The `stderr` summary is retained for backward compatibility (the `/uberdev:install-aliases` command and existing test `S1` both rely on it); `UBERDEV_ALIAS_NOTICE` becomes the authoritative *user-facing* channel.
+
+### 3.4 Notice content — conditional and low-noise
+
+| State                       | Notice text                                                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| First run, all installed    | `uberdev: installed N short-form aliases (/issue, /solve, …). Opt out with UBERDEV_NO_AUTO_ALIAS=1.`                                                      |
+| Collision skip              | `uberdev: /turbo not installed — ~/.claude/commands/turbo.md exists and isn't uberdev-managed. Use /uberdev:turbo, or rename that file and run /uberdev:install-aliases.` |
+| Write failure               | `uberdev: failed to install alias(es): <names>. Re-run /uberdev:install-aliases.`                                                                        |
+| Steady state (all in sync)  | *(empty — nothing is injected)*                                                                                                                          |
+
+The notice fires only when there is something to say. After a clean first run, every subsequent session is silent — no per-session noise.
+
+### 3.5 Safety invariants — unchanged
+
+`aliases_sync_main` keeps its **fail-open contract**: it always returns `0`; a missing `PLUGIN_ROOT`, an unreadable manifest, a symlinked `~/.claude/commands`, or an empty version string each short-circuit to a no-op. Collisions still **never** overwrite a hand-authored file — the marker-scoped check (`managed-by: uberdev-aliases`) is untouched. This RFC makes a skip **visible**, not **aggressive**: a user's own `/turbo` always wins; we just tell them it did.
+
+### 3.6 In-passing cleanup
+
+The comment at `session-start:45-46` still enumerates only five of the seven aliases (`/issue, /solve, /turbo, /simplify, /review-pr` — `/merge` and `/dev` were never added). It is corrected while editing that file.
+
+## 4. File impact summary
+
+| File                                          | Change                                                                                                                |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `docs/rfc/0004-alias-install-reliability.md`  | NEW — this RFC.                                                                                                       |
+| `plugins/uberdev/lib/aliases-sync.sh`         | MOD — add `_aliases_read_version()`; remove the `jq` gate; build and export `UBERDEV_ALIAS_NOTICE`.                   |
+| `plugins/uberdev/hooks/session-start`         | MOD — move alias-sync above the `jq` guard; inject the notice (jq-present path); emit the constant jq-missing notice; fix the stale five-of-seven comment. |
+| `tests/aliases.test.sh`                       | MOD — new cases: version-read parity, notice composition, jq-masked install, notice surfaced on collision and on first run. |
+| `tests/solve-claim.test.sh`                   | MOD — retarget the version-drift assertions (pinned to `0.28.0`) to `0.29.0`.                                          |
+| `README.md`                                   | MOD — version badge; clarify near line 66 that alias auto-install no longer requires `jq`.                            |
+| `CHANGELOG.md`                                | MOD — new `## [0.29.0]` section.                                                                                      |
+| `.claude-plugin/marketplace.json`             | MOD — `plugins[0].version` → `0.29.0`.                                                                                |
+| `plugins/uberdev/.claude-plugin/plugin.json`  | MOD — `version` → `0.29.0`.                                                                                           |
+
+**Testing strategy.** Extend the existing bash harness (`tests/aliases.test.sh`, the `A`/`S` sections; run in CI via `.github/workflows/test.yml`). New `S`-series cases:
+
+- **jq-masked install** — run `session-start` (and `aliases_sync_main` directly) with `jq` removed from `PATH`; assert all seven forwarders *and* the version marker are written.
+- **version-read parity** — `_aliases_read_version` against the real `plugin.json` equals `jq -r .version`.
+- **collision surfaced** — extend `S5`: assert the skip notice appears in the hook's stdout `additionalContext`, not only on `stderr`.
+- **first-run surfaced** — assert the first-run notice appears in `additionalContext`.
+
+The `A1`–`A6` structural checks (notably the `A6` `ALIASES` ↔ `allowed-tools` drift check) and the existing `S1`–`S8` lifecycle cases are unaffected and must stay green.
+
+## 5. Migration / rollout
+
+A user-facing reliability change → a **minor** version bump `0.28.0 → 0.29.0` across every location, per the project "bump version everywhere" mandate: `plugin.json`, `marketplace.json`, the `README.md` badge, a `CHANGELOG.md` `## [0.29.0] — 2026-05-19` section, the `v0.29.0` git tag, and the GitHub Release. (Minor rather than patch because the notice channel is genuinely new user-visible behaviour, not only a bug fix.)
+
+The change is **backward-compatible**. Existing users who already have the forwarders installed see a steady-state no-op (empty notice); the version bump triggers the usual single refresh pass. The `~/.claude/.uberdev-aliases-version` marker file format is **unchanged**, so there is no marker migration.
+
+## 6. Alternatives considered
+
+### 6.1 Surface failures only — keep the `jq` dependency
+
+Make skips and failures visible, but leave `jq` load-bearing for alias-install. **Rejected:** a jq-less machine still ends up with zero aliases — the user is merely *told* it failed. This treats the symptom, not the root cause. (This was the explicit scope fork put to the user; the user chose guarantee + surface — see §9 Q1.)
+
+### 6.2 Provision aliases from `install.sh`
+
+Have the bootstrap `install.sh` run the alias sync itself after `/plugin install`. **Rejected as the primary mechanism:** `install.sh` is not run by every user — many install via `/plugin marketplace add` + `/plugin install` directly inside Claude Code and never touch the script — and it does not run on plugin *upgrades*. It would be a second, drift-prone code path delivering no reliability gain over a hardened hook (which already runs for every user, every session). Out of scope; see §7.
+
+### 6.3 Status file instead of an exported shell variable
+
+Have `aliases_sync_main` write a `~/.claude/.uberdev-aliases-status` file that the hook reads. **Rejected:** the hook *already* `source`s the library, so a shell variable is sufficient. A file would add a new artifact with its own lifecycle (uninstall cleanup, staleness handling) for no benefit at the one call site that needs it.
+
+### 6.4 Content-hash idempotency in `${CLAUDE_PLUGIN_DATA}`
+
+Replace the version-keyed marker with a content-hash sentinel — the pattern Claude Code's own plugin docs recommend for "run once after install, re-run on update" work. **Deferred, not adopted here:** it would additionally fix two latent bugs — a skipped alias stays "sticky" until the next version bump, and a new alias added without a version bump never propagates — but it changes the idempotency contract and the marker file's location and format, and needs a migration path. That is a separate concern from the stated reliability goal; it is captured as follow-up work (§7).
+
+## 7. Open questions
+
+None blocking. The single design fork — *how far the fix goes* — was resolved with the user as **guarantee + surface** (§9, Q1). Scope is focused enough for a single implementation plan.
+
+Deliberately deferred to a follow-up issue, not designed here:
+
+- Content-hash idempotency (§6.4) and the two latent bugs it would close.
+- Retry of a previously skipped alias once the colliding file is removed (today a skip is "sticky" until the next version bump; the manual `/uberdev:install-aliases` is the current recovery path).
+- `install.sh`-side provisioning (§6.2).
+
+## 8. Risk / rollout
+
+- **Risk: the `sed` version read mis-parses an unusually formatted `plugin.json`** (multi-line `version`, exotic whitespace). *Mitigation:* the manifest is the plugin's own controlled file and is conventionally formatted; the version-read-parity test (§4) catches any reformatting that breaks the parse; an empty read fails open to a no-op, exactly as a bad `jq` read does today.
+- **Risk: notice noise** — a message on every session. *Mitigation:* the notice is conditional and empty in steady state (§3.4), so the post-first-run happy path stays silent.
+- **Risk: reordering regression** — moving the alias-sync block changes hook control flow. *Mitigation:* the `S1`–`S8` hook-integration cases already exercise the full lifecycle, run in CI, and must stay green; the new jq-masked case adds the previously-missing coverage.
+- **Rollback:** revert the two behaviour files and the version edits. The marker file format is unchanged, so a rollback is clean with no user-side migration.
+
+## 9. Decision log
+
+| #   | Decision              | Choice                                                                                                                          | Source                         |
+| --- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| Q1  | Fix depth             | **Guarantee + surface** — decouple from `jq` *and* surface skips/failures; not surface-only.                                    | User.                          |
+| D2  | Mechanism             | Harden the existing `SessionStart` hook — Claude Code has no install-time hook (anthropics/claude-code#11240, closed unshipped). | Author (research).             |
+| D3  | Version read          | A `jq`-free `sed` parse of the plugin's own `plugin.json`; not a separate plain-text `VERSION` file.                            | Author.                        |
+| D4  | lib → hook channel    | An exported shell variable `UBERDEV_ALIAS_NOTICE`; not a status file (the hook already `source`s the library).                  | Author.                        |
+| D5  | jq-missing notice     | A fixed constant string (safe to hand-encode); the dynamic notice is emitted only on the jq-present path.                       | Author.                        |
+| D6  | Published artifact    | This RFC (`docs/rfc/`, tracked). `docs/uberdev/specs/` is gitignored, local-only — established by RFC 0003 §9 D9.               | Author (`.gitignore` — `docs/uberdev/*`). |
+| D7  | Out of scope          | Content-hash idempotency, sticky-collision retry, and `install.sh` provisioning → a follow-up issue.                            | Author.                        |

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via claude --bg background sessions (Agent View), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/hooks/session-start
+++ b/plugins/uberdev/hooks/session-start
@@ -7,17 +7,40 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-# Require jq for safe JSON encoding. The previous manual escape function
-# missed control bytes 0x00-0x1f and `%` (which printf would interpret as a
-# format specifier, corrupting output). If jq is missing, degrade gracefully:
-# emit an empty injection rather than risk producing malformed JSON.
+# ── auto-alias sync (issue #21; RFC 0004) ────────────────────────────
+# Install / refresh the seven top-level forwarders (/issue, /solve, /turbo,
+# /simplify, /review-pr, /merge, /dev) in ~/.claude/commands. This runs
+# BEFORE the jq guard below on purpose: alias sync has no jq dependency
+# (RFC 0004), so a machine without jq still gets its aliases. Idempotent:
+# if installed_version == plugin_version the helper returns immediately.
+# Opt out with UBERDEV_NO_AUTO_ALIAS=1 or `auto_install_aliases: false` in
+# .claude/uberdev.local.md. The helper handles all error paths internally
+# and returns 0; the `|| true` is defence-in-depth so set -e cannot abort
+# the hook if the helper ever does emit non-zero. aliases_sync_main sets
+# UBERDEV_ALIAS_NOTICE (a user-facing notice, or "" when there is nothing
+# to report); it is injected into the session context further down.
+UBERDEV_ALIAS_NOTICE=""
+if [ -f "${PLUGIN_ROOT}/lib/aliases-sync.sh" ]; then
+  # shellcheck source=../lib/aliases-sync.sh
+  . "${PLUGIN_ROOT}/lib/aliases-sync.sh"
+  aliases_sync_main || true
+fi
+
+# Require jq for safe JSON encoding of the rich context injection below. The
+# previous manual escape function missed control bytes 0x00-0x1f and `%`
+# (which printf would interpret as a format specifier, corrupting output).
+# If jq is missing, degrade gracefully: the alias sync above has already run
+# (it needs no jq), so emit a single FIXED notice — a constant string with
+# no interpolation, hence safe to hand-encode into JSON without jq — instead
+# of a silently-empty context.
 if ! command -v jq >/dev/null 2>&1; then
+    jqmsg="uberdev: jq not found — install jq (e.g. brew install jq) for the full session context."
     if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
-        printf '{"additional_context":""}\n'
+        printf '{"additional_context":"%s"}\n' "$jqmsg"
     elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
-        printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":""}}\n'
+        printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$jqmsg"
     else
-        printf '{"additionalContext":""}\n'
+        printf '{"additionalContext":"%s"}\n' "$jqmsg"
     fi
     exit 0
 fi
@@ -41,18 +64,13 @@ if [ -d "$legacy_skills_dir" ]; then
     warning_message=$'\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER:⚠️ **WARNING:** UberDev now uses Claude Code\'s skills system. Custom skills in ~/.config/uberdev/skills will not be read. Move custom skills to ~/.claude/skills instead. To make this message go away, remove ~/.config/uberdev/skills</important-reminder>'
 fi
 
-# ── auto-alias sync (issue #21) ──────────────────────────────────────
-# Install / refresh top-level forwarders /issue, /solve, /turbo, /simplify,
-# /review-pr in ~/.claude/commands. Idempotent: if installed_version ==
-# plugin_version, the helper returns immediately. Opt out with
-# UBERDEV_NO_AUTO_ALIAS=1 or `auto_install_aliases: false` in
-# .claude/uberdev.local.md. The helper handles all error paths internally
-# and returns 0; the `|| true` is defence-in-depth so set -e cannot abort
-# the hook if the helper ever does emit non-zero.
-if [ -f "${PLUGIN_ROOT}/lib/aliases-sync.sh" ]; then
-  # shellcheck source=../lib/aliases-sync.sh
-  . "${PLUGIN_ROOT}/lib/aliases-sync.sh"
-  aliases_sync_main || true
+# Build the alias-sync notice set by aliases_sync_main above. Non-empty only
+# on first install or a refresh that skipped/failed an alias; a steady-state
+# session leaves it "". Wrapped as an <important-reminder> so Claude relays
+# it to the user, mirroring gh_warning / warning_message.
+alias_warning=""
+if [ -n "${UBERDEV_ALIAS_NOTICE:-}" ]; then
+    alias_warning=$'\n\n<important-reminder>'"${UBERDEV_ALIAS_NOTICE}"$'</important-reminder>'
 fi
 
 # Read using-uberdev content
@@ -60,7 +78,7 @@ using_uberdev_content=$(cat "${PLUGIN_ROOT}/skills/using-uberdev/SKILL.md" 2>/de
 
 # Build the full session context as a raw string, then let jq handle JSON
 # encoding in one shot — covers control bytes, quotes, backslashes, and `%`.
-session_context=$'<EXTREMELY_IMPORTANT>\nYou have uberdev superpowers.\n\n**Below is the full content of your \'uberdev:using-uberdev\' skill - your introduction to using skills. For all other skills, use the \'Skill\' tool:**\n\n'"${using_uberdev_content}"$'\n\n'"${warning_message}${gh_warning}"$'\n</EXTREMELY_IMPORTANT>'
+session_context=$'<EXTREMELY_IMPORTANT>\nYou have uberdev superpowers.\n\n**Below is the full content of your \'uberdev:using-uberdev\' skill - your introduction to using skills. For all other skills, use the \'Skill\' tool:**\n\n'"${using_uberdev_content}"$'\n\n'"${warning_message}${gh_warning}${alias_warning}"$'\n</EXTREMELY_IMPORTANT>'
 
 # Output context injection as JSON, built with jq so the string is encoded safely.
 # Cursor hooks expect additional_context (snake_case).

--- a/plugins/uberdev/lib/aliases-sync.sh
+++ b/plugins/uberdev/lib/aliases-sync.sh
@@ -139,7 +139,7 @@ aliases_sync_main() {
   # jq-free read of the plugin's own manifest version (RFC 0004) — alias
   # sync has no external dependency, so it works without jq on PATH.
   VERSION="$(_aliases_read_version "$PLUGIN_ROOT_LOCAL/.claude-plugin/plugin.json")"
-  [ -n "$VERSION" ] && [ "$VERSION" != "null" ] || return 0
+  [ -n "$VERSION" ] || return 0
 
   INSTALLED="$(cat "$MARKER" 2>/dev/null || true)"
 

--- a/plugins/uberdev/lib/aliases-sync.sh
+++ b/plugins/uberdev/lib/aliases-sync.sh
@@ -8,6 +8,9 @@
 #   BUILTINS                  — list of Claude Code built-in command names
 #                               that must never be overwritten.
 #   aliases_sync_main()       — top-level entry; idempotent; always returns 0.
+#   UBERDEV_ALIAS_NOTICE      — global set by aliases_sync_main(): a one-line
+#                               user-facing notice (or "") for the SessionStart
+#                               hook to inject into the session context.
 #   aliases_sync_remove()     — companion for /uberdev:uninstall-aliases.
 #
 # Sourced by:
@@ -87,12 +90,31 @@ _aliases_check_marker() {
   head -c 1024 "$TARGET" 2>/dev/null | grep -q 'managed-by: uberdev-aliases'
 }
 
+# _aliases_read_version PLUGIN_JSON
+# Prints the top-level "version" string from a plugin.json — without jq.
+# The manifest is the plugin's own shipped file, where `"version": "x.y.z"`
+# sits on a single line. Prints nothing on any failure; the caller treats an
+# empty result as "version undeterminable" and fails open (RFC 0004).
+_aliases_read_version() {
+  local file="$1"
+  [ -r "$file" ] || return 0
+  sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$file" \
+    2>/dev/null | head -n1
+}
+
 # aliases_sync_main
 # Idempotent. Always returns 0. Reads:
 #   - $PLUGIN_ROOT (must be set by caller)
 #   - $UBERDEV_NO_AUTO_ALIAS (env, optional)
 #   - $PWD/.claude/uberdev.local.md (file, optional)
+# Sets:
+#   - $UBERDEV_ALIAS_NOTICE (global) — a one-line user-facing notice for the
+#     SessionStart hook to inject, or "" when there is nothing to report.
 aliases_sync_main() {
+  # Always define the notice first so EVERY return path leaves it set (the
+  # hook runs under `set -u`). Empty string ⇒ the hook injects nothing.
+  UBERDEV_ALIAS_NOTICE=""
+
   # 1. Opt-out gates (env + file). Env wins (precedence: env > file > default).
   case "${UBERDEV_NO_AUTO_ALIAS:-}" in
     1|true|TRUE|yes|YES) return 0 ;;
@@ -102,10 +124,7 @@ aliases_sync_main() {
     return 0
   fi
 
-  # 2. Hard-dep check: jq required to read plugin.json version.
-  command -v jq >/dev/null 2>&1 || return 0  # fail-open
-
-  # 3. Plugin-root sanity.
+  # 2. Plugin-root sanity.
   local PLUGIN_ROOT_LOCAL="${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-}}}"
   [ -n "$PLUGIN_ROOT_LOCAL" ] || return 0
   [ -f "$PLUGIN_ROOT_LOCAL/.claude-plugin/plugin.json" ] || return 0
@@ -115,12 +134,14 @@ aliases_sync_main() {
   local DEST_DIR="$HOME/.claude/commands"
   local MARKER="$HOME/.claude/.uberdev-aliases-version"
   local VERSION INSTALLED FIRST_RUN
-  VERSION="$(jq -r .version "$PLUGIN_ROOT_LOCAL/.claude-plugin/plugin.json" 2>/dev/null)" || return 0
+  # jq-free read of the plugin's own manifest version (RFC 0004) — alias
+  # sync has no external dependency, so it works without jq on PATH.
+  VERSION="$(_aliases_read_version "$PLUGIN_ROOT_LOCAL/.claude-plugin/plugin.json")"
   [ -n "$VERSION" ] && [ "$VERSION" != "null" ] || return 0
 
   INSTALLED="$(cat "$MARKER" 2>/dev/null || true)"
 
-  # 4. Idempotency check.
+  # 3. Idempotency check.
   if [ "$INSTALLED" = "$VERSION" ]; then
     return 0
   fi
@@ -131,14 +152,14 @@ aliases_sync_main() {
     FIRST_RUN=0
   fi
 
-  # 5. Realpath/symlink containment guard (security mitigation 3).
+  # 4. Realpath/symlink containment guard (security mitigation 3).
   if [ -L "$DEST_DIR" ]; then
     echo "uberdev: ~/.claude/commands is a symlink; refusing to sync" >&2
     return 0
   fi
   mkdir -p "$DEST_DIR" 2>/dev/null || return 0
 
-  # 6. Per-alias loop.
+  # 5. Per-alias loop.
   local INSTALLED_LIST=()
   local SKIPPED_LIST=()
   local FAILED_LIST=()
@@ -163,13 +184,15 @@ aliases_sync_main() {
     fi
   done <<< "$ALIASES"
 
-  # 7. Atomic version-marker write.
+  # 6. Atomic version-marker write.
   local MTMP
   MTMP="$(mktemp "$HOME/.claude/.uberdev-aliases-version.XXXXXX")" || return 0
   printf '%s\n' "$VERSION" > "$MTMP"
   mv -f "$MTMP" "$MARKER" || { rm -f "$MTMP"; return 0; }
 
-  # 8. First-run summary line (Q5: only on first install).
+  # 7. First-run summary line (Q5: only on first install) — stderr only,
+  # retained verbatim for backward compatibility (tests S1/S5 assert this
+  # exact wording).
   if [ "$FIRST_RUN" = "1" ]; then
     local skipped_str=""
     if [ "${#SKIPPED_LIST[@]}" -gt 0 ]; then
@@ -180,6 +203,24 @@ aliases_sync_main() {
       failed_str=", failed ${#FAILED_LIST[@]} (${FAILED_LIST[*]})"
     fi
     echo "first run: installed ${#INSTALLED_LIST[@]} aliases, skipped ${#SKIPPED_LIST[@]} conflicts (${skipped_str})${failed_str}; opt out with UBERDEV_NO_AUTO_ALIAS=1" >&2
+  fi
+
+  # 8. User-facing notice (RFC 0004) — consumed by the SessionStart hook and
+  # injected into the session context. Reached only when the per-alias loop
+  # ran (first install or a version refresh); the idempotency early-return at
+  # step 3 means a steady-state session never gets here, so the notice is
+  # naturally low-noise. Priority: failure > collision > first-run.
+  local sk
+  if [ "${#FAILED_LIST[@]}" -gt 0 ]; then
+    UBERDEV_ALIAS_NOTICE="uberdev: failed to install alias(es): ${FAILED_LIST[*]}. Re-run /uberdev:install-aliases."
+  elif [ "${#SKIPPED_LIST[@]}" -gt 0 ]; then
+    UBERDEV_ALIAS_NOTICE="uberdev: these short-form aliases were not installed because a non-uberdev file already exists at ~/.claude/commands/<name>.md:"
+    for sk in "${SKIPPED_LIST[@]}"; do
+      UBERDEV_ALIAS_NOTICE="${UBERDEV_ALIAS_NOTICE} /${sk}"
+    done
+    UBERDEV_ALIAS_NOTICE="${UBERDEV_ALIAS_NOTICE} — use /uberdev:<name>, or rename the existing file and run /uberdev:install-aliases."
+  elif [ "$FIRST_RUN" = "1" ]; then
+    UBERDEV_ALIAS_NOTICE="uberdev: installed ${#INSTALLED_LIST[@]} short-form aliases (/issue, /solve, /turbo, /simplify, /review-pr, /merge, /dev). Opt out with UBERDEV_NO_AUTO_ALIAS=1."
   fi
   return 0
 }

--- a/plugins/uberdev/lib/aliases-sync.sh
+++ b/plugins/uberdev/lib/aliases-sync.sh
@@ -91,10 +91,12 @@ _aliases_check_marker() {
 }
 
 # _aliases_read_version PLUGIN_JSON
-# Prints the top-level "version" string from a plugin.json — without jq.
-# The manifest is the plugin's own shipped file, where `"version": "x.y.z"`
-# sits on a single line. Prints nothing on any failure; the caller treats an
-# empty result as "version undeterminable" and fails open (RFC 0004).
+# Prints the first "version" string found in a plugin.json — without jq.
+# The sed matches the first `"version"` key on any line, not specifically a
+# top-level one; this is safe because the manifest is the plugin's own
+# shipped, controlled file, where `"version": "x.y.z"` sits on a single
+# top-level line. Prints nothing on any failure; the caller treats an empty
+# result as "version undeterminable" and fails open (RFC 0004).
 _aliases_read_version() {
   local file="$1"
   [ -r "$file" ] || return 0

--- a/tests/aliases.test.sh
+++ b/tests/aliases.test.sh
@@ -576,6 +576,69 @@ esac
 rm -rf "$S11_HOME"
 
 echo
+echo "== S12: aliases install with jq absent (RFC 0004) =="
+# Mask jq: build a bin dir holding symlinks to every tool the hook needs
+# EXCEPT jq, then run the hook with PATH pointed only at it. With the
+# RFC-0004 reorder, alias sync runs before the jq guard, so the seven
+# forwarders must still install, and a fixed jq-missing notice must surface.
+S12_BIN="$(mktemp -d)"
+for t in bash grep sed head cat mkdir mktemp mv rm dirname; do
+  src="$(command -v "$t" 2>/dev/null)" && ln -s "$src" "$S12_BIN/$t"
+done
+S12_HOME="$(mktemp -d)"
+S12_STDOUT="$(mktemp)"
+PATH="$S12_BIN" HOME="$S12_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
+  bash "$HOOK" >"$S12_STDOUT" 2>/dev/null || true
+S12_OK=1
+for short in issue solve turbo simplify review-pr merge dev; do
+  if [ ! -f "$S12_HOME/.claude/commands/${short}.md" ] \
+     || ! grep -q 'managed-by: uberdev-aliases' "$S12_HOME/.claude/commands/${short}.md"; then
+    S12_OK=0; break
+  fi
+done
+if [ "$S12_OK" = "1" ]; then
+  echo "  PASS  S12: all 7 forwarders installed with jq masked"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  S12: forwarders missing when jq absent"; FAIL=$((FAIL + 1))
+fi
+if grep -q 'jq not found' "$S12_STDOUT"; then
+  echo "  PASS  S12: jq-missing notice surfaced in context"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  S12: jq-missing notice not surfaced"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$S12_BIN" "$S12_HOME" "$S12_STDOUT"
+
+echo
+echo "== S13: a collision is surfaced in the session context =="
+# A hand-authored forwarder collides; the skipped alias must be named in the
+# hook's stdout context injection, not just on stderr (RFC 0004).
+S13_HOME="$(mktemp -d)"
+mkdir -p "$S13_HOME/.claude/commands"
+printf '# my custom turbo\n' > "$S13_HOME/.claude/commands/turbo.md"
+S13_STDOUT="$(mktemp)"
+HOME="$S13_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
+  bash "$HOOK" >"$S13_STDOUT" 2>/dev/null || true
+if grep -q 'turbo' "$S13_STDOUT" && grep -qE 'not installed|already exists' "$S13_STDOUT"; then
+  echo "  PASS  S13: collision notice present in context injection"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  S13: collision notice missing from context"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$S13_HOME" "$S13_STDOUT"
+
+echo
+echo "== S14: the first-run notice is surfaced in the session context =="
+S14_HOME="$(mktemp -d)"
+S14_STDOUT="$(mktemp)"
+HOME="$S14_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
+  bash "$HOOK" >"$S14_STDOUT" 2>/dev/null || true
+if grep -q 'installed 7 short-form aliases' "$S14_STDOUT"; then
+  echo "  PASS  S14: first-run notice present in context injection"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  S14: first-run notice missing from context"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$S14_HOME" "$S14_STDOUT"
+
+echo
 echo "== Summary =="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"

--- a/tests/aliases.test.sh
+++ b/tests/aliases.test.sh
@@ -541,6 +541,41 @@ else
 fi
 
 echo
+echo "== S10: _aliases_read_version matches jq -r .version =="
+# RFC 0004: the jq-free version reader must return the byte-identical string
+# that `jq -r .version` returns on the plugin's own manifest. Sourcing the
+# library in a command-substitution subshell keeps its functions scoped.
+S10_GOT="$(
+  . "$REPO_ROOT/plugins/uberdev/lib/aliases-sync.sh"
+  _aliases_read_version "$PLUGIN_JSON"
+)"
+if [ "$S10_GOT" = "$PLUGIN_VERSION" ]; then
+  echo "  PASS  S10: _aliases_read_version → $S10_GOT"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  S10: got '$S10_GOT', expected '$PLUGIN_VERSION'"; FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== S11: aliases_sync_main sets UBERDEV_ALIAS_NOTICE on first run =="
+# RFC 0004: on a fresh install aliases_sync_main must compose a first-run
+# notice into the UBERDEV_ALIAS_NOTICE global for the hook to inject.
+S11_HOME="$(mktemp -d)"
+S11_GOT="$(
+  HOME="$S11_HOME"
+  PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"
+  . "$REPO_ROOT/plugins/uberdev/lib/aliases-sync.sh"
+  aliases_sync_main >/dev/null 2>&1
+  printf '%s' "${UBERDEV_ALIAS_NOTICE:-}"
+)"
+case "$S11_GOT" in
+  *"installed 7 short-form aliases"*)
+    echo "  PASS  S11: first-run notice composed"; PASS=$((PASS + 1)) ;;
+  *)
+    echo "  FAIL  S11: UBERDEV_ALIAS_NOTICE='$S11_GOT'"; FAIL=$((FAIL + 1)) ;;
+esac
+rm -rf "$S11_HOME"
+
+echo
 echo "== Summary =="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"

--- a/tests/aliases.test.sh
+++ b/tests/aliases.test.sh
@@ -639,6 +639,25 @@ fi
 rm -rf "$S14_HOME" "$S14_STDOUT"
 
 echo
+echo "== S15: a write failure surfaces a failure notice (RFC 0004) =="
+# Force _aliases_write_forwarder to fail by making ~/.claude/commands
+# read-only after creating it; the per-alias loop then populates FAILED_LIST
+# and the hook must inject the "failed to install alias(es)" notice.
+S15_HOME="$(mktemp -d)"
+mkdir -p "$S15_HOME/.claude/commands"
+chmod 555 "$S15_HOME/.claude/commands"
+S15_STDOUT="$(mktemp)"
+HOME="$S15_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
+  bash "$HOOK" >"$S15_STDOUT" 2>/dev/null || true
+chmod 755 "$S15_HOME/.claude/commands" 2>/dev/null || true
+if grep -qE 'failed to install alias' "$S15_STDOUT"; then
+  echo "  PASS  S15: write-failure notice surfaced in context"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  S15: write-failure notice missing from context"; FAIL=$((FAIL + 1))
+fi
+rm -rf "$S15_HOME" "$S15_STDOUT"
+
+echo
 echo "== Summary =="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -253,19 +253,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.27.1 -> 0.28.0 propagated =="
+echo "== Version bump 0.28.0 -> 0.29.0 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.28.0"' \
-  "plugin.json bumped to 0.28.0"
+  '"version": "0.29.0"' \
+  "plugin.json bumped to 0.29.0"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.28.0"' \
-  "marketplace.json bumped to 0.28.0"
+  '"version": "0.29.0"' \
+  "marketplace.json bumped to 0.29.0"
 assert_grep "$README" \
-  "version-0\\.28\\.0-blue" \
-  "README version badge bumped to 0.28.0"
+  "version-0\\.29\\.0-blue" \
+  "README version badge bumped to 0.29.0"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.28\.0\]' \
-  "CHANGELOG has [0.28.0] section header"
+  '^## \[0\.29\.0\]' \
+  "CHANGELOG has [0.29.0] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary

Hardens short-form alias provisioning (`/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr`, `/merge`, `/dev`) so a fresh install reliably ends up with the aliases — closing a silent reliability gap against the auto-install promise already made in `README.md`. Implements **RFC 0004** (`docs/rfc/0004-alias-install-reliability.md`).

- **jq-independent** — `lib/aliases-sync.sh` no longer calls `jq` at all: a `sed`-based `_aliases_read_version` replaces the lone `jq -r .version`, and `hooks/session-start` now runs the alias-sync block *before* its `jq` guard (which previously `exit 0`-ed first when `jq` was missing). Forwarders install whether or not `jq` is on `PATH`.
- **Observable** — `aliases_sync_main` composes a `UBERDEV_ALIAS_NOTICE` that the hook injects into the session context: a first-run summary, a collision notice naming any alias skipped because a non-uberdev file already holds its short name (with resolution steps), or a write-failure notice. Previously this went only to `stderr`, only on first run — so a skipped `/turbo` was invisible. When `jq` is absent the hook now emits a fixed notice instead of a silently-empty context.
- **Version bump** `0.28.0` → `0.29.0` across `plugin.json`, `marketplace.json`, the README badge, and `CHANGELOG.md`.

Safety invariants are unchanged: the sync stays fail-open, and a hand-authored `~/.claude/commands/<name>.md` is still never overwritten — the change makes a skip *visible*, not aggressive.

Out of scope (deferred to a follow-up): content-hash idempotency, retry of a previously-skipped alias, and `install.sh`-side provisioning.

## Test Plan

- [x] `tests/aliases.test.sh` — extended with cases **S10–S14**: jq-free version-read parity with `jq -r .version`, `UBERDEV_ALIAS_NOTICE` composition, jq-masked install (all 7 forwarders install with `jq` off `PATH`), and collision + first-run notices reaching the context injection. 66/66 pass.
- [x] `tests/solve-claim.test.sh` — version-drift assertions retargeted `0.28.0` → `0.29.0`. 101/101 pass.
- [x] Full suite — all 28 `tests/*.test.sh` files green.
- [x] Each task passed spec-compliance + code-quality review via subagent-driven-dev; zero Critical/Important findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session context notices reporting alias installation status (first-run, collisions, failures).

* **Bug Fixes**
  * Alias auto-installation now operates independently of jq, ensuring reliability when jq is unavailable.

* **Documentation**
  * Added RFC documenting alias installation reliability hardening.

* **Tests**
  * Expanded test coverage for version reading parity, notice composition, jq-masked installation, and collision reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->