### PR TITLE
fix(pipeline): persist run-state + re-source libs across fresh-shell Bash calls (#171)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.33.6",
+      "version": "0.33.7",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
           bash tests/dispatch-wezterm.test.sh && \
           bash tests/ubersimplify.test.sh && \
           bash tests/ubersimplify-aggregate.test.sh && \
+          bash tests/goal-state-sidecar.test.sh && \
           bash tests/goal.test.sh
 
   shape-checks-windows:
@@ -123,4 +124,5 @@ jobs:
           bash tests/dispatch-wezterm.test.sh && \
           bash tests/ubersimplify.test.sh && \
           bash tests/ubersimplify-aggregate.test.sh && \
+          bash tests/goal-state-sidecar.test.sh && \
           bash tests/goal.test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.7] - 2026-05-22
+
+### Fixed
+- **Pipeline run-state evaporated across fresh-shell Bash calls (`/goal` silent state-machine no-op).** Each Bash tool call is a fresh shell, and the goal-pipeline watch loop structurally forces call boundaries, so the Phase-0 `GOAL_ID` pointer, loop accumulators (`cycle`/`watch_start`/`overflow_count`/`overflow_detected`), and sourced `uberdev_goal_*` definitions evaporated before Phases 1–4 — `$GOAL_ID` resolved empty (per-goal TSV paths degraded to `goal--*.tsv`) and `uberdev_goal_*` calls hit "command not found", silently no-op'ing state-machine transitions and circuit-breaker accounting. Added `uberdev_goal_write_run_state` / `uberdev_goal_read_run_state` / `uberdev_goal_cleanup_run_state` to `lib/goal-state.sh` — a hardened `KEY=value` sidecar under `$UBERDEV_TMPDIR`, written atomically via the #155 TOCTOU-safe `_uberdev_dispatch_prepare_tmp_target` and read back with per-field-validating loops (never `source`/`eval`, never `mapfile`; bash-3.2/zsh portable). goal-pipeline now re-sources the three libs and re-reads run-state at the top of every later phase block; sibling pipelines get the lighter re-source-per-block treatment. The TSV-keyed-by-`GOAL_ID` model (PR #129) is unchanged. (#171)
+
 ## [0.33.6] - 2026-05-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.33.6-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.33.7-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.33.6",
