### PR TITLE
test(goal): BT12-BT19 behavioural coverage for uberdev_goal_read_trust_signal (#137)

### DIFF
--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -274,9 +274,30 @@ uberdev_goal_read_trust_signal() {
   # the rc; without this branch, malformed phase2_5 → empty TSV → empty
   # blocker/critical/halted vars → fall-through to "green" (the exact
   # YELLOW->GREEN misclassification path issue #137 was filed against).
-  local tsv jq_rc
-  tsv="$(jq -r '[.by_severity.blocker // 0, .by_severity.critical // 0, (.halted // false | tostring)] | @tsv' <<<"$p25" 2>/dev/null)"
-  jq_rc=$?
+  #
+  # Audit parity (S4): this second pass operates on the in-memory $p25
+  # string, so it cannot route through the gh_jq_or_jq shim (which takes a
+  # FILE path). Instead, mirror that shim's breadcrumb directly — capture
+  # jq stderr and emit one audit-friendly warning line before failing
+  # closed to `missing`, so a structural type error leaves an operator
+  # trail rather than vanishing. Behaviour is unchanged: rc!=0 still maps
+  # to `missing` (BT20-locked); the warning is stderr-only and additive.
+  local tsv jq_rc jq_err
+  jq_err="$(mktemp 2>/dev/null)"
+  if [ -n "$jq_err" ]; then
+    tsv="$(jq -r '[.by_severity.blocker // 0, .by_severity.critical // 0, (.halted // false | tostring)] | @tsv' <<<"$p25" 2>"$jq_err")"
+    jq_rc=$?
+    if [ "$jq_rc" -ne 0 ]; then
+      local first_line
+      first_line="$(head -n 1 "$jq_err" 2>/dev/null)"
+      printf 'goal-state: jq failed on phase2_5 by_severity projection: %s\n' \
+        "${first_line:-unknown error}" >&2
+    fi
+    rm -f "$jq_err"
+  else
+    tsv="$(jq -r '[.by_severity.blocker // 0, .by_severity.critical // 0, (.halted // false | tostring)] | @tsv' <<<"$p25" 2>/dev/null)"
+    jq_rc=$?
+  fi
   [ "$jq_rc" -eq 0 ] || { printf 'missing\n'; return 0; }
   local blocker critical halted
   read -r blocker critical halted <<<"$tsv"

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -275,8 +275,7 @@ uberdev_goal_read_trust_signal() {
   # blocker/critical/halted vars → fall-through to "green" (the exact
   # YELLOW->GREEN misclassification path issue #137 was filed against).
   local tsv jq_rc
-  tsv="$(printf '%s' "$p25" \
-    | jq -r '[.by_severity.blocker // 0, .by_severity.critical // 0, (.halted // false | tostring)] | @tsv' 2>/dev/null)"
+  tsv="$(jq -r '[.by_severity.blocker // 0, .by_severity.critical // 0, (.halted // false | tostring)] | @tsv' <<<"$p25" 2>/dev/null)"
   jq_rc=$?
   [ "$jq_rc" -eq 0 ] || { printf 'missing\n'; return 0; }
   local blocker critical halted

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -265,9 +265,22 @@ uberdev_goal_read_trust_signal() {
   # into three locals in one syscall (3 jq forks -> 1; F1 simplify-lens). The
   # `// 0` and `// false` defaults preserve the prior shape-tolerance for
   # audit JSONs missing either by_severity counter or the halted field.
+  #
+  # B5 defense-in-depth: capture the jq pipeline's rc into a separate
+  # assignment so a structural type error (e.g. by_severity is a string
+  # instead of an object — the `// 0` default cannot rescue indexing into
+  # a string) is treated as "missing" rather than silently fall through.
+  # Inlining the substitution into `read -r <<<"$(...)"` would discard
+  # the rc; without this branch, malformed phase2_5 → empty TSV → empty
+  # blocker/critical/halted vars → fall-through to "green" (the exact
+  # YELLOW->GREEN misclassification path issue #137 was filed against).
+  local tsv jq_rc
+  tsv="$(printf '%s' "$p25" \
+    | jq -r '[.by_severity.blocker // 0, .by_severity.critical // 0, (.halted // false | tostring)] | @tsv' 2>/dev/null)"
+  jq_rc=$?
+  [ "$jq_rc" -eq 0 ] || { printf 'missing\n'; return 0; }
   local blocker critical halted
-  read -r blocker critical halted <<<"$(printf '%s' "$p25" \
-    | jq -r '[.by_severity.blocker // 0, .by_severity.critical // 0, (.halted // false | tostring)] | @tsv')"
+  read -r blocker critical halted <<<"$tsv"
   if [ "$halted" = "true" ] || [ "$blocker" -gt 0 ]; then printf 'red\n'; return 0; fi
   if [ "$critical" -gt 0 ]; then printf 'yellow\n'; return 0; fi
   printf 'green\n'

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -277,28 +277,26 @@ uberdev_goal_read_trust_signal() {
   #
   # Audit parity (S4): this second pass operates on the in-memory $p25
   # string, so it cannot route through the gh_jq_or_jq shim (which takes a
-  # FILE path). Instead, mirror that shim's breadcrumb directly — capture
-  # jq stderr and emit one audit-friendly warning line before failing
-  # closed to `missing`, so a structural type error leaves an operator
-  # trail rather than vanishing. Behaviour is unchanged: rc!=0 still maps
-  # to `missing` (BT20-locked); the warning is stderr-only and additive.
-  local tsv jq_rc jq_err
-  jq_err="$(mktemp 2>/dev/null)"
-  if [ -n "$jq_err" ]; then
-    tsv="$(jq -r '[.by_severity.blocker // 0, .by_severity.critical // 0, (.halted // false | tostring)] | @tsv' <<<"$p25" 2>"$jq_err")"
-    jq_rc=$?
-    if [ "$jq_rc" -ne 0 ]; then
-      local first_line
-      first_line="$(head -n 1 "$jq_err" 2>/dev/null)"
-      printf 'goal-state: jq failed on phase2_5 by_severity projection: %s\n' \
-        "${first_line:-unknown error}" >&2
-    fi
-    rm -f "$jq_err"
-  else
-    tsv="$(jq -r '[.by_severity.blocker // 0, .by_severity.critical // 0, (.halted // false | tostring)] | @tsv' <<<"$p25" 2>/dev/null)"
-    jq_rc=$?
+  # FILE path). Instead, mirror that shim's breadcrumb directly — but the
+  # success path stays a clean in-memory capture (no temp file): run jq with
+  # stderr discarded and read its rc. ONLY on the failure path (about to
+  # return `missing` anyway) re-run jq capturing stderr in-memory and emit
+  # one audit-friendly warning line, so a structural type error leaves an
+  # operator trail rather than vanishing. Behaviour is unchanged: rc!=0
+  # still maps to `missing` (BT20-locked); the warning is stderr-only and
+  # additive.
+  local jq_filter='[.by_severity.blocker // 0, .by_severity.critical // 0, (.halted // false | tostring)] | @tsv'
+  local tsv jq_rc
+  tsv="$(jq -r "$jq_filter" <<<"$p25" 2>/dev/null)"
+  jq_rc=$?
+  if [ "$jq_rc" -ne 0 ]; then
+    local jq_err first_line
+    jq_err="$(jq -r "$jq_filter" <<<"$p25" 2>&1 1>/dev/null)"
+    first_line="${jq_err%%$'\n'*}"
+    printf 'goal-state: jq failed on phase2_5 by_severity projection: %s\n' \
+      "${first_line:-unknown error}" >&2
+    printf 'missing\n'; return 0
   fi
-  [ "$jq_rc" -eq 0 ] || { printf 'missing\n'; return 0; }
   local blocker critical halted
   read -r blocker critical halted <<<"$tsv"
   if [ "$halted" = "true" ] || [ "$blocker" -gt 0 ]; then printf 'red\n'; return 0; fi

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -364,17 +364,18 @@ else
   printf '        expected non-zero, got %s\n' "$_bt4_rc" >&2
 fi
 
-# BT12-BT19 — uberdev_goal_read_trust_signal: trust-signal enum coverage
+# BT12-BT20 — uberdev_goal_read_trust_signal: trust-signal enum coverage
 # (issue #137; finding fingerprint d599c295ba4d2846 from /review-pr Phase
 # 2.5 on PR #129). Each test stages a synthetic audit JSON under
 # $_b12_tmpdir, invokes the function, and asserts the printed enum
 # (green/yellow/red/stale/missing) matches the D17 spec mapping.
 #
-# Covers the four uncovered branches called out by pr-test-analyzer:
+# Covers the uncovered branches called out by pr-test-analyzer:
 #   - actual JSON parsing of .phases.phase2_5      (BT12, BT13, BT14, BT19)
 #   - blocker / critical threshold logic           (BT12, BT13, BT14)
 #   - halted_due_to_overflow flag                  (BT15)
 #   - 'stale' vs 'missing' distinction             (BT16, BT17, BT18)
+#   - malformed-by_severity second-jq failure      (BT20)
 #
 # Misclassification risk these guard: YELLOW silently treated as GREEN
 # (PR auto-merged despite CRITICAL findings); STALE silently treated as
@@ -503,7 +504,8 @@ assert_eq "$(uberdev_goal_read_trust_signal "$_bt19_audit_minimal")" "green" \
 # present, so p25 is non-empty and we fall past the 'stale' branch.
 # The SECOND jq call then errors because by_severity is a string rather
 # than an object — `.by_severity.blocker` cannot index a string and jq
-# exits non-zero. Without the explicit rc check at goal-state.sh:268-271,
+# exits non-zero. Without the explicit rc check at goal-state.sh:301
+# (`[ "$jq_rc" -eq 0 ] || { printf 'missing\n'; return 0; }`),
 # `read -r blocker critical halted <<<""` would leave all three vars
 # empty, the `[ $blocker -gt 0 ]` arithmetic would silently evaluate to
 # false, and the function would fall through to printf 'green'. That is
@@ -515,6 +517,68 @@ cat > "$_bt20_audit_malformed_severity" <<'EOF'
 EOF
 assert_eq "$(uberdev_goal_read_trust_signal "$_bt20_audit_malformed_severity" 2>/dev/null)" "missing" \
   "BT20.malformed-by_severity-emits-missing"
+
+# BT21 — RED via blocker>0 AND critical>0 simultaneously. BT14 isolates
+# blocker-only and BT13 isolates critical-only; this fixture exercises
+# both >0 at once to lock the red branch
+# (`[ "$halted" = "true" ] || [ "$blocker" -gt 0 ]`) against an accidental
+# `&&` / short-circuit regression. blocker dominates: the function returns
+# red before ever reaching the `[ "$critical" -gt 0 ]` yellow branch, so a
+# regression that ANDed the conditions (or swapped the branch order) would
+# surface here as yellow instead of red.
+_bt21_audit_red_both="$_b12_tmpdir/audit-red-both.json"
+cat > "$_bt21_audit_red_both" <<'EOF'
+{
+  "phases": {
+    "phase2_5": {
+      "by_severity": {"blocker": 1, "critical": 1},
+      "halted": false
+    }
+  }
+}
+EOF
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt21_audit_red_both")" "red" \
+  "BT21.blocker-and-critical-both-emits-red"
+
+# BT22 — RED via halted=true AND blocker>0. BT15 isolates halted-only with
+# clean counters; this variant adds blocker>0 to verify halted's red
+# precedence is not masked (and that the OR short-circuit still resolves to
+# red) when both red-triggering conditions hold. A regression that dropped
+# or reordered the halted check would still surface red here via blocker,
+# so this is the companion to BT23 (halted+critical) which has no
+# blocker fallback.
+_bt22_audit_red_halted_blocker="$_b12_tmpdir/audit-red-halted-blocker.json"
+cat > "$_bt22_audit_red_halted_blocker" <<'EOF'
+{
+  "phases": {
+    "phase2_5": {
+      "by_severity": {"blocker": 1, "critical": 0},
+      "halted": true
+    }
+  }
+}
+EOF
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt22_audit_red_halted_blocker")" "red" \
+  "BT22.halted-and-blocker-emits-red"
+
+# BT23 — RED via halted=true AND critical>0 (blocker=0). The load-bearing
+# variant: with blocker=0, the ONLY thing that produces red is the halted
+# check. If halted were reordered after / masked by the critical>0 yellow
+# branch, this fixture would regress to yellow. Locks halted's red
+# precedence over a non-zero critical count.
+_bt23_audit_red_halted_critical="$_b12_tmpdir/audit-red-halted-critical.json"
+cat > "$_bt23_audit_red_halted_critical" <<'EOF'
+{
+  "phases": {
+    "phase2_5": {
+      "by_severity": {"blocker": 0, "critical": 1},
+      "halted": true
+    }
+  }
+}
+EOF
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt23_audit_red_halted_critical")" "red" \
+  "BT23.halted-and-critical-emits-red"
 
 # Cleanup: remove the isolated tmpdir we created via mktemp -d above.
 # The single `rm -rf "$_b12_tmpdir"` subsumes any per-BT artifacts

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -516,9 +516,10 @@ EOF
 assert_eq "$(uberdev_goal_read_trust_signal "$_bt20_audit_malformed_severity" 2>/dev/null)" "missing" \
   "BT20.malformed-by_severity-emits-missing"
 
-# Cleanup: remove the isolated tmpdir contents (we created the whole
-# directory via mktemp -d, so we can rm -rf safely — it's our own).
-rm -rf "$_b12_tmpdir/goal-test-bt3"* 2>/dev/null || true
+# Cleanup: remove the isolated tmpdir we created via mktemp -d above.
+# The single `rm -rf "$_b12_tmpdir"` subsumes any per-BT artifacts
+# (goal-test-bt3-fingerprints.tsv, audit-*.json, etc.) because they
+# all live INSIDE the tmpdir under the section-local UBERDEV_TMPDIR.
 rm -rf "$_b12_tmpdir" 2>/dev/null || true
 
 echo

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -280,10 +280,10 @@ echo "== Behavioral tests (B12 — sourced-function exercises) =="
 #   BT2      Blocks: parser ReDoS-safe anchoring
 #   BT3      fingerprint repeat detector
 #   BT4      gh_jq_or_jq jq shim file-not-found path
-#   BT12-BT20 uberdev_goal_read_trust_signal enum mapping
+#   BT12-BT23 uberdev_goal_read_trust_signal enum mapping
 #            (green/yellow/red-via-blocker/red-via-halted/stale/missing/
 #             missing-via-malformed-json/shape-tolerance/missing-via-
-#             second-jq-failure — see #137)
+#             second-jq-failure/combined-red-triggers — see #137)
 #
 # Isolation: mktemp $UBERDEV_TMPDIR for this section so writes do not
 # collide with production state nor with each other.
@@ -364,7 +364,7 @@ else
   printf '        expected non-zero, got %s\n' "$_bt4_rc" >&2
 fi
 
-# BT12-BT20 — uberdev_goal_read_trust_signal: trust-signal enum coverage
+# BT12-BT23 — uberdev_goal_read_trust_signal: trust-signal enum coverage
 # (issue #137; finding fingerprint d599c295ba4d2846 from /review-pr Phase
 # 2.5 on PR #129). Each test stages a synthetic audit JSON under
 # $_b12_tmpdir, invokes the function, and asserts the printed enum
@@ -376,6 +376,8 @@ fi
 #   - halted_due_to_overflow flag                  (BT15)
 #   - 'stale' vs 'missing' distinction             (BT16, BT17, BT18)
 #   - malformed-by_severity second-jq failure      (BT20)
+#   - combined red-triggers (blocker+critical,      (BT21, BT22, BT23)
+#     halted+blocker, halted+critical)
 #
 # Misclassification risk these guard: YELLOW silently treated as GREEN
 # (PR auto-merged despite CRITICAL findings); STALE silently treated as

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -280,9 +280,10 @@ echo "== Behavioral tests (B12 — sourced-function exercises) =="
 #   BT2      Blocks: parser ReDoS-safe anchoring
 #   BT3      fingerprint repeat detector
 #   BT4      gh_jq_or_jq jq shim file-not-found path
-#   BT12-BT19 uberdev_goal_read_trust_signal enum mapping
+#   BT12-BT20 uberdev_goal_read_trust_signal enum mapping
 #            (green/yellow/red-via-blocker/red-via-halted/stale/missing/
-#             missing-via-malformed-json/shape-tolerance — see #137)
+#             missing-via-malformed-json/shape-tolerance/missing-via-
+#             second-jq-failure — see #137)
 #
 # Isolation: mktemp $UBERDEV_TMPDIR for this section so writes do not
 # collide with production state nor with each other.
@@ -433,10 +434,15 @@ EOF
 assert_eq "$(uberdev_goal_read_trust_signal "$_bt14_audit_red_blocker")" "red" \
   "BT14.blocker-emits-red"
 
-# BT15 — RED via halted: halted=true forces RED even when both severity
-# counters are 0. This is the "halted_due_to_overflow" path from RFC
-# 0002 §3.4: Phase 2.5 truncated findings beyond MAX_NEW=10 so the
-# severity counters are unreliable; the only safe action is red-held.
+# BT15 — RED via halted: halted=true is one of two OR-equal conditions
+# that triggers RED (blocker>0 is the other; both share the same
+# `red` branch in goal-state.sh:271 via a single `||`). This test
+# isolates the halted-only path with blocker=critical=0 so a regression
+# that drops the halted check (or reorders the OR) would surface here
+# without being masked by a non-zero blocker. RFC 0002 §3.4 calls this
+# the "halted_due_to_overflow" signal: Phase 2.5 truncated findings
+# beyond MAX_NEW=10 so the severity counters are unreliable; the only
+# safe action is red-held.
 _bt15_audit_red_halted="$_b12_tmpdir/audit-red-halted.json"
 cat > "$_bt15_audit_red_halted" <<'EOF'
 {
@@ -491,6 +497,24 @@ cat > "$_bt19_audit_minimal" <<'EOF'
 EOF
 assert_eq "$(uberdev_goal_read_trust_signal "$_bt19_audit_minimal")" "green" \
   "BT19.empty-phase2_5-defaults-to-green"
+
+# BT20 — MISSING via second-jq failure (B5 defense-in-depth). The first
+# jq call (.phases.phase2_5 // empty) succeeds because phase2_5 IS
+# present, so p25 is non-empty and we fall past the 'stale' branch.
+# The SECOND jq call then errors because by_severity is a string rather
+# than an object — `.by_severity.blocker` cannot index a string and jq
+# exits non-zero. Without the explicit rc check at goal-state.sh:268-271,
+# `read -r blocker critical halted <<<""` would leave all three vars
+# empty, the `[ $blocker -gt 0 ]` arithmetic would silently evaluate to
+# false, and the function would fall through to printf 'green'. That is
+# the YELLOW->GREEN misclassification path the original #137 finding
+# was filed against — this test locks the defense-in-depth fix.
+_bt20_audit_malformed_severity="$_b12_tmpdir/audit-malformed-severity.json"
+cat > "$_bt20_audit_malformed_severity" <<'EOF'
+{"phases":{"phase2_5":{"by_severity":"not_an_object","halted":false}}}
+EOF
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt20_audit_malformed_severity" 2>/dev/null)" "missing" \
+  "BT20.malformed-by_severity-emits-missing"
 
 # Cleanup: remove the isolated tmpdir contents (we created the whole
 # directory via mktemp -d, so we can rm -rf safely — it's our own).

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -273,11 +273,16 @@ echo
 echo "== Behavioral tests (B12 — sourced-function exercises) =="
 # These tests SOURCE plugins/uberdev/lib/goal-state.sh and exercise the
 # real bash functions, not just grep their shape. They cover the four
-# silently-shape-checked-only contracts called out in post-impl review B12:
-#   BT1 — state-machine forbidden transitions (D17)
-#   BT2 — Blocks: parser ReDoS-safe anchoring
-#   BT3 — fingerprint repeat detector
-#   BT4 — gh_jq_or_jq jq shim file-not-found path
+# silently-shape-checked-only contracts called out in post-impl review
+# B12, plus the trust-signal coverage gap (issue #137) flagged by
+# /review-pr Phase 2.5 on PR #129:
+#   BT1      state-machine forbidden transitions (D17)
+#   BT2      Blocks: parser ReDoS-safe anchoring
+#   BT3      fingerprint repeat detector
+#   BT4      gh_jq_or_jq jq shim file-not-found path
+#   BT12-BT19 uberdev_goal_read_trust_signal enum mapping
+#            (green/yellow/red-via-blocker/red-via-halted/stale/missing/
+#             missing-via-malformed-json/shape-tolerance — see #137)
 #
 # Isolation: mktemp $UBERDEV_TMPDIR for this section so writes do not
 # collide with production state nor with each other.
@@ -357,6 +362,135 @@ else
   printf '  FAIL  %s\n' "BT4.file-not-found-nonzero-rc" >&2
   printf '        expected non-zero, got %s\n' "$_bt4_rc" >&2
 fi
+
+# BT12-BT19 — uberdev_goal_read_trust_signal: trust-signal enum coverage
+# (issue #137; finding fingerprint d599c295ba4d2846 from /review-pr Phase
+# 2.5 on PR #129). Each test stages a synthetic audit JSON under
+# $_b12_tmpdir, invokes the function, and asserts the printed enum
+# (green/yellow/red/stale/missing) matches the D17 spec mapping.
+#
+# Covers the four uncovered branches called out by pr-test-analyzer:
+#   - actual JSON parsing of .phases.phase2_5      (BT12, BT13, BT14, BT19)
+#   - blocker / critical threshold logic           (BT12, BT13, BT14)
+#   - halted_due_to_overflow flag                  (BT15)
+#   - 'stale' vs 'missing' distinction             (BT16, BT17, BT18)
+#
+# Misclassification risk these guard: YELLOW silently treated as GREEN
+# (PR auto-merged despite CRITICAL findings); STALE silently treated as
+# GREEN (PR auto-merged on legacy/pre-v0.26.0 audit shape that has no
+# phase2_5 block); malformed-JSON silently treated as STALE instead of
+# MISSING (the B5 hardening would regress).
+
+# BT12 — GREEN: by_severity zeros + halted=false -> "green". The clean
+# trust-signal path; required precondition for /goal to auto-dispatch
+# /merge per goal-pipeline §D17.
+_bt12_audit_green="$_b12_tmpdir/audit-green.json"
+cat > "$_bt12_audit_green" <<'EOF'
+{
+  "phases": {
+    "phase2_5": {
+      "by_severity": {"blocker": 0, "critical": 0},
+      "halted": false
+    }
+  }
+}
+EOF
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt12_audit_green")" "green" \
+  "BT12.clean-phase2_5-emits-green"
+
+# BT13 — YELLOW: critical>0, blocker=0, halted=false. /goal must hold
+# YELLOW PRs; a green misclassification here is the "auto-merged despite
+# CRITICAL findings" regression the post-impl finding explicitly flags.
+_bt13_audit_yellow="$_b12_tmpdir/audit-yellow.json"
+cat > "$_bt13_audit_yellow" <<'EOF'
+{
+  "phases": {
+    "phase2_5": {
+      "by_severity": {"blocker": 0, "critical": 1},
+      "halted": false
+    }
+  }
+}
+EOF
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt13_audit_yellow")" "yellow" \
+  "BT13.critical-only-emits-yellow"
+
+# BT14 — RED via blocker>0. Blocker count dominates: even with zero
+# critical findings the PR must enter red-held. D17 forbids
+# yellow-held->merging and red-held->merging transitions (BT1 covers
+# that arc; BT14 covers the signal that drives the state transition).
+_bt14_audit_red_blocker="$_b12_tmpdir/audit-red-blocker.json"
+cat > "$_bt14_audit_red_blocker" <<'EOF'
+{
+  "phases": {
+    "phase2_5": {
+      "by_severity": {"blocker": 2, "critical": 0},
+      "halted": false
+    }
+  }
+}
+EOF
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt14_audit_red_blocker")" "red" \
+  "BT14.blocker-emits-red"
+
+# BT15 — RED via halted: halted=true forces RED even when both severity
+# counters are 0. This is the "halted_due_to_overflow" path from RFC
+# 0002 §3.4: Phase 2.5 truncated findings beyond MAX_NEW=10 so the
+# severity counters are unreliable; the only safe action is red-held.
+_bt15_audit_red_halted="$_b12_tmpdir/audit-red-halted.json"
+cat > "$_bt15_audit_red_halted" <<'EOF'
+{
+  "phases": {
+    "phase2_5": {
+      "by_severity": {"blocker": 0, "critical": 0},
+      "halted": true
+    }
+  }
+}
+EOF
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt15_audit_red_halted")" "red" \
+  "BT15.halted-overrides-clean-counters-emits-red"
+
+# BT16 — STALE: phase2_5 key absent (legacy/pre-v0.26.0 audit shape).
+# Distinct from 'missing': the audit ran but predates the Phase 2.5
+# trust-signal contract. Caller must re-dispatch /review-pr (never
+# silently assume GREEN on a stale artifact per D17).
+_bt16_audit_stale="$_b12_tmpdir/audit-stale.json"
+cat > "$_bt16_audit_stale" <<'EOF'
+{"phases": {}}
+EOF
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt16_audit_stale")" "stale" \
+  "BT16.phase2_5-absent-emits-stale"
+
+# BT17 — MISSING: audit file does not exist. Distinct from 'stale':
+# /review-pr has not yet produced an artifact for this PR. State
+# machine treats both as "re-dispatch /review-pr" today but the
+# distinction is load-bearing for goal-pipeline telemetry (stale
+# means we already ran once; missing means we haven't).
+assert_eq "$(uberdev_goal_read_trust_signal /nonexistent/audit.json)" "missing" \
+  "BT17.file-not-found-emits-missing"
+
+# BT18 — MISSING via jq failure (malformed JSON). B5 hardening: the
+# jq exit code drives control flow; empty-stdout-as-success would let
+# corrupted audit JSON silently misclassify as 'stale' (and thence
+# YELLOW->GREEN if a later run produced a halted-but-empty payload).
+# stderr suppressed because gh_jq_or_jq emits a warning by design.
+_bt18_audit_malformed="$_b12_tmpdir/audit-malformed.json"
+printf 'not valid json {{\n' > "$_bt18_audit_malformed"
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt18_audit_malformed" 2>/dev/null)" "missing" \
+  "BT18.malformed-json-emits-missing"
+
+# BT19 — Shape-tolerance: empty phase2_5 object. The `// 0` and
+# `// false` jq defaults preserve GREEN when by_severity counters and
+# halted are all absent; the F1 simplify-lens refactor (goal-state.sh
+# :265-267) is contracted to keep this invariant. Regressing this
+# would surface as false-RED across every pre-counters audit payload.
+_bt19_audit_minimal="$_b12_tmpdir/audit-minimal.json"
+cat > "$_bt19_audit_minimal" <<'EOF'
+{"phases": {"phase2_5": {}}}
+EOF
+assert_eq "$(uberdev_goal_read_trust_signal "$_bt19_audit_minimal")" "green" \
+  "BT19.empty-phase2_5-defaults-to-green"
 
 # Cleanup: remove the isolated tmpdir contents (we created the whole
 # directory via mktemp -d, so we can rm -rf safely — it's our own).


### PR DESCRIPTION
## Summary

Closes #137

Adds 9 behavioural test cases (BT12-BT20) to `tests/goal.test.sh` covering `uberdev_goal_read_trust_signal` (`plugins/uberdev/lib/goal-state.sh:256-285`), addressing the blocker finding flagged by pr-test-analyzer on PR #129 (fingerprint `d599c295ba4d2846`). Targets `worktree-solve-issue-128` (PR #129) — same stacking pattern as PR #142 for the sibling `_uberdev_goal_check_unblock` coverage gap (#140).

`/uberdev:review-pr` Phase 1 surfaced a real production bug (SF1: no rc check on the second jq pipeline → malformed by_severity silently produced GREEN instead of MISSING — the exact YELLOW→GREEN misclassification path issue #137 was filed against). The fix is included in this PR as a separate `fix(goal):` commit; BT20 locks the contract.

## Coverage matrix

| Test | Input shape | Expected enum |
| --- | --- | --- |
| BT12 | `{blocker:0, critical:0, halted:false}` | `green` |
| BT13 | `{blocker:0, critical:1, halted:false}` | `yellow` |
| BT14 | `{blocker:2, critical:0, halted:false}` | `red` |
| BT15 | `{blocker:0, critical:0, halted:true}` (overflow) | `red` |
| BT16 | `{phases: {}}` (phase2_5 absent) | `stale` |
| BT17 | file does not exist | `missing` |
| BT18 | malformed JSON | `missing` |
| BT19 | `{phases: {phase2_5: {}}}` (shape-tolerance) | `green` |
| BT20 | `{phases:{phase2_5:{by_severity:"not_an_object",halted:false}}}` (B5 defense-in-depth) | `missing` |

## Commits

| SHA | Type | Summary |
|---|---|---|
| `dcf6440` | `test(goal):` | BT12-BT19 — initial behavioural coverage for the 8 documented branches |
| `64bcc76` | `fix(goal):` | Defense-in-depth on second jq pipeline + BT20 + BT15 wording (addresses /review-pr Phase 1 SF1 blocker + comment-analyzer medium) |
| `0c97283` | `refactor(goal):` | Simplify-pass: herestring + drop redundant cleanup (Phase 2 lens findings) |
| `249d16a` | `chore(review-pr):` | Trust trail anchor — `Reviewed-by: uberdev/review-pr@0c97283c50c362acac04607a57ec241d0a17897a` |

## /uberdev:review-pr — Phase outcomes (GREEN)

| Phase | Status | Verdict | Auto-applied | Advisory findings |
|---|---|---|---|---|
| Phase 1 — Review + Fix | ran | APPROVE | `64bcc76` | 1 BLOCKER (SF1 — APPLIED); 1 MEDIUM (BT15 wording — APPLIED); 5 sev=suggestion (pr-test-analyzer edge cases — deferred as low-risk) |
| Phase 2 — Simplify | ran | APPROVE | `0c97283` | 2 APPLIED (herestring efficiency + redundant cleanup); 1 DEFERRED (stderr observability — anti-simplify); 14 advisory NOT_APPLIED |
| Phase 2.5 — Defer issues | skipped | n/a | (no eligible deferred-critical findings filed; F1 below noted in PR body) | n/a |
| Phase 3 — CI Health | ran (green) | n/a | n/a | All 5 checks pass on HEAD SHA `0c97283` (shape-checks, shape-checks-windows, CodeRabbit — 0 iterations, 0 failure classes) |

Trust-trail state: **GREEN** — `uberdev-approved` label applied; audit JSON at `.uberdev/runs/20260521-160622-dcf6440/review-pr-verdict.json`.

## Coordination note (F1 — code-reviewer general lens)

This PR (BT12-BT20) overlaps the `BT12-BT18` namespace claimed by **PR #144** (`fix/138-issue-state-transition-tests`), which targets the same base branch. Both PRs add new test functions to `tests/goal.test.sh`; the labels themselves do not affect runtime correctness but a naive merge order will produce duplicate assert-label values in the merged file. Whichever PR merges SECOND should renumber its BT range (mechanical find-and-replace on assert labels + `_bt<N>_` tmp vars + section-header docblock). Sibling PRs on the same base: #142 (BT5-BT11), #144 (BT12-BT18), #145 (BT12-BT20, this PR), #146 (BT3a-BT3c, disjoint), #147 (BT5.*, collides with #142). Not blocking for this PR alone — flagged here so `/merge` ordering can route around it.

## Test plan

- [x] `bash tests/goal.test.sh` passes — 109 PASS, 0 FAIL (was 100 baseline; +9 net).
- [x] SF1 reproduction (malformed `by_severity`) now returns `missing` (was `green`).
- [x] CI runs `tests/goal.test.sh` on ubuntu-latest + windows-latest (`Tests` workflow) — both pass on HEAD SHA `0c97283`.