### PR TITLE
test(testers): add P5/P6/P7 property tests for malformed/null/collision

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
         # needs the zsh binary, not the recommends graph).
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh
       - name: Run shape-check tests
+        # SYNC: this list MUST match the windows-latest job below, plus the
+        # zsh fixture. When a test file is added or removed, update BOTH jobs
+        # by hand — there is no automated drift guard between the two lists.
         run: |
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \
           bash tests/post-impl-review.test.sh && \
+          bash tests/testers-pipeline.test.sh && \
           bash tests/spec-reviewer-plan-aware.test.sh && \
           bash tests/audit-fixups.test.sh && \
           bash tests/review-pr.test.sh && \
@@ -84,6 +85,7 @@ jobs:
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \
           bash tests/post-impl-review.test.sh && \
+          bash tests/testers-pipeline.test.sh && \
           bash tests/spec-reviewer-plan-aware.test.sh && \
           bash tests/audit-fixups.test.sh && \
           bash tests/review-pr.test.sh && \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh
       - name: Run shape-check tests
         # SYNC: this list MUST match the windows-latest job below, plus the
-        # zsh fixture. When a test file is added or removed, update BOTH jobs
-        # by hand — there is no automated drift guard between the two lists.
+        # zsh fixture and testers-pipeline (both Unix-runtime fixtures the
+        # Windows job intentionally skips). When a test file is added or
+        # removed, update BOTH jobs by hand — there is no automated drift
+        # guard between the two lists.
         run: |
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \
@@ -76,25 +78,26 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install PyYAML
-        # windows-latest ships Python on PATH but not PyYAML; tests/testers-pipeline.test.sh
-        # (via plugins/uberdev/skills/testers-pipeline/aggregate.py) imports yaml.
-        # ubuntu-latest's base image already includes PyYAML so the parallel job is
-        # silent — install here to keep Windows hermetic.
-        run: python -m pip install --disable-pip-version-check pyyaml
       - name: Run shape-check tests
         # No zsh on windows-latest Git Bash; solve-pipeline-zsh.test.sh is a
         # Unix-runtime fixture and is intentionally skipped here. Every other
         # test is a portable grep-and-assert shape-check.
         #
+        # testers-pipeline.test.sh is ALSO a Unix-runtime fixture — it shells
+        # out to python3 with `$SCRATCH/...` paths assembled by mktemp -d,
+        # which on Git Bash for Windows resolve to /tmp/... strings that
+        # python.exe can't translate when they're embedded inside `python3 -c`
+        # source code. The aggregator itself is portable, but the per-assertion
+        # python3 -c invocations are not — skipped here, runs on Linux.
+        #
         # SYNC: this list MUST match the ubuntu-latest job above, minus the
-        # zsh fixture. When a test file is added or removed, update BOTH jobs
-        # by hand — there is no automated drift guard between the two lists.
+        # zsh fixture and testers-pipeline. When a test file is added or
+        # removed, update BOTH jobs by hand — there is no automated drift
+        # guard between the two lists.
         run: |
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \
           bash tests/post-impl-review.test.sh && \
-          bash tests/testers-pipeline.test.sh && \
           bash tests/spec-reviewer-plan-aware.test.sh && \
           bash tests/audit-fixups.test.sh && \
           bash tests/review-pr.test.sh && \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,12 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install PyYAML
+        # windows-latest ships Python on PATH but not PyYAML; tests/testers-pipeline.test.sh
+        # (via plugins/uberdev/skills/testers-pipeline/aggregate.py) imports yaml.
+        # ubuntu-latest's base image already includes PyYAML so the parallel job is
+        # silent — install here to keep Windows hermetic.
+        run: python -m pip install --disable-pip-version-check pyyaml
       - name: Run shape-check tests
         # No zsh on windows-latest Git Bash; solve-pipeline-zsh.test.sh is a
         # Unix-runtime fixture and is intentionally skipped here. Every other