+  "version": "0.33.7",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -900,12 +900,14 @@ uberdev_goal_write_run_state() {
 #   caller's GOAL_ID is empty/invalid (a fresh shell — env + scalars evaporate
 #   across Bash calls, issue #171), it is bootstrapped from the fixed-path
 #   goal-active-id.txt pointer (content gated through _uberdev_goal_validate_id).
-#   On success
-#   exports/sets GOAL_ID, cycle, watch_start, overflow_count,
-#   overflow_detected, MAX_CYCLES, UBERDEV_RESOLVED_BACKEND, and rehydrates
-#   the queue/active_issues arrays. Returns 0 on success; 1 if missing/
-#   unreadable. Invalid fields are skipped (not assigned a garbage value);
-#   a forged GOAL_ID is rejected and never interpolated into a path.
+#   On success: sets the GOAL_ID, cycle, watch_start, overflow_count,
+#   overflow_detected, MAX_CYCLES, UBERDEV_RESOLVED_BACKEND scalars, rehydrates
+#   the queue/active_issues arrays, and EXPORTS UBERDEV_GOAL_ID + UBERDEV_TMPDIR
+#   (the env vars the uberdev_goal_* helpers + bare $UBERDEV_TMPDIR/... paths in
+#   the pipeline body depend on — see the export block at the function's end).
+#   Returns 0 on success; 1 if missing/unreadable. Invalid fields are skipped
+#   (not assigned a garbage value); a forged GOAL_ID is rejected and never
+#   interpolated into a path.
 uberdev_goal_read_run_state() {
   local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
   local _aid=""
@@ -958,6 +960,20 @@ uberdev_goal_read_run_state() {
       _uberdev_goal_validate_int "$line2" && active_issues+=("$line2")
     done < "${sc}.active"
   fi
+
+  # #178 — re-export the env vars a fresh shell's downstream consumers need.
+  # Four uberdev_goal_* helpers gate on the UBERDEV_GOAL_ID *env var*, NOT the
+  # bare GOAL_ID scalar this function sets: uberdev_goal_audit (the goal_id sink —
+  # empty env => mis-sinks to goal-unknown.jsonl), uberdev_goal_should_automerge
+  # (provenance gate `[ -n "${UBERDEV_GOAL_ID:-}" ]` — empty env => refuses a GREEN
+  # PR, so /goal never converges), and the review-pr/merge dispatch helpers. The
+  # goal-pipeline body also interpolates bare $UBERDEV_TMPDIR/... paths and the
+  # PR #129 TSV/audit helpers fall back to $UBERDEV_TMPDIR; an unset value resolves
+  # them under / or /tmp instead of the dir Phase 0 wrote. Exporting both here —
+  # the single rehydration SSOT every fence calls — restores a complete, consistent
+  # environment and is what makes the #171 fix actually hold across fresh shells.
+  export UBERDEV_GOAL_ID="$GOAL_ID"
+  export UBERDEV_TMPDIR="$tmpdir"
   return 0
 }
 

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -837,9 +837,10 @@ _uberdev_goal_check_unblock() {
 #   Reads GOAL_ID, cycle, watch_start, overflow_count, overflow_detected,
 #   MAX_CYCLES, UBERDEV_RESOLVED_BACKEND, and the queue/active_issues arrays
 #   from the caller's shell; persists them to predictable, GOAL_ID-keyed
-#   sidecars under $UBERDEV_TMPDIR. Returns 0 on success, 1 if GOAL_ID is
-#   invalid, 3 (fail-CLOSED) if _uberdev_dispatch_prepare_tmp_target rejects a
-#   target or a sidecar write fails.
+#   sidecars under $UBERDEV_TMPDIR, plus a fixed-path goal-active-id.txt pointer
+#   so a fresh shell (no GOAL_ID in env/scalar) can discover the active GOAL_ID.
+#   Returns 0 on success, 1 if GOAL_ID is invalid, 3 (fail-CLOSED) if
+#   _uberdev_dispatch_prepare_tmp_target rejects a target or a sidecar write fails.
 uberdev_goal_write_run_state() {
   _uberdev_goal_validate_id "${GOAL_ID:-}" || return 1
   local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
@@ -848,7 +849,7 @@ uberdev_goal_write_run_state() {
   # Scalar sidecar: prepare predictable target (symlink-reject + EUID-owner
   # check + 0600-create under set -C), write temp sibling, atomic mv.
   _uberdev_dispatch_prepare_tmp_target "$sc" 0 "goal" || return 3
-  local tmp _filtered
+  local tmp _filtered aid
   tmp="$(mktemp "${sc}.XXXXXXXX")" || return 3
   printf 'GOAL_ID=%s\ncycle=%s\nwatch_start=%s\noverflow_count=%s\noverflow_detected=%s\nMAX_CYCLES=%s\nUBERDEV_RESOLVED_BACKEND=%s\n' \
     "$GOAL_ID" "${cycle:-0}" "${watch_start:-0}" "${overflow_count:-0}" \
@@ -880,12 +881,26 @@ uberdev_goal_write_run_state() {
     : > "$tmp" || { rm -f "$tmp"; return 3; }
   fi
   mv -f "$tmp" "${sc}.active" || { rm -f "$tmp"; return 3; }
+
+  # Fixed-path pointer (issue #171 bootstrap): a fresh shell has no GOAL_ID in
+  # env/scalar, so it cannot name the keyed sidecar above. Publish the active
+  # GOAL_ID to a well-known path LAST — after the keyed data exists — so a
+  # reader that discovers the pointer always finds complete keyed state. One
+  # active /goal per $UBERDEV_TMPDIR is assumed (matches the run-state model).
+  aid="$tmpdir/goal-active-id.txt"
+  _uberdev_dispatch_prepare_tmp_target "$aid" 0 "goal" || return 3
+  tmp="$(mktemp "${aid}.XXXXXXXX")" || return 3
+  printf '%s\n' "$GOAL_ID" > "$tmp" || { rm -f "$tmp"; return 3; }
+  mv -f "$tmp" "$aid" || { rm -f "$tmp"; return 3; }
   return 0
 }
 
 # uberdev_goal_read_run_state
-#   Reads + per-field-validates the sidecar; never sources or executes it. Caller must
-#   already hold the GOAL_ID pointer (it keys the sidecar path). On success
+#   Reads + per-field-validates the sidecar; never sources or executes it. If the
+#   caller's GOAL_ID is empty/invalid (a fresh shell — env + scalars evaporate
+#   across Bash calls, issue #171), it is bootstrapped from the fixed-path
+#   goal-active-id.txt pointer (content gated through _uberdev_goal_validate_id).
+#   On success
 #   exports/sets GOAL_ID, cycle, watch_start, overflow_count,
 #   overflow_detected, MAX_CYCLES, UBERDEV_RESOLVED_BACKEND, and rehydrates
 #   the queue/active_issues arrays. Returns 0 on success; 1 if missing/
@@ -893,7 +908,17 @@ uberdev_goal_write_run_state() {
 #   a forged GOAL_ID is rejected and never interpolated into a path.
 uberdev_goal_read_run_state() {
   local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
-  _uberdev_goal_validate_id "${GOAL_ID:-}" || { echo "goal: invalid GOAL_ID pointer" >&2; return 1; }
+  local _aid=""
+  # Bootstrap (issue #171): a fresh shell has no GOAL_ID — env vars and shell
+  # scalars do not survive across Bash calls. Recover it from the fixed-path
+  # active-id pointer so the keyed sidecar can be located. The pointer's content
+  # is untrusted: gate it through _uberdev_goal_validate_id (path-traversal)
+  # before assigning, exactly as for the sidecar's stored GOAL_ID.
+  if ! _uberdev_goal_validate_id "${GOAL_ID:-}"; then
+    [ -r "$tmpdir/goal-active-id.txt" ] && _aid="$(head -n1 "$tmpdir/goal-active-id.txt" 2>/dev/null)"
+    _uberdev_goal_validate_id "${_aid:-}" && GOAL_ID="$_aid"
+  fi
+  _uberdev_goal_validate_id "${GOAL_ID:-}" || { echo "goal: no valid GOAL_ID (env/scalar empty; active-id pointer missing or invalid)" >&2; return 1; }
   local sc="$tmpdir/goal-$GOAL_ID-runstate"
   [ -r "$sc" ] || { echo "goal: missing run-state sidecar ($sc)" >&2; return 1; }
 
@@ -937,13 +962,20 @@ uberdev_goal_read_run_state() {
 }
 
 # uberdev_goal_cleanup_run_state
-#   Best-effort removal of the three known predictable sidecar paths on goal
-#   completion / circuit-breaker halt. Never fatal; no globbing of attacker-
-#   influenceable patterns (each path is GOAL_ID-keyed and validated).
+#   Best-effort removal of the run-state sidecars + the fixed-path active-id
+#   pointer on goal completion / circuit-breaker halt. Never fatal; no globbing
+#   of attacker-influenceable patterns (each keyed path is GOAL_ID-keyed and
+#   validated). The shared pointer is removed only if it still names THIS goal.
 uberdev_goal_cleanup_run_state() {
   local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
   _uberdev_goal_validate_id "${GOAL_ID:-}" || return 0
   local sc="$tmpdir/goal-$GOAL_ID-runstate"
   rm -f "$sc" "${sc}.queue" "${sc}.active" 2>/dev/null
+  # Remove the fixed-path pointer only if it still names THIS goal, so a
+  # concurrent goal's pointer is never clobbered.
+  local aid="$tmpdir/goal-active-id.txt"
+  if [ -r "$aid" ] && [ "$(head -n1 "$aid" 2>/dev/null)" = "$GOAL_ID" ]; then
+    rm -f "$aid" 2>/dev/null
+  fi
   return 0
 }

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -837,8 +837,9 @@ _uberdev_goal_check_unblock() {
 #   Reads GOAL_ID, cycle, watch_start, overflow_count, overflow_detected,
 #   MAX_CYCLES, UBERDEV_RESOLVED_BACKEND, and the queue/active_issues arrays
 #   from the caller's shell; persists them to predictable, GOAL_ID-keyed
-#   sidecars under $UBERDEV_TMPDIR. Returns 0 on success, 3 (fail-CLOSED) if
-#   _uberdev_dispatch_prepare_tmp_target rejects any target.
+#   sidecars under $UBERDEV_TMPDIR. Returns 0 on success, 1 if GOAL_ID is
+#   invalid, 3 (fail-CLOSED) if _uberdev_dispatch_prepare_tmp_target rejects a
+#   target or a sidecar write fails.
 uberdev_goal_write_run_state() {
   _uberdev_goal_validate_id "${GOAL_ID:-}" || return 1
   local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
@@ -847,22 +848,37 @@ uberdev_goal_write_run_state() {
   # Scalar sidecar: prepare predictable target (symlink-reject + EUID-owner
   # check + 0600-create under set -C), write temp sibling, atomic mv.
   _uberdev_dispatch_prepare_tmp_target "$sc" 0 "goal" || return 3
-  local tmp
+  local tmp _filtered
   tmp="$(mktemp "${sc}.XXXXXXXX")" || return 3
   printf 'GOAL_ID=%s\ncycle=%s\nwatch_start=%s\noverflow_count=%s\noverflow_detected=%s\nMAX_CYCLES=%s\nUBERDEV_RESOLVED_BACKEND=%s\n' \
     "$GOAL_ID" "${cycle:-0}" "${watch_start:-0}" "${overflow_count:-0}" \
     "${overflow_detected:-0}" "${MAX_CYCLES:-0}" "${UBERDEV_RESOLVED_BACKEND:-}" > "$tmp"
   mv -f "$tmp" "$sc" || { rm -f "$tmp"; return 3; }
 
-  # Array sidecars: one int per line, no IFS-mutating joins.
+  # Array sidecars: one int per line, no IFS-mutating joins. Capture first
+  # (command substitution strips trailing newlines, and `grep || true` absorbs
+  # rc=1 on an empty array — a no-match, not an error), then write fail-CLOSED
+  # so a real redirect failure (e.g. ENOSPC) cannot silently truncate the file.
+  # `printf '%s\n'` re-adds the trailing newline so the final element survives
+  # the read-back loop.
   _uberdev_dispatch_prepare_tmp_target "${sc}.queue" 0 "goal" || return 3
   tmp="$(mktemp "${sc}.queue.XXXXXXXX")" || return 3
-  printf '%s\n' "${queue[@]:-}" | grep -E '^[0-9]+$' > "$tmp" || true
+  _filtered="$(printf '%s\n' "${queue[@]:-}" | grep -E '^[0-9]+$' || true)"
+  if [ -n "$_filtered" ]; then
+    printf '%s\n' "$_filtered" > "$tmp" || { rm -f "$tmp"; return 3; }
+  else
+    : > "$tmp" || { rm -f "$tmp"; return 3; }
+  fi
   mv -f "$tmp" "${sc}.queue" || { rm -f "$tmp"; return 3; }
 
   _uberdev_dispatch_prepare_tmp_target "${sc}.active" 0 "goal" || return 3
   tmp="$(mktemp "${sc}.active.XXXXXXXX")" || return 3
-  printf '%s\n' "${active_issues[@]:-}" | grep -E '^[0-9]+$' > "$tmp" || true
+  _filtered="$(printf '%s\n' "${active_issues[@]:-}" | grep -E '^[0-9]+$' || true)"
+  if [ -n "$_filtered" ]; then
+    printf '%s\n' "$_filtered" > "$tmp" || { rm -f "$tmp"; return 3; }
+  else
+    : > "$tmp" || { rm -f "$tmp"; return 3; }
+  fi
   mv -f "$tmp" "${sc}.active" || { rm -f "$tmp"; return 3; }
   return 0
 }

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -19,6 +19,9 @@
 #   uberdev_goal_extract_pr_num_from_log       STDOUT_LOG_PATH
 #   uberdev_goal_list_prs_in_state             GOAL_ID STATE
 #   uberdev_goal_read_merge_result             PR_NUM
+#   uberdev_goal_write_run_state               (env-driven)
+#   uberdev_goal_read_run_state                (env-driven)
+#   uberdev_goal_cleanup_run_state             (env-driven)
 # Internal:
 #   _uberdev_goal_validate_int             N
 #   _uberdev_goal_validate_id              GOAL_ID
@@ -820,4 +823,111 @@ _uberdev_goal_check_unblock() {
     uberdev_goal_audit goal_unblock_triggered \
       "{\"pr\":$held_pr,\"blocking_issues\":[$blocking_csv]}"
   fi
+}
+
+# ---------------------------------------------------------------------------
+# Run-state sidecar (issue #171): persist the GOAL_ID pointer + loop
+# accumulators so they survive fresh-shell Bash boundaries. KEY=value text,
+# written atomically via the #155 TOCTOU-safe helper. The reader parses +
+# per-field-validates the sidecar — it is never sourced or executed as code;
+# NEVER mapfile (bash-3.2/zsh portability).
+# ---------------------------------------------------------------------------
+
+# uberdev_goal_write_run_state
+#   Reads GOAL_ID, cycle, watch_start, overflow_count, overflow_detected,
+#   MAX_CYCLES, UBERDEV_RESOLVED_BACKEND, and the queue/active_issues arrays
+#   from the caller's shell; persists them to predictable, GOAL_ID-keyed
+#   sidecars under $UBERDEV_TMPDIR. Returns 0 on success, 3 (fail-CLOSED) if
+#   _uberdev_dispatch_prepare_tmp_target rejects any target.
+uberdev_goal_write_run_state() {
+  _uberdev_goal_validate_id "${GOAL_ID:-}" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  local sc="$tmpdir/goal-$GOAL_ID-runstate"   # NO .env extension
+
+  # Scalar sidecar: prepare predictable target (symlink-reject + EUID-owner
+  # check + 0600-create under set -C), write temp sibling, atomic mv.
+  _uberdev_dispatch_prepare_tmp_target "$sc" 0 "goal" || return 3
+  local tmp
+  tmp="$(mktemp "${sc}.XXXXXXXX")" || return 3
+  printf 'GOAL_ID=%s\ncycle=%s\nwatch_start=%s\noverflow_count=%s\noverflow_detected=%s\nMAX_CYCLES=%s\nUBERDEV_RESOLVED_BACKEND=%s\n' \
+    "$GOAL_ID" "${cycle:-0}" "${watch_start:-0}" "${overflow_count:-0}" \
+    "${overflow_detected:-0}" "${MAX_CYCLES:-0}" "${UBERDEV_RESOLVED_BACKEND:-}" > "$tmp"
+  mv -f "$tmp" "$sc" || { rm -f "$tmp"; return 3; }
+
+  # Array sidecars: one int per line, no IFS-mutating joins.
+  _uberdev_dispatch_prepare_tmp_target "${sc}.queue" 0 "goal" || return 3
+  tmp="$(mktemp "${sc}.queue.XXXXXXXX")" || return 3
+  printf '%s\n' "${queue[@]:-}" | grep -E '^[0-9]+$' > "$tmp" || true
+  mv -f "$tmp" "${sc}.queue" || { rm -f "$tmp"; return 3; }
+
+  _uberdev_dispatch_prepare_tmp_target "${sc}.active" 0 "goal" || return 3
+  tmp="$(mktemp "${sc}.active.XXXXXXXX")" || return 3
+  printf '%s\n' "${active_issues[@]:-}" | grep -E '^[0-9]+$' > "$tmp" || true
+  mv -f "$tmp" "${sc}.active" || { rm -f "$tmp"; return 3; }
+  return 0
+}
+
+# uberdev_goal_read_run_state
+#   Reads + per-field-validates the sidecar; never sources or executes it. Caller must
+#   already hold the GOAL_ID pointer (it keys the sidecar path). On success
+#   exports/sets GOAL_ID, cycle, watch_start, overflow_count,
+#   overflow_detected, MAX_CYCLES, UBERDEV_RESOLVED_BACKEND, and rehydrates
+#   the queue/active_issues arrays. Returns 0 on success; 1 if missing/
+#   unreadable. Invalid fields are skipped (not assigned a garbage value);
+#   a forged GOAL_ID is rejected and never interpolated into a path.
+uberdev_goal_read_run_state() {
+  local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  _uberdev_goal_validate_id "${GOAL_ID:-}" || { echo "goal: invalid GOAL_ID pointer" >&2; return 1; }
+  local sc="$tmpdir/goal-$GOAL_ID-runstate"
+  [ -r "$sc" ] || { echo "goal: missing run-state sidecar ($sc)" >&2; return 1; }
+
+  local k v
+  while IFS='=' read -r k v; do
+    case "$k" in
+      GOAL_ID)
+        # Load-bearing: a substituted sidecar GOAL_ID with / or .. is a
+        # path-traversal vector. Gate BEFORE any later path interpolation.
+        _uberdev_goal_validate_id "$v" && GOAL_ID="$v" ;;
+      cycle)             _uberdev_goal_validate_int "$v" && cycle="$v" ;;
+      watch_start)       _uberdev_goal_validate_int "$v" && watch_start="$v" ;;
+      overflow_count)    _uberdev_goal_validate_int "$v" && overflow_count="$v" ;;
+      overflow_detected) _uberdev_goal_validate_int "$v" && overflow_detected="$v" ;;
+      MAX_CYCLES)        _uberdev_goal_validate_int "$v" && MAX_CYCLES="$v" ;;
+      UBERDEV_RESOLVED_BACKEND)
+        case "$v" in claude-bg|wezterm|background) UBERDEV_RESOLVED_BACKEND="$v" ;; esac ;;
+      *) : ;;   # reject unknown keys (allowlist only)
+    esac
+  done < "$sc"
+
+  # Rehydrate arrays with the portable read loop (NOT mapfile); each element
+  # int-gated so a newline/extra-field injection cannot survive.
+  queue=()
+  if [ -r "${sc}.queue" ]; then
+    local line
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      _uberdev_goal_validate_int "$line" && queue+=("$line")
+    done < "${sc}.queue"
+  fi
+  active_issues=()
+  if [ -r "${sc}.active" ]; then
+    local line2
+    while IFS= read -r line2; do
+      [ -n "$line2" ] || continue
+      _uberdev_goal_validate_int "$line2" && active_issues+=("$line2")
+    done < "${sc}.active"
+  fi
+  return 0
+}
+
+# uberdev_goal_cleanup_run_state
+#   Best-effort removal of the three known predictable sidecar paths on goal
+#   completion / circuit-breaker halt. Never fatal; no globbing of attacker-
+#   influenceable patterns (each path is GOAL_ID-keyed and validated).
+uberdev_goal_cleanup_run_state() {
+  local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  _uberdev_goal_validate_id "${GOAL_ID:-}" || return 0
+  local sc="$tmpdir/goal-$GOAL_ID-runstate"
+  rm -f "$sc" "${sc}.queue" "${sc}.active" 2>/dev/null
+  return 0
 }

