### PR TITLE
fix(aliases): S5b skips when ln -s yields no symlink (Windows)

### DIFF
--- a/plugins/uberdev/lib/aliases-sync.sh
+++ b/plugins/uberdev/lib/aliases-sync.sh
@@ -132,7 +132,14 @@ aliases_sync_main() {
   fi
 
   # 5. Realpath/symlink containment guard (security mitigation 3).
-  if [ -L "$DEST_DIR" ]; then
+  # `[ -L ]` catches POSIX symlinks on Linux/macOS. On Windows with Git Bash
+  # in admin/Developer Mode, `ln -s` against a directory may produce an
+  # NTFS junction (a reparse point that POSIX `[ -L ]` does NOT recognise
+  # as a symlink). `readlink` resolves both: it returns the target for
+  # POSIX symlinks and reparse points, and empty for regular files/dirs.
+  # Belt-and-braces: keep `[ -L ]` for correctness on POSIX where it is
+  # authoritative, and add `readlink` as the Windows-junction net. (#126.)
+  if [ -L "$DEST_DIR" ] || [ -n "$(readlink "$DEST_DIR" 2>/dev/null)" ]; then
     echo "uberdev: ~/.claude/commands is a symlink; refusing to sync" >&2
     return 0
   fi

--- a/plugins/uberdev/lib/aliases-sync.sh
+++ b/plugins/uberdev/lib/aliases-sync.sh
@@ -132,13 +132,14 @@ aliases_sync_main() {
   fi
 
   # 5. Realpath/symlink containment guard (security mitigation 3).
-  # `[ -L ]` catches POSIX symlinks on Linux/macOS. On Windows with Git Bash
-  # in admin/Developer Mode, `ln -s` against a directory may produce an
-  # NTFS junction (a reparse point that POSIX `[ -L ]` does NOT recognise
-  # as a symlink). `readlink` resolves both: it returns the target for
-  # POSIX symlinks and reparse points, and empty for regular files/dirs.
-  # Belt-and-braces: keep `[ -L ]` for correctness on POSIX where it is
-  # authoritative, and add `readlink` as the Windows-junction net. (#126.)
+  # On POSIX systems `[ -L ]` is authoritative — it catches symlinks and
+  # rejects regular files. On Windows, `[ -L ]` does NOT recognise NTFS
+  # junctions (reparse points) that `ln -s` may produce against a directory,
+  # so we additionally test `readlink`: it writes the target to stdout for
+  # both POSIX symlinks AND NTFS junctions, and writes nothing for regular
+  # files and dirs. Both checks are necessary for cross-platform correctness;
+  # the `2>/dev/null` discards the "Not a symbolic link" stderr that BSD
+  # readlink emits on non-symlinks (no signal we care about).
   if [ -L "$DEST_DIR" ] || [ -n "$(readlink "$DEST_DIR" 2>/dev/null)" ]; then
     echo "uberdev: ~/.claude/commands is a symlink; refusing to sync" >&2
     return 0

--- a/tests/aliases.test.sh
+++ b/tests/aliases.test.sh
@@ -457,20 +457,53 @@ S5B_HOME="$(mktemp -d)"
 S5B_DECOY="$(mktemp -d)"
 mkdir -p "$S5B_HOME/.claude"
 ln -s "$S5B_DECOY" "$S5B_HOME/.claude/commands"
-S5B_STDERR="$(mktemp)"
-HOME="$S5B_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
-  bash "$HOOK" >/dev/null 2>"$S5B_STDERR" || true
-if grep -q "refusing to sync" "$S5B_STDERR"; then
-  echo "  PASS  S5b: symlinked commands dir refused"; PASS=$((PASS + 1))
+# Precondition: on Git Bash (windows-latest CI) without admin / Developer
+# Mode, `ln -s` does not create a POSIX symlink — it either fails silently
+# or copies the target directory. `[ -L ]` then returns false and there is
+# no symlink-shaped thing for the hook to refuse, so the refusal assertion
+# below cannot be satisfied. Convert that into a SKIP rather than a FAIL:
+# the test cannot meaningfully run when the platform's `ln -s` cannot
+# produce a real symlink. (Issue #126.)
+if [ ! -L "$S5B_HOME/.claude/commands" ]; then
+  echo "  SKIP  S5b: ln -s did not produce a symlink on this platform (Git Bash without admin/Developer Mode?)"
 else
-  echo "  FAIL  S5b: symlink refusal stderr line missing"; FAIL=$((FAIL + 1))
+  S5B_STDERR="$(mktemp)"
+  HOME="$S5B_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
+    bash "$HOOK" >/dev/null 2>"$S5B_STDERR" || true
+  if grep -q "refusing to sync" "$S5B_STDERR"; then
+    echo "  PASS  S5b: symlinked commands dir refused"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  S5b: symlink refusal stderr line missing"; FAIL=$((FAIL + 1))
+  fi
+  if [ -z "$(ls -A "$S5B_DECOY")" ]; then
+    echo "  PASS  S5b: no writes into symlink target"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  S5b: files written into symlinked dir"; FAIL=$((FAIL + 1))
+  fi
+  rm -f "$S5B_STDERR"
 fi
-if [ -z "$(ls -A "$S5B_DECOY")" ]; then
-  echo "  PASS  S5b: no writes into symlink target"; PASS=$((PASS + 1))
+rm -rf "$S5B_HOME" "$S5B_DECOY"
+
+echo
+echo "== S5b-guard: hook does not refuse a regular (non-symlinked) commands dir =="
+# Complement to S5b — pins down the false-positive direction: a regular
+# pre-existing ~/.claude/commands directory must NOT trigger the symlink
+# refusal. Catches regressions if the symlink detection is ever tightened
+# to also flag non-symlinks (e.g. accidentally refusing every existing dir).
+# This test runs on every platform; on Windows it doubles as the live
+# coverage for the precondition-skip path in S5b (since `mkdir -p` is the
+# same shape as the directory-copy fallback `ln -s` produces there).
+S5B_GUARD_HOME="$(mktemp -d)"
+mkdir -p "$S5B_GUARD_HOME/.claude/commands"
+S5B_GUARD_STDERR="$(mktemp)"
+HOME="$S5B_GUARD_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
+  bash "$HOOK" >/dev/null 2>"$S5B_GUARD_STDERR" || true
+if grep -q "refusing to sync" "$S5B_GUARD_STDERR"; then
+  echo "  FAIL  S5b-guard: hook emitted refusal for a regular (non-symlink) dir"; FAIL=$((FAIL + 1))
 else
-  echo "  FAIL  S5b: files written into symlinked dir"; FAIL=$((FAIL + 1))
+  echo "  PASS  S5b-guard: hook does not refuse a regular (non-symlink) commands dir"; PASS=$((PASS + 1))
 fi
-rm -rf "$S5B_HOME" "$S5B_DECOY" "$S5B_STDERR"
+rm -rf "$S5B_GUARD_HOME" "$S5B_GUARD_STDERR"
 
 echo
 echo "== S6: uninstall-aliases removes version-marker =="

--- a/tests/aliases.test.sh
+++ b/tests/aliases.test.sh
@@ -463,7 +463,7 @@ ln -s "$S5B_DECOY" "$S5B_HOME/.claude/commands"
 # no symlink-shaped thing for the hook to refuse, so the refusal assertion
 # below cannot be satisfied. Convert that into a SKIP rather than a FAIL:
 # the test cannot meaningfully run when the platform's `ln -s` cannot
-# produce a real symlink. (Issue #126.)
+# produce a real symlink.
 if [ ! -L "$S5B_HOME/.claude/commands" ]; then
   echo "  SKIP  S5b: ln -s did not produce a symlink on this platform (Git Bash without admin/Developer Mode?)"
 else
@@ -486,13 +486,14 @@ rm -rf "$S5B_HOME" "$S5B_DECOY"
 
 echo
 echo "== S5b-guard: hook does not refuse a regular (non-symlinked) commands dir =="
-# Complement to S5b — pins down the false-positive direction: a regular
-# pre-existing ~/.claude/commands directory must NOT trigger the symlink
-# refusal. Catches regressions if the symlink detection is ever tightened
-# to also flag non-symlinks (e.g. accidentally refusing every existing dir).
-# This test runs on every platform; on Windows it doubles as the live
-# coverage for the precondition-skip path in S5b (since `mkdir -p` is the
-# same shape as the directory-copy fallback `ln -s` produces there).
+# Complement to S5b — pins the false-positive direction: a regular pre-
+# existing ~/.claude/commands directory must NOT trigger the symlink
+# refusal. Catches regressions if the detection is ever tightened to
+# also flag non-symlinks. This test runs on every platform; on Windows
+# (where the precondition above SKIPs S5b) it doubles as live coverage
+# for the directory-shape that `ln -s` produces when it cannot create
+# a real symlink and silently copies / fails — the hook must accept
+# that shape just as it accepts a fresh `mkdir -p`.
 S5B_GUARD_HOME="$(mktemp -d)"
 mkdir -p "$S5B_GUARD_HOME/.claude/commands"
 S5B_GUARD_STDERR="$(mktemp)"


### PR DESCRIPTION
## Summary

- `tests/aliases.test.sh` S5b assertion *"symlink refusal stderr line missing"* deterministically failed on `windows-latest` because Git Bash without admin / Developer Mode does not let `ln -s` produce a POSIX symlink — `[ -L ]` returns false and the hook has nothing symlink-shaped to refuse, making S5b's first assertion unsatisfiable.
- **Test fix**: precondition guard converts the unsatisfiable scenario into a `SKIP` rather than a `FAIL`. New complementary `S5b-guard` pins down the false-positive direction (regular non-symlinked dir must NOT trigger refusal) and runs on every platform.
- **Hook hardening**: belt-and-braces `readlink` non-empty check alongside `[ -L ]` to catch Windows NTFS junctions / reparse points that POSIX `[ -L ]` does not recognise as symlinks. Defence in depth for Windows-with-admin where `ln -s dir target` may produce a directory junction.

## Test Plan

- [x] `bash tests/aliases.test.sh` — 61 PASS / 0 FAIL on macOS (was 60/0; +1 from `S5b-guard`)
- [x] `bash tests/audit-fixups.test.sh` — 22 PASS / 0 FAIL (the other hook-exercising suite)
- [x] `bash tests/review-pr.test.sh` — 130 PASS / 0 FAIL (broader spot-check)
- [x] Simulated Git-Bash-no-admin locally — S5b emits `SKIP`, no `PASS`/`FAIL` increment, exits cleanly
- [ ] CI `windows-latest` job (added by PR #125) — `S5b` emits `SKIP`, no `FAIL`

## Notes for reviewers

The issue body's "recommended fix" framed this as *"intended-symlink-but-actually-junction"* on Windows. On analysis, the GHA `windows-latest` behaviour is most likely **not** a junction — junctions propagate writes to the target, but the issue reports "no writes into symlink target" still passes (59/60). The most plausible explanation is that `ln -s` either fails silently or shallow-copies the target dir on default Git Bash without admin. The hook cannot detect *"the user intended to create a symlink but `ln -s` did something else"* — there is no signal.

So the surgical fix is to make the test self-aware about its precondition (skip when the symlink could not be set up), complemented by `readlink` hardening for the junction case **if** it ever does appear on a Windows-with-admin / Developer Mode runner.

Closes #126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened symlink and directory junction detection to prevent unsafe alias synchronization configurations.
  * Improved cross-platform compatibility for detecting symbolic links and reparse points.

* **Tests**
  * Enhanced test coverage with platform-aware symlink detection and verification of normal directory handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->