### PR TITLE
docs(aliases): align stale alias enumerations with installed set (v0.33.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.33.3",
+      "version": "0.33.4",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.4] - 2026-05-22
+
+### Fixed
+- **Aligned the stale alias enumerations in `skills/using-uberdev/SKILL.md` with the installed set (#162).** The "Auto-installed aliases" line said "**six** … (`/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr`, `/merge`)" — missing `/dev`, `/testers`, `/ubergoal`, `/uberscan`, `/ubersimplify` (the set has grown to **eleven**); now lists all eleven. The `auto_install_aliases` config-example comment was de-enumerated (points at `aliases-sync.sh` as the canonical set) to stop it drifting again. `aliases-sync.sh` and the README already listed eleven. Docs-only; no behaviour change. Closes #162.
+
 ## [0.33.3] - 2026-05-22
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.33.3-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.33.4-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.33.3",
+  "version": "0.33.4",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/skills/using-uberdev/SKILL.md
+++ b/plugins/uberdev/skills/using-uberdev/SKILL.md
@@ -125,7 +125,7 @@ UberDev reads optional config from `.claude/uberdev.local.md` in your project ro
 solve_tier_default: small        # one of: small, medium, large
 review_depth: full               # one of: quick, full
 parallel_solve: true
-auto_install_aliases: true       # boolean — auto-install /issue, /solve, /turbo, /simplify, /review-pr, /merge at SessionStart (default: true; env override: UBERDEV_NO_AUTO_ALIAS=1)
+auto_install_aliases: true       # boolean — auto-install the short-form aliases (see aliases-sync.sh for the canonical set) at SessionStart (default: true; env override: UBERDEV_NO_AUTO_ALIAS=1)
 integration_branch: main         # branch /merge lands PRs into; default = repo default branch
 dispatch_backend: auto           # one of: auto, claude-bg, wezterm, background — how /solve & /turbo dispatch per-issue agents (RFC 0004); default auto (platform-aware); env override: UBERDEV_DISPATCH_BACKEND
 auto_review_on_merge: false      # boolean — when true, /merge Phase 1.4 auto-dispatches /review-pr <N> --turbo once per PR with missing trust trail (whitelisted reasons only); default false; env override: UBERDEV_AUTO_REVIEW_ON_MERGE (#89)
@@ -160,7 +160,7 @@ command_timeouts:
 
 Settings take effect on next SessionStart. Environment variables (`UBERDEV_FANOUT_SOLVE_BG`, `SOLVE_AUTO`, etc.) override file settings — use whichever is more convenient for your workflow.
 
-**Auto-installed aliases:** UberDev's SessionStart hook installs six top-level forwarder commands (`/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr`, `/merge`) into `~/.claude/commands/` on first session and refreshes them on plugin upgrade. Hand-authored files at any of those paths are preserved (the hook detects them via a `managed-by: uberdev-aliases` marker and skips). Disable per-project with `auto_install_aliases: false` or globally with `UBERDEV_NO_AUTO_ALIAS=1`. Remove already-installed forwarders with `/uberdev:uninstall-aliases`.
+**Auto-installed aliases:** UberDev's SessionStart hook installs eleven top-level forwarder commands (`/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr`, `/merge`, `/dev`, `/testers`, `/ubergoal`, `/uberscan`, `/ubersimplify`) into `~/.claude/commands/` on first session and refreshes them on plugin upgrade. Hand-authored files at any of those paths are preserved (the hook detects them via a `managed-by: uberdev-aliases` marker and skips). Disable per-project with `auto_install_aliases: false` or globally with `UBERDEV_NO_AUTO_ALIAS=1`. Remove already-installed forwarders with `/uberdev:uninstall-aliases`.
 
 **`integration_branch` precedence:** CLI flag `--integration-branch=<name>` > env var `UBERDEV_INTEGRATION_BRANCH` > config file (this YAML) > `gh repo view --json defaultBranchRef`. If all four tiers are empty, `/merge` falls back to the literal `main` and emits a one-line stderr warning — it does NOT prompt (autopilot is unconditional).
 

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -271,11 +271,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.33.3) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.3"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.3"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.3-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.3\]'        "G20.changelog"
+echo "== G20: version bump locked (0.33.4) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.4"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.4"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.4-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.4\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 echo

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.2 -> 0.33.3 propagated =="
+echo "== Version bump 0.33.3 -> 0.33.4 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.33.3"' \
-  "plugin.json bumped to 0.33.3"
+  '"version": "0.33.4"' \
+  "plugin.json bumped to 0.33.4"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.33.3"' \
-  "marketplace.json bumped to 0.33.3"
+  '"version": "0.33.4"' \
+  "marketplace.json bumped to 0.33.4"
 assert_grep "$README" \
-  "version-0\\.33\\.3-blue" \
-  "README version badge bumped to 0.33.3"
+  "version-0\\.33\\.4-blue" \
+  "README version badge bumped to 0.33.4"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.33\.3\]' \
-  "CHANGELOG has [0.33.3] section header"
+  '^## \[0\.33\.4\]' \
+  "CHANGELOG has [0.33.4] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
Aligns the stale alias enumerations in `skills/using-uberdev/SKILL.md` with the installed set: the "Auto-installed aliases" line said **six** (`/issue`…`/merge`), missing `/dev`, `/testers`, `/ubergoal`, `/uberscan`, `/ubersimplify` — now lists all **eleven**. The `auto_install_aliases` config comment is de-enumerated (points at `aliases-sync.sh`) to stop future drift. `aliases-sync.sh` + README already listed eleven. Docs-only, no behaviour change. v0.33.4. Closes #162.