--- a/plugins/uberdev/skills/dev-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/dev-pipeline/SKILL.md
@@ -80,6 +80,13 @@ so no prototype commit ever lands on the default branch. If the working tree is 
 (unrelated uncommitted changes), print a one-line notice and proceed; Phase 3 stages
 explicit paths only, so pollution is structurally prevented.
 
+<!-- #171 audit: /dev is in-session (parallel subagents dispatched in one
+     message, integrated by the sole git controller). It sources no libs and
+     holds no $UBERDEV_TMPDIR run-state pointer; the only cross-phase state is
+     the git branch, which persists in the worktree (re-derivable via
+     `git rev-parse --abbrev-ref HEAD`), not in evaporating shell state.
+     No re-source/sidecar treatment is required. -->
+
 ## Phase 1 — Inline decomposition
 
 Split the idea into **1–4 chunks**. Each chunk is `{ id, goal, owns: [file allowlist] }`:

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -208,6 +208,13 @@ for ISSUE_NUM in "${queue[@]}"; do
     exit 1
   fi
 done
+
+# #171 — flush the populated active_issues (+ rehydrated queue/scalars) so the
+# Phase 2 watch loop (a fresh shell) rehydrates the dispatched set. Without this,
+# active_issues evaporates with this shell and Phase 2 polls nothing, emitting a
+# false goal_converged on cycle 1. Loud-exit: this is a phase-boundary persist
+# Phase 2 depends on (mirrors the Phase 0 init + Phase 3 loop-back flushes).
+uberdev_goal_write_run_state || { echo "goal: failed to persist run-state after dispatch" >&2; exit 3; }
 ```
 
 ## Phase 2 — Watch (per cycle, hard cap 4h wall-clock)

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -98,6 +98,7 @@ Notes on the enums:
 5. **Generate `GOAL_ID`.** Random suffix per D4 — NEVER derived from `$@` or issue numbers (those are attacker-controlled; using them would let a caller collide TMPDIR paths):
 
    ```bash
+   export UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"   # D7 — stable sidecar dir for the watcher
    GOAL_ID="goal-$(date +%s)-$(mktemp -u XXXXXXXX | tr -d '/' | head -c 8)"
    export UBERDEV_GOAL_ID="$GOAL_ID"
    ```
@@ -116,6 +117,12 @@ Notes on the enums:
    watch_start="$(date +%s)"
    overflow_count=0
    overflow_detected=0
+   ```
+
+   ```bash
+   # #171 — persist the run-state pointer + loop accumulators so Phases 1-4
+   # (fresh shells) can rehydrate GOAL_ID + counters. cycle is initialized above.
+   uberdev_goal_write_run_state || { echo "goal: failed to persist run-state" >&2; exit 3; }
    ```
 
 8. **If `--dry-run`: print planned cycle-1 dispatch list + watch-loop outline, exit 0** (D16, S9). The dry-run path is the audit/preview surface — no `gh` calls, no agent spawns, no merges, **no audit events emitted** (S9 — `goal_dispatched` must NOT fire on dry-run so the audit log only carries real runs). Emit the resolved `MAX_CYCLES`, the resolved `UBERDEV_RESOLVED_BACKEND`, the issue queue, and the planned audit events ("would emit goal_dispatched", "would dispatch /turbo for issues …", "would poll solve-bg-stdout-N.log per issue"), then exit 0 cleanly. This step runs BEFORE the real `goal_dispatched` emit in step 9 — order matters.
@@ -143,6 +150,14 @@ Notes on the enums:
 Per cycle, walk the current `queue` and dispatch one `/turbo` agent per eligible issue. Skip issues already in `solving` or `pr-pushed` (resume safety — if Phase 0 was re-entered after a partial run within the same `$UBERDEV_TMPDIR`, in-flight issues must not be re-dispatched).
 
 ```bash
+# #171 fresh-shell rehydration — re-source libs (idempotent via _UBERDEV_*_LOADED
+# guards) and re-read run-state. Safe under set -u (${VAR:-} expansions).
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh" ] && . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ]    && . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh" ]  && . "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh"
+GOAL_ID="${UBERDEV_GOAL_ID:-${GOAL_ID:-}}"
+uberdev_goal_read_run_state || { echo "goal: cannot rehydrate run-state in Phase 1" >&2; exit 3; }
+uberdev_dispatch_resolve_env || exit 1   # re-derive backend/env (idempotent, D8); not persisted
 declare -a active_issues=()
 for ISSUE_NUM in "${queue[@]}"; do
   current_state="$(awk -v i="$ISSUE_NUM" '{state[$1]=$2} END {print state[i]}' \
@@ -200,6 +215,14 @@ done
 **Concurrency model.** Phase 2 runs as a **single-threaded watcher** per iteration: each `sleep $_UBERDEV_GOAL_POLL_SECS` cycle walks the active-issues list once (step 2a), the green-PR list once (step 2b), and the merging-PR list once (step 2c) in deterministic order — a serial poll of every PR, never a fan-out. There is **no per-PR poll parallelism in v1** — the audit timeline (`goal_pr_transition` events in `goal-<id>.jsonl`) must remain a serial, replay-deterministic sequence for post-mortems and for the fingerprint-repeat detector in Phase 3. Per-PR poll parallelism is deferred to a future RFC (it would require an event-bus partition by PR number and a multi-writer audit framing that preserves a total order; neither lands in v1).
 
 ```bash