--- a/tests/fixtures/testers-mock-outputs/wave-1-malformed.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-1-malformed.yaml
@@ -5,7 +5,7 @@ findings:
     invariant_violated: no_5xx
     location: /checkout
     summary: malformed YAML fixture for P5
-    detail: an unclosed flow mapping is unambiguously broken
+    detail: "Intentionally malformed: the unclosed `{` on line 9 is required — P5 in tests/testers-pipeline.test.sh asserts the aggregator skips this file with a stderr warning. Do NOT fix the syntax."
     evidence: { screenshot: scratch/x.png, dom_hash: deadbeef
     confidence: high
 confidence: high

--- a/tests/fixtures/testers-mock-outputs/wave-1-malformed.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-1-malformed.yaml
@@ -1,0 +1,11 @@
+verdict: AUDITED
+findings:
+  - severity: critical
+    persona: chaos_engineer
+    invariant_violated: no_5xx
+    location: /checkout
+    summary: malformed YAML fixture for P5
+    detail: an unclosed flow mapping is unambiguously broken
+    evidence: { screenshot: scratch/x.png, dom_hash: deadbeef
+    confidence: high
+confidence: high

--- a/tests/fixtures/testers-mock-outputs/wave-1-null-evidence.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-1-null-evidence.yaml
@@ -1,0 +1,16 @@
+verdict: AUDITED
+findings:
+  - severity: major
+    persona: chaos_engineer
+    location: /checkout
+    invariant_violated: no_5xx
+    summary: vague concerns with no anchor
+    detail: All evidence fields explicitly null or empty — has_evidence() must reject.
+    evidence:
+      screenshot: null
+      dom_hash: null
+      repro_steps: []
+      observed: nothing concrete
+      expected: nothing concrete
+    confidence: low
+confidence: low

--- a/tests/fixtures/testers-mock-outputs/wave-1-null-evidence.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-1-null-evidence.yaml
@@ -5,7 +5,7 @@ findings:
     location: /checkout
     invariant_violated: no_5xx
     summary: vague concerns with no anchor
-    detail: All evidence fields explicitly null or empty — has_evidence() must reject.
+    detail: "All evidence fields explicitly null or empty — has_evidence() must reject. Used by P6 in tests/testers-pipeline.test.sh."
     evidence:
       screenshot: null
       dom_hash: null

--- a/tests/fixtures/testers-mock-outputs/wave-2-grandma-collision.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-2-grandma-collision.yaml
@@ -1,0 +1,19 @@
+verdict: AUDITED
+findings:
+  - severity: blocker
+    persona: panicked_grandma
+    location: /checkout
+    invariant_violated: no_5xx
+    summary: wave-2 escalation of the wave-1 500 — full outage on retry
+    detail: Same persona/invariant/location as wave-1; wave-2 reproduces the 500 and observes site-wide 503 for 30s, which is stronger evidence and bumps severity to blocker.
+    evidence:
+      screenshot: scratch/panicked-grandma/shot-2.png
+      dom_hash: feedface
+      repro_steps:
+        - navigate to /checkout
+        - double-click Pay button
+        - retry once — entire site returns 503 for 30s
+      observed: "500 then site-wide 503 for 30s"
+      expected: "single 200 or visible error"
+    confidence: high
+confidence: high

--- a/tests/testers-pipeline.test.sh
+++ b/tests/testers-pipeline.test.sh
@@ -58,4 +58,100 @@ DIFF="$(python3 -c "import yaml; a=yaml.safe_load(open('$SCRATCH/wave-1.yaml'))[
 [ "$DIFF" = "True" ] || { echo "P4: stable-id determinism broken"; exit 1; }
 echo "PASS P4: finding IDs are deterministic"
 
+# ----------------------------------------------------------------------
+# P5: malformed YAML in scratch dir
+#   aggregate.py wraps each per-agent load in try/except yaml.YAMLError;
+#   a broken file is logged to stderr and the run continues with N-1.
+#   Regression guard for the silent-failure fix in commit 1182dbe.
+# ----------------------------------------------------------------------
+P5="$SCRATCH/p5"
+mkdir -p "$P5/scratch/panicked-grandma" \
+         "$P5/scratch/power-user" \
+         "$P5/scratch/adversarial-security" \
+         "$P5/scratch/chaos-engineer"
+cp "$FIX/wave-1-grandma.yaml"    "$P5/scratch/panicked-grandma/out.yaml"
+cp "$FIX/wave-1-power-user.yaml" "$P5/scratch/power-user/out.yaml"
+cp "$FIX/wave-1-security.yaml"   "$P5/scratch/adversarial-security/out.yaml"
+cp "$FIX/wave-1-malformed.yaml"  "$P5/scratch/chaos-engineer/out.yaml"
+
+P5_ERR="$P5/stderr.log"
+python3 "$AGG" --run-id smoke --wave 1 --scratch-dir "$P5/scratch" \
+  --invariants "$INV" --out "$P5/wave-1.yaml" 2> "$P5_ERR"
+
+[ -f "$P5/wave-1.yaml" ] || { echo "P5: aggregator produced no output"; exit 1; }
+python3 -c "import yaml; yaml.safe_load(open('$P5/wave-1.yaml'))" \
+  || { echo "P5: aggregator output is itself malformed"; exit 1; }
+
+COUNT_P5="$(python3 -c "import yaml; print(len(yaml.safe_load(open('$P5/wave-1.yaml'))['findings']))")"
+[ "$COUNT_P5" = "3" ] || { echo "P5: expected 3 findings after malformed-skip, got $COUNT_P5"; exit 1; }
+
+grep -q "warning: skipping malformed" "$P5_ERR" || {
+  echo "P5: expected 'warning: skipping malformed' on stderr; got:"; cat "$P5_ERR"; exit 1;
+}
+echo "PASS P5: malformed YAML skipped with stderr warning, aggregator continues"
+
+# ----------------------------------------------------------------------
+# P6: partial / null evidence shapes are dropped
+#   evidence: {screenshot: null, dom_hash: null, repro_steps: []} carries
+#   no anchor; has_evidence() must return False and the finding must not
+#   appear in the aggregate. Regression guard for the evidence-presence
+#   contract in aggregate.py (commit f58c11c).
+# ----------------------------------------------------------------------
+P6="$SCRATCH/p6"
+mkdir -p "$P6/scratch/panicked-grandma" \
+         "$P6/scratch/power-user" \
+         "$P6/scratch/chaos-engineer"
+cp "$FIX/wave-1-grandma.yaml"        "$P6/scratch/panicked-grandma/out.yaml"
+cp "$FIX/wave-1-power-user.yaml"     "$P6/scratch/power-user/out.yaml"
+cp "$FIX/wave-1-null-evidence.yaml"  "$P6/scratch/chaos-engineer/out.yaml"
+
+python3 "$AGG" --run-id smoke --wave 1 --scratch-dir "$P6/scratch" \
+  --invariants "$INV" --out "$P6/wave-1.yaml"
+
+COUNT_P6="$(python3 -c "import yaml; print(len(yaml.safe_load(open('$P6/wave-1.yaml'))['findings']))")"
+[ "$COUNT_P6" = "2" ] || { echo "P6: expected 2 findings (null-evidence dropped), got $COUNT_P6"; exit 1; }
+
+LEAKED="$(python3 -c "import yaml; ff=yaml.safe_load(open('$P6/wave-1.yaml'))['findings']; print(any(f.get('persona')=='chaos_engineer' for f in ff))")"
+[ "$LEAKED" = "False" ] || { echo "P6: null-evidence finding leaked into output"; exit 1; }
+echo "PASS P6: partial/null evidence dropped via has_evidence()"
+
+# ----------------------------------------------------------------------
+# P7: finding-ID collisions across waves keep the highest-severity record
+#   stable_id(persona, invariant, location) collides for two waves; wave-2
+#   carries a stronger severity. report.py:merge_findings (post-Phase-1)
+#   must keep the wave-2 record, not the wave-1 one. Regression guard for
+#   the setdefault → severity-rank fix in commit f58c11c.
+# ----------------------------------------------------------------------
+P7="$SCRATCH/p7"
+mkdir -p "$P7/w1/scratch/panicked-grandma" \
+         "$P7/w2/scratch/panicked-grandma" \
+         "$P7/waves"
+cp "$FIX/wave-1-grandma.yaml"           "$P7/w1/scratch/panicked-grandma/out.yaml"
+cp "$FIX/wave-2-grandma-collision.yaml" "$P7/w2/scratch/panicked-grandma/out.yaml"
+
+python3 "$AGG" --run-id smoke --wave 1 --scratch-dir "$P7/w1/scratch" \
+  --invariants "$INV" --out "$P7/waves/wave-1.yaml"
+python3 "$AGG" --run-id smoke --wave 2 --scratch-dir "$P7/w2/scratch" \
+  --invariants "$INV" --out "$P7/waves/wave-2.yaml"
+
+SAME_ID="$(python3 -c "
+import yaml
+a = yaml.safe_load(open('$P7/waves/wave-1.yaml'))['findings'][0]['id']
+b = yaml.safe_load(open('$P7/waves/wave-2.yaml'))['findings'][0]['id']
+print(a == b)
+")"
+[ "$SAME_ID" = "True" ] || { echo "P7: fixtures must collide on stable_id; check persona/invariant/location"; exit 1; }
+
+MERGED_SEV="$(python3 -c "
+import sys, yaml
+sys.path.insert(0, 'plugins/uberdev/skills/testers-pipeline')
+from report import load_waves, merge_findings
+merged = merge_findings(load_waves('$P7/waves'))
+assert len(merged) == 1, f'expected 1 merged finding after collision, got {len(merged)}'
+print(next(iter(merged.values()))['severity'])
+")"
+[ "$MERGED_SEV" = "blocker" ] || \
+  { echo "P7: collision should keep highest-severity (blocker); got $MERGED_SEV"; exit 1; }
+echo "PASS P7: finding-ID collision keeps highest-severity record across waves"
+
 echo "ALL TESTS PASS"

--- a/tests/testers-pipeline.test.sh
+++ b/tests/testers-pipeline.test.sh
@@ -62,7 +62,8 @@ echo "PASS P4: finding IDs are deterministic"
 # P5: malformed YAML in scratch dir
 #   aggregate.py wraps each per-agent load in try/except yaml.YAMLError;
 #   a broken file is logged to stderr and the run continues with N-1.
-#   Regression guard for the silent-failure fix in commit f58c11c.
+#   Regression guard: aggregator must skip malformed YAML (issue #132,
+#   PR #130 fix in aggregate.py main loop).
 # ----------------------------------------------------------------------
 P5="$SCRATCH/p5"
 mkdir -p "$P5/scratch/panicked-grandma" \
@@ -83,7 +84,11 @@ python3 -c "import yaml; yaml.safe_load(open('$P5/wave-1.yaml'))" \
   || { echo "P5: aggregator output is itself malformed"; exit 1; }
 
 COUNT_P5="$(python3 -c "import yaml; print(len(yaml.safe_load(open('$P5/wave-1.yaml'))['findings']))")"
-[ "$COUNT_P5" = "3" ] || { echo "P5: expected 3 findings after malformed-skip, got $COUNT_P5"; exit 1; }
+[ "$COUNT_P5" = "3" ] || {
+  echo "P5: expected 3 findings after malformed-skip (grandma + power-user + security), got $COUNT_P5"
+  echo "P5:   personas in output: $(python3 -c "import yaml; print([f.get('persona') for f in yaml.safe_load(open('$P5/wave-1.yaml'))['findings']])")"
+  exit 1
+}
 
 grep -q "warning: skipping malformed" "$P5_ERR" || {
   echo "P5: expected 'warning: skipping malformed' on stderr; got:"; cat "$P5_ERR"; exit 1;
@@ -94,8 +99,9 @@ echo "PASS P5: malformed YAML skipped with stderr warning, aggregator continues"
 # P6: partial / null evidence shapes are dropped
 #   evidence: {screenshot: null, dom_hash: null, repro_steps: []} carries
 #   no anchor; has_evidence() must return False and the finding must not
-#   appear in the aggregate. Regression guard for the evidence-presence
-#   contract in aggregate.py (commit f58c11c).
+#   appear in the aggregate.
+#   Regression guard: aggregator must reject null/empty evidence (issue
+#   #132, PR #130 fix in aggregate.py has_evidence()).
 # ----------------------------------------------------------------------
 P6="$SCRATCH/p6"
 mkdir -p "$P6/scratch/panicked-grandma" \
@@ -118,9 +124,11 @@ echo "PASS P6: partial/null evidence dropped via has_evidence()"
 # ----------------------------------------------------------------------
 # P7: finding-ID collisions across waves keep the highest-severity record
 #   stable_id(persona, invariant, location) collides for two waves; wave-2
-#   carries a stronger severity. report.py:merge_findings (post-Phase-1)
-#   must keep the wave-2 record, not the wave-1 one. Regression guard for
-#   the setdefault → severity-rank fix in commit f58c11c.
+#   carries a stronger severity. report.py:merge_findings must keep the
+#   wave-2 record, not the wave-1 one.
+#   Regression guard: collision must keep highest-severity, not first-seen
+#   (issue #132, PR #130 fix in report.py merge_findings — setdefault to
+#   severity-rank).
 # ----------------------------------------------------------------------
 P7="$SCRATCH/p7"
 mkdir -p "$P7/w1/scratch/panicked-grandma" \

--- a/tests/testers-pipeline.test.sh
+++ b/tests/testers-pipeline.test.sh
@@ -62,7 +62,7 @@ echo "PASS P4: finding IDs are deterministic"
 # P5: malformed YAML in scratch dir
 #   aggregate.py wraps each per-agent load in try/except yaml.YAMLError;
 #   a broken file is logged to stderr and the run continues with N-1.
-#   Regression guard for the silent-failure fix in commit 1182dbe.
+#   Regression guard for the silent-failure fix in commit f58c11c.
 # ----------------------------------------------------------------------
 P5="$SCRATCH/p5"
 mkdir -p "$P5/scratch/panicked-grandma" \


### PR DESCRIPTION
## Summary

- Backfills P5/P6/P7 property tests in `tests/testers-pipeline.test.sh` for the three blocker scenarios pr-test-analyzer flagged on PR #130.
- P5 covers malformed YAML in the agent scratch dir (aggregate.py warns + continues with N-1). P6 covers partial/null evidence (has_evidence drops the finding). P7 covers stable-id collisions across waves (report.py:merge_findings keeps the highest-severity record per the post-Phase-1 fix).
- Three new fixtures under `tests/fixtures/testers-mock-outputs/`: `wave-1-malformed.yaml`, `wave-1-null-evidence.yaml`, `wave-2-grandma-collision.yaml` (the last one intentionally shares persona+invariant+location with `wave-1-grandma.yaml` so `stable_id` collides).
- No production code changes — the underlying fixes already landed in PR #130 (commits f58c11c, 1182dbe). This PR is purely additive regression coverage.

## Test Plan

- [x] `bash tests/testers-pipeline.test.sh` → all 7 tests (P1–P7) pass locally on macOS.
- [x] Red phase confirmed: writing the test block before adding the fixtures fails on `cp: wave-1-malformed.yaml: No such file or directory`, proving each new test exercises its fixture path.
- [x] Mutation-sense check: P7's wave-1 file sorts lexically before wave-2, so a regression to the old `setdefault(fid, f)` would keep wave-1's `critical` instead of wave-2's `blocker` — the assertion `MERGED_SEV = "blocker"` would fail.

Closes #132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test fixtures for malformed input, null evidence conditions, and cross-wave collision scenarios
  * Expanded integration test coverage for handling edge cases, including malformed data validation, evidence filtering, and multi-wave data aggregation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->