### PR TITLE
fix(dispatch): extract uberdev_dispatch_resolve_env SSOT helper (fixes /goal rc=126)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.33.5",
+      "version": "0.33.6",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.6] - 2026-05-22
+
+### Fixed
+- **`/goal` first-dispatch crash (rc=126).** Extracted the six dispatch-env vars (`TIMEOUT_BIN`, `SOLVE_TIMEOUT`, `MODEL`, `PERM_FLAG`, `EFFORT_FLAG`, `BG_PROMPT_MODE`) from solve-pipeline Phase A into a shared sourced helper `uberdev_dispatch_resolve_env()` in `lib/dispatch.sh`, now called by both solve-pipeline and goal-pipeline. goal-pipeline previously sourced `lib/dispatch.sh` and called `uberdev_dispatch_preflight` (backend only) but never established the env vars, so its first `uberdev_dispatch_one` exec'd an empty `$TIMEOUT_BIN` and failed with `permission denied` (rc=126). The helper mirrors `/turbo`'s unattended dispatch env (`AUTO_MODE=1`, `AUTO_PERMISSIONS=0`, `EFFORT_LEVEL=max`) and preserves the verbatim fail-loud `timeout(1)`/`gtimeout(1)` probe guard. Backend resolution (`UBERDEV_RESOLVED_BACKEND`) is unchanged (RFC 0005 D15). (#175)
+
 ## [0.33.5] - 2026-05-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.33.5-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.33.6-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/lib/dispatch.sh
+++ b/plugins/uberdev/lib/dispatch.sh
@@ -5,12 +5,14 @@
 #
 # Public surface (functions):
 #   uberdev_dispatch_preflight                       -> resolves auto -> concrete backend
+#   uberdev_dispatch_resolve_env                      -> sets the 6 dispatch-env vars; call after preflight
 #   uberdev_dispatch_one  ISSUE_NUM TIER PROMPT_FILE  -> dispatch one issue
 # Internal:
 #   _uberdev_dispatch_claude_bg / _uberdev_dispatch_wezterm / _uberdev_dispatch_background
 #
 # Sourced by:
 #   - skills/solve-pipeline/SKILL.md Step 5b'
+#   - skills/goal-pipeline/SKILL.md Phase 0
 #   - tests/dispatch-claude-bg.test.sh, dispatch-fallback.test.sh,
 #     dispatch-background.test.sh, dispatch-wezterm.test.sh
 #
@@ -187,8 +189,9 @@ uberdev_dispatch_resolve_env() {
     SOLVE_TIMEOUT=3600
   fi
 
-  # TIMEOUT_BIN probe (RFC 0004 §3.8 order — MSYS coreutils absolute path FIRST,
-  # then Unix `timeout`, then macOS Homebrew `gtimeout`). MOVED VERBATIM.
+  # TIMEOUT_BIN probe (RFC 0004 §3.8 order — absolute /usr/bin/timeout FIRST
+  # (MSYS coreutils on Windows, and Linux distros that ship it there),
+  # then Unix `timeout` on PATH, then macOS Homebrew `gtimeout`).
   TIMEOUT_BIN=""
   if   [ -x /usr/bin/timeout ];                 then TIMEOUT_BIN=/usr/bin/timeout
   elif command -v timeout  >/dev/null 2>&1;     then TIMEOUT_BIN=timeout

--- a/plugins/uberdev/lib/dispatch.sh
+++ b/plugins/uberdev/lib/dispatch.sh
@@ -139,6 +139,75 @@ uberdev_dispatch_preflight() {
   return 0
 }
 
+# ---------------------------------------------------------------------------
+# uberdev_dispatch_resolve_env
+# Resolves the six deterministic dispatch-env vars consumed by every backend:
+#   BG_PROMPT_MODE, MODEL, PERM_FLAG[], EFFORT_FLAG[], SOLVE_TIMEOUT, TIMEOUT_BIN.
+# SSOT for both solve-pipeline (replaces its inline Phase A block) and
+# goal-pipeline (Phase 0). Sourced, NEVER exec'd — PERM_FLAG/EFFORT_FLAG are
+# bash arrays that cannot survive an env(1)/fork+exec boundary, so they must be
+# set in the caller's shell scope. Idempotent: deterministic scalars, arrays
+# rebuilt each call. Returns 1 (fail-loud) when no timeout(1)/gtimeout(1) is on
+# PATH. Does NOT read or write UBERDEV_RESOLVED_BACKEND (that is preflight's;
+# RFC 0005 D15 constrains backend resolution only — env resolution is exempt).
+# Inputs (read with safe defaults so goal-pipeline, which has no arg-parser,
+# can call it): AUTO_PERMISSIONS (default 0), EFFORT_LEVEL (default max).
+uberdev_dispatch_resolve_env() {
+  # BG_PROMPT_MODE: hardcoded `argv` (claude --bg 2.1.139 has no documented
+  # --prompt-file / stdin form; the file/stdin arms in _uberdev_dispatch_claude_bg
+  # remain a pre-wired migration target, unexercised at runtime).
+  BG_PROMPT_MODE=argv
+
+  # MODEL: single-quoted to keep zsh from glob-evaluating [1m] under NOMATCH.
+  MODEL='claude-opus-4-7[1m]'
+
+  # PERM_FLAG: array form (zsh SH_WORD_SPLIT=off would treat a scalar at command
+  # position as one argv slot). Empty by default; populated only when the caller
+  # opted into --permission-mode auto via AUTO_PERMISSIONS=1.
+  AUTO_PERMISSIONS="${AUTO_PERMISSIONS:-0}"
+  PERM_FLAG=()
+  [[ "$AUTO_PERMISSIONS" == "1" ]] && PERM_FLAG=( --permission-mode auto )
+
+  # EFFORT_FLAG: threaded form of EFFORT_LEVEL (default max for callers without
+  # an --effort parser, e.g. goal-pipeline). Bash+zsh array.
+  EFFORT_LEVEL="${EFFORT_LEVEL:-max}"
+  EFFORT_FLAG=( --effort "$EFFORT_LEVEL" )
+
+  # Wall-clock timeout: read command_timeouts.solve (env override
+  # UBERDEV_SOLVE_TIMEOUT; default 3600s; range [60, 86400]). Guard with
+  # `command -v` so this block is independently sourceable.
+  if command -v uberdev_read_int_in_range >/dev/null 2>&1; then
+    SOLVE_TIMEOUT="$(uberdev_read_int_in_range command_timeouts.solve UBERDEV_SOLVE_TIMEOUT 60 86400 3600)"
+  elif [ -r "${CLAUDE_PLUGIN_ROOT:-}/lib/config-read.sh" ]; then
+    # shellcheck source=/dev/null
+    . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
+    SOLVE_TIMEOUT="$(uberdev_read_int_in_range command_timeouts.solve UBERDEV_SOLVE_TIMEOUT 60 86400 3600)"
+  else
+    echo "warning: config-read.sh not found at ${CLAUDE_PLUGIN_ROOT:-}/lib/; uberdev.local.md timeout settings ignored" >&2
+    SOLVE_TIMEOUT=3600
+  fi
+
+  # TIMEOUT_BIN probe (RFC 0004 §3.8 order — MSYS coreutils absolute path FIRST,
+  # then Unix `timeout`, then macOS Homebrew `gtimeout`). MOVED VERBATIM.
+  TIMEOUT_BIN=""
+  if   [ -x /usr/bin/timeout ];                 then TIMEOUT_BIN=/usr/bin/timeout
+  elif command -v timeout  >/dev/null 2>&1;     then TIMEOUT_BIN=timeout
+  elif command -v gtimeout >/dev/null 2>&1;     then TIMEOUT_BIN=gtimeout
+  fi
+
+  # Runtime guard: fail-loud if neither timeout(1) nor gtimeout(1) is on PATH.
+  # Regression guard: tests/config-override.test.sh I2f anchors on this
+  # `if [[ -n "$TIMEOUT_BIN" ]]; then` pattern; do not collapse to `[[ … ]] ||`.
+  if [[ -n "$TIMEOUT_BIN" ]]; then
+    : # timeout(1) or gtimeout(1) available; bg dispatch arms wrap correctly
+  else
+    echo "error: neither timeout(1) nor gtimeout(1) found on PATH" >&2
+    echo "       install with: brew install coreutils  # provides gtimeout" >&2
+    return 1
+  fi
+  return 0
+}
+
 # uberdev_dispatch_one ISSUE_NUM TIER PROMPT_FILE
 # Routes one issue to the backend resolved by uberdev_dispatch_preflight.
 # Sets DISPATCH_RC + DISPATCH_ID (+ DISPATCH_LOG on failure); returns the backend's rc.

--- a/plugins/uberdev/lib/dispatch.sh
+++ b/plugins/uberdev/lib/dispatch.sh
@@ -4,7 +4,7 @@
 # SOURCED, never executed. No shebang (sourced only); .sh extension (convention).
 #
 # Public surface (functions):
-#   uberdev_dispatch_preflight                       -> resolves auto -> concrete backend
+#   uberdev_dispatch_preflight                        -> resolves auto -> concrete backend
 #   uberdev_dispatch_resolve_env                      -> sets the 6 dispatch-env vars; call after preflight
 #   uberdev_dispatch_one  ISSUE_NUM TIER PROMPT_FILE  -> dispatch one issue
 # Internal:
@@ -181,6 +181,9 @@ uberdev_dispatch_resolve_env() {
   if command -v uberdev_read_int_in_range >/dev/null 2>&1; then
     SOLVE_TIMEOUT="$(uberdev_read_int_in_range command_timeouts.solve UBERDEV_SOLVE_TIMEOUT 60 86400 3600)"
   elif [ -r "${CLAUDE_PLUGIN_ROOT:-}/lib/config-read.sh" ]; then
+    # Re-sourcing is safe even if config-read.sh was already loaded: it carries
+    # its own idempotency guard (_UBERDEV_CONFIG_READ_LOADED), so no explicit
+    # already-sourced check is needed here.
     # shellcheck source=/dev/null
     . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
     SOLVE_TIMEOUT="$(uberdev_read_int_in_range command_timeouts.solve UBERDEV_SOLVE_TIMEOUT 60 86400 3600)"

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -87,7 +87,12 @@ Notes on the enums:
    ```bash
    [ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ] && . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
    uberdev_dispatch_preflight "${backend_cli:-auto}"
-   # UBERDEV_RESOLVED_BACKEND is now exported.
+   # UBERDEV_RESOLVED_BACKEND is now exported (D15: resolved once, frozen for the run).
+   # /goal dispatches /turbo per issue, so mirror /turbo's unattended dispatch env.
+   export AUTO_MODE=1            # matches commands/turbo.md (enables UBERDEV_TURBO=1 in the bg env)
+   # AUTO_PERMISSIONS and EFFORT_LEVEL are intentionally left unset -> helper applies
+   # :-0 / :-max defaults (turbo-parity: empty PERM_FLAG, EFFORT_FLAG=( --effort max )).
+   uberdev_dispatch_resolve_env || exit 1   # establishes TIMEOUT_BIN/SOLVE_TIMEOUT/MODEL/PERM_FLAG/EFFORT_FLAG/BG_PROMPT_MODE once
    ```
 
 5. **Generate `GOAL_ID`.** Random suffix per D4 — NEVER derived from `$@` or issue numbers (those are attacker-controlled; using them would let a caller collide TMPDIR paths):

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -462,16 +462,6 @@ _uberdev_require_claude_version "2.1.139"
 # claim json, status file) lives under it. Git Bash on native Windows sets
 # TMPDIR; fall back to /tmp on Unix. Exported so lib/dispatch.sh inherits it.
 export UBERDEV_TMPDIR="${TMPDIR:-/tmp}"
-# BG_PROMPT_MODE: hardcoded `argv` because claude --bg 2.1.139 has no documented
-# --prompt-file or stdin-passthrough form (prior-art research). T6 implements the
-# bash-array argv form (spec-reviewer finding #1). A runtime probe is deferred until
-# upstream documents a passthrough flag — `claude --bg --help` is NOT introspective
-# in 2.1.139 (it spawns a real session).
-# TODO(upstream-claude-code-rfe): switch to file or stdin mode once a documented
-# --prompt-file / stdin-passthrough form ships in Claude Code (tracking the RFE
-# for safer prompt-passthrough). The file/stdin arms below remain in place as a
-# pre-wired migration target; today only the argv arm is exercised at runtime.
-BG_PROMPT_MODE=argv
 if [ -r "${CLAUDE_PLUGIN_ROOT:-}/lib/config-read.sh" ]; then
   # shellcheck source=/dev/null
   . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
@@ -480,94 +470,11 @@ else
   MAX_PARALLEL_BG_AGENTS=6
 fi
 
-# --- Phase A: hoisted from retired launcher heredoc (#85 / v0.22.0) ---
-# These four variables formerly lived inside the per-issue launcher shell
-# script that Step 5b previously wrote (the per-N temp-file form is now
-# retired). The launcher is retired in v0.22.0; the values are
-# batch-invariant, so resolve them once at Phase A entry and let the
-# inline Step 5b' dispatch (Phase B) consume them.
-
-# MODEL: single-quoted to keep zsh from glob-evaluating [1m] under NOMATCH.
-MODEL='claude-opus-4-7[1m]'
-
-# PERM_FLAG: issue bodies are remote-fetched (untrusted). Default mode gates
-# every tool use. PERM_FLAG=( --permission-mode auto ) enables Claude Code's
-# AI classifier — auto-approves safe ops (read, in-scope edits, tests, push
-# to feature branch) and soft-denies dangerous ones (force push, rm -rf on
-# pre-existing files, exfil, self-modification). Strictly safer than
-# --dangerously-skip-permissions for autonomous /solve runs.
-#
-# Array form (not scalar): zsh's default SH_WORD_SPLIT=off would treat a
-# scalar `PERM_FLAG="--permission-mode auto"` passed as unquoted `$PERM_FLAG`
-# at command position as ONE argv slot, and `claude` would reject it with
-# `error: unknown option '--permission-mode auto'`. Same zsh trap as the
-# TIMEOUT_BIN block below — but the fix shape differs by token count:
-# TIMEOUT_BIN holds a single argv[0] token and uses quoted-scalar form
-# (`"$TIMEOUT_BIN"`); PERM_FLAG/EFFORT_FLAG hold multi-token sequences and
-# need array expansion. `"${PERM_FLAG[@]}"` at the call site expands an
-# empty array to zero slots and a populated one to its elements verbatim
-# — identical behaviour in bash and zsh.
-PERM_FLAG=()
-[[ "$AUTO_PERMISSIONS" == "1" ]] && PERM_FLAG=( --permission-mode auto )
-
-# EFFORT_FLAG is the threaded form of EFFORT_LEVEL (resolved by the Phase A
-# --effort parser block above). Bash+zsh array, expanded as
-# `"${EFFORT_FLAG[@]}"` at each dispatch arm — see PERM_FLAG above for the
-# zsh-word-split rationale. Regression guard: tests/dispatch-claude-bg.test.sh
-# anchors on `^EFFORT_FLAG=\( --effort `; tests/solve-pipeline-zsh.test.sh
-# captures the dispatched argv under a real zsh subshell.
-EFFORT_FLAG=( --effort "$EFFORT_LEVEL" )
 # See `_uberdev_audit_emit` definition near the top of Phase A (anchor:
 # `^_uberdev_audit_emit\(\)`); no-op when $SOLVE_AUDIT_LOG is unset.
 _uberdev_audit_emit effort_resolved \
   "{\"source\":\"$EFFORT_SOURCE\",\"level\":\"$EFFORT_LEVEL\"}" || true
 
-# Wall-clock timeout: read command_timeouts.solve from .claude/uberdev.local.md
-# (env override: UBERDEV_SOLVE_TIMEOUT; default 3600s; range [60, 86400]).
-# config-read.sh is already sourced by the MAX_PARALLEL_BG_AGENTS block above
-# when readable, so `uberdev_read_int_in_range` is in scope here; guard with
-# `command -v` so this block is independently sourceable.
-if command -v uberdev_read_int_in_range >/dev/null 2>&1; then
-  SOLVE_TIMEOUT="$(uberdev_read_int_in_range command_timeouts.solve UBERDEV_SOLVE_TIMEOUT 60 86400 3600)"
-elif [ -r "${CLAUDE_PLUGIN_ROOT:-}/lib/config-read.sh" ]; then
-  # shellcheck source=/dev/null
-  . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
-  SOLVE_TIMEOUT="$(uberdev_read_int_in_range command_timeouts.solve UBERDEV_SOLVE_TIMEOUT 60 86400 3600)"
-else
-  echo "warning: config-read.sh not found at ${CLAUDE_PLUGIN_ROOT:-}/lib/; uberdev.local.md timeout settings ignored" >&2
-  SOLVE_TIMEOUT=3600
-fi
-
-# Wrap claude in timeout(1)/gtimeout when one is on PATH; fail-open otherwise
-# (graceful degradation when required tooling is unavailable). macOS does NOT
-# ship GNU timeout; `brew install coreutils` installs it as `gtimeout` (Homebrew
-# `g`-prefix), so we probe both. The if/elif/else form is mandatory: zsh's
-# default SH_WORD_SPLIT=off would treat a scalar `$PREFIX="timeout 3600"` at
-# command position as ONE token and abort with "command not found: timeout 3600"
-# under set -e. Quoting "$TIMEOUT_BIN" keeps it as a single argv[0] token.
-# Probe order (RFC 0004 §3.8): the explicit MSYS coreutils path FIRST, so on
-# native Windows Git Bash we get coreutils `timeout` and never resolve a bare
-# `timeout` to C:\Windows\System32\timeout.exe (an incompatible command that
-# takes /T /NOBREAK, not a duration+command). Then the Unix `timeout`, then
-# macOS's Homebrew `gtimeout`.
-TIMEOUT_BIN=""
-if   [ -x /usr/bin/timeout ];                 then TIMEOUT_BIN=/usr/bin/timeout
-elif command -v timeout  >/dev/null 2>&1;     then TIMEOUT_BIN=timeout
-elif command -v gtimeout >/dev/null 2>&1;     then TIMEOUT_BIN=gtimeout
-fi
-
-# Runtime guard: if neither timeout(1) nor gtimeout(1) is on PATH, the
-# bg dispatch below will pass empty wrap args to claude --bg, failing
-# silently. Detect and abort with an actionable install pointer.
-# Regression guard: tests/config-override.test.sh I2f anchors on this
-# `if [[ -n "$TIMEOUT_BIN" ]]; then` pattern; do not collapse to `[[ … ]] ||`.
-if [[ -n "$TIMEOUT_BIN" ]]; then
-  : # timeout(1) or gtimeout(1) available; bg dispatch arms wrap correctly
-else
-  echo "error: neither timeout(1) nor gtimeout(1) found on PATH" >&2
-  echo "       install with: brew install coreutils  # provides gtimeout" >&2
-  exit 1
-fi
 # --- Phase A: dispatch preflight + Windows guards (NEW v0.29.0 — RFC 0004) ---
 # Native-Windows-no-bash fast-fail: this pipeline is bash; under the
 # PowerShell tool it cannot parse. If we are on Windows and $BASH is unset,
@@ -588,6 +495,7 @@ if [ -r "${CLAUDE_PLUGIN_ROOT:-}/lib/dispatch.sh" ]; then
   # shellcheck source=/dev/null
   . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
   uberdev_dispatch_preflight || exit 1
+  uberdev_dispatch_resolve_env || exit 1
 else
   echo "error: lib/dispatch.sh not found at ${CLAUDE_PLUGIN_ROOT:-}/lib/" >&2
   exit 1

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -267,9 +267,11 @@ gh repo view --json nameWithOwner --jq .nameWithOwner
 ### 3. (RETIRED v0.22.0 — terminal detection removed for #85)
 
 The Phase A bg-dispatch probes (added near the top of the SKILL.md Phase A
-block by the v0.22.0 refactor: the claude-version gate at 2.1.139, the
-hardcoded prompt-mode (`argv`), and the `MAX_PARALLEL_BG_AGENTS`
-resolution) replace the entire former Step 3 terminal-detection cascade.
+block by the v0.22.0 refactor: the claude-version gate at 2.1.139 and the
+`MAX_PARALLEL_BG_AGENTS` resolution, both still in SKILL.md Phase A) replace
+the entire former Step 3 terminal-detection cascade. The hardcoded
+prompt-mode (`BG_PROMPT_MODE=argv`) is now set by
+`uberdev_dispatch_resolve_env` in `lib/dispatch.sh`, not inline here.
 The terminal, real-claude-path, and permission-description variables no
 longer exist; see `## Deprecated Flags` in `commands/solve.md` /
 `commands/turbo.md` for the `--terminal=` migration pointer.
@@ -787,8 +789,8 @@ invocation, and the BSD/GNU-`sed` placeholder substitution have all been
 replaced by the inline `claude --bg` dispatch in Step 5b' below.
 `claude --bg --worktree solve-issue-N` handles the worktree-cleanup and
 supervised-daemon spawn natively. `MODEL`, `PERM_FLAG`, `SOLVE_TIMEOUT`,
-and `TIMEOUT_BIN` have been hoisted from the launcher into Phase A
-(immediately after the bg-dispatch probes block) — see the Phase A region.
+and `TIMEOUT_BIN` are resolved by `uberdev_dispatch_resolve_env()` in
+`lib/dispatch.sh` (sourced + called at the end of Phase A).
 
 #### 5b'. Dispatch via `claude --bg` (NEW v0.22.0)
 
@@ -802,7 +804,7 @@ SAFE prompt-passthrough forms — Q1 decision per `docs/uberdev/specs/2026-05-12
 - Re-evaluation forms (any `eval`-driven dispatch using `printf %q` to quote the prompt body) → re-evaluation of attacker-influenced text; security research §Findings classified this ERROR-class.
 - `bash -c` wrapper with `$PROMPT` interpolated inside the inner double-quoted command string → double-quote-inside-double-quote interpolation hazard.
 
-`MODEL`, `PERM_FLAG`, `SOLVE_TIMEOUT`, and `TIMEOUT_BIN` are resolved in Phase A (immediately after the bg-dispatch probes block). They're batch-invariant — resolved once per `/solve` or `/turbo` invocation, then consumed by the wave-batching dispatch below.
+`MODEL`, `PERM_FLAG`, `SOLVE_TIMEOUT`, and `TIMEOUT_BIN` are resolved by `uberdev_dispatch_resolve_env()` in `lib/dispatch.sh` (sourced + called at the end of Phase A). They're batch-invariant — resolved once per `/solve` or `/turbo` invocation, then consumed by the wave-batching dispatch below.
 
 The per-issue dispatch is wrapped in a wave-batching outer loop. Mirrors `merge-pipeline/SKILL.md:421`'s idiom: `ceil(N / cap)` sequential single-message waves, one `solve_bg_fanout_wave_started` audit event per wave.
 

--- a/tests/config-override.test.sh
+++ b/tests/config-override.test.sh
@@ -355,22 +355,22 @@ assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
 
 echo
 echo "== I2: solve-pipeline claude --bg dispatch timeout-wrap (v0.22.0) =="
-assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
+assert_grep_in "$REPO_ROOT/plugins/uberdev/lib/dispatch.sh" \
   'uberdev_read_int_in_range command_timeouts.solve[[:space:]]+UBERDEV_SOLVE_TIMEOUT[[:space:]]+60[[:space:]]+86400[[:space:]]+3600' \
   "I2a: launcher reads command_timeouts.solve with bounds [60,86400] default 3600"
-assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
+assert_grep_in "$REPO_ROOT/plugins/uberdev/lib/dispatch.sh" \
   'command -v timeout' \
   "I2b: launcher checks timeout(1) availability"
-assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
+assert_grep_in "$REPO_ROOT/plugins/uberdev/lib/dispatch.sh" \
   'command -v gtimeout' \
   "I2c: launcher probes gtimeout fallback (Homebrew coreutils installs the macOS binary as gtimeout, not timeout)"
 assert_grep_in "$REPO_ROOT/plugins/uberdev/lib/dispatch.sh" \
   '"\$TIMEOUT_BIN" "\$SOLVE_TIMEOUT" env "\${BG_TURBO_ENV\[@\]}" claude --bg' \
   "I2d: bg dispatch wraps claude --bg in timeout(1)/gtimeout with env(1)-mediated zsh-safe BG_TURBO_ENV[@] inline-prefix (#97 — env(1) is required because timeout(1) sits between the shell and the env-prefix slot and would otherwise consume the KEY=value tokens as argv; array form preserves zsh SH_WORD_SPLIT=off compatibility)"
-assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
+assert_grep_in "$REPO_ROOT/plugins/uberdev/lib/dispatch.sh" \
   'brew install coreutils' \
   "I2e: missing-timeout warning includes remediation pointer"
-assert_grep_in "$SKILL_DIR/solve-pipeline/SKILL.md" \
+assert_grep_in "$REPO_ROOT/plugins/uberdev/lib/dispatch.sh" \
   'if \[\[ -n "\$TIMEOUT_BIN" \]\]; then' \
   "I2f: launcher guards wrap branch with -n TIMEOUT_BIN check (prevents silent regression on guard inversion/removal)"
 assert_grep_in "$REPO_ROOT/plugins/uberdev/lib/dispatch.sh" \

--- a/tests/dispatch-claude-bg.test.sh
+++ b/tests/dispatch-claude-bg.test.sh
@@ -127,10 +127,10 @@ assert_grep "$SOLVE_PIPELINE" \
   'uberdev_read_enum solve_effort UBERDEV_SOLVE_EFFORT' \
   "Phase A reads solve_effort from .claude/uberdev.local.md via uberdev_read_enum"
 assert_grep "$DISPATCH_LIB" \
-  '^EFFORT_FLAG=\( --effort "\$EFFORT_LEVEL" \)$' \
+  '^[[:space:]]*EFFORT_FLAG=\( --effort "\$EFFORT_LEVEL" \)$' \
   "Phase A hoist binds EFFORT_FLAG as a bash+zsh array — scalar form regresses to a one-slot \`--effort max\` argv element under zsh SH_WORD_SPLIT=off (v0.22.2 fix)"
 assert_grep "$DISPATCH_LIB" \
-  '^PERM_FLAG=\(\)$' \
+  '^[[:space:]]*PERM_FLAG=\(\)$' \
   "Phase A hoist binds PERM_FLAG as an empty bash+zsh array — same zsh-word-split rationale as EFFORT_FLAG (v0.22.2 fix)"
 assert_grep "$DISPATCH_LIB" \
   'PERM_FLAG=\( --permission-mode auto \)' \

--- a/tests/dispatch-claude-bg.test.sh
+++ b/tests/dispatch-claude-bg.test.sh
@@ -126,13 +126,13 @@ assert_grep "$SOLVE_PIPELINE" \
 assert_grep "$SOLVE_PIPELINE" \
   'uberdev_read_enum solve_effort UBERDEV_SOLVE_EFFORT' \
   "Phase A reads solve_effort from .claude/uberdev.local.md via uberdev_read_enum"
-assert_grep "$SOLVE_PIPELINE" \
+assert_grep "$DISPATCH_LIB" \
   '^EFFORT_FLAG=\( --effort "\$EFFORT_LEVEL" \)$' \
   "Phase A hoist binds EFFORT_FLAG as a bash+zsh array — scalar form regresses to a one-slot \`--effort max\` argv element under zsh SH_WORD_SPLIT=off (v0.22.2 fix)"
-assert_grep "$SOLVE_PIPELINE" \
+assert_grep "$DISPATCH_LIB" \
   '^PERM_FLAG=\(\)$' \
   "Phase A hoist binds PERM_FLAG as an empty bash+zsh array — same zsh-word-split rationale as EFFORT_FLAG (v0.22.2 fix)"
-assert_grep "$SOLVE_PIPELINE" \
+assert_grep "$DISPATCH_LIB" \
   'PERM_FLAG=\( --permission-mode auto \)' \
   "Phase A AUTO_PERMISSIONS branch populates PERM_FLAG as an array, not a scalar"
 assert_grep "$SOLVE_PIPELINE" \
@@ -200,6 +200,28 @@ assert_grep "$DISPATCH_LIB" \
 assert_grep "$DISPATCH_LIB" \
   '_uberdev_dispatch_claude_bg\(\)' \
   "lib/dispatch.sh defines the _uberdev_dispatch_claude_bg function"
+
+echo
+echo "== #175: uberdev_dispatch_resolve_env SSOT helper (structural) =="
+assert_grep "$DISPATCH_LIB" \
+  '^uberdev_dispatch_resolve_env\(\)' \
+  "#175 — uberdev_dispatch_resolve_env function is defined in lib/dispatch.sh"
+assert_grep "$DISPATCH_LIB" \
+  "MODEL='claude-opus-4-7\[1m\]'" \
+  "#175 — helper sets MODEL single-quoted (blocks zsh [1m] glob)"
+assert_grep "$DISPATCH_LIB" \
+  'if \[\[ -n "\$TIMEOUT_BIN" \]\]; then' \
+  "#175 — helper carries the verbatim fail-loud TIMEOUT_BIN guard (config-override I2f shape)"
+assert_grep "$DISPATCH_LIB" \
+  'brew install coreutils' \
+  "#175 — helper carries the brew install coreutils remediation pointer"
+# AC3: the env resolver must never read or write the backend var (that is preflight's).
+RESOLVE_BODY="$(awk '/^uberdev_dispatch_resolve_env\(\)/{f=1} f{print} f&&/^}/{exit}' "$DISPATCH_LIB")"
+if printf '%s' "$RESOLVE_BODY" | grep -q 'UBERDEV_RESOLVED_BACKEND'; then
+  echo "  FAIL  #175 — resolve_env must NOT reference UBERDEV_RESOLVED_BACKEND (D15)"; FAIL=$((FAIL + 1))
+else
+  echo "  PASS  #175 — resolve_env does not reference UBERDEV_RESOLVED_BACKEND (D15)"; PASS=$((PASS + 1))
+fi
 
 echo "== Functional: id_extract rc capture + subphase discriminator (#154) =="
 # These cases SOURCE lib/dispatch.sh and drive _uberdev_dispatch_claude_bg with
@@ -539,6 +561,90 @@ else
   echo "  FAIL  #155 runtime — guard behaviour (subshell exit $_rc155)"
   FAIL=$((FAIL + 1))
 fi
+
+TALLY_FILE="$(mktemp)"   # subshell PASS/FAIL hand-off for #175 cases
+
+echo
+echo "== #175 D-iso: uberdev_dispatch_resolve_env populates env from a clean shell =="
+(
+  set +u
+  unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG AUTO_PERMISSIONS EFFORT_LEVEL
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"
+  # shellcheck disable=SC1090
+  . "$DISPATCH_LIB"
+  uberdev_dispatch_resolve_env; rc=$?
+  [[ "$rc" -eq 0 ]] && { echo "  PASS  D-iso resolve_env returns 0"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso resolve_env rc=$rc"; FAIL=$((FAIL + 1)); }
+  [[ -n "$TIMEOUT_BIN" ]] && { echo "  PASS  D-iso TIMEOUT_BIN non-empty"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso TIMEOUT_BIN empty"; FAIL=$((FAIL + 1)); }
+  if [ -x "$TIMEOUT_BIN" ] || command -v "$TIMEOUT_BIN" >/dev/null 2>&1; then echo "  PASS  D-iso TIMEOUT_BIN executable/resolvable"; PASS=$((PASS + 1)); else echo "  FAIL  D-iso TIMEOUT_BIN not executable ($TIMEOUT_BIN)"; FAIL=$((FAIL + 1)); fi
+  [[ "$MODEL" == 'claude-opus-4-7[1m]' ]] && { echo "  PASS  D-iso MODEL correct"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso MODEL='$MODEL'"; FAIL=$((FAIL + 1)); }
+  case "$SOLVE_TIMEOUT" in (''|*[!0-9]*) echo "  FAIL  D-iso SOLVE_TIMEOUT not numeric ('$SOLVE_TIMEOUT')"; FAIL=$((FAIL + 1));; (*) echo "  PASS  D-iso SOLVE_TIMEOUT numeric"; PASS=$((PASS + 1));; esac
+  [[ "$BG_PROMPT_MODE" == "argv" ]] && { echo "  PASS  D-iso BG_PROMPT_MODE=argv"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso BG_PROMPT_MODE='$BG_PROMPT_MODE'"; FAIL=$((FAIL + 1)); }
+  [[ "${EFFORT_FLAG[*]}" == "--effort max" ]] && { echo "  PASS  D-iso EFFORT_FLAG=( --effort max )"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso EFFORT_FLAG=( ${EFFORT_FLAG[*]} )"; FAIL=$((FAIL + 1)); }
+  [[ "${#PERM_FLAG[@]}" -eq 0 ]] && { echo "  PASS  D-iso PERM_FLAG empty (default AUTO_PERMISSIONS=0)"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso PERM_FLAG=( ${PERM_FLAG[*]} )"; FAIL=$((FAIL + 1)); }
+  printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
+) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
+
+echo
+echo "== #175 D-perm: AUTO_PERMISSIONS=1 yields --permission-mode auto =="
+(
+  set +u
+  unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG EFFORT_LEVEL
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"; AUTO_PERMISSIONS=1
+  # shellcheck disable=SC1090
+  . "$DISPATCH_LIB"
+  uberdev_dispatch_resolve_env
+  [[ "${PERM_FLAG[*]}" == "--permission-mode auto" ]] && { echo "  PASS  D-perm PERM_FLAG=( --permission-mode auto )"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-perm PERM_FLAG=( ${PERM_FLAG[*]} )"; FAIL=$((FAIL + 1)); }
+  printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
+) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
+
+echo
+echo "== #175 D-regression: goal-pipeline preflight->resolve_env->dispatch is NOT rc=126 =="
+(
+  set +u
+  UBERDEV_TMPDIR="$(mktemp -d)"
+  printf 'Agent starting...\nbackgrounded · def67890\n' > "$UBERDEV_TMPDIR/solve-bg-stdout-42.log"
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"
+  declare -a AUDIT_EVENTS=(); _uberdev_audit_emit() { AUDIT_EVENTS+=( "$1 $2" ); }
+  timeout() { shift; "$@"; }
+  env() { while [[ "$1" == *=* ]]; do shift; done; "$@"; }
+  claude() { printf 'backgrounded · def67890\n'; return 0; }
+  DISPATCH_RC=0; DISPATCH_ID=""; DISPATCH_LOG=""
+  # shellcheck disable=SC1090
+  . "$DISPATCH_LIB"
+  uberdev_dispatch_preflight
+  UBERDEV_DISPATCH_BACKEND_REQUESTED=claude-bg uberdev_dispatch_preflight
+  uberdev_dispatch_resolve_env
+  TIMEOUT_BIN="timeout"
+  PROMPT_FILE="$UBERDEV_TMPDIR/solve-prompt-42.txt"; printf '/uberdev:orchestrator --turbo solve GH issue #42\n' > "$PROMPT_FILE"
+  uberdev_dispatch_one 42 small "$PROMPT_FILE"; rc=$?
+  [[ "$rc" -ne 126 ]] && { echo "  PASS  D-regression dispatch rc != 126 (got $rc) — #175 fixed"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-regression dispatch rc=126 — #175 NOT fixed"; FAIL=$((FAIL + 1)); }
+  [[ "$rc" -eq 0 ]] && { echo "  PASS  D-regression happy-path rc=0"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-regression happy-path rc=$rc"; FAIL=$((FAIL + 1)); }
+  rm -rf "$UBERDEV_TMPDIR"
+  printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
+) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
+
+echo
+echo "== #175 D-failloud: no timeout/gtimeout on PATH -> return 1 + brew pointer =="
+_ff_out="$(
+  set +eu
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"
+  # shellcheck disable=SC1090
+  . "$DISPATCH_LIB" >/dev/null 2>&1
+  _sandbox="$(mktemp -d)"
+  PATH="$_sandbox" uberdev_dispatch_resolve_env 2>&1
+  echo "RC=$?"
+  rm -rf "$_sandbox"
+)"
+if [ -x /usr/bin/timeout ]; then
+  case "$_ff_out" in (*RC=0*) echo "  PASS  D-failloud (/usr/bin/timeout present) resolve_env rc=0"; PASS=$((PASS + 1));; (*) echo "  FAIL  D-failloud expected rc=0 with /usr/bin/timeout present: $_ff_out"; FAIL=$((FAIL + 1));; esac
+else
+  case "$_ff_out" in
+    (*"brew install coreutils"*RC=1*|*RC=1*"brew install coreutils"*) echo "  PASS  D-failloud rc=1 + brew pointer"; PASS=$((PASS + 1));;
+    (*) echo "  FAIL  D-failloud expected rc=1 + brew pointer: $_ff_out"; FAIL=$((FAIL + 1));;
+  esac
+fi
+
+rm -f "$TALLY_FILE"
 
 echo
 echo "== Summary =="

--- a/tests/dispatch-claude-bg.test.sh
+++ b/tests/dispatch-claude-bg.test.sh
@@ -363,9 +363,9 @@ assert_grep "$SOLVE_PIPELINE" \
 assert_grep "$SOLVE_PIPELINE" \
   'npm i -g @anthropic-ai/claude-code' \
   "version-gate error includes actionable npm install pointer"
-assert_grep "$SOLVE_PIPELINE" \
-  '^BG_PROMPT_MODE=argv' \
-  "Phase A hardcodes BG_PROMPT_MODE=argv (probe deferred per fix(solve) commit 0c17169 — claude --bg --help is not introspective in v2.1.139)"
+assert_grep "$DISPATCH_LIB" \
+  '^[[:space:]]*BG_PROMPT_MODE=argv' \
+  "uberdev_dispatch_resolve_env hardcodes BG_PROMPT_MODE=argv (probe deferred per fix(solve) commit 0c17169 — claude --bg --help is not introspective in v2.1.139; moved to lib/dispatch.sh in #175)"
 assert_grep "$SOLVE_PIPELINE" \
   'TERMINAL_FLAG_DEPRECATED_NOTE' \
   "Constants table defines TERMINAL_FLAG_DEPRECATED_NOTE"

--- a/tests/dispatch-claude-bg.test.sh
+++ b/tests/dispatch-claude-bg.test.sh
@@ -128,13 +128,13 @@ assert_grep "$SOLVE_PIPELINE" \
   "Phase A reads solve_effort from .claude/uberdev.local.md via uberdev_read_enum"
 assert_grep "$DISPATCH_LIB" \
   '^[[:space:]]*EFFORT_FLAG=\( --effort "\$EFFORT_LEVEL" \)$' \
-  "Phase A hoist binds EFFORT_FLAG as a bash+zsh array — scalar form regresses to a one-slot \`--effort max\` argv element under zsh SH_WORD_SPLIT=off (v0.22.2 fix)"
+  "uberdev_dispatch_resolve_env binds EFFORT_FLAG as a bash+zsh array — scalar form regresses to a one-slot \`--effort max\` argv element under zsh SH_WORD_SPLIT=off (v0.22.2 fix)"
 assert_grep "$DISPATCH_LIB" \
   '^[[:space:]]*PERM_FLAG=\(\)$' \
-  "Phase A hoist binds PERM_FLAG as an empty bash+zsh array — same zsh-word-split rationale as EFFORT_FLAG (v0.22.2 fix)"
+  "uberdev_dispatch_resolve_env binds PERM_FLAG as an empty bash+zsh array — same zsh-word-split rationale as EFFORT_FLAG (v0.22.2 fix)"
 assert_grep "$DISPATCH_LIB" \
   'PERM_FLAG=\( --permission-mode auto \)' \
-  "Phase A AUTO_PERMISSIONS branch populates PERM_FLAG as an array, not a scalar"
+  "uberdev_dispatch_resolve_env AUTO_PERMISSIONS branch populates PERM_FLAG as an array, not a scalar"
 assert_grep "$SOLVE_PIPELINE" \
   '_uberdev_audit_emit effort_resolved' \
   "Phase A emits effort_resolved audit event with {source, level}"
@@ -614,6 +614,13 @@ echo "== #175 D-regression: goal-pipeline preflight->resolve_env->dispatch is NO
   uberdev_dispatch_preflight
   UBERDEV_DISPATCH_BACKEND_REQUESTED=claude-bg uberdev_dispatch_preflight
   uberdev_dispatch_resolve_env
+  # Prove the #175 root cause (empty TIMEOUT_BIN) is fixed HERE too, not only in
+  # D-iso: resolve_env must populate TIMEOUT_BIN before any override below.
+  [[ -n "$TIMEOUT_BIN" ]] && { echo "  PASS  D-regression resolve_env set TIMEOUT_BIN non-empty before override"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-regression resolve_env left TIMEOUT_BIN empty"; FAIL=$((FAIL + 1)); }
+  # Override swaps in an equivalent valid binary for the bare-word `timeout()`
+  # mock above; absolute /usr/bin/timeout (resolve_env's first choice on this
+  # host) would bypass the function mock. The empty-TIMEOUT_BIN root cause of
+  # #175 is asserted just above — this line is mock plumbing, not the guard.
   TIMEOUT_BIN="timeout"
   PROMPT_FILE="$UBERDEV_TMPDIR/solve-prompt-42.txt"; printf '/uberdev:orchestrator --turbo solve GH issue #42\n' > "$PROMPT_FILE"
   uberdev_dispatch_one 42 small "$PROMPT_FILE"; rc=$?

--- a/tests/dispatch-claude-bg.test.sh
+++ b/tests/dispatch-claude-bg.test.sh
@@ -611,6 +611,8 @@ echo "== #175 D-regression: goal-pipeline preflight->resolve_env->dispatch is NO
   DISPATCH_RC=0; DISPATCH_ID=""; DISPATCH_LOG=""
   # shellcheck disable=SC1090
   . "$DISPATCH_LIB"
+  # First call exercises auto backend-resolution; second forces claude-bg so the
+  # dispatch stub below routes deterministically on any host.
   uberdev_dispatch_preflight
   UBERDEV_DISPATCH_BACKEND_REQUESTED=claude-bg uberdev_dispatch_preflight
   uberdev_dispatch_resolve_env
@@ -632,6 +634,9 @@ echo "== #175 D-regression: goal-pipeline preflight->resolve_env->dispatch is NO
 
 echo
 echo "== #175 D-failloud: no timeout/gtimeout on PATH -> return 1 + brew pointer =="
+# Unlike the other #175 cases, this block captures via $(...) rather than the
+# subshell+TALLY_FILE idiom: it must run the PATH-sandboxed probe inline and grab
+# stderr+rc together, which the subshell-then-tally hand-off pattern can't express.
 _ff_out="$(
   set +eu
   CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -271,12 +271,15 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.33.5) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.5"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.5"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.5-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.5\]'        "G20.changelog"
+echo "== G20: version bump locked (0.33.6) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.6"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.6"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.6-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.6\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
+
+assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"
+assert_grep "$GOAL_SKILL" 'export AUTO_MODE=1'            "G20b.phase0-sets-AUTO_MODE (#175 turbo-parity)"
 
 echo
 echo "== G21: held-PR re-review poll loop (issue #159) =="

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.4 -> 0.33.5 propagated =="
+echo "== Version bump 0.33.5 -> 0.33.6 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.33.5"' \
-  "plugin.json bumped to 0.33.5"
+  '"version": "0.33.6"' \
+  "plugin.json bumped to 0.33.6"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.33.5"' \
-  "marketplace.json bumped to 0.33.5"
+  '"version": "0.33.6"' \
+  "marketplace.json bumped to 0.33.6"
 assert_grep "$README" \
-  "version-0\\.33\\.5-blue" \
-  "README version badge bumped to 0.33.5"
+  "version-0\\.33\\.6-blue" \
+  "README version badge bumped to 0.33.6"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.33\.5\]' \
-  "CHANGELOG has [0.33.5] section header"
+  '^## \[0\.33\.6\]' \
+  "CHANGELOG has [0.33.6] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/solve-pipeline-zsh.test.sh
+++ b/tests/solve-pipeline-zsh.test.sh
@@ -26,9 +26,14 @@ set -u
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SOLVE_PIPELINE="$REPO_ROOT/plugins/uberdev/skills/solve-pipeline/SKILL.md"
+# #175: the PERM_FLAG/EFFORT_FLAG array hoist moved from solve-pipeline Phase A
+# into uberdev_dispatch_resolve_env() in lib/dispatch.sh (shared SSOT helper).
+# R1a/R1b now anchor on dispatch.sh; the runtime word-split fixtures (R2-R4)
+# below are unaffected (they bind the arrays inline in their own subshells).
+DISPATCH_LIB="$REPO_ROOT/plugins/uberdev/lib/dispatch.sh"
 
-if [ ! -r "$SOLVE_PIPELINE" ]; then
-  echo "FATAL: required file missing or unreadable: $SOLVE_PIPELINE" >&2
+if [ ! -r "$SOLVE_PIPELINE" ] || [ ! -r "$DISPATCH_LIB" ]; then
+  echo "FATAL: required file missing or unreadable: $SOLVE_PIPELINE or $DISPATCH_LIB" >&2
   exit 2
 fi
 
@@ -51,16 +56,18 @@ fail() { echo "  FAIL  $1"; FAIL=$((FAIL + 1)); }
 # inline `sort -n | tr '\n' ' ' | sed 's/ $//'` chain it replaces.
 _normalize_nums() { sort -n | tr '\n' ' ' | sed 's/ $//'; }
 
-echo "== R1: SKILL.md Phase A hoist defines PERM_FLAG/EFFORT_FLAG as arrays =="
-# Anchored grep on the SKILL.md hoist. If a future edit reverts to scalar
-# form, this assertion fires before R2/R3 even execute the dispatch.
-if grep -qE '^EFFORT_FLAG=\( --effort "\$EFFORT_LEVEL" \)$' "$SOLVE_PIPELINE"; then
+echo "== R1: lib/dispatch.sh resolve_env defines PERM_FLAG/EFFORT_FLAG as arrays =="
+# Anchored grep on the resolve_env hoist (moved from solve-pipeline Phase A into
+# lib/dispatch.sh in #175). If a future edit reverts to scalar form, this
+# assertion fires before R2/R3 even execute the dispatch. The ^[[:space:]]*
+# prefix tolerates the function-body indentation in dispatch.sh.
+if grep -qE '^[[:space:]]*EFFORT_FLAG=\( --effort "\$EFFORT_LEVEL" \)$' "$DISPATCH_LIB"; then
   pass "R1a: EFFORT_FLAG hoist binds an array — \`EFFORT_FLAG=( --effort \"\$EFFORT_LEVEL\" )\`"
 else
   fail "R1a: EFFORT_FLAG hoist no longer matches the array form"
-  echo "        searched: ^EFFORT_FLAG=\\( --effort \"\\\$EFFORT_LEVEL\" \\)\$ in $SOLVE_PIPELINE"
+  echo "        searched: ^[[:space:]]*EFFORT_FLAG=\\( --effort \"\\\$EFFORT_LEVEL\" \\)\$ in $DISPATCH_LIB"
 fi
-if grep -qE '^PERM_FLAG=\(\)$' "$SOLVE_PIPELINE"; then
+if grep -qE '^[[:space:]]*PERM_FLAG=\(\)$' "$DISPATCH_LIB"; then
   pass "R1b: PERM_FLAG hoist binds an empty array — \`PERM_FLAG=()\`"
 else
   fail "R1b: PERM_FLAG hoist no longer matches the empty-array form"


### PR DESCRIPTION
## Summary

Fixes `/uberdev:goal`'s first-dispatch crash (`rc=126`, `permission denied` from exec'ing an empty `$TIMEOUT_BIN` as argv[0]).

**Root cause:** `goal-pipeline` Phase 0 sourced `lib/dispatch.sh` and called `uberdev_dispatch_preflight` (which sets only `UBERDEV_RESOLVED_BACKEND`) but never established the six dispatch-env vars (`TIMEOUT_BIN`, `SOLVE_TIMEOUT`, `MODEL`, `PERM_FLAG[]`, `EFFORT_FLAG[]`, `BG_PROMPT_MODE`). Those lived only in solve-pipeline's Phase A, so goal-pipeline's first `uberdev_dispatch_one` ran with an empty `TIMEOUT_BIN`.

**Fix (SSOT extraction):**
- Extracted a **sourced** helper `uberdev_dispatch_resolve_env()` into `plugins/uberdev/lib/dispatch.sh`, mirroring the existing `uberdev_dispatch_preflight` precedent. It resolves all six vars and carries the `timeout`/`gtimeout` probe + fail-loud guard **byte-identical** to the original (only `exit 1` becomes `return 1` for the sourced form). It is sourced (never exec'd) because `PERM_FLAG`/`EFFORT_FLAG` are bash arrays that cannot cross an env/fork boundary. It does **not** read or write `UBERDEV_RESOLVED_BACKEND` (RFC 0005 D15 — backend stays owned by preflight).
- **solve-pipeline** now calls the helper instead of carrying the inline Phase A block — behaviour identical. The interleaved solve-specific survivors (`MAX_PARALLEL_BG_AGENTS` wave-batching, the `effort_resolved` audit emit) and the upstream `--effort`/`AUTO_PERMISSIONS` parsers are preserved.
- **goal-pipeline** Phase 0 now sets `AUTO_MODE=1` (turbo-parity) and calls the helper after preflight, before any dispatch. One Phase-0 call covers Phase 1 and both `goal-state.sh` dispatchers (single shell process).
- **Behavioural regression test** added to `tests/dispatch-claude-bg.test.sh` (already CI-wired on ubuntu + windows): `D-iso` (clean-env resolve), `D-perm` (`AUTO_PERMISSIONS=1`), `D-regression` (goal `preflight -> resolve_env -> dispatch` is not `rc=126`), `D-failloud` (no timeout binary -> `return 1` + brew pointer), plus structural anchors. Closes the structural-grep-only gap that let this regress silently.
- Version bump `0.33.5` -> `0.33.6` across all 6 in-PR locations (plugin.json, marketplace.json, README badge, CHANGELOG, and the two hidden test ratchets in `solve-claim.test.sh` + `goal.test.sh` G20).

## Test Plan
- [x] All 28 CI suites pass locally (27 bash + zsh)
- [x] `shellcheck plugins/uberdev/lib/dispatch.sh` — no new findings vs baseline
- [x] Clean-shell smoke: `env -i` fresh process sources `dispatch.sh`, calls `resolve_env`, gets a non-empty `TIMEOUT_BIN` (conclusive proof the rc=126 root cause is gone)
- [x] Byte-fidelity verified: moved `TIMEOUT_BIN` probe+guard identical to original except `exit 1` -> `return 1`
- [ ] CI green on ubuntu-latest + windows-latest (Git Bash)

## Open questions answered by /turbo

These design decisions were auto-picked under `--turbo` and confirmed against source by the spec/plan reviewers — please review, especially any non-`high` confidence row:

| Question | Choice | Confidence |
|----------|--------|------------|
| Q1: Helper location/structure | New sourced `uberdev_dispatch_resolve_env()` in `lib/dispatch.sh`, idempotent, mirrors `uberdev_dispatch_preflight` | high |
| Q2: What it resolves + input handling | Sets the 6 outputs; reads `AUTO_PERMISSIONS:-0` / `EFFORT_LEVEL:-max`; verbatim probe + fail-loud `if/elif/else` guard; no backend ref | high |
| Q3: goal dispatch semantics | Mirror `/turbo`: `AUTO_MODE=1`, `AUTO_PERMISSIONS=0`, `EFFORT_LEVEL=max` (confirmed from `turbo.md` + solve arg-parser) | high |
| Q4: Which call sites | Single Phase-0 `resolve_env` covers Phase 1 + both `goal-state.sh` dispatchers (goal renders inline = one shell process) | high |
| Q5: Test location/assertions | Extend `tests/dispatch-claude-bg.test.sh` (already CI-wired, shell-function mock idiom); regression test targets rc=126 | high |
| Q6: Version bump | `fix(dispatch):` patch bump `0.33.5` -> `0.33.6` across 8 locations (6 in-PR + 2 post-merge) | high |

> Note: the wave-decomposition surfaced a re-pointing requirement the spec under-specified — moving the env strings into a function breaks structural greps in `config-override.test.sh`, `dispatch-claude-bg.test.sh`, and `solve-pipeline-zsh.test.sh` unless their anchors are re-pointed to `dispatch.sh` (the last file was caught by full-suite verification, not the plan). All three are handled in this PR.

Closes #175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved crash occurring during `/goal` command dispatch

* **Chores**
  * Version updated to 0.33.6
  * Updated manifest, changelog, and documentation files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->