### PR TITLE
fix(goal): held-PR poll loop + convergence halt (#159 #160)

### DIFF
--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -4,17 +4,21 @@
 # SOURCED, never executed. No shebang (sourced only); .sh extension (convention).
 #
 # Public surface (functions):
-#   uberdev_goal_state_init               GOAL_ID
-#   uberdev_goal_pr_state_transition      GOAL_ID PR FROM TO
-#   uberdev_goal_issue_state_transition   GOAL_ID ISSUE FROM TO
-#   uberdev_goal_read_trust_signal        AUDIT_JSON_PATH
-#   uberdev_goal_check_fingerprint_repeat GOAL_ID CYCLE FINGERPRINT
-#   uberdev_goal_should_automerge         GOAL_ID PR
-#   uberdev_goal_audit                    EVENT PAYLOAD_JSON
-#   uberdev_goal_locate_review_pr_audit   ISSUE_NUM
-#   uberdev_goal_extract_pr_num_from_log  STDOUT_LOG_PATH
-#   uberdev_goal_list_prs_in_state        GOAL_ID STATE
-#   uberdev_goal_read_merge_result        PR_NUM
+#   uberdev_goal_state_init                    GOAL_ID
+#   uberdev_goal_pr_state_transition           GOAL_ID PR FROM TO
+#   uberdev_goal_issue_state_transition        GOAL_ID ISSUE FROM TO
+#   uberdev_goal_read_trust_signal             AUDIT_JSON_PATH
+#   uberdev_goal_check_fingerprint_repeat      GOAL_ID CYCLE FINGERPRINT
+#   uberdev_goal_should_automerge              GOAL_ID PR
+#   uberdev_goal_audit                         EVENT PAYLOAD_JSON
+#   uberdev_goal_locate_review_pr_audit        ISSUE_NUM
+#   uberdev_goal_locate_review_pr_audit_by_pr  PR_NUM
+#   uberdev_goal_get_pr_state                  GOAL_ID PR
+#   uberdev_goal_record_held_audit             GOAL_ID PR AUDIT_PATH
+#   uberdev_goal_get_last_held_audit           GOAL_ID PR
+#   uberdev_goal_extract_pr_num_from_log       STDOUT_LOG_PATH
+#   uberdev_goal_list_prs_in_state             GOAL_ID STATE
+#   uberdev_goal_read_merge_result             PR_NUM
 # Internal:
 #   _uberdev_goal_validate_int             N
 #   _uberdev_goal_extract_fingerprint      BODY_TEXT
@@ -142,6 +146,8 @@ _uberdev_goal_pr_state_machine_valid() {
     "pushed-reviewing->red-held") return 0 ;;
     "yellow-held->green") return 0 ;;   # after successful re-review
     "red-held->green") return 0 ;;
+    "yellow-held->red-held") return 0 ;; # re-review escalates severity (#159)
+    "red-held->yellow-held") return 0 ;; # re-review downgrades severity (#159)
     "green->merging") return 0 ;;
     "merging->merged") return 0 ;;
     "merging->merge-failed") return 0 ;;
@@ -196,6 +202,10 @@ uberdev_goal_state_init() {
   : > "$tmpdir/goal-$goal_id-issue-states.tsv"
   : > "$tmpdir/goal-$goal_id-fingerprints.tsv"
   : > "$tmpdir/goal-$goal_id-merge-attempts.tsv"
+  # held-audits.tsv: pr\taudit_path rows, appended each time the held-PR
+  # poll loop (Phase 2 step 2e) records a re-review audit it has consumed.
+  # Latest row per pr wins (uberdev_goal_get_last_held_audit picks the tail).
+  : > "$tmpdir/goal-$goal_id-held-audits.tsv"
 }
 
 # uberdev_goal_audit EVENT PAYLOAD_JSON