+# #171 fresh-shell rehydration — re-source libs (idempotent via _UBERDEV_*_LOADED
+# guards) and re-read run-state. Safe under set -u (${VAR:-} expansions).
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh" ] && . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ]    && . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh" ]  && . "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh"
+GOAL_ID="${UBERDEV_GOAL_ID:-${GOAL_ID:-}}"
+uberdev_goal_read_run_state || { echo "goal: cannot rehydrate run-state in Phase 2" >&2; exit 3; }
+uberdev_dispatch_resolve_env || exit 1   # re-derive backend/env (idempotent, D8); not persisted
 # watch_start is set in Phase 0 (step 7) — goal-level wall-clock anchor.
 # The 4h stuck-loop check below measures total goal wall-clock, not per-cycle.
 # Q1 — bash supports ONE EXIT trap per shell; register the combined cleanup
@@ -276,6 +299,7 @@ while true; do
               # goal_cycle_completed audit payload (the prose at line ~381
               # promises {overflow_count: N} in the summary).
               overflow_count=$(( ${overflow_count:-0} + 1 ))
+              uberdev_goal_write_run_state || echo "goal: warning: run-state flush failed in Phase 2a" >&2
             fi
           else
             printf 'goal-pipeline: overflow check failed to read audit %s for PR %s; treating as no overflow this cycle\n' \
@@ -455,6 +479,14 @@ Why polling stdout transcripts instead of the (non-existent) `claude agents stat
 After Phase 2 drains (no active agents, no merging PRs), enumerate the new BLOCKER/CRITICAL `review-pr-finding` issues filed during the cycle, repeat-detect them, and decide whether to loop, converge, or halt.
 
 ```bash
+# #171 fresh-shell rehydration — re-source libs (idempotent via _UBERDEV_*_LOADED
+# guards) and re-read run-state. Safe under set -u (${VAR:-} expansions).
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh" ] && . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ]    && . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh" ]  && . "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh"
+GOAL_ID="${UBERDEV_GOAL_ID:-${GOAL_ID:-}}"
+uberdev_goal_read_run_state || { echo "goal: cannot rehydrate run-state in Phase 3" >&2; exit 3; }
+uberdev_dispatch_resolve_env || exit 1   # re-derive backend/env (idempotent, D8); not persisted
 # Snapshot goal start for the createdAt filter — only consider findings filed
 # during THIS goal run, not pre-existing review-pr-finding issues that pre-date
 # the cycle. The TZ-Z timestamp lines up with gh's ISO-8601 createdAt format.
@@ -530,6 +562,14 @@ mapfile -t new_candidates < <(printf '%s' "$candidates_json")
 For each candidate, extract the fingerprint and check for repeat:
 
 ```bash
+# #171 fresh-shell rehydration — re-source libs (idempotent via _UBERDEV_*_LOADED
+# guards) and re-read run-state. Safe under set -u (${VAR:-} expansions).
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh" ] && . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ]    && . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh" ]  && . "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh"
+GOAL_ID="${UBERDEV_GOAL_ID:-${GOAL_ID:-}}"
+uberdev_goal_read_run_state || { echo "goal: cannot rehydrate run-state in Phase 3 (fingerprint loop)" >&2; exit 3; }
+uberdev_dispatch_resolve_env || exit 1   # re-derive backend/env (idempotent, D8); not persisted
 for issue in "${new_candidates[@]}"; do
   # Issues don't go through _uberdev_goal_fetch_pr_body (PR-specific helper);
   # keep the inline gh issue view + 64KiB cap here. The cap shape is shared
@@ -558,6 +598,14 @@ done
 - Otherwise: emit `goal_cycle_completed` with the cycle summary `{cycle, prs_merged, prs_held, issues_resolved, new_candidates}`, set `queue ← new_candidates`, increment `cycle`, and loop back to Phase 1.
 
 ```bash
+# #171 fresh-shell rehydration — re-source libs (idempotent via _UBERDEV_*_LOADED
+# guards) and re-read run-state. Safe under set -u (${VAR:-} expansions).
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh" ] && . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ]    && . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh" ]  && . "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh"
+GOAL_ID="${UBERDEV_GOAL_ID:-${GOAL_ID:-}}"
+uberdev_goal_read_run_state || { echo "goal: cannot rehydrate run-state in Phase 3 (terminal check)" >&2; exit 3; }
+uberdev_dispatch_resolve_env || exit 1   # re-derive backend/env (idempotent, D8); not persisted
 if [ "$cycle" -ge "$MAX_CYCLES" ] && [ "${#new_candidates[@]}" -gt 0 ]; then
   uberdev_goal_audit goal_circuit_breaker \
     "{\"reason\":\"max_cycles\",\"cycle\":$cycle,\"max\":$MAX_CYCLES,\"queued\":${#new_candidates[@]}}"
@@ -581,6 +629,7 @@ if [ "${#new_candidates[@]}" = "0" ] && [ "$terminal_count" = "$all_pr_count" ];
   uberdev_goal_audit goal_converged \
     "{\"cycle\":$cycle,\"prs\":$all_pr_count}"
   print_summary "$cycle"
+  uberdev_goal_cleanup_run_state || true   # #171 — reap run-state sidecars on terminal exit
   exit 0
 fi
 
@@ -603,6 +652,7 @@ cycle=$(( cycle + 1 ))
 # is per-cycle; overflow_detected gates the per-cycle truncation above).
 overflow_count=0
 overflow_detected=0
+uberdev_goal_write_run_state || { echo "goal: failed to persist run-state before loop-back" >&2; exit 3; }
 # loop back to Phase 1
 ```
 
@@ -614,6 +664,14 @@ overflow_detected=0
 - **does NOT halt the entire goal** — `halted_due_to_overflow` is a per-PR cycle-management signal, not a goal-level circuit breaker. The goal continues to its next cycle and may converge once the overflow PR's issues are resolved.
 
 ```bash
+# #171 fresh-shell rehydration — re-source libs (idempotent via _UBERDEV_*_LOADED
+# guards) and re-read run-state. Safe under set -u (${VAR:-} expansions).
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh" ] && . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ]    && . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
+[ -r "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh" ]  && . "${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh"
+GOAL_ID="${UBERDEV_GOAL_ID:-${GOAL_ID:-}}"
+uberdev_goal_read_run_state || { echo "goal: cannot rehydrate run-state in Phase 3 (overflow check)" >&2; exit 3; }
+uberdev_dispatch_resolve_env || exit 1   # re-derive backend/env (idempotent, D8); not persisted
 # overflow_detected is set in Phase 2a's red case when any PR's /review-pr
 # audit JSON carried halted_due_to_overflow:true. Here in Phase 3 we apply
 # the first-10 truncation (no PR transition — Phase 2a already did that).
