### PR TITLE
fix(review-pr): provision trust label before --add-label (v0.33.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.33.1",
+      "version": "0.33.2",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.2] - 2026-05-22
+
+### Fixed
+- **`/uberdev:review-pr` now provisions the trust label before adding it (#170).** GREEN/YELLOW runs add `uberdev-approved` / `uberdev-approved-with-concerns` via `gh pr edit --add-label`, which CANNOT auto-create a repo label and exits non-zero when it is missing — so on a fresh repo (or any repo where the trust labels were never created) the first GREEN/YELLOW run aborted the entire trust-signal emission with `exit 2`. Each label is now provisioned fail-loud via `gh label create --force` (idempotent — updates colour/description, never errors on "already exists") with a per-tier colour/description immediately before the add. Same assume-label-exists class as #168; surfaced by PR #169. Regression-tested in `tests/review-pr.test.sh` (R9.16/R9.16b). Closes #170.
+
 ## [0.33.1] - 2026-05-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.33.1-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.33.2-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/review-pr.md
+++ b/plugins/uberdev/commands/review-pr.md
@@ -840,12 +840,16 @@ The remainder of this section describes the GREEN/YELLOW emission shape (RED ski
 
    The anchor commit goes through pre-commit hooks normally — never `--no-verify`. Author = current `git config user.email` / `user.name`; the trailer is procedural attribution to the `/review-pr` command. Per global CLAUDE.md, the anchor commit MUST NOT include a `Co-Authored-By: Claude` trailer or any `🤖 Generated with Claude Code` footer. The trailer payload (`Reviewed-by: uberdev/review-pr@<40-hex>`) is the only trailer in the body. Verify with `git log -1 --format=%B | grep -E '^Reviewed-by: uberdev/review-pr@[a-f0-9]{40}$'` before proceeding to artifact 2.
 
-2. **Label** — tier-aware. GREEN runs add `uberdev-approved` (canonical literal — see `skills/merge-pipeline/SKILL.md` Constants `UBERDEV_APPROVED_LABEL`). YELLOW runs add `uberdev-approved-with-concerns` (RFC 0002 §3.4). Both forms are idempotent — `gh` no-ops if the label is already present.
+2. **Label** — tier-aware. GREEN runs add `uberdev-approved` (canonical literal — see `skills/merge-pipeline/SKILL.md` Constants `UBERDEV_APPROVED_LABEL`). YELLOW runs add `uberdev-approved-with-concerns` (RFC 0002 §3.4). Each label is **provisioned fail-loud via `gh label create --force` immediately before the add** (issue #170 — `gh pr edit --add-label` CANNOT auto-create a repo label and exits non-zero when the label is missing, which on a fresh repo aborts the whole trust-signal emission; same assume-label-exists class as #168). `--force` is idempotent: it updates an existing label's colour/description and never errors on "already exists", so a non-zero `gh label create` exit is always a genuine failure (auth / repo write-or-triage scope / API). Adding the label to the PR is itself idempotent — `gh` no-ops if the label is already on the PR.
 
    ```bash
    case "$TRUST_TRAIL_STATE" in
-     GREEN)  TRUST_LABEL="uberdev-approved" ;;
-     YELLOW) TRUST_LABEL="uberdev-approved-with-concerns" ;;
+     GREEN)  TRUST_LABEL="uberdev-approved"
+             TRUST_LABEL_COLOR="0E8A16"
+             TRUST_LABEL_DESC="Trust trail: /uberdev:review-pr verified GREEN. Auto-managed — set by /review-pr, read by /merge." ;;
+     YELLOW) TRUST_LABEL="uberdev-approved-with-concerns"
+             TRUST_LABEL_COLOR="FBCA04"
+             TRUST_LABEL_DESC="Trust trail: /uberdev:review-pr verified with deferred CRITICAL findings (YELLOW). Auto-managed — /merge requires --accept-critical-deferred." ;;
    esac
    # Belt-and-braces: clear the OPPOSITE-tier label if present, so a re-run that
    # downgrades GREEN→YELLOW (or upgrades YELLOW→GREEN) doesn't leave a stale
@@ -858,6 +862,20 @@ The remainder of this section describes the GREEN/YELLOW emission shape (RED ski
    ```
 
    ```bash
+   # Provision the trust label BEFORE adding it (#170). `gh pr edit --add-label`
+   # CANNOT auto-create a repo label and exits non-zero when it is missing — on a
+   # fresh repo (or any repo where the trust labels were never created) this
+   # aborts the whole trust-signal emission. `--force` makes this idempotent (it
+   # updates an existing label's colour/description, never errors on "already
+   # exists"), so a non-zero exit here is a genuine failure (auth / missing repo
+   # write-or-triage scope / API error). Fail-loud + exit 2 mirrors the --add-label
+   # guard below: the label is the load-bearing trust artifact /merge reads, so
+   # emission cannot proceed without it. (Same assume-label-exists class as #168,
+   # but fail-loud rather than swallowed.)
+   if ! gh label create --force "$TRUST_LABEL" --color "$TRUST_LABEL_COLOR" --description "$TRUST_LABEL_DESC"; then
+     echo "error: failed to provision the '$TRUST_LABEL' trust label (gh pr edit --add-label cannot auto-create it). Check gh auth and repo write/triage permission." >&2
+     exit 2
+   fi
    # Mirror artifact 1's push-failure guard: if `gh pr edit` exits non-zero
    # (network, auth, rate limit, label-permission denial), bash continues silently
    # and the audit JSON below gets written without the label being applied.

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -271,11 +271,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.33.1) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.1"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.1"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.1-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.1\]'        "G20.changelog"
+echo "== G20: version bump locked (0.33.2) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.2"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.2"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.2-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.2\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 echo

--- a/tests/review-pr.test.sh
+++ b/tests/review-pr.test.sh
@@ -403,6 +403,19 @@ assert_no_grep "$REVIEW_PR" \
   '^[[:space:]]*gh pr edit <N> --add-label uberdev-approved[[:space:]]*$' \
   "R9.15 — bare 'gh pr edit <N> --add-label uberdev-approved' (unguarded, EOL-anchored, recipe form) is not present"
 
+# R9.16 (#170) — trust-label provisioning. `gh pr edit --add-label` CANNOT
+# auto-create a repo label and exits non-zero when it is missing, so on a fresh
+# repo the GREEN/YELLOW trust-signal emission aborts at the --add-label (exit 2).
+# The fix provisions $TRUST_LABEL via a fail-loud `gh label create --force`
+# immediately before the add (same assume-label-exists class as #168). Assert
+# the fail-loud provisioning is present AND the per-tier colour is set.
+assert_grep "$REVIEW_PR" \
+  'if ! gh label create --force "\$TRUST_LABEL" --color "\$TRUST_LABEL_COLOR"' \
+  "R9.16 (#170) — trust label provisioned fail-loud via gh label create --force before --add-label"
+assert_grep "$REVIEW_PR" \
+  'TRUST_LABEL_COLOR="0E8A16"' \
+  "R9.16b (#170) — per-tier TRUST_LABEL_COLOR set in the TRUST_LABEL case (GREEN=0E8A16)"
+
 echo
 echo "== R10 (#73): Sequential argument honored — env-var export + stderr notice =="
 

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.0 -> 0.33.1 propagated =="
+echo "== Version bump 0.33.1 -> 0.33.2 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.33.1"' \
-  "plugin.json bumped to 0.33.1"
+  '"version": "0.33.2"' \
+  "plugin.json bumped to 0.33.2"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.33.1"' \
-  "marketplace.json bumped to 0.33.1"
+  '"version": "0.33.2"' \
+  "marketplace.json bumped to 0.33.2"
 assert_grep "$README" \
-  "version-0\\.33\\.1-blue" \
-  "README version badge bumped to 0.33.1"
+  "version-0\\.33\\.2-blue" \
+  "README version badge bumped to 0.33.2"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.33\.1\]' \
-  "CHANGELOG has [0.33.1] section header"
+  '^## \[0\.33\.2\]' \
+  "CHANGELOG has [0.33.2] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary
`/uberdev:review-pr`'s GREEN/YELLOW trust-signal emission adds `uberdev-approved` / `uberdev-approved-with-concerns` via `gh pr edit --add-label`, which **cannot auto-create a repo label** and exits non-zero when it's missing. On a fresh repo (or any where the trust labels were never created) the first GREEN/YELLOW run aborted the whole emission with `exit 2`.

## Fix
Provision `$TRUST_LABEL` **fail-loud** via `gh label create --force` (idempotent — updates colour/description, never errors on "already exists") with a per-tier colour/description immediately before the `--add-label`. Same assume-label-exists class as #168, but fail-loud rather than swallowed. Surfaced by PR #169's own GREEN emission.

## Tests
`tests/review-pr.test.sh` R9.16 (fail-loud `gh label create --force "$TRUST_LABEL"` present) + R9.16b (per-tier colour set). Full suite green; goal 289/0, solve-claim 104/0.

## Release
v0.33.2 across all 8 version locations.

Closes #170.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing the review-pr command from working on fresh repositories. Trust labels are now provisioned before being added to pull requests.

* **Chores**
  * Version bumped to 0.33.2 and documentation updated accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->