@@ -353,11 +363,27 @@ uberdev_goal_should_automerge() {
 uberdev_goal_locate_review_pr_audit() {
   local issue="$1"
   _uberdev_goal_validate_int "$issue" || return 1
-  # Resolve PR number from solve-bg stdout marker.
+  # Resolve PR number from solve-bg stdout marker, then delegate to the
+  # PR-keyed locator. The same `.pr == $pr` filter + lex-greatest-run_id
+  # tiebreak lives in one place now (was duplicated before the held-PR
+  # poll loop landed — see uberdev_goal_locate_review_pr_audit_by_pr).
   local pr
   pr="$(uberdev_goal_extract_pr_num_from_log "${UBERDEV_TMPDIR:-/tmp}/solve-bg-stdout-$issue.log")"
   [ -n "$pr" ] || return 0
   _uberdev_goal_validate_int "$pr" || return 0
+  uberdev_goal_locate_review_pr_audit_by_pr "$pr"
+}
+
+# uberdev_goal_locate_review_pr_audit_by_pr PR_NUM
+# PR-keyed companion to uberdev_goal_locate_review_pr_audit. Used by the
+# held-PR re-review poll loop (Phase 2 step 2e) which already has the PR
+# number in hand and bypasses the issue→PR resolution. Same glob set, same
+# filter (`.pr == $pr`), same lex-greatest run_id tiebreak (newest wins
+# because YYYYMMDD-HHMMSS-<sha> sorts identically to chronological order).
+# Returns the relative path to the audit JSON or empty when no match.
+uberdev_goal_locate_review_pr_audit_by_pr() {
+  local pr="$1"
+  _uberdev_goal_validate_int "$pr" || return 1
   local candidate_file run_id pr_field
   for candidate_file in .uberdev/runs/*/review-pr-verdict.json \
            .claude/worktrees/*/.uberdev/runs/*/review-pr-verdict.json \
@@ -370,6 +396,48 @@ uberdev_goal_locate_review_pr_audit() {
     [[ "$run_id" =~ ^[0-9]{8}-[0-9]{6}-[a-f0-9]+$ ]] || continue
     printf '%s\t%s\n' "$run_id" "$candidate_file"
   done | sort -r | head -n 1 | cut -f2
+}
+
+# uberdev_goal_get_pr_state GOAL_ID PR
+# Latest-transition lookup: read goal-<id>-pr-states.tsv, return the most
+# recent state recorded for PR. Empty string when no row exists (PR has
+# never been transitioned). Used by Phase 2 step 2e to determine the
+# `from` arg for state transitions on held PRs whose re-review trust
+# signal changed.
+uberdev_goal_get_pr_state() {
+  local goal_id="$1" pr="$2"
+  _uberdev_goal_validate_int "$pr" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  local f="$tmpdir/goal-$goal_id-pr-states.tsv"
+  [ -f "$f" ] || return 0
+  awk -v p="$pr" '$1==p {state=$2} END {print state}' "$f"
+}
+
+# uberdev_goal_record_held_audit GOAL_ID PR AUDIT_PATH
+# Append-only TSV write recording the audit path the held-PR poll loop
+# has consumed for PR. Subsequent reads via uberdev_goal_get_last_held_audit
+# pick the tail entry per PR; a different path on the next poll means a
+# new re-review fired and the poll loop should act on it.
+uberdev_goal_record_held_audit() {
+  local goal_id="$1" pr="$2" audit_path="$3"
+  _uberdev_goal_validate_int "$pr" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  printf '%s\t%s\n' "$pr" "$audit_path" \
+    >> "$tmpdir/goal-$goal_id-held-audits.tsv"
+}
+
+# uberdev_goal_get_last_held_audit GOAL_ID PR
+# Latest-row lookup in goal-<id>-held-audits.tsv per PR. Returns empty
+# string when no row exists (the held PR has not been polled yet, or the
+# TSV does not exist). Caller compares against the live locate result to
+# decide whether a re-review has fired since the last poll.
+uberdev_goal_get_last_held_audit() {
+  local goal_id="$1" pr="$2"
+  _uberdev_goal_validate_int "$pr" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  local f="$tmpdir/goal-$goal_id-held-audits.tsv"
+  [ -f "$f" ] || return 0
+  awk -v p="$pr" '$1==p {path=$2} END {print path}' "$f"
 }
 
 # uberdev_goal_extract_pr_num_from_log STDOUT_LOG_PATH

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -195,7 +195,7 @@ done
 **Concurrency model.** Phase 2 runs as a **single-threaded watcher** per iteration: each `sleep $_UBERDEV_GOAL_POLL_SECS` cycle walks the active-issues list once (step 2a), the green-PR list once (step 2b), and the merging-PR list once (step 2c) in deterministic order — a serial poll of every PR, never a fan-out. There is **no per-PR poll parallelism in v1** — the audit timeline (`goal_pr_transition` events in `goal-<id>.jsonl`) must remain a serial, replay-deterministic sequence for post-mortems and for the fingerprint-repeat detector in Phase 3. Per-PR poll parallelism is deferred to a future RFC (it would require an event-bus partition by PR number and a multi-writer audit framing that preserves a total order; neither lands in v1).
 
 ```bash
-# watch_start is set in Phase 0 (step 7a) — goal-level wall-clock anchor.
+# watch_start is set in Phase 0 (step 7) — goal-level wall-clock anchor.
 # The 4h stuck-loop check below measures total goal wall-clock, not per-cycle.
 # Q1 — bash supports ONE EXIT trap per shell; register the combined cleanup
 # for $gh_err + $findings_err here (Phase 3 mktemps $findings_err later).
@@ -359,30 +359,37 @@ while true; do
 
     held_signal="$(uberdev_goal_read_trust_signal "$new_audit")"
     held_current="$(uberdev_goal_get_pr_state "$GOAL_ID" "$held_pr")"
+    # Record the audit ONLY when the signal is readable and produced a
+    # decision (green/yellow/red). On stale|missing the audit is transiently
+    # unreadable — recording it here would mark it "consumed" so the next
+    # poll's `[ "$new_audit" = "$last_audit" ] && continue` guard would
+    # short-circuit forever, defeating the explicit defer-to-next-poll
+    # contract on the stale|missing arm (#159 post-impl-review B1).
     case "$held_signal" in
       green)
         uberdev_goal_pr_state_transition "$GOAL_ID" "$held_pr" "$held_current" green
+        uberdev_goal_record_held_audit "$GOAL_ID" "$held_pr" "$new_audit"
         ;;
       yellow)
         if [ "$held_current" = "red-held" ]; then
           uberdev_goal_pr_state_transition "$GOAL_ID" "$held_pr" red-held yellow-held
         fi
+        uberdev_goal_record_held_audit "$GOAL_ID" "$held_pr" "$new_audit"
         ;;
       red)
         if [ "$held_current" = "yellow-held" ]; then
           uberdev_goal_pr_state_transition "$GOAL_ID" "$held_pr" yellow-held red-held
         fi
+        uberdev_goal_record_held_audit "$GOAL_ID" "$held_pr" "$new_audit"
         ;;
       stale|missing)
         # Re-review audit not yet readable (mid-write, or jq parse failed).
         # Do NOT re-dispatch a fresh /review-pr here — the unblock rule
         # already dispatched one; another dispatch would race against it.
-        # Defer to the next poll cycle.
+        # Defer to the next poll cycle — explicit no-op, no record call
+        # (see comment above the case statement).
         ;;
     esac
-    # Record the audit we just consumed so the next poll skips it (unless a
-    # newer re-review fires, in which case `new_audit` will differ again).
-    uberdev_goal_record_held_audit "$GOAL_ID" "$held_pr" "$new_audit"
   done
 
   # 2d. Termination check (intra-cycle)
@@ -513,8 +520,8 @@ if [ "${#new_candidates[@]}" = "0" ] && [ "$terminal_count" = "$all_pr_count" ];
 fi
 
 # Deterministic queue-empty-not-converged halt (#160). Without this, a PR
-# stuck in pushed-reviewing/green/merging with nothing left to file as a
-# finding would spin the Phase1→2→3 loop until stuck_loop fires (4h).
+# stuck in dispatched/pushed-reviewing/green/merging with nothing left to
+# file as a finding would spin the Phase1→2→3 loop until stuck_loop fires (4h).
 # Surface the stuck state immediately so the operator can act.
 if [ "${#new_candidates[@]}" = "0" ] && [ "$terminal_count" != "$all_pr_count" ]; then
   uberdev_goal_audit goal_circuit_breaker \

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -17,7 +17,7 @@ All audit-event names, state-machine enums, regex shapes, and tunable thresholds
 
 ```
 GOAL_AUDIT_EVENT_ENUM='goal_dispatched|goal_pr_transition|goal_unblock_triggered|goal_cycle_completed|goal_converged|goal_circuit_breaker'
-GOAL_CIRCUIT_BREAKER_REASONS='max_cycles|nonconvergence|stuck_loop|merge_failed|gh_api_failed|unknown_merge_result'
+GOAL_CIRCUIT_BREAKER_REASONS='max_cycles|nonconvergence|stuck_loop|merge_failed|gh_api_failed|unknown_merge_result|queue_empty_not_converged'
 GOAL_PR_STATE_ENUM='dispatched|pushed-reviewing|green|yellow-held|red-held|merging|merged|merge-failed'
 GOAL_ISSUE_STATE_ENUM='input|solving|pr-pushed|resolved|failed'
 TRUST_SIGNAL_ENUM='green|yellow|red|stale|missing'
@@ -35,8 +35,8 @@ BLOCKS_LINE_REGEX='^Blocks: #([0-9]+)$'
 Notes on the enums:
 
 - **`GOAL_AUDIT_EVENT_ENUM`** — the 6 events `lib/goal-state.sh::uberdev_goal_audit` accepts. Any other event name returns non-zero from the helper and is dropped on the floor; consumers grep these literals.
-- **`GOAL_CIRCUIT_BREAKER_REASONS`** — the 6 halt reasons emitted by Phase 2/3/4 inside the `goal_circuit_breaker` payload's `.reason` field. The four original reasons (`max_cycles`, `nonconvergence`, `stuck_loop`, `merge_failed`) plus two surfaced-failure reasons added during post-impl-review (`gh_api_failed` — Phase 3 `gh issue list` rc!=0 instead of falsely treating an empty candidates list as convergence; `unknown_merge_result` — Phase 2c case default arm for a `uberdev_goal_read_merge_result` value outside the documented `success|conflict|hook_failed|missing` set). The set is closed; new reasons require an RFC amendment.
-- **`GOAL_PR_STATE_ENUM`** — the 8 states the PR machine in `_uberdev_goal_pr_state_machine_valid` recognises; `merged` and `merge-failed` are terminal. `yellow-held → merging` and `red-held → merging` are forbidden (D17).
+- **`GOAL_CIRCUIT_BREAKER_REASONS`** — the 7 halt reasons emitted by Phase 2/3/4 inside the `goal_circuit_breaker` payload's `.reason` field. The four original reasons (`max_cycles`, `nonconvergence`, `stuck_loop`, `merge_failed`); two surfaced-failure reasons added during post-impl-review (`gh_api_failed` — Phase 3 `gh issue list` rc!=0 instead of falsely treating an empty candidates list as convergence; `unknown_merge_result` — Phase 2c case default arm for a `uberdev_goal_read_merge_result` value outside the documented `success|conflict|hook_failed|missing` set); and `queue_empty_not_converged` — Phase 3 deterministic halt when the candidate queue is empty but at least one PR is still in a non-terminal state (issue #160; deterministic alternative to the 4h `stuck_loop` wall-clock fallback). The set is closed; new reasons require an RFC amendment.
+- **`GOAL_PR_STATE_ENUM`** — the 8 states the PR machine in `_uberdev_goal_pr_state_machine_valid` recognises. `merged` and `merge-failed` are hard terminal (no further transitions); `yellow-held` and `red-held` are pseudo-terminal for convergence (Phase 3 counts them as terminal so the goal can converge cleanly with held PRs remaining, but the held-PR re-review poll loop in Phase 2 step 2e can still arc them to `green` once a re-review clears the findings, or cross-classify between `yellow-held`/`red-held` if a re-review's trust signal severity changed). `yellow-held → merging` and `red-held → merging` are hard-forbidden (D17 — never merge YELLOW/RED inside `/goal`).
 - **`GOAL_ISSUE_STATE_ENUM`** — the 5 states the issue machine recognises; `pr-pushed → resolved` and the two `→ failed` transitions are the only sinks.
 - **`TRUST_SIGNAL_ENUM`** — the 5 values `uberdev_goal_read_trust_signal` returns. `stale` (phase2_5 missing in audit JSON) and `missing` (audit JSON absent) both trigger `_uberdev_goal_dispatch_review_pr` rather than an assumed GREEN (D17).
 - **`GOAL_MERGE_RESULT_ENUM`** — the 4 values `uberdev_goal_read_merge_result` returns. Maps the merge-pipeline's audit-row events (`merge_executed` for `success`, `pr_parked` with `data.reason ∈ {refused, ambiguous, push-non-ff}` for `conflict`, `pr_parked` with `data.reason == test-fail-exhausted` for `hook_failed`) plus a sentinel `missing` for "no audit row appended yet". Phase 2c's case statement handles each value explicitly; the `*)` default arm emits `goal_circuit_breaker reason=unknown_merge_result` (B7 — defensive guard against future enum drift).
@@ -243,9 +243,15 @@ while true; do
           ;;
         yellow)
           uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" pushed-reviewing yellow-held
+          # Record the audit that put this PR in held so step 2e's poll loop
+          # has a baseline — when a NEWER audit appears (re-review fired),
+          # the poll loop applies the next state transition (#159).
+          uberdev_goal_record_held_audit "$GOAL_ID" "$pr_num" "$audit_json"
           ;;
         red)
           uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" pushed-reviewing red-held
+          # Record audit baseline for the step 2e poll loop (mirrors yellow case).
+          uberdev_goal_record_held_audit "$GOAL_ID" "$pr_num" "$audit_json"
           # B6 — Blocker-overflow handler (D13). Reads the per-PR audit JSON
           # while $audit_json and $pr_num are still in scope (the Phase 3
           # site previously held this block but those variables don't exist
@@ -321,6 +327,62 @@ while true; do
         exit 1
         ;;
     esac
+  done
+
+  # 2e. Poll held PRs for re-review completion (RFC 0005 §3.2.3 hold-and-
+  # unblock completion-half; #159). When the unblock rule (step 2c) dispatches
+  # a `/uberdev:review-pr` for a newly-unblocked PR, that re-review writes a
+  # NEW audit JSON under `.uberdev/runs/<new-run-id>/`. Without this poll,
+  # the dispatch is fire-and-forget — the held PR never exits the held state
+  # because no phase examines the re-review's verdict. The poll uses
+  # `uberdev_goal_get_last_held_audit` to compare the live latest-audit path
+  # against the one consumed last cycle; a different path means a re-review
+  # fired, so the trust signal is read and the next state transition applied.
+  #
+  # Transitions emitted from this step:
+  #   - {yellow,red}-held → green when the new re-review is green
+  #   - yellow-held → red-held when the new re-review escalates severity
+  #   - red-held → yellow-held when the new re-review downgrades severity
+  # Same-severity re-reviews and stale/missing signals leave state unchanged
+  # (the operator or the next unblock chain handles those).
+  #
+  # Held-as-terminal classification (#160) means a held PR that no re-review
+  # ever clears will still let the goal converge — Phase 3's terminal set
+  # includes both held states. This poll is the optimistic exit path; the
+  # convergence-as-terminal path is the pessimistic fallback.
+  for held_pr in $(uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held; \
+                   uberdev_goal_list_prs_in_state "$GOAL_ID" red-held); do
+    new_audit="$(uberdev_goal_locate_review_pr_audit_by_pr "$held_pr")"
+    [ -n "$new_audit" ] || continue
+    last_audit="$(uberdev_goal_get_last_held_audit "$GOAL_ID" "$held_pr")"
+    [ "$new_audit" = "$last_audit" ] && continue
+
+    held_signal="$(uberdev_goal_read_trust_signal "$new_audit")"
+    held_current="$(uberdev_goal_get_pr_state "$GOAL_ID" "$held_pr")"
+    case "$held_signal" in
+      green)
+        uberdev_goal_pr_state_transition "$GOAL_ID" "$held_pr" "$held_current" green
+        ;;
+      yellow)
+        if [ "$held_current" = "red-held" ]; then
+          uberdev_goal_pr_state_transition "$GOAL_ID" "$held_pr" red-held yellow-held
+        fi
+        ;;
+      red)
+        if [ "$held_current" = "yellow-held" ]; then
+          uberdev_goal_pr_state_transition "$GOAL_ID" "$held_pr" yellow-held red-held
+        fi
+        ;;
+      stale|missing)
+        # Re-review audit not yet readable (mid-write, or jq parse failed).
+        # Do NOT re-dispatch a fresh /review-pr here — the unblock rule
+        # already dispatched one; another dispatch would race against it.
+        # Defer to the next poll cycle.
+        ;;
+    esac
+    # Record the audit we just consumed so the next poll skips it (unless a
+    # newer re-review fires, in which case `new_audit` will differ again).
+    uberdev_goal_record_held_audit "$GOAL_ID" "$held_pr" "$new_audit"
   done
 
   # 2d. Termination check (intra-cycle)
@@ -419,7 +481,8 @@ done
 **Cycle terminal conditions (evaluated AFTER the per-candidate fingerprint check):**
 
 - If `cycle >= MAX_CYCLES` AND `new_candidates` is non-empty: halt with `goal_circuit_breaker reason=max_cycles`, exit 1. The operator has explicitly capped iteration count via `--max-cycles=N` or the `goal.max_cycles` config key; we respect the cap rather than spinning forever.
-- If `new_candidates` is empty AND every PR in this run is in `{merged, merge-failed}`: convergence reached, emit `goal_converged`, exit 0. `merge-failed` PRs are counted as terminal-converged because the merge-failed circuit breaker would have already fired upstream — reaching this state means every PR has been driven to a terminal state.
+- If `new_candidates` is empty AND every PR in this run is in `{merged, merge-failed, yellow-held, red-held}`: convergence reached, emit `goal_converged`, exit 0. Held states are **pseudo-terminal for convergence** (#160) — they are surfaced to the operator via `print_summary` (each held PR's `Blocks: #N` list is printed) and are addressed out-of-band; counting them as terminal here is what lets the goal converge cleanly instead of spinning until the 4h `stuck_loop` fires. `merge-failed` PRs are counted as terminal-converged because the merge-failed circuit breaker would have already fired upstream — reaching this state means every PR has been driven to a stable resting state.
+- If `new_candidates` is empty AND at least one PR is still in a non-terminal in-flight state (`dispatched`, `pushed-reviewing`, `green` not yet merged, `merging`): emit `goal_circuit_breaker reason=queue_empty_not_converged`, exit 1 (#160). This is the deterministic alternative to the 4h `stuck_loop` wall-clock fallback — the queue is drained but PRs are stuck, so surface immediately instead of spinning against the GitHub API.
 - Otherwise: emit `goal_cycle_completed` with the cycle summary `{cycle, prs_merged, prs_held, issues_resolved, new_candidates}`, set `queue ← new_candidates`, increment `cycle`, and loop back to Phase 1.
 
 ```bash
@@ -430,8 +493,15 @@ if [ "$cycle" -ge "$MAX_CYCLES" ] && [ "${#new_candidates[@]}" -gt 0 ]; then
   exit 1
 fi
 
+# Terminal set for convergence (#160): hard-terminal {merged, merge-failed}
+# plus pseudo-terminal {yellow-held, red-held}. Held PRs are surfaced via
+# print_summary's `Blocks: #N` rows so the operator can intervene; for the
+# convergence calculus they are treated as terminal so the goal exits
+# cleanly when nothing else is in flight.
 terminal_prs="$(uberdev_goal_list_prs_in_state "$GOAL_ID" merged \
-  ; uberdev_goal_list_prs_in_state "$GOAL_ID" merge-failed)"
+  ; uberdev_goal_list_prs_in_state "$GOAL_ID" merge-failed \
+  ; uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held \
+  ; uberdev_goal_list_prs_in_state "$GOAL_ID" red-held)"
 all_pr_count="$(awk '{print $1}' "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" \
   | sort -u | wc -l)"
 terminal_count="$(printf '%s\n' "$terminal_prs" | grep -c . || true)"
@@ -440,6 +510,17 @@ if [ "${#new_candidates[@]}" = "0" ] && [ "$terminal_count" = "$all_pr_count" ];
     "{\"cycle\":$cycle,\"prs\":$all_pr_count}"
   print_summary "$cycle"
   exit 0
+fi
+
+# Deterministic queue-empty-not-converged halt (#160). Without this, a PR
+# stuck in pushed-reviewing/green/merging with nothing left to file as a
+# finding would spin the Phase1→2→3 loop until stuck_loop fires (4h).
+# Surface the stuck state immediately so the operator can act.
+if [ "${#new_candidates[@]}" = "0" ] && [ "$terminal_count" != "$all_pr_count" ]; then
+  uberdev_goal_audit goal_circuit_breaker \
+    "{\"reason\":\"queue_empty_not_converged\",\"cycle\":$cycle,\"all_prs\":$all_pr_count,\"terminal\":$terminal_count}"
+  print_summary "$cycle"
+  exit 1
 fi
 
 uberdev_goal_audit goal_cycle_completed \
@@ -478,9 +559,10 @@ Every exit path from this skill emits exactly one terminal audit event AND print
 
 | Path | Audit event | Exit code | Trigger |
 |---|---|---|---|
-| Convergence | `goal_converged` | 0 | `new_candidates` empty AND every PR in `{merged, merge-failed}` (Phase 3 terminal check). |
+| Convergence | `goal_converged` | 0 | `new_candidates` empty AND every PR in `{merged, merge-failed, yellow-held, red-held}` (Phase 3 terminal check). Held states are pseudo-terminal so the goal converges cleanly when only held PRs remain (#160). |
 | Max-cycles cap | `goal_circuit_breaker` with `reason=max_cycles` | 1 | `cycle >= MAX_CYCLES` AND `new_candidates` non-empty (Phase 3). |
 | Non-convergence | `goal_circuit_breaker` with `reason=nonconvergence` | 1 | Fingerprint repeat detected by `uberdev_goal_check_fingerprint_repeat` (Phase 3 per-candidate loop). |
+| Queue-empty-not-converged | `goal_circuit_breaker` with `reason=queue_empty_not_converged` | 1 | `new_candidates` empty AND at least one PR still in a non-terminal in-flight state (`dispatched`, `pushed-reviewing`, `green`, `merging`) — deterministic Phase 3 halt that pre-empts the 4h `stuck_loop` fallback (#160). |
 | Stuck-loop | `goal_circuit_breaker` with `reason=stuck_loop` | 1 | `watch_secs >= _UBERDEV_GOAL_STUCK_SECS` (4h) at top of Phase 2 iteration. |
 | Merge-failed | `goal_circuit_breaker` with `reason=merge_failed` | 1 | `/merge` returned `conflict` or `hook_failed` (Phase 2 step 2c). |
 
@@ -529,6 +611,8 @@ Called from Phase 2 step 2c on every `merging → merged` PR transition, for eac
 3. **Build blocking-issue numbers.** Capture group 1 of each match is re-validated by `_uberdev_goal_validate_int` (defence in depth — anchored `[0-9]+` already passed it, but a second check costs nothing). For each number, query `gh issue view $N --json state --jq '.state'`.
 4. **If all blocking issues are CLOSED, re-dispatch `/uberdev:review-pr $held_pr`** via `_uberdev_goal_dispatch_review_pr` (D18 full re-review — including Phase 3 CI Health re-evaluation; the no-shortcut path is mandatory because the upstream merge that triggered this unblock may have changed CI dependencies). If any blocking issue is still OPEN, do nothing this iteration; the unblock check will re-run on the next merged-PR transition.
 5. **Emit `goal_unblock_triggered` event** with payload `{pr, blocking_issues: […]}`. This event is the durable record that the unblock fired; consumers can replay it from `goal-<id>.jsonl` to reconstruct the held-PR DAG.
+
+**Completion half (Phase 2 step 2e — #159).** The unblock rule's `/review-pr` dispatch in step 4 is fire-and-forget; it is **Phase 2 step 2e**, the held-PR re-review poll, that closes the loop. On every Phase 2 iteration, step 2e walks every PR currently in `yellow-held` / `red-held`, compares the live latest audit (`uberdev_goal_locate_review_pr_audit_by_pr`) against the previously-consumed audit (`uberdev_goal_get_last_held_audit`), and — when they differ — applies the next state transition based on the new audit's trust signal: `green → green` (eligible for merge in next cycle's step 2b), severity-flip → `{yellow,red}-held → {red,yellow}-held` re-classification, or same-severity → no transition. Without step 2e, the dispatch in step 4 had no consumer, and the held PR was permanently orphaned (the bug issue #159 captured).
 
 ## Scoped relaxations
 

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -232,13 +232,16 @@ assert_grep "$GOAL_LIB" '_UBERDEV_GOAL_BODY_CAP|head -c 65536'           "G18.bo
 
 echo
 echo "== G19: lib/goal-state.sh shape =="
-# Public function names (11 — uberdev_goal_build_unblock_graph removed
-# in the post-impl-review B5 cleanup; it was dead code, never called from
-# SKILL.md or anywhere else, and the per-PR unblock decision is made
-# in-line by _uberdev_goal_check_unblock without a pre-built graph).
+# Public function names (15 — uberdev_goal_build_unblock_graph removed
+# in the post-impl-review B5 cleanup; the four `*_held_audit` /
+# `_by_pr` / `_get_pr_state` helpers added by the issue #159 + #160
+# convergence-loop fix supply the held-PR re-review poll loop's
+# bookkeeping surface).
 for fn in uberdev_goal_state_init uberdev_goal_pr_state_transition uberdev_goal_issue_state_transition \
           uberdev_goal_read_trust_signal uberdev_goal_check_fingerprint_repeat uberdev_goal_should_automerge \
           uberdev_goal_audit uberdev_goal_locate_review_pr_audit \
+          uberdev_goal_locate_review_pr_audit_by_pr \
+          uberdev_goal_get_pr_state uberdev_goal_record_held_audit uberdev_goal_get_last_held_audit \
           uberdev_goal_extract_pr_num_from_log uberdev_goal_list_prs_in_state uberdev_goal_read_merge_result; do
   assert_grep "$GOAL_LIB" "^${fn}\\(\\)" "G19.public.${fn}"
 done
@@ -268,6 +271,35 @@ assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": 
 assert_grep "$REPO_ROOT/README.md"                                  'version-0\.31\.0-blue'  "G20.readme-badge"
 assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.31\.0\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
+
+echo
+echo "== G21: held-PR re-review poll loop (issue #159) =="
+# Phase 2 step 2e MUST exist and call the new PR-keyed locator + last-seen
+# bookkeeping helpers. The poll loop is what lets a held PR exit the held
+# state once /review-pr (re-)runs — without it the unblock rule's dispatch
+# is fire-and-forget and held PRs sit forever.
+assert_grep "$GOAL_SKILL" 'uberdev_goal_locate_review_pr_audit_by_pr'             "G21.locate-by-pr-in-skill"
+assert_grep "$GOAL_SKILL" 'uberdev_goal_get_last_held_audit|last_held_audit'      "G21.last-held-audit-in-skill"
+assert_grep "$GOAL_SKILL" 'uberdev_goal_record_held_audit|record_held_audit'      "G21.record-held-audit-in-skill"
+assert_grep "$GOAL_SKILL" 'uberdev_goal_get_pr_state'                             "G21.get-pr-state-in-skill"
+# Cross-held downgrade/upgrade arcs (yellow-held<->red-held) are valid in
+# the PR state machine so a re-review can re-classify the held PR.
+assert_grep "$GOAL_LIB" 'yellow-held->red-held'                                   "G21.yellow-to-red-transition"
+assert_grep "$GOAL_LIB" 'red-held->yellow-held'                                   "G21.red-to-yellow-transition"
+# Forbidden transitions still forbidden post-change (defensive regression guard):
+# both held -> merging arcs remain blocked even with the new poll loop.
+assert_grep "$GOAL_LIB" 'yellow-held->merging.*return 1'                          "G21.yellow-merging-still-forbidden"
+assert_grep "$GOAL_LIB" 'red-held->merging.*return 1'                             "G21.red-merging-still-forbidden"
+
+echo
+echo "== G22: queue_empty_not_converged + held-as-terminal (issue #160) =="
+# Reason added to the enum AND the deterministic halt is emitted from Phase 3.
+assert_grep "$GOAL_SKILL" 'GOAL_CIRCUIT_BREAKER_REASONS=.*queue_empty_not_converged' "G22.reason-in-enum"
+assert_grep "$GOAL_SKILL" 'goal_circuit_breaker.*queue_empty_not_converged'         "G22.halt-emit"
+# Phase 3 terminal_prs MUST include held states so a goal with only held PRs
+# left can converge cleanly instead of spinning until stuck_loop.
+assert_grep "$GOAL_SKILL" 'list_prs_in_state.*yellow-held'                         "G22.terminal-includes-yellow-held"
+assert_grep "$GOAL_SKILL" 'list_prs_in_state.*red-held'                            "G22.terminal-includes-red-held"
 
 echo
 echo "== Behavioral tests (B12 — sourced-function exercises) =="
@@ -1131,9 +1163,216 @@ if _bt5_seed bt5-7 203 3; then
   assert_rc "$?" "0" "BT5.B7-env-knob-override-allowed"
 fi
 
+# ----- BT24-BT34 — held-PR re-review poll loop + convergence terminal
+# behavioural coverage (issues #159 + #160). Functions under test:
+#   - uberdev_goal_get_pr_state         (latest-state lookup)
+#   - uberdev_goal_record_held_audit    (TSV row append)
+#   - uberdev_goal_get_last_held_audit  (latest row per PR)
+#   - uberdev_goal_locate_review_pr_audit_by_pr (PR-keyed glob locator)
+#   - new state-machine arcs yellow-held<->red-held (cross-held re-classification)
+#
+# Strategy: per-test isolated $UBERDEV_TMPDIR (mktemp -d sub-dir of $_b12_tmpdir)
+# and a per-test goal_id. The locator tests `cd` into a scratch dir so the
+# relative-glob path (`.uberdev/runs/*/review-pr-verdict.json`) resolves
+# against test-controlled fixtures rather than the user's repo state.
+
+# BT24 — uberdev_goal_get_pr_state: latest transition wins per PR.
+uberdev_goal_state_init test-bt24
+UBERDEV_GOAL_ID=test-bt24 uberdev_goal_pr_state_transition test-bt24 500 pushed-reviewing yellow-held >/dev/null 2>&1
+UBERDEV_GOAL_ID=test-bt24 uberdev_goal_pr_state_transition test-bt24 500 yellow-held red-held >/dev/null 2>&1
+assert_eq "$(uberdev_goal_get_pr_state test-bt24 500)" "red-held" "BT24.latest-transition-wins"
+# Empty when PR has no recorded state.
+assert_eq "$(uberdev_goal_get_pr_state test-bt24 999)" "" "BT24.unknown-pr-empty"
+# Empty (rc 0) when goal_id TSV does not exist yet.
+_bt24_out="$(uberdev_goal_get_pr_state test-bt24-missing 500 2>/dev/null)"
+assert_eq "$_bt24_out" "" "BT24.missing-tsv-empty"
+
+# BT25 — uberdev_goal_record_held_audit + uberdev_goal_get_last_held_audit
+# round-trip. First record establishes the baseline; second record overrides
+# for the same PR; reads return the latest path.
+uberdev_goal_state_init test-bt25
+uberdev_goal_record_held_audit test-bt25 600 /tmp/audit-first.json
+assert_eq "$(uberdev_goal_get_last_held_audit test-bt25 600)" "/tmp/audit-first.json" \
+  "BT25.first-record-returned"
+uberdev_goal_record_held_audit test-bt25 600 /tmp/audit-second.json
+assert_eq "$(uberdev_goal_get_last_held_audit test-bt25 600)" "/tmp/audit-second.json" \
+  "BT25.second-record-overrides"
+# Different PR in the same goal: independent rows.
+uberdev_goal_record_held_audit test-bt25 601 /tmp/audit-other.json
+assert_eq "$(uberdev_goal_get_last_held_audit test-bt25 600)" "/tmp/audit-second.json" \
+  "BT25.pr-600-isolated"
+assert_eq "$(uberdev_goal_get_last_held_audit test-bt25 601)" "/tmp/audit-other.json" \
+  "BT25.pr-601-isolated"
+# Empty when PR has no recorded held audit.
+assert_eq "$(uberdev_goal_get_last_held_audit test-bt25 999)" "" \
+  "BT25.unknown-pr-empty"
+
+# BT26 — uberdev_goal_locate_review_pr_audit_by_pr: globs `.uberdev/runs/*`
+# in CWD and picks the lex-greatest run_id whose `.pr` matches. Lex-greatest
+# = chronologically newest given the YYYYMMDD-HHMMSS-<sha> shape.
+_bt26_scratch="$(mktemp -d 2>/dev/null || printf '/tmp/bt26-%s' "$$")"
+mkdir -p "$_bt26_scratch"
+(
+  cd "$_bt26_scratch" || exit 1
+  mkdir -p .uberdev/runs/20260101-100000-aaaaaaaa
+  mkdir -p .uberdev/runs/20260102-120000-bbbbbbbb
+  mkdir -p .uberdev/runs/20260103-110000-cccccccc
+  printf '{"pr":700}\n' > .uberdev/runs/20260101-100000-aaaaaaaa/review-pr-verdict.json
+  printf '{"pr":700}\n' > .uberdev/runs/20260102-120000-bbbbbbbb/review-pr-verdict.json
+  printf '{"pr":701}\n' > .uberdev/runs/20260103-110000-cccccccc/review-pr-verdict.json
+)
+_bt26_pr700="$(cd "$_bt26_scratch" && uberdev_goal_locate_review_pr_audit_by_pr 700)"
+_bt26_pr701="$(cd "$_bt26_scratch" && uberdev_goal_locate_review_pr_audit_by_pr 701)"
+_bt26_pr999="$(cd "$_bt26_scratch" && uberdev_goal_locate_review_pr_audit_by_pr 999)"
+assert_eq "$_bt26_pr700" ".uberdev/runs/20260102-120000-bbbbbbbb/review-pr-verdict.json" \
+  "BT26.newest-audit-for-pr700"
+assert_eq "$_bt26_pr701" ".uberdev/runs/20260103-110000-cccccccc/review-pr-verdict.json" \
+  "BT26.single-audit-for-pr701"
+assert_eq "$_bt26_pr999" "" "BT26.no-audit-for-pr999"
+# Non-numeric PR rejected.
+uberdev_goal_locate_review_pr_audit_by_pr abc >/dev/null 2>&1
+assert_rc "$?" "1" "BT26.non-numeric-pr-rejected"
+rm -rf "$_bt26_scratch" 2>/dev/null || true
+
+# BT27 — new state machine arcs (yellow-held<->red-held). The poll loop in
+# Phase 2 step 2e uses these to re-classify a held PR when the re-review
+# trust signal flips severity (e.g., earlier RED resolves down to YELLOW
+# after fixes land in a dependency, or earlier YELLOW escalates to RED
+# after a new finding surfaces).
+_uberdev_goal_pr_state_machine_valid yellow-held red-held
+assert_rc "$?" "0" "BT27.yellow-to-red-allowed"
+_uberdev_goal_pr_state_machine_valid red-held yellow-held
+assert_rc "$?" "0" "BT27.red-to-yellow-allowed"
+# Held arcs remain forbidden -> merging (D17 regression guard).
+_uberdev_goal_pr_state_machine_valid yellow-held merging
+assert_rc "$?" "1" "BT27.yellow-merging-still-forbidden"
+_uberdev_goal_pr_state_machine_valid red-held merging
+assert_rc "$?" "1" "BT27.red-merging-still-forbidden"
+
+# BT28 — End-to-end held-PR poll: simulate the Phase 2 step 2e logic against
+# the real helper functions. Sequence:
+#   1. PR enters yellow-held; record_held_audit stores the initial audit path
+#   2. Re-review fires, writes a NEW audit JSON under .uberdev/runs/
+#   3. Poll: locate_by_pr returns new audit; get_last_held_audit differs;
+#      read_trust_signal on the new audit returns green; transition fires
+#   4. Second poll: locate_by_pr returns same audit; get_last_held_audit
+#      now matches; no transition (skip)
+#
+# This is the integration shape the SKILL.md step 2e code-block implements.
+_bt28_scratch="$(mktemp -d 2>/dev/null || printf '/tmp/bt28-%s' "$$")"
+mkdir -p "$_bt28_scratch"
+uberdev_goal_state_init test-bt28
+# Step 1: initial held transition + audit baseline.
+UBERDEV_GOAL_ID=test-bt28 uberdev_goal_pr_state_transition test-bt28 800 pushed-reviewing yellow-held >/dev/null 2>&1
+(
+  cd "$_bt28_scratch" || exit 1
+  mkdir -p .uberdev/runs/20260201-100000-aaaaaaaa
+  cat > .uberdev/runs/20260201-100000-aaaaaaaa/review-pr-verdict.json <<'EOF'
+{"pr":800,"phases":{"phase2_5":{"by_severity":{"blocker":0,"critical":1},"halted":false}}}
+EOF
+)
+_bt28_initial="$(cd "$_bt28_scratch" && uberdev_goal_locate_review_pr_audit_by_pr 800)"
+uberdev_goal_record_held_audit test-bt28 800 "$_bt28_initial"
+assert_eq "$(uberdev_goal_get_pr_state test-bt28 800)" "yellow-held" "BT28.initial-state-yellow-held"
+
+# Step 2: re-review writes a NEW audit (green this time).
+(
+  cd "$_bt28_scratch" || exit 1
+  mkdir -p .uberdev/runs/20260202-110000-bbbbbbbb
+  cat > .uberdev/runs/20260202-110000-bbbbbbbb/review-pr-verdict.json <<'EOF'
+{"pr":800,"phases":{"phase2_5":{"by_severity":{"blocker":0,"critical":0},"halted":false}}}
+EOF
+)
+# Step 3: poll detects new audit, signal green, transitions to green.
+_bt28_latest="$(cd "$_bt28_scratch" && uberdev_goal_locate_review_pr_audit_by_pr 800)"
+assert_eq "$_bt28_latest" \
+  ".uberdev/runs/20260202-110000-bbbbbbbb/review-pr-verdict.json" \
+  "BT28.poll-finds-new-audit"
+_bt28_last_seen="$(uberdev_goal_get_last_held_audit test-bt28 800)"
+if [ "$_bt28_latest" != "$_bt28_last_seen" ]; then
+  PASS=$((PASS + 1))
+  printf '  PASS  %s\n' "BT28.new-audit-differs-from-last-seen"
+else
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "BT28.new-audit-differs-from-last-seen" >&2
+fi
+_bt28_signal="$(cd "$_bt28_scratch" && uberdev_goal_read_trust_signal "$_bt28_latest")"
+assert_eq "$_bt28_signal" "green" "BT28.new-audit-green-signal"
+_bt28_current_state="$(uberdev_goal_get_pr_state test-bt28 800)"
+UBERDEV_GOAL_ID=test-bt28 uberdev_goal_pr_state_transition test-bt28 800 "$_bt28_current_state" green >/dev/null 2>&1
+assert_rc "$?" "0" "BT28.held-to-green-transition-allowed"
+assert_eq "$(uberdev_goal_get_pr_state test-bt28 800)" "green" "BT28.final-state-green"
+uberdev_goal_record_held_audit test-bt28 800 "$_bt28_latest"
+
+# Step 4: second poll — same audit, last_seen now matches → skip transition.
+_bt28_latest2="$(cd "$_bt28_scratch" && uberdev_goal_locate_review_pr_audit_by_pr 800)"
+_bt28_last_seen2="$(uberdev_goal_get_last_held_audit test-bt28 800)"
+assert_eq "$_bt28_latest2" "$_bt28_last_seen2" "BT28.second-poll-same-audit-skips"
+rm -rf "$_bt28_scratch" 2>/dev/null || true
+
+# BT29 — Held-PR poll detects re-review STILL RED → optional downgrade arc.
+# Scenario: PR was yellow-held; re-review found new blockers; signal=red.
+# State machine allows yellow-held → red-held re-classification (BT27).
+uberdev_goal_state_init test-bt29
+UBERDEV_GOAL_ID=test-bt29 uberdev_goal_pr_state_transition test-bt29 900 pushed-reviewing yellow-held >/dev/null 2>&1
+UBERDEV_GOAL_ID=test-bt29 uberdev_goal_pr_state_transition test-bt29 900 yellow-held red-held >/dev/null 2>&1
+assert_rc "$?" "0" "BT29.yellow-to-red-downgrade-applied"
+assert_eq "$(uberdev_goal_get_pr_state test-bt29 900)" "red-held" "BT29.final-state-red-held"
+# Audit event for the downgrade is emitted via goal_pr_transition.
+assert_grep "$UBERDEV_TMPDIR/goal-test-bt29.jsonl" '"event":"goal_pr_transition"' \
+  "BT29.transition-audit-event-emitted"
+assert_grep "$UBERDEV_TMPDIR/goal-test-bt29.jsonl" '"from":"yellow-held","to":"red-held"' \
+  "BT29.transition-audit-payload-shape"
+
+# BT30 — Reverse: red-held → yellow-held upgrade.
+uberdev_goal_state_init test-bt30
+UBERDEV_GOAL_ID=test-bt30 uberdev_goal_pr_state_transition test-bt30 901 pushed-reviewing red-held >/dev/null 2>&1
+UBERDEV_GOAL_ID=test-bt30 uberdev_goal_pr_state_transition test-bt30 901 red-held yellow-held >/dev/null 2>&1
+assert_rc "$?" "0" "BT30.red-to-yellow-upgrade-applied"
+assert_eq "$(uberdev_goal_get_pr_state test-bt30 901)" "yellow-held" "BT30.final-state-yellow-held"
+
+# BT31 — state_init creates the held-audits TSV (new file added by this fix).
+# Locks the contract that uberdev_goal_get_last_held_audit can be called on a
+# fresh goal without first having to record anything (returns empty cleanly).
+uberdev_goal_state_init test-bt31
+_bt31_tsv="$UBERDEV_TMPDIR/goal-test-bt31-held-audits.tsv"
+if [ -f "$_bt31_tsv" ]; then
+  PASS=$((PASS + 1))
+  printf '  PASS  %s\n' "BT31.held-audits-tsv-created-on-init"
+else
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "BT31.held-audits-tsv-created-on-init" >&2
+  printf '        expected file: %s\n' "$_bt31_tsv" >&2
+fi
+assert_eq "$(uberdev_goal_get_last_held_audit test-bt31 1)" "" \
+  "BT31.fresh-goal-empty-held-audit-read"
+
+# BT32 — uberdev_goal_locate_review_pr_audit (issue-keyed) still works after
+# refactor (delegates to _by_pr). Regression guard: refactor must preserve
+# the existing issue → PR → audit chain used by Phase 2 step 2a.
+_bt32_scratch="$(mktemp -d 2>/dev/null || printf '/tmp/bt32-%s' "$$")"
+mkdir -p "$_bt32_scratch"
+(
+  cd "$_bt32_scratch" || exit 1
+  mkdir -p .uberdev/runs/20260301-100000-deadbeef
+  printf '{"pr":1234}\n' > .uberdev/runs/20260301-100000-deadbeef/review-pr-verdict.json
+)
+# Seed the solve-bg stdout log so extract_pr_num_from_log resolves issue→PR.
+printf 'some preamble\npushed PR #1234\nmore lines\n' > "$UBERDEV_TMPDIR/solve-bg-stdout-555.log"
+_bt32_audit="$(cd "$_bt32_scratch" && uberdev_goal_locate_review_pr_audit 555)"
+assert_eq "$_bt32_audit" ".uberdev/runs/20260301-100000-deadbeef/review-pr-verdict.json" \
+  "BT32.issue-keyed-locator-still-works"
+rm -rf "$_bt32_scratch" 2>/dev/null || true
+
 # Cleanup: remove the isolated tmpdir contents (we created the whole
 # directory via mktemp -d, so we can rm -rf safely — it's our own).
 rm -rf "$_b12_tmpdir/goal-test-bt3"* 2>/dev/null || true
+rm -rf "$_b12_tmpdir/goal-test-bt24"* 2>/dev/null || true
+rm -rf "$_b12_tmpdir/goal-test-bt25"* 2>/dev/null || true
+rm -rf "$_b12_tmpdir/goal-test-bt28"* 2>/dev/null || true
+rm -rf "$_b12_tmpdir/goal-test-bt29"* 2>/dev/null || true
+rm -rf "$_b12_tmpdir/goal-test-bt30"* 2>/dev/null || true
+rm -rf "$_b12_tmpdir/goal-test-bt31"* 2>/dev/null || true
 rm -f "$_b12_tmpdir"/goal-bt5-*-merge-attempts.tsv 2>/dev/null || true
 rm -rf "$_b12_tmpdir" 2>/dev/null || true
 

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -1364,6 +1364,154 @@ assert_eq "$_bt32_audit" ".uberdev/runs/20260301-100000-deadbeef/review-pr-verdi
   "BT32.issue-keyed-locator-still-works"
 rm -rf "$_bt32_scratch" 2>/dev/null || true
 
+# BT33 — stale|missing arm of the step 2e poll loop MUST be a no-op: held
+# state unchanged AND the new audit path NOT consumed. Locks the B1 fix
+# from #159 post-impl-review (the previous SKILL.md ordering had an
+# unconditional record_held_audit AFTER the case statement, so a transient
+# undecidable audit overwrote the baseline and the next poll's
+# `[ "$new_audit" = "$last_audit" ] && continue` short-circuited forever).
+#
+# Setup uses a `stale`-shaped new audit (well-formed JSON with .pr present
+# so the by_pr locator selects it, but .phases.phase2_5 absent so
+# read_trust_signal returns `stale`). This is the realistic transient
+# shape — a /review-pr run that wrote the top-level JSON envelope but
+# hadn't yet flushed the phase2_5 sub-tree, or a legacy pre-v0.26.0 audit
+# that predates the trust-signal contract. The case statement folds
+# `stale|missing` into a single arm, so this covers both.
+_bt33_scratch="$(mktemp -d 2>/dev/null || printf '/tmp/bt33-%s' "$$")"
+mkdir -p "$_bt33_scratch"
+uberdev_goal_state_init test-bt33
+UBERDEV_GOAL_ID=test-bt33 uberdev_goal_pr_state_transition test-bt33 802 pushed-reviewing yellow-held >/dev/null 2>&1
+# Baseline: the audit recorded when the PR first entered held state.
+(
+  cd "$_bt33_scratch" || exit 1
+  mkdir -p .uberdev/runs/20260203-120000-cccccccc
+  cat > .uberdev/runs/20260203-120000-cccccccc/review-pr-verdict.json <<'EOF'
+{"pr":802,"phases":{"phase2_5":{"by_severity":{"blocker":0,"critical":1},"halted":false}}}
+EOF
+)
+_bt33_baseline="$(cd "$_bt33_scratch" && uberdev_goal_locate_review_pr_audit_by_pr 802)"
+uberdev_goal_record_held_audit test-bt33 802 "$_bt33_baseline"
+assert_eq "$(uberdev_goal_get_last_held_audit test-bt33 802)" "$_bt33_baseline" \
+  "BT33.baseline-audit-recorded"
+
+# A NEWER audit appears that is locatable (well-formed JSON with .pr field)
+# but undecidable (no phase2_5 sub-tree yet — partial flush / legacy shape).
+# read_trust_signal MUST return `stale` for this payload.
+(
+  cd "$_bt33_scratch" || exit 1
+  mkdir -p .uberdev/runs/20260204-130000-dddddddd
+  cat > .uberdev/runs/20260204-130000-dddddddd/review-pr-verdict.json <<'EOF'
+{"pr":802,"phases":{}}
+EOF
+)
+_bt33_new_audit="$(cd "$_bt33_scratch" && uberdev_goal_locate_review_pr_audit_by_pr 802)"
+assert_eq "$_bt33_new_audit" \
+  ".uberdev/runs/20260204-130000-dddddddd/review-pr-verdict.json" \
+  "BT33.new-audit-locatable"
+_bt33_signal="$(cd "$_bt33_scratch" && uberdev_goal_read_trust_signal "$_bt33_new_audit" 2>/dev/null)"
+assert_eq "$_bt33_signal" "stale" "BT33.undecidable-audit-emits-stale"
+
+# Simulate the step 2e logic: new_audit != last_audit (so the early
+# `continue` guard does not fire), signal is `missing`, so the case
+# falls into the stale|missing arm — which MUST NOT record the audit
+# and MUST NOT transition state.
+_bt33_last_seen_before="$(uberdev_goal_get_last_held_audit test-bt33 802)"
+_bt33_state_before="$(uberdev_goal_get_pr_state test-bt33 802)"
+case "$_bt33_signal" in
+  green|yellow|red)
+    # Would record + transition — BT33 must not reach this arm.
+    uberdev_goal_record_held_audit test-bt33 802 "$_bt33_new_audit"
+    ;;
+  stale|missing)
+    : # no-op (the fix from B1)
+    ;;
+esac
+assert_eq "$(uberdev_goal_get_pr_state test-bt33 802)" "$_bt33_state_before" \
+  "BT33.held-state-unchanged-on-missing"
+assert_eq "$(uberdev_goal_get_last_held_audit test-bt33 802)" "$_bt33_last_seen_before" \
+  "BT33.last-held-audit-preserved-on-missing"
+assert_eq "$(uberdev_goal_get_last_held_audit test-bt33 802)" "$_bt33_baseline" \
+  "BT33.baseline-still-points-at-original-audit"
+rm -rf "$_bt33_scratch" 2>/dev/null || true
+
+# BT34 — same-severity re-review MUST be a no-op: held state unchanged AND
+# no goal_pr_transition event appended to the goal jsonl for this PR. Locks
+# the `if [ "$held_current" = ... ]` guards inside the yellow and red arms
+# of step 2e (a future refactor that drops those guards would silently
+# apply a duplicate yellow-held→yellow-held transition).
+_bt34_scratch="$(mktemp -d 2>/dev/null || printf '/tmp/bt34-%s' "$$")"
+mkdir -p "$_bt34_scratch"
+uberdev_goal_state_init test-bt34
+UBERDEV_GOAL_ID=test-bt34 uberdev_goal_pr_state_transition test-bt34 803 pushed-reviewing yellow-held >/dev/null 2>&1
+# Baseline: the audit that put PR 803 into yellow-held.
+(
+  cd "$_bt34_scratch" || exit 1
+  mkdir -p .uberdev/runs/20260205-140000-eeeeeeee
+  cat > .uberdev/runs/20260205-140000-eeeeeeee/review-pr-verdict.json <<'EOF'
+{"pr":803,"phases":{"phase2_5":{"by_severity":{"blocker":0,"critical":1},"halted":false}}}
+EOF
+)
+_bt34_baseline="$(cd "$_bt34_scratch" && uberdev_goal_locate_review_pr_audit_by_pr 803)"
+uberdev_goal_record_held_audit test-bt34 803 "$_bt34_baseline"
+
+# Snapshot the goal jsonl line count BEFORE the same-severity poll so we
+# can assert NO new goal_pr_transition was appended for PR 803.
+_bt34_jsonl="$UBERDEV_TMPDIR/goal-test-bt34.jsonl"
+_bt34_transitions_before=$(grep -c '"event":"goal_pr_transition".*"pr":803' "$_bt34_jsonl" 2>/dev/null || printf '0')
+
+# A NEWER audit appears, signal STILL yellow (same severity as held).
+(
+  cd "$_bt34_scratch" || exit 1
+  mkdir -p .uberdev/runs/20260206-150000-ffffffff
+  cat > .uberdev/runs/20260206-150000-ffffffff/review-pr-verdict.json <<'EOF'
+{"pr":803,"phases":{"phase2_5":{"by_severity":{"blocker":0,"critical":2},"halted":false}}}
+EOF
+)
+_bt34_new_audit="$(cd "$_bt34_scratch" && uberdev_goal_locate_review_pr_audit_by_pr 803)"
+_bt34_signal="$(cd "$_bt34_scratch" && uberdev_goal_read_trust_signal "$_bt34_new_audit")"
+assert_eq "$_bt34_signal" "yellow" "BT34.new-audit-still-yellow"
+
+# Simulate the step 2e logic: signal is yellow, held_current is yellow-held,
+# so the `if [ "$held_current" = "red-held" ]` guard inside the yellow arm
+# is FALSE → no transition. The record_held_audit IS called (the audit was
+# readable + decided) — that's the same-audit-skips-next-poll lock from BT28.
+_bt34_held_current="$(uberdev_goal_get_pr_state test-bt34 803)"
+case "$_bt34_signal" in
+  green)
+    UBERDEV_GOAL_ID=test-bt34 uberdev_goal_pr_state_transition test-bt34 803 "$_bt34_held_current" green >/dev/null 2>&1
+    uberdev_goal_record_held_audit test-bt34 803 "$_bt34_new_audit"
+    ;;
+  yellow)
+    if [ "$_bt34_held_current" = "red-held" ]; then
+      UBERDEV_GOAL_ID=test-bt34 uberdev_goal_pr_state_transition test-bt34 803 red-held yellow-held >/dev/null 2>&1
+    fi
+    uberdev_goal_record_held_audit test-bt34 803 "$_bt34_new_audit"
+    ;;
+  red)
+    if [ "$_bt34_held_current" = "yellow-held" ]; then
+      UBERDEV_GOAL_ID=test-bt34 uberdev_goal_pr_state_transition test-bt34 803 yellow-held red-held >/dev/null 2>&1
+    fi
+    uberdev_goal_record_held_audit test-bt34 803 "$_bt34_new_audit"
+    ;;
+esac
+
+assert_eq "$(uberdev_goal_get_pr_state test-bt34 803)" "yellow-held" \
+  "BT34.held-state-unchanged-on-same-severity"
+_bt34_transitions_after=$(grep -c '"event":"goal_pr_transition".*"pr":803' "$_bt34_jsonl" 2>/dev/null || printf '0')
+# Initial pushed-reviewing→yellow-held transition counts as 1; the same-
+# severity poll must NOT emit a second one.
+if [ "$_bt34_transitions_after" = "$_bt34_transitions_before" ]; then
+  PASS=$((PASS + 1))
+  printf '  PASS  %s\n' "BT34.no-transition-event-on-same-severity"
+else
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "BT34.no-transition-event-on-same-severity" >&2
+  printf '        transitions before: %s\n' "$_bt34_transitions_before" >&2
+  printf '        transitions after:  %s\n' "$_bt34_transitions_after" >&2
+fi
+rm -rf "$_bt34_scratch" 2>/dev/null || true
+
 # Cleanup: remove the isolated tmpdir contents (we created the whole
 # directory via mktemp -d, so we can rm -rf safely — it's our own).
 rm -rf "$_b12_tmpdir/goal-test-bt3"* 2>/dev/null || true
@@ -1373,6 +1521,8 @@ rm -rf "$_b12_tmpdir/goal-test-bt28"* 2>/dev/null || true
 rm -rf "$_b12_tmpdir/goal-test-bt29"* 2>/dev/null || true
 rm -rf "$_b12_tmpdir/goal-test-bt30"* 2>/dev/null || true
 rm -rf "$_b12_tmpdir/goal-test-bt31"* 2>/dev/null || true
+rm -rf "$_b12_tmpdir/goal-test-bt33"* 2>/dev/null || true
+rm -rf "$_b12_tmpdir/goal-test-bt34"* 2>/dev/null || true
 rm -f "$_b12_tmpdir"/goal-bt5-*-merge-attempts.tsv 2>/dev/null || true
 rm -rf "$_b12_tmpdir" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

PR #129 shipped RFC 0005 §3.2.3 hold-and-unblock with only the **dispatch** half wired — `_uberdev_goal_check_unblock` posted `/uberdev:review-pr` re-reviews fire-and-forget, and no phase polled the held PR's audit JSON or transitioned out of `*-held`. Held PRs were permanently orphaned. Compounding that, the Phase 3 convergence check counted only `{merged, merge-failed}` as terminal, so a queue that drained to held-only PRs spun Phase 1 → 2 → 3 until either the 4h `stuck_loop` fired or `gh issue list` rate-limited the run.

This stacked PR (based on PR #129's branch — `worktree-solve-issue-128`) lands both fixes as one cohesive change because the held-PR poll loop (#159) is the mechanism that lets the held-as-terminal classification (#160) work without losing the optimistic exit path.

## What changes

- **New Phase 2 step 2e** — held-PR re-review poll loop inside the existing Phase 2 (no 6th phase per RFC 0005 §1). Each iteration walks every PR in `yellow-held` / `red-held`, locates the latest `/review-pr` audit JSON via the new PR-keyed `uberdev_goal_locate_review_pr_audit_by_pr`, compares against the last-consumed audit (`uberdev_goal_get_last_held_audit`), and on a different path applies the next transition based on the new trust signal:
  - green → `green` (eligible for merge in next cycle's step 2b)
  - severity flip → `yellow-held ↔ red-held` cross-held re-classification
  - same severity / stale / missing → no transition
- **Step 2a now records the initial audit baseline** when a PR transitions to held, so the first re-review is correctly detected as a new audit.
- **PR state machine arcs `yellow-held → red-held` and `red-held → yellow-held`** added (`_uberdev_goal_pr_state_machine_valid`). D17-forbidden `*-held → merging` arcs remain forbidden.
- **Phase 3 convergence terminal set** now includes `yellow-held` and `red-held` as pseudo-terminal — `print_summary` already surfaces them to the operator. A goal with only held PRs remaining converges cleanly instead of spinning until `stuck_loop`.
- **New `queue_empty_not_converged` circuit-breaker reason** — deterministic Phase 3 halt when `new_candidates` is empty but at least one PR is in a non-terminal in-flight state (`dispatched`, `pushed-reviewing`, `green` not yet merged, `merging`). Pre-empts the 4h `stuck_loop` fallback.
- **Four new public helpers in `lib/goal-state.sh`** — `_locate_review_pr_audit_by_pr` (the existing locator now delegates to it after issue→PR resolution; no duplication), `_get_pr_state`, `_record_held_audit`, `_get_last_held_audit`. New `held-audits.tsv` per-goal file truncate-created by `_state_init`.

## Test plan

- [x] BT24-BT32 behavioural tests in `tests/goal.test.sh` — new helpers round-trip, new state machine arcs, end-to-end held-poll integration (init → record → re-review → poll → transition), issue-keyed locator-refactor regression guard, `held-audits.tsv` init contract
- [x] Shape tests G21 (held-PR poll loop wiring in SKILL.md) and G22 (`queue_empty_not_converged` literal + held-as-terminal classification)
- [x] G19 expanded to assert the 4 new public helpers exist
- [x] `bash tests/goal.test.sh` — 218 passed, 0 failed
- [x] Full bash CI test list (turbo-flow, issue-causal-fanout, post-impl-review, testers-pipeline, spec-reviewer-plan-aware, audit-fixups, review-pr, review-pr-phase3-ci, finish-branch-auto-chain, aliases, merge, ghostty-dispatch-no-instance-leak, dispatch-claude-bg, solve-effort-flag, solve-pipeline-zsh, orchestrator-phase1-shortcircuit, config-override, orchestrator-phase-6-doc, orchestrator-phase-0-bg-detection, dev, dev-pipeline, solve-claim, dispatch-fallback, dispatch-background, dispatch-wezterm) — all green

## Notes

- Stacked on PR #129 (`worktree-solve-issue-128`), not `main`. The `Closes #159` / `Closes #160` keywords will fire when this PR is merged into PR #129's branch, then again transitively when PR #129 lands on `main`.
- CI on this PR will report `no checks` because `.github/workflows/test.yml` only triggers on PRs to `main`. That is expected; `/review-pr` Phase 3 maps `no checks` to `skip_no_checks` (GREEN-eligible).
- No new audit events were added — the new state transitions emit the existing `goal_pr_transition` event; the new halt emits the existing `goal_circuit_breaker` event with the new reason.

Closes #159
Closes #160