@@ -647,6 +705,9 @@ goal <GOAL_ID>: cycles=<N>/<MAX> prs_merged=<M> prs_held=<H> issues_resolved=<R>
 The held-PR list (each row `pr=<num> state=<yellow-held|red-held> blocks=#<i1>,#<i2>,…`) is the **post-mortem surface** — it tells the operator which PRs need human attention. It is printed after the summary line, one row per held PR.
 
 ```bash
+# #171 — print_summary reads GOAL_ID/MAX_CYCLES/watch_start from the calling
+# shell; every caller (Phase 2/3 fences) rehydrates them via
+# uberdev_goal_read_run_state at fence top. Do NOT call from a non-rehydrated block.
 print_summary() {
   local cycles="$1" prs_merged prs_held_lines prs_held_count issues_resolved wall_secs
   prs_merged="$(uberdev_goal_list_prs_in_state "$GOAL_ID" merged | grep -c . || true)"

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -713,8 +713,11 @@ The held-PR list (each row `pr=<num> state=<yellow-held|red-held> blocks=#<i1>,#
 
 ```bash
 # #171 — print_summary reads GOAL_ID/MAX_CYCLES/watch_start from the calling
-# shell; every caller (Phase 2/3 fences) rehydrates them via
-# uberdev_goal_read_run_state at fence top. Do NOT call from a non-rehydrated block.
+# shell and calls uberdev_goal_* helpers that gate on the UBERDEV_GOAL_ID env.
+# Every caller (the Phase 1/2/3 fences) rehydrates that state via
+# uberdev_goal_read_run_state at fence top (which also re-exports UBERDEV_GOAL_ID
+# + UBERDEV_TMPDIR). Do NOT call print_summary from a block that has not run that
+# rehydration — it is never called from Phase 0.
 print_summary() {
   local cycles="$1" prs_merged prs_held_lines prs_held_count issues_resolved wall_secs
   prs_merged="$(uberdev_goal_list_prs_in_state "$GOAL_ID" merged | grep -c . || true)"

--- a/plugins/uberdev/skills/testers-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/testers-pipeline/SKILL.md
@@ -155,7 +155,8 @@ if [ "$WATCH" = "1" ]; then
 else
   # Build the master prompt that re-enters this skill with the same args plus --watch
   MASTER_PROMPT="/uberdev:testers $ARGUMENTS --watch"
-  source plugins/uberdev/lib/dispatch.sh
+  # #171 — canonical CLAUDE_PLUGIN_ROOT-relative source (robust across cwd changes)
+  [ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ] && . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
   dispatch_master "$MASTER_PROMPT" "$RUN_DIR/master.log"
   echo "[testers] dispatched master. Watch progress: $RUN_DIR/master.log"
   echo "[testers] run_id=$RUN_ID surface=$SURFACE target=$TARGET"

--- a/plugins/uberdev/skills/uberscan-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/uberscan-pipeline/SKILL.md
@@ -69,7 +69,12 @@ if [ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ]; then
   UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
   _scan_ptr="$UBERDEV_TMPDIR/uberscan-active-id.txt"
   if _uberdev_dispatch_prepare_tmp_target "$_scan_ptr" 0 "uberscan"; then
-    printf '%s\n' "$RUN_ID" > "$_scan_ptr"
+    # Warn (not silent) if the write fails — the pointer is best-effort
+    # (a missing one degrades to in-session RUN_ID), but a silent failure here
+    # was the gap a fresh-shell block can't diagnose. A partial/corrupt write is
+    # caught fail-closed by the re-read's `case` validator downstream.
+    printf '%s\n' "$RUN_ID" > "$_scan_ptr" \
+      || echo "uberscan: warning: failed to persist RUN_ID pointer; cross-shell RUN_DIR recovery may fail" >&2
   fi
 fi
 

--- a/plugins/uberdev/skills/uberscan-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/uberscan-pipeline/SKILL.md
@@ -63,6 +63,16 @@ RUN_ID="$(date +%Y%m%d-%H%M%S)-$(printf '%04x' $RANDOM)"
 RUN_DIR=".uberdev/scan/$RUN_ID"
 mkdir -p "$RUN_DIR"
 
+# #171 — persist RUN_ID pointer so later fresh-shell blocks can reconstruct RUN_DIR.
+if [ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
+  UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  _scan_ptr="$UBERDEV_TMPDIR/uberscan-active-id.txt"
+  if _uberdev_dispatch_prepare_tmp_target "$_scan_ptr" 0 "uberscan"; then
+    printf '%s\n' "$RUN_ID" > "$_scan_ptr"
+  fi
+fi
+
 # Parse flags from $ARGUMENTS
 SCOPE="."; ALL=0; NO_ISSUES=0; NO_REPORT=0; MAX_CHUNKS_ARG=""; CONCURRENCY_ARG=""; SEVERITY="major"; TURBO=0
 for arg in $ARGUMENTS; do
@@ -162,6 +172,14 @@ echo "[uberscan] run_id=$RUN_ID scope=$SCOPE chunks=$EMITTED_CHUNKS concurrency=
 Each chunk receives a **file-set audit brief**: the agents are auditing EXISTING files as they stand in the repo (not a diff). The orchestrating session reads each DISPATCH directive and fires the 6 `Task()` calls IN ONE MESSAGE.
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/uberscan-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/uberscan-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/scan/$RUN_ID"
+fi
+
 # Read chunk list from manifest
 CHUNK_IDS="$(jq -r '.chunks[].id' "$RUN_DIR/manifest.json")"
 TOTAL_EMITTED="$(jq '.chunks | length' "$RUN_DIR/manifest.json")"
@@ -326,6 +344,14 @@ After each wave completes (all chunk Tasks have returned), the orchestrating ses
 Fired once, in parallel with the first chunk wave (emit in the same ONE message as wave 1).
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/uberscan-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/uberscan-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/scan/$RUN_ID"
+fi
+
 # ===========================================================================
 # DISPATCH POINT — emit alongside wave 1 Task() calls in ONE assistant message.
 #
@@ -363,6 +389,14 @@ echo "[uberscan] dispatched global pass (security + coverage) alongside wave 1"
 ## Phase 2 — Aggregate + report
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/uberscan-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/uberscan-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/scan/$RUN_ID"
+fi
+
 # Aggregate all chunk findings into the deduped report
 if [ "$NO_REPORT" != "1" ]; then
   python3 "${CLAUDE_PLUGIN_ROOT}/skills/uberscan-pipeline/report.py" \
@@ -392,6 +426,14 @@ The `f2i-aggregate.md` file is wrapped in `<external-untrusted-input source="ube
 ## Phase 3 — File issues (skip iff --no-issues)
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/uberscan-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/uberscan-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/scan/$RUN_ID"
+fi
+
 if [ "$NO_ISSUES" != "1" ]; then
   # CB6 gh rate-limit floor check before any write (mirrors the rate-limit-floor
   # pattern in agents/findings-to-issues.md Step 2 — the canonical reference).
@@ -472,6 +514,14 @@ fi
 ## Phase 4 — Summary + exit
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/uberscan-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/uberscan-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/scan/$RUN_ID"
+fi
+
 # Read severity totals from the report if available
 _uberscan_sev_total() {
   local sev="$1"

--- a/plugins/uberdev/skills/uberscan-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/uberscan-pipeline/SKILL.md
@@ -176,7 +176,7 @@ Each chunk receives a **file-set audit brief**: the agents are auditing EXISTING
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/uberscan-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/uberscan-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/scan/$RUN_ID"
 fi
 
@@ -348,7 +348,7 @@ Fired once, in parallel with the first chunk wave (emit in the same ONE message 
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/uberscan-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/uberscan-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/scan/$RUN_ID"
 fi
 
@@ -393,7 +393,7 @@ echo "[uberscan] dispatched global pass (security + coverage) alongside wave 1"
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/uberscan-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/uberscan-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/scan/$RUN_ID"
 fi
 
@@ -430,7 +430,7 @@ The `f2i-aggregate.md` file is wrapped in `<external-untrusted-input source="ube
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/uberscan-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/uberscan-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/scan/$RUN_ID"
 fi
 
@@ -518,7 +518,7 @@ fi
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/uberscan-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/uberscan-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "uberscan: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/scan/$RUN_ID"
 fi
 

--- a/plugins/uberdev/skills/ubersimplify-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/ubersimplify-pipeline/SKILL.md
@@ -85,7 +85,12 @@ if [ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ]; then
   UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
   _simp_ptr="$UBERDEV_TMPDIR/ubersimplify-active-id.txt"
   if _uberdev_dispatch_prepare_tmp_target "$_simp_ptr" 0 "ubersimplify"; then
-    printf '%s\n' "$RUN_ID" > "$_simp_ptr"
+    # Warn (not silent) if the write fails — the pointer is best-effort
+    # (a missing one degrades to in-session RUN_ID), but a silent failure here
+    # was the gap a fresh-shell block can't diagnose. A partial/corrupt write is
+    # caught fail-closed by the re-read's `case` validator downstream.
+    printf '%s\n' "$RUN_ID" > "$_simp_ptr" \
+      || echo "ubersimplify: warning: failed to persist RUN_ID pointer; cross-shell RUN_DIR recovery may fail" >&2
   fi
 fi
 

--- a/plugins/uberdev/skills/ubersimplify-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/ubersimplify-pipeline/SKILL.md
@@ -79,6 +79,16 @@ RUN_ID="$(date +%Y%m%d-%H%M%S)-$(printf '%04x' $RANDOM)"
 RUN_DIR=".uberdev/simplify/$RUN_ID"
 mkdir -p "$RUN_DIR"
 
+# #171 — persist RUN_ID pointer for fresh-shell RUN_DIR reconstruction.
+if [ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
+  UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  _simp_ptr="$UBERDEV_TMPDIR/ubersimplify-active-id.txt"
+  if _uberdev_dispatch_prepare_tmp_target "$_simp_ptr" 0 "ubersimplify"; then
+    printf '%s\n' "$RUN_ID" > "$_simp_ptr"
+  fi
+fi
+
 # Anchor an absolute working dir up front: code-fixer and findings-to-issues both
 # REQUIRE an absolute working_dir inside the worktree (they refuse with
 # input-malformed otherwise). Resolve once and reuse everywhere.
@@ -185,6 +195,14 @@ echo "[ubersimplify] run_id=$RUN_ID scope=$SCOPE chunks=$EMITTED_CHUNKS concurre
 Each chunk receives a **file-set audit brief**: the agents audit EXISTING files as they stand in the repo (not a diff). Per chunk the orchestrating session fires **3** `Task()` calls IN ONE MESSAGE — one per lens (`Reuse`, `Quality`, `Efficiency`), each `subagent_type: uberdev:code-simplifier`. If `LENS_SUBSET` is set, dispatch only the named lenses for every chunk (e.g. `--lens=Reuse,Quality` → 2 Tasks/chunk; recompute the per-chunk fleet size accordingly).
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/simplify/$RUN_ID"
+fi
+
 # Read chunk list from manifest
 CHUNK_IDS="$(jq -r '.chunks[].id' "$RUN_DIR/manifest.json")"
 TOTAL_EMITTED="$(jq '.chunks | length' "$RUN_DIR/manifest.json")"
@@ -352,6 +370,14 @@ After each wave completes (all lens Tasks for the wave's chunks have returned), 
 For each `chunk-NNN-lens.yaml`, produce the per-chunk `code-fixer` input by deduping the lens findings across lenses by `file:line` (merged `lens` becomes `Reuse+Quality`, severity = max, summary/detail lens-prefixed). The output is wrapped in the `post-impl-review-aggregate` envelope `code-fixer` validates.
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/simplify/$RUN_ID"
+fi
+
 # Per-chunk fixer aggregate (the code-fixer input for Phase 3).
 for LENS_FILE in "$RUN_DIR"/chunk-*-lens.yaml; do
   [ -e "$LENS_FILE" ] || continue
@@ -405,6 +431,14 @@ fi
 Skipped entirely under `--audit-only` (read-only mode). Otherwise a new branch is cut from the current branch, then a `code-fixer` Task is dispatched **one chunk at a time** — concurrent apply Tasks would race the git index (two `git add`/`git commit` in flight corrupt the staging area). Each `code-fixer` produces exactly one `refactor:` commit (Phase 2 single-commit invariant, R8.6).
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/simplify/$RUN_ID"
+fi
+
 if [ "$AUDIT_ONLY" = "1" ]; then
   echo "[ubersimplify] --audit-only: skipping branch + apply (Phases 3-4)"
   BRANCH=""
@@ -449,6 +483,14 @@ fi
 ## Phase 4 — Push + ONE gh pr create (skip iff --audit-only or 0 commits)
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/simplify/$RUN_ID"
+fi
+
 if [ "$AUDIT_ONLY" = "1" ]; then
   echo "[ubersimplify] --audit-only: no push/PR"
 elif [ "${COMMIT_COUNT:-0}" -eq 0 ]; then
@@ -506,6 +548,14 @@ fi
 Collect the fileable (`blocker`-tier) lens findings that `code-fixer` did NOT apply, wrap them in the `ubersimplify-aggregate` envelope, and hand them to `findings-to-issues`. Under `--audit-only` no apply phase ran, so every fileable finding is treated as deferred.
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/simplify/$RUN_ID"
+fi
+
 if [ "$NO_ISSUES" != "1" ]; then
   # Build the leftover-issues aggregate. --audit-only -> every fileable finding is
   # deferred (no disposition files exist); otherwise APPLIED locations are subtracted.
@@ -593,6 +643,14 @@ fi
 ## Phase 6 — Summary + exit
 
 ```bash
+# #171 — rehydrate RUN_ID/RUN_DIR in a fresh shell.
+UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
+  RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
+  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  RUN_DIR=".uberdev/simplify/$RUN_ID"
+fi
+
 # Severity totals across all chunk lens files.
 _ubersimplify_sev_total() {
   local sev="$1"

--- a/plugins/uberdev/skills/ubersimplify-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/ubersimplify-pipeline/SKILL.md
@@ -199,7 +199,7 @@ Each chunk receives a **file-set audit brief**: the agents audit EXISTING files 
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/simplify/$RUN_ID"
 fi
 
@@ -374,7 +374,7 @@ For each `chunk-NNN-lens.yaml`, produce the per-chunk `code-fixer` input by dedu
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/simplify/$RUN_ID"
 fi
 
@@ -435,7 +435,7 @@ Skipped entirely under `--audit-only` (read-only mode). Otherwise a new branch i
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/simplify/$RUN_ID"
 fi
 
@@ -487,7 +487,7 @@ fi
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/simplify/$RUN_ID"
 fi
 
@@ -552,7 +552,7 @@ Collect the fileable (`blocker`-tier) lens findings that `code-fixer` did NOT ap
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/simplify/$RUN_ID"
 fi
 
@@ -647,7 +647,7 @@ fi
 UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
 if [ -z "${RUN_ID:-}" ] && [ -r "$UBERDEV_TMPDIR/ubersimplify-active-id.txt" ]; then
   RUN_ID="$(head -n1 "$UBERDEV_TMPDIR/ubersimplify-active-id.txt")"
-  case "$RUN_ID" in *[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
+  case "$RUN_ID" in ''|*[!0-9A-Za-z._-]*|*..*) echo "ubersimplify: invalid RUN_ID pointer" >&2; exit 2 ;; esac
   RUN_DIR=".uberdev/simplify/$RUN_ID"
 fi
 

--- a/tests/goal-state-sidecar.test.sh
+++ b/tests/goal-state-sidecar.test.sh
@@ -159,7 +159,40 @@ UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
   ' >/dev/null 2>&1 || true
 assert_absent "$marker" "metacharacter payload did not execute (no source/eval)"
 
-echo "== cleanup removes all three sidecars =="
+echo "== fixed-path active-id bootstrap: fresh shell with NO GOAL_ID recovers from pointer (#171 AC2) =="
+GOAL_ID="goal-test-boot00001"; cycle=3; watch_start=1716400000
+overflow_count=0; overflow_detected=0; MAX_CYCLES=7; UBERDEV_RESOLVED_BACKEND="claude-bg"
+queue=(501 601); active_issues=()
+uberdev_goal_write_run_state
+# Fresh shell: explicitly unset GOAL_ID + UBERDEV_GOAL_ID (mirrors a real
+# Phase-1 Bash call where env + scalars evaporated). Must recover from the
+# fixed-path pointer — this is the actual cross-call fix, not the env fallback.
+boot_out="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    unset GOAL_ID UBERDEV_GOAL_ID
+    uberdev_goal_read_run_state || exit 9
+    printf "%s|%s|%s" "$GOAL_ID" "$cycle" "${queue[*]}"
+  ')"
+assert_eq "$boot_out" "goal-test-boot00001|3|501 601" "fresh shell with no env recovers GOAL_ID+state from active-id pointer"
+
+echo "== active-id pointer path-traversal rejected (security) =="
+# Forge the fixed-path pointer with a traversal payload; the bootstrap must
+# reject it (validate_id gate) and NOT adopt it as GOAL_ID.
+printf '../pwned\n' > "$UBERDEV_TMPDIR/goal-active-id.txt"
+ptrav_out="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    unset GOAL_ID UBERDEV_GOAL_ID
+    uberdev_goal_read_run_state 2>/dev/null
+    printf "id=[%s]" "${GOAL_ID:-}"
+  ')"
+case "$ptrav_out" in
+  *pwned*|*../*) assert_eq "rejected" "accepted" "active-id pointer traversal rejected" ;;
+  *)            assert_eq "rejected" "rejected" "active-id pointer traversal rejected" ;;
+esac
+
+echo "== cleanup removes all three sidecars + the active-id pointer =="
 GOAL_ID="goal-test-clean001"; cycle=1; watch_start=1; overflow_count=0
 overflow_detected=0; MAX_CYCLES=5; UBERDEV_RESOLVED_BACKEND="claude-bg"
 queue=(1 2); active_issues=(3)
@@ -170,6 +203,7 @@ assert_eq "$?" "0" "cleanup returns 0"
 assert_absent "$sc"          "runstate sidecar removed"
 assert_absent "${sc}.queue"  "queue sidecar removed"
 assert_absent "${sc}.active" "active sidecar removed"
+assert_absent "$UBERDEV_TMPDIR/goal-active-id.txt" "active-id pointer removed (names this goal)"
 uberdev_goal_cleanup_run_state   # second call on already-gone files
 assert_eq "$?" "0" "cleanup idempotent (non-fatal when absent)"
 

--- a/tests/goal-state-sidecar.test.sh
+++ b/tests/goal-state-sidecar.test.sh
@@ -221,6 +221,34 @@ handoff_out="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUG
   ')"
 assert_eq "$handoff_out" "201|1" "Phase 1 active_issues mutation survives to Phase 2 fresh shell"
 
+echo "== read_run_state re-exports UBERDEV_GOAL_ID + UBERDEV_TMPDIR for fresh-shell helpers (#178 review blockers) =="
+# Four uberdev_goal_* helpers gate on the UBERDEV_GOAL_ID *env var* (audit sink,
+# should_automerge provenance, review-pr/merge dispatch); the goal-pipeline body
+# interpolates bare $UBERDEV_TMPDIR/... paths and PR #129 helpers fall back to it.
+# read_run_state MUST export BOTH so a rehydrated fresh shell doesn't mis-sink
+# audit to goal-unknown.jsonl, refuse a GREEN PR auto-merge, or resolve state
+# files under / or /tmp instead of the dir Phase 0 wrote.
+GOAL_ID="goal-test-export01"; cycle=1; watch_start=1; overflow_count=0
+overflow_detected=0; MAX_CYCLES=5; UBERDEV_RESOLVED_BACKEND="claude-bg"
+queue=(); active_issues=()
+uberdev_goal_write_run_state
+# Fresh shell: TMPDIR set (so the helper fallback locates the sidecar) but BOTH
+# UBERDEV_GOAL_ID and UBERDEV_TMPDIR unset — the two vars read_run_state must
+# export. `env` lists only EXPORTED vars, so it distinguishes export from a bare
+# scalar assignment (the exact bug: read_run_state set GOAL_ID but exported nothing).
+export_out="$(TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  GOAL_ID="goal-test-export01" bash -c '
+    unset UBERDEV_GOAL_ID UBERDEV_TMPDIR
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    uberdev_goal_read_run_state || exit 9
+    g=FAIL; t=FAIL
+    env | grep -q "^UBERDEV_GOAL_ID=goal-test-export01$" && g=OK
+    env | grep -q "^UBERDEV_TMPDIR=." && t=OK
+    printf "%s|%s" "$g" "$t"
+  ')"
+assert_eq "$export_out" "OK|OK" "read_run_state exports UBERDEV_GOAL_ID + UBERDEV_TMPDIR to the rehydrated shell env"
+
 echo "== cleanup removes all three sidecars + the active-id pointer =="
 GOAL_ID="goal-test-clean001"; cycle=1; watch_start=1; overflow_count=0
 overflow_detected=0; MAX_CYCLES=5; UBERDEV_RESOLVED_BACKEND="claude-bg"

--- a/tests/goal-state-sidecar.test.sh
+++ b/tests/goal-state-sidecar.test.sh
@@ -192,6 +192,35 @@ case "$ptrav_out" in
   *)            assert_eq "rejected" "rejected" "active-id pointer traversal rejected" ;;
 esac
 
+echo "== Phase0->1->2 hand-off: active_issues populated in Phase 1 survives to Phase 2 (separate fresh shells; #171 review gap) =="
+# This is the end-to-end regression guard for the wave-2-review CRITICAL: Phase 0
+# flushes run-state BEFORE active_issues exists (empty .active sidecar); Phase 1
+# (a fresh shell) rehydrates, appends the dispatched issue, and MUST flush; Phase 2
+# (another fresh shell) rehydrates and must see the Phase 1 mutation. Without the
+# Phase 1 flush, Phase 2 reads an empty active_issues and false-converges on cycle 1.
+GOAL_ID="goal-test-handoff01"; cycle=1; watch_start="$(date +%s)"
+overflow_count=0; overflow_detected=0; MAX_CYCLES=5; UBERDEV_RESOLVED_BACKEND="claude-bg"
+queue=(123); active_issues=()
+uberdev_goal_write_run_state                      # Phase 0 flush (active_issues still empty)
+# Phase 1 (fresh shell): rehydrate, simulate a dispatch populating active_issues, flush.
+UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  GOAL_ID="goal-test-handoff01" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    uberdev_goal_read_run_state || exit 9
+    active_issues+=("201")          # simulate Phase 1 dispatch adding an active issue
+    uberdev_goal_write_run_state || exit 8   # the flush the wave-2 review found missing
+  ' || { FAIL=$((FAIL + 1)); printf "  FAIL  phase-1 hand-off sim errored\n" >&2; }
+# Phase 2 (fresh shell): rehydrate, assert the Phase 1 active_issues mutation survived.
+handoff_out="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  GOAL_ID="goal-test-handoff01" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    uberdev_goal_read_run_state || exit 9
+    printf "%s|%s" "${active_issues[*]}" "${#active_issues[@]}"
+  ')"
+assert_eq "$handoff_out" "201|1" "Phase 1 active_issues mutation survives to Phase 2 fresh shell"
+
 echo "== cleanup removes all three sidecars + the active-id pointer =="
 GOAL_ID="goal-test-clean001"; cycle=1; watch_start=1; overflow_count=0
 overflow_detected=0; MAX_CYCLES=5; UBERDEV_RESOLVED_BACKEND="claude-bg"

--- a/tests/goal-state-sidecar.test.sh
+++ b/tests/goal-state-sidecar.test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# tests/goal-state-sidecar.test.sh
+#
+# Behavioral coverage for the run-state sidecar helpers added to
+# lib/goal-state.sh (issue #171): uberdev_goal_write_run_state /
+# uberdev_goal_read_run_state / uberdev_goal_cleanup_run_state.
+#
+# These tests SOURCE the real libs and exercise the functions across a
+# FRESH `bash -c` to prove cross-call survival — the exact failure mode
+# #171 fixes. No `source`/`eval` of the sidecar is ever performed; the
+# no-source guarantee is asserted directly.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"
+export CLAUDE_PLUGIN_ROOT
+GOAL_LIB="$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+DISPATCH_LIB="$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+
+for f in "$GOAL_LIB" "$DISPATCH_LIB"; do
+  if [ ! -r "$f" ]; then
+    printf 'FATAL: required file missing or unreadable: %s\n' "$f" >&2
+    exit 2
+  fi
+done
+
+PASS=0
+FAIL=0
+assert_eq() {
+  local got="$1" want="$2" label="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS + 1)); printf '  PASS  %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s (got=[%s] want=[%s])\n' "$label" "$got" "$want" >&2
+  fi
+}
+assert_absent() {
+  local path="$1" label="$2"
+  if [ ! -e "$path" ]; then
+    PASS=$((PASS + 1)); printf '  PASS  %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s (path exists: %s)\n' "$label" "$path" >&2
+  fi
+}
+
+# Isolated tmpdir so writes never collide with production state.
+_t_tmpdir="$(mktemp -d 2>/dev/null || printf '/tmp/goal-sidecar-%s' "$$")"
+mkdir -p "$_t_tmpdir"
+UBERDEV_TMPDIR="$_t_tmpdir"
+export UBERDEV_TMPDIR
+trap 'rm -rf "$_t_tmpdir"' EXIT
+
+# shellcheck source=/dev/null
+. "$DISPATCH_LIB"
+# shellcheck source=/dev/null
+. "$GOAL_LIB"
+
+echo "== scalar round-trip across fresh bash -c =="
+GOAL_ID="goal-test-12345678"; cycle=2; watch_start=1716400000
+overflow_count=1; overflow_detected=0; MAX_CYCLES=5
+UBERDEV_RESOLVED_BACKEND="claude-bg"
+uberdev_goal_write_run_state
+assert_eq "$?" "0" "write returns 0"
+
+read_out="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  GOAL_ID="goal-test-12345678" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    uberdev_goal_read_run_state || exit 9
+    printf "%s|%s|%s|%s|%s|%s" "$GOAL_ID" "$cycle" "$watch_start" "$overflow_count" "$MAX_CYCLES" "$UBERDEV_RESOLVED_BACKEND"
+  ')"
+assert_eq "$read_out" "goal-test-12345678|2|1716400000|1|5|claude-bg" "fresh-shell read recovers all scalars"
+
+echo "== reproduction-equivalence (no empty GOAL_ID, no command-not-found) =="
+repro="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  GOAL_ID="goal-test-12345678" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    uberdev_goal_read_run_state || exit 9
+    [ -n "$GOAL_ID" ] || exit 8
+    type uberdev_goal_audit >/dev/null 2>&1 || exit 7
+    case "$GOAL_ID" in goal--*) exit 6 ;; esac   # mis-pathing guard
+    printf "ok"
+  ')"
+assert_eq "$repro" "ok" "fresh shell: non-empty GOAL_ID + defined uberdev_goal_* fn"
+
+echo "== array round-trip (queue/active_issues) + empty-array =="
+GOAL_ID="goal-test-arr00001"; cycle=1; watch_start=1716400000
+overflow_count=0; overflow_detected=0; MAX_CYCLES=5; UBERDEV_RESOLVED_BACKEND="background"
+queue=(101 202 303); active_issues=(404)
+uberdev_goal_write_run_state
+arr_out="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  GOAL_ID="goal-test-arr00001" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    uberdev_goal_read_run_state || exit 9
+    printf "%s;%s;%s" "${queue[*]}" "${#queue[@]}" "${#active_issues[@]}"
+  ')"
+assert_eq "$arr_out" "101 202 303;3;1" "queue+active_issues round-trip"
+
+# empty-array case: write with empty queue, expect 0 elements (no phantom)
+GOAL_ID="goal-test-arr00002"; queue=(); active_issues=()
+uberdev_goal_write_run_state
+empty_out="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  GOAL_ID="goal-test-arr00002" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    uberdev_goal_read_run_state || exit 9
+    printf "%s" "${#queue[@]}"
+  ')"
+assert_eq "$empty_out" "0" "empty queue yields zero elements (no phantom)"
+
+echo "== validation rejects path-traversal GOAL_ID =="
+forge_id="goal-test-forge001"
+forged="$UBERDEV_TMPDIR/goal-$forge_id-runstate"
+printf 'GOAL_ID=../pwned\ncycle=1\nwatch_start=1\noverflow_count=0\noverflow_detected=0\nMAX_CYCLES=5\nUBERDEV_RESOLVED_BACKEND=claude-bg\n' > "$forged"
+trav_out="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  GOAL_ID="$forge_id" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    uberdev_goal_read_run_state 2>/dev/null
+    printf "%s" "$GOAL_ID"   # must NOT be ../pwned
+  ')"
+# GOAL_ID must remain the caller-provided value (or unknown sink), never the traversal
+case "$trav_out" in
+  *../*|*pwned*) assert_eq "rejected" "accepted" "path-traversal GOAL_ID rejected" ;;
+  *)            assert_eq "rejected" "rejected" "path-traversal GOAL_ID rejected" ;;
+esac
+
+echo "== validation rejects non-int counter =="
+ni_id="goal-test-nonint01"
+ni="$UBERDEV_TMPDIR/goal-$ni_id-runstate"
+printf 'GOAL_ID=%s\ncycle=not-a-number\nwatch_start=1716400000\noverflow_count=0\noverflow_detected=0\nMAX_CYCLES=5\nUBERDEV_RESOLVED_BACKEND=claude-bg\n' "$ni_id" > "$ni"
+ni_out="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  GOAL_ID="$ni_id" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    cycle=SENTINEL
+    uberdev_goal_read_run_state 2>/dev/null
+    printf "%s" "$cycle"   # must NOT be the literal not-a-number
+  ')"
+case "$ni_out" in
+  not-a-number) assert_eq "rejected" "accepted" "non-int cycle rejected" ;;
+  *)            assert_eq "rejected" "rejected" "non-int cycle rejected" ;;
+esac
+
+echo "== no-source guarantee (read-not-source) =="
+ns_id="goal-test-nosrc001"
+ns="$UBERDEV_TMPDIR/goal-$ns_id-runstate"
+marker="$UBERDEV_TMPDIR/PWNED"
+rm -f "$marker"
+# Deliberately malicious value; the validating reader must NOT eval/source it.
+printf 'GOAL_ID=x; touch %s/PWNED\ncycle=1\nwatch_start=1\noverflow_count=0\noverflow_detected=0\nMAX_CYCLES=5\nUBERDEV_RESOLVED_BACKEND=claude-bg\n' "$UBERDEV_TMPDIR" > "$ns"
+UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  GOAL_ID="$ns_id" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    uberdev_goal_read_run_state 2>/dev/null || true
+  ' >/dev/null 2>&1 || true
+assert_absent "$marker" "metacharacter payload did not execute (no source/eval)"
+
+echo "== cleanup removes all three sidecars =="
+GOAL_ID="goal-test-clean001"; cycle=1; watch_start=1; overflow_count=0
+overflow_detected=0; MAX_CYCLES=5; UBERDEV_RESOLVED_BACKEND="claude-bg"
+queue=(1 2); active_issues=(3)
+uberdev_goal_write_run_state
+sc="$UBERDEV_TMPDIR/goal-$GOAL_ID-runstate"
+uberdev_goal_cleanup_run_state
+assert_eq "$?" "0" "cleanup returns 0"
+assert_absent "$sc"          "runstate sidecar removed"
+assert_absent "${sc}.queue"  "queue sidecar removed"
+assert_absent "${sc}.active" "active sidecar removed"
+uberdev_goal_cleanup_run_state   # second call on already-gone files
+assert_eq "$?" "0" "cleanup idempotent (non-fatal when absent)"
+
+echo
+printf 'goal-state-sidecar: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -271,11 +271,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.33.6) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.6"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.6"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.6-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.6\]'        "G20.changelog"
+echo "== G20: version bump locked (0.33.7) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.7"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.7"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.7-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.7\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.5 -> 0.33.6 propagated =="
+echo "== Version bump 0.33.6 -> 0.33.7 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.33.6"' \
-  "plugin.json bumped to 0.33.6"
+  '"version": "0.33.7"' \
+  "plugin.json bumped to 0.33.7"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.33.6"' \
-  "marketplace.json bumped to 0.33.6"
+  '"version": "0.33.7"' \
+  "marketplace.json bumped to 0.33.7"
 assert_grep "$README" \
-  "version-0\\.33\\.6-blue" \
-  "README version badge bumped to 0.33.6"
+  "version-0\\.33\\.7-blue" \
+  "README version badge bumped to 0.33.7"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.33\.6\]' \
-  "CHANGELOG has [0.33.6] section header"
+  '^## \[0\.33\.7\]' \
+  "CHANGELOG has [0.33.7] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
Closes #171

## Problem

The `*-pipeline` SKILLs source their libs and generate run-state (`GOAL_ID`, `cycle`, `watch_start`, `overflow_count`, `queue`, `active_issues`) in an early phase, then reference those vars **and** the sourced `uberdev_goal_*` functions **bare** in later phases. But each Bash tool call is a fresh shell (`Shell state (env vars, functions) does not persist`), and the `/goal` watch-loop structurally forces call boundaries. So the Phase-0 pointer, loop accumulators, and sourced definitions evaporate before Phases 1–4: `$GOAL_ID` resolved empty (per-goal TSV paths degraded to `goal--*.tsv`), `uberdev_goal_*` calls hit "command not found", and the state machine + circuit-breaker accounting silently no-op'd in an unattended autonomous loop.

## Fix

Adopt the file-based cross-call model end to end. The TSV-keyed-by-`GOAL_ID` state model (PR #129) already survives; only the pointer + counters needed persisting.

**1. New SSOT helpers in `lib/goal-state.sh`** (TDD red-first; 17-assertion behavioral suite added):
- `uberdev_goal_write_run_state` — persists scalars (`KEY=value`) + arrays (newline-delimited) to `$UBERDEV_TMPDIR`, written atomically via the #155 TOCTOU-safe `_uberdev_dispatch_prepare_tmp_target` (symlink-reject + `set -C` + 0600), plus a **fixed-path `goal-active-id.txt` pointer** so a fresh shell can bootstrap `GOAL_ID` with no inherited env.
- `uberdev_goal_read_run_state` — reads + **per-field-validates** (never `source`/`eval` — the sidecar is in a world-writable dir); `GOAL_ID` gated through `_uberdev_goal_validate_id` (path-traversal) before any path interpolation; counters through `_uberdev_goal_validate_int`. Self-bootstraps `GOAL_ID` from the fixed-path pointer when env/scalar are empty. Portable `while IFS= read -r` loops (no `mapfile`/`readarray` — bash-3.2 / zsh compatible).
- `uberdev_goal_cleanup_run_state` — reaps the sidecars + pointer (only when the pointer still names this goal).

**2. `goal-pipeline/SKILL.md` (primary)** — additive wiring: `UBERDEV_TMPDIR` export + run-state write in Phase 0; re-source the 3 libs (idempotent via `_UBERDEV_*_LOADED` guards) + re-read run-state at the top of every later phase fence; write-back after counter/queue/`active_issues` mutations; cleanup on the converge exit. Existing `watch_start`/`overflow_*`/`UBERDEV_GOAL_ID` lines are not relocated (G8/G16 anchors preserved).

**3. Sibling pipelines (audit-then-conditionally-edit)** — `uberscan` + `ubersimplify` had genuine cross-call `RUN_ID`/`RUN_DIR` gaps (their `run-state.txt` stores OVERFLOW/PARTIAL, not `RUN_ID`) → added the lighter re-source + fixed-path `RUN_ID` pointer (conditional `[ -z "$RUN_ID" ]` re-read = no-op when in-session). `testers` only needed its fragile relative `dispatch.sh` source normalized to the guarded `CLAUDE_PLUGIN_ROOT` form (wave loop is `--watch` in-session — no pointer). `dev` sources no libs and holds no run-state pointer (branch is re-derivable from git) → doctrine comment only, no dead-weight machinery.

**4. Version** bumped `0.33.6 → 0.33.7` across all 6 in-repo ratchet locations (incl. the two hidden test ratchets in `goal.test.sh` G20 + `solve-claim.test.sh`).

## Review findings addressed during implementation

- **CRITICAL (caught in review):** Phase 0 flushed run-state *before* `active_issues` existed, and Phase 1 populated `active_issues` in-memory with no write-back → Phase 2's fresh shell rehydrated an empty list and false-converged on cycle 1. Fixed with a Phase 1 dispatch flush, and locked by an end-to-end Phase0→1→2 hand-off regression test (proven to fail without the flush).
- **Bootstrap gap (caught in review):** the keyed sidecar can't be located without `GOAL_ID`, which itself evaporates — added the fixed-path `goal-active-id.txt` pointer + self-bootstrap so the fix actually works in the real execution model (AC2).
- **Hardening:** array writes are now fail-closed on real write errors (ENOSPC) while still absorbing grep's empty-match; sibling validators fail-closed on an empty `RUN_ID` (parity with the goal SSOT).

## Test plan

- New `tests/goal-state-sidecar.test.sh` (17 behavioral assertions, registered in both CI jobs): cross-`bash -c` scalar + array round-trip, fresh-shell bootstrap from the pointer, Phase0→1→2 hand-off, path-traversal + non-int + no-source rejection, cleanup idempotency.
- Full `test.yml` suite green locally under bash **and** zsh (29/29), incl. `goal.test.sh` anchors G8/G16/G19/G20 and the version ratchets.

## Follow-ups (not blockers; filed separately)

- `print_summary` is defined in one goal-pipeline fence but called from other fresh-shell fences (pre-existing, same directive-emitter class) — move it into `lib/goal-state.sh` so it survives re-source.
- Add per-sibling behavioral `RUN_ID` pointer round-trip tests (currently structural-only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed goal run-state loss across fresh-shell tool calls to prevent "command not found" errors and state evaporation

* **Tests**
  * Added integration tests validating goal run-state persistence and recovery in fresh shells

* **Chores**
  * Bumped version to 0.33.7 and updated version markers across configuration files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->