### PR TITLE
fix(goal): Phase-2 watch loop CLI-version-independent via gh+file signals (#180)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.33.8",
+      "version": "0.33.9",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.9] - 2026-05-23
+
+### Fixed
+- **`/goal` Phase-2 watch loop never advanced on Claude Code CLI 2.1.150 — auto-merged nothing (#180).** The loop keyed solver-completion, PR discovery, and merge detection on stdout markers grepped from the captured `solve-bg-stdout-<N>.log`. On CLI 2.1.150 `claude --bg` detaches in ~4s writing only a launch banner there, so `backgrounded · ` (a *startup* banner, not a terminal marker), `pushed PR #N` (which has **zero** producers — `finish-branch` prints `PR created:`), and the merge gate's read of `merge-bg-stdout-<pr>.log` (a file that is **never written**) could not reflect real state; the loop spun to the 4h `stuck_loop` breaker. Detection is now CLI-version-independent and GitHub-native:
+  - PR discovery / solve completion → `gh pr list --json number,closingIssuesReferences,headRefName` (a PR closing issue N, or whose head is `feat/N-…`), via new `uberdev_goal_find_pr_for_issue`.
+  - merge completion → `gh pr view <pr> --json state == MERGED`, via new `uberdev_goal_pr_is_merged` / `uberdev_goal_pr_state_gh`. `uberdev_goal_read_merge_result` now consults gh state first, decoupling convergence from the (formerly agent-improvised) `merge_executed` audit-row shape.
+  - solver liveness → `claude agents --json` (cwd `solve-issue-N` + busy status), via new `uberdev_goal_agent_busy_for_issue`, used only to tell "still working" from "died".
+  - the already-correct file-based contracts are unchanged: the review-pr verdict JSON locator (`uberdev_goal_locate_review_pr_audit_by_pr`), `uberdev_goal_read_trust_signal`, and the flat `.uberdev/audit.jsonl` merge audit. The retired `uberdev_goal_extract_pr_num_from_log` (`pushed PR #N` parser) is removed.
+- **`/goal` review timing (#180).** The leaf solver runs its OWN `/review-pr` ~20 min after pushing and frequently goes idle in that window, so "agent idle ⇒ review done" is false. Phase 2 now waits `_UBERDEV_GOAL_REVIEW_GRACE` (30 min, re-read every poll) for the leaf's verdict before dispatching its own `/review-pr` — eliminating redundant reviews and premature red-holds of a PR whose GREEN verdict simply has not landed.
+- **`/goal` requires bash ≥ 4 with a clear preflight error (#180).** macOS's default `/bin/bash` is 3.2 (no `mapfile`/`declare -A`) and zsh fatals on the verdict locator's unmatched-glob iteration. Phase 0 now refuses anything below bash 4 (`brew install bash`); Phase 3 replaced `mapfile` with a portable `while read` loop.
+- **`/merge` `merge_executed` audit row now has a concrete printf template (#180).** Previously agent-improvised with no guaranteed `data.pr`; now emitted success-only (a failed merge emits `error`, never `merge_executed`, so it can never falsely advance `/goal`).
+
+### Changed
+- Version bumped to 0.33.9 across `plugin.json`, `marketplace.json`, the README badge, and the test version ratchets (`goal.test.sh` G20, `solve-claim.test.sh`).
+
 ## [0.33.8] - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.33.8-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.33.9-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.33.8",
+  "version": "0.33.9",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -16,7 +16,10 @@
 #   uberdev_goal_get_pr_state                  GOAL_ID PR
 #   uberdev_goal_record_held_audit             GOAL_ID PR AUDIT_PATH
 #   uberdev_goal_get_last_held_audit           GOAL_ID PR
-#   uberdev_goal_extract_pr_num_from_log       STDOUT_LOG_PATH
+#   uberdev_goal_find_pr_for_issue             ISSUE_NUM   (gh; issue #180)
+#   uberdev_goal_pr_state_gh                   PR_NUM      (gh; issue #180)
+#   uberdev_goal_pr_is_merged                  PR_NUM      (gh; issue #180)
+#   uberdev_goal_agent_busy_for_issue          ISSUE_NUM   (claude agents; issue #180)
 #   uberdev_goal_list_prs_in_state             GOAL_ID STATE
 #   uberdev_goal_read_merge_result             PR_NUM
 #   uberdev_goal_write_run_state               (env-driven)
@@ -502,12 +505,14 @@ uberdev_goal_should_automerge() {
 uberdev_goal_locate_review_pr_audit() {
   local issue="$1"
   _uberdev_goal_validate_int "$issue" || return 1
-  # Resolve PR number from solve-bg stdout marker, then delegate to the
-  # PR-keyed locator. The same `.pr == $pr` filter + lex-greatest-run_id
-  # tiebreak lives in one place now (was duplicated before the held-PR
-  # poll loop landed — see uberdev_goal_locate_review_pr_audit_by_pr).
+  # Resolve PR number via the GitHub-native finder (issue #180), then delegate
+  # to the PR-keyed locator. The old solve-bg stdout `pushed PR #N` marker has
+  # ZERO producers and `claude --bg` stdout is a detached banner on CLI 2.1.150,
+  # so the only reliable issue->PR link is `closingIssuesReferences` / `feat/N-`
+  # head. The `.pr == $pr` filter + lex-greatest-run_id tiebreak lives in one
+  # place (see uberdev_goal_locate_review_pr_audit_by_pr).
   local pr
-  pr="$(uberdev_goal_extract_pr_num_from_log "${UBERDEV_TMPDIR:-/tmp}/solve-bg-stdout-$issue.log")"
+  pr="$(uberdev_goal_find_pr_for_issue "$issue")"
   [ -n "$pr" ] || return 0
   _uberdev_goal_validate_int "$pr" || return 0
   uberdev_goal_locate_review_pr_audit_by_pr "$pr"
@@ -582,12 +587,76 @@ uberdev_goal_get_last_held_audit() {
   awk -v p="$pr" '$1==p {path=$2} END {print path}' "$f"
 }
 
-# uberdev_goal_extract_pr_num_from_log STDOUT_LOG_PATH
-# Parse `pushed PR #N` marker from solve-bg stdout transcript.
-uberdev_goal_extract_pr_num_from_log() {
-  local log="$1"
-  [ -f "$log" ] || return 0
-  grep -oE 'pushed PR #[0-9]+' "$log" | head -n 1 | grep -oE '[0-9]+' || true
+# uberdev_goal_find_pr_for_issue ISSUE_NUM   (issue #180)
+# GitHub-native issue->PR resolver. Echoes the highest PR number whose
+# `closingIssuesReferences` includes issue N (the `Closes #N` link every solver
+# PR carries) OR whose head branch is `feat/N-…`. Replaces the retired
+# solve-bg `pushed PR #N` log parser: that marker has ZERO producers and
+# `claude --bg` stdout is a detached banner on CLI 2.1.150, so the loop keying
+# on it never advanced (issue #180).
+#
+# ISSUE_NUM is digits-only validated BEFORE interpolation into the gh --jq
+# filter (R3 gh-argument-injection guard — the same int gate Phase 0 applies
+# to every positional). The filter runs inside gh's own jq (no external pipe),
+# so gh progress bytes cannot pollute the result. Empty stdout + rc 0 when no
+# PR exists yet — a not-yet-pushed solver must NOT read as an error. A gh
+# failure also yields empty (fail-open; the caller treats "no PR" as "keep
+# waiting", bounded by the per-issue solve-timeout).
+uberdev_goal_find_pr_for_issue() {
+  local n="$1"
+  _uberdev_goal_validate_int "$n" || return 1
+  # `any(.closingIssuesReferences[]?; .number == N)` is deliberate: a bare
+  # `.closingIssuesReferences[]?.number == N` yields an EMPTY stream when the
+  # array is empty (a PR whose Closes-link was dropped), and `empty or X`
+  # collapses to empty in jq — silently discarding a row that the `feat/N-`
+  # head-ref arm would have matched. `any/2` returns a concrete `false` on an
+  # empty generator, so the `or` stays boolean and the head-ref fallback works.
+  gh pr list --state all --limit 200 \
+    --json number,closingIssuesReferences,headRefName \
+    --jq "[.[] | select(any(.closingIssuesReferences[]?; .number == ${n}) or (.headRefName | test(\"^feat/${n}-\"))) | .number] | max // empty" \
+    2>/dev/null
+}
+
+# uberdev_goal_pr_state_gh PR_NUM   (issue #180)
+# Echo the GitHub PR state (OPEN|CLOSED|MERGED) for PR_NUM — the authoritative,
+# CLI-version-independent merge signal (replaces the never-written
+# merge-bg-stdout-<pr>.log marker probe). Empty string on gh failure.
+uberdev_goal_pr_state_gh() {
+  local pr="$1"
+  _uberdev_goal_validate_int "$pr" || return 1
+  gh pr view "$pr" --json state --jq '.state' 2>/dev/null
+}
+
+# uberdev_goal_pr_is_merged PR_NUM   (issue #180)
+# rc 0 iff gh reports PR_NUM as MERGED. The Phase 2d merge-completion gate (a
+# merging PR is done when GitHub says MERGED, not when an stdout marker that is
+# never written appears).
+uberdev_goal_pr_is_merged() {
+  local pr="$1"
+  _uberdev_goal_validate_int "$pr" || return 1
+  [ "$(uberdev_goal_pr_state_gh "$pr")" = "MERGED" ]
+}
+
+# uberdev_goal_agent_busy_for_issue ISSUE_NUM   (issue #180)
+# rc 0 iff a live `claude` background session is working in the solver's
+# worktree for issue N (cwd ends `solve-issue-N`, status ∈ busy|running|
+# starting|working). Phase 2a uses it to disambiguate "solver still working,
+# no PR yet" from "solver died" before the per-issue solve-timeout fires.
+# Deliberately NOT used to gate review-readiness: the leaf solver routinely
+# goes idle for ~20m while its OWN finish-branch /review-pr runs, so keying
+# re-review on liveness fires redundant reviews and prematurely red-holds a PR
+# whose GREEN verdict simply has not landed (Phase 2b uses a time-grace +
+# verdict-poll model instead). jq parses the agent list (codebase-standard;
+# avoids a python3 runtime dependency); a parse failure or empty list yields
+# rc!=0 ("not busy"), the fail-safe default.
+uberdev_goal_agent_busy_for_issue() {
+  local n="$1"
+  _uberdev_goal_validate_int "$n" || return 1
+  claude agents --json 2>/dev/null | jq -e --arg n "$n" '
+    any(.[]?;
+        (((.cwd // "") | rtrimstr("/")) | endswith("solve-issue-" + $n))
+        and ((.status // "") | test("^(busy|running|starting|working)$")))' \
+    >/dev/null 2>&1
 }
 
 # uberdev_goal_list_prs_in_state GOAL_ID STATE
@@ -603,24 +672,31 @@ uberdev_goal_list_prs_in_state() {
 }
 
 # uberdev_goal_read_merge_result PR_NUM
-# Reads the canonical `.uberdev/audit.jsonl` JSONL stream written by every
-# merge-pipeline phase (see merge-pipeline/SKILL.md §"Audit log JSONL schema"
-# (D15) — `AUDIT_LOG_FILENAME='audit.jsonl'`). Filters rows by
-# `.event ∈ {merge_executed, pr_parked}` AND `.data.pr == $pr`, takes the
-# most recent (last appended line). Maps the merge-pipeline's PARK_REASON_ENUM
-# + merge_executed semantics onto goal-pipeline's tri-state result:
-#   - `merge_executed`                                    -> success
-#   - `pr_parked` with data.reason ∈ {refused, ambiguous, push-non-ff}
-#                                                         -> conflict
-#   - `pr_parked` with data.reason == test-fail-exhausted -> hook_failed
-#   - no matching row                                     -> missing
-# The legacy `.claude/audit/merge-<PR>-<run>.json` path is never written by
-# /merge — reading it (the pre-B2 behavior) silently returned "missing"
-# forever, which then fell through to no PR transition in Phase 2c and the
-# goal would never converge.
+# Resolves the merge outcome for PR_NUM as one of success|conflict|hook_failed|
+# missing. Two-tier signal (issue #180 — defect #5):
+#
+#   1. gh state FIRST: if `gh pr view <pr> --json state` == MERGED, the PR
+#      landed -> `success`, regardless of whether merge-pipeline appended a
+#      (formerly agent-improvised, shape-unguaranteed) merge_executed audit row.
+#      This is the authoritative, CLI-version-independent completion signal and
+#      decouples goal convergence from the audit-row shape.
+#   2. local audit FALLBACK: for PRs that did NOT merge, read the canonical
+#      `.uberdev/audit.jsonl` JSONL stream (D15 — `AUDIT_LOG_FILENAME='audit.jsonl'`),
+#      filter rows by `.event ∈ {merge_executed, pr_parked}` AND `.data.pr == $pr`,
+#      take the most recent (last appended line), and map merge-pipeline's
+#      PARK_REASON_ENUM onto the failure classes:
+#        - `merge_executed`                                    -> success
+#        - `pr_parked` reason ∈ {refused, ambiguous, push-non-ff} -> conflict
+#        - `pr_parked` reason == test-fail-exhausted             -> hook_failed
+#        - no matching row                                       -> missing
 uberdev_goal_read_merge_result() {
   local pr="$1"
   _uberdev_goal_validate_int "$pr" || return 1
+  # Tier 1 — gh state is authoritative for the success path.
+  if [ "$(uberdev_goal_pr_state_gh "$pr" 2>/dev/null)" = "MERGED" ]; then
+    printf 'success\n'; return 0
+  fi
+  # Tier 2 — local audit classifies failures for PRs that did not merge.
   local audit=".uberdev/audit.jsonl"
   [ -f "$audit" ] || { printf 'missing\n'; return 0; }
   # Pick the LAST matching JSONL line (most recent). Use a single jq pass

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -204,6 +204,7 @@ _uberdev_goal_pr_state_machine_valid() {
     "green->merging") return 0 ;;
     "merging->merged") return 0 ;;
     "merging->merge-failed") return 0 ;;
+    "merging->green") return 0 ;;       # #180 — merge-stall recovery: re-queue a stalled /merge agent (Phase 2d) back to green; bounded by the per-PR merge-attempt cap so it cannot loop
     "yellow-held->merging") return 1 ;; # D17 forbidden
     "red-held->merging")    return 1 ;; # D17 forbidden
     *) return 1 ;;
@@ -227,9 +228,10 @@ _uberdev_goal_count_merge_attempts() {
 # latest integer count for given PR (0 if absent). Append-only writes from
 # _uberdev_goal_dispatch_review_pr below; cap enforced by the same helper
 # at ${_UBERDEV_GOAL_MAX_REVIEW_PR_ATTEMPTS:-3}. The cap bounds the Phase
-# 2a stale|missing re-dispatch loop (SKILL.md line 280-283) so the watch
-# loop's 60s cadence cannot fire >3 /review-pr dispatches per PR over the
-# 4h stuck_loop window (was unbounded at 240/PR).
+# 2b stale|missing graced re-dispatch arm (issue #180 split the old monolithic
+# 2a into 2a PR-detect + 2b verdict-read) so the watch loop's 60s cadence
+# cannot fire >3 /review-pr dispatches per PR over the 4h stuck_loop window
+# (was unbounded at 240/PR).
 _uberdev_goal_count_review_pr_attempts() {
   local goal_id="$1" pr="$2"
   local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
@@ -293,7 +295,7 @@ uberdev_goal_state_init() {
   #   fingerprints.tsv       — non-convergence fingerprint stream
   #   merge-attempts.tsv     — per-PR /merge attempt counter
   #   review-pr-attempts.tsv — per-PR /review-pr re-dispatch counter (B3 bound,
-  #                            bounds Phase 2a's stale|missing re-dispatch loop)
+  #                            bounds Phase 2b's stale|missing graced re-dispatch arm)
   #   held-audits.tsv        — last re-review audit consumed per held PR (2e);
   #                            latest row per pr wins (get_last_held_audit tail)
   local f
@@ -611,20 +613,45 @@ uberdev_goal_find_pr_for_issue() {
   # collapses to empty in jq — silently discarding a row that the `feat/N-`
   # head-ref arm would have matched. `any/2` returns a concrete `false` on an
   # empty generator, so the `or` stays boolean and the head-ref fallback works.
-  gh pr list --state all --limit 200 \
+  #
+  # Capture gh's rc so a gh FAILURE (auth expiry, rate-limit 403, network) is
+  # surfaced as a one-line breadcrumb rather than masquerading as "no PR yet"
+  # (rc 0 + empty) — without it a transient gh outage stalls the goal until the
+  # 150m solve-timeout with a MISattributed "agent idle" diagnostic. Still
+  # fail-open (return empty, rc 0) so the caller keeps waiting/re-polls; the
+  # breadcrumb only distinguishes the two empty cases in the operator's log.
+  local out rc
+  out="$(gh pr list --state all --limit 200 \
     --json number,closingIssuesReferences,headRefName \
     --jq "[.[] | select(any(.closingIssuesReferences[]?; .number == ${n}) or (.headRefName | test(\"^feat/${n}-\"))) | .number] | max // empty" \
-    2>/dev/null
+    2>/dev/null)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf 'goal-state: gh pr list failed (rc=%s) resolving PR for issue %s; treating as no-PR-yet (will re-poll)\n' "$rc" "$n" >&2
+    return 0
+  fi
+  printf '%s' "$out"
 }
 
 # uberdev_goal_pr_state_gh PR_NUM   (issue #180)
 # Echo the GitHub PR state (OPEN|CLOSED|MERGED) for PR_NUM — the authoritative,
 # CLI-version-independent merge signal (replaces the never-written
-# merge-bg-stdout-<pr>.log marker probe). Empty string on gh failure.
+# merge-bg-stdout-<pr>.log marker probe). On gh failure: emit a one-line
+# breadcrumb to stderr and echo empty — so the Phase 2d CLOSED gate and
+# read_merge_result's gh-first arm see "" (treated as "not CLOSED / not MERGED"
+# → defer + re-poll) but the operator's log shows WHY, instead of a silent
+# gh-outage being indistinguishable from a genuinely-OPEN PR.
 uberdev_goal_pr_state_gh() {
   local pr="$1"
   _uberdev_goal_validate_int "$pr" || return 1
-  gh pr view "$pr" --json state --jq '.state' 2>/dev/null
+  local out rc
+  out="$(gh pr view "$pr" --json state --jq '.state' 2>/dev/null)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf 'goal-state: gh pr view failed (rc=%s) reading state for PR %s; treating as not-merged/not-closed (will re-poll)\n' "$rc" "$pr" >&2
+    return 0
+  fi
+  printf '%s' "$out"
 }
 
 # uberdev_goal_pr_is_merged PR_NUM   (issue #180)
@@ -648,15 +675,21 @@ uberdev_goal_pr_is_merged() {
 # whose GREEN verdict simply has not landed (Phase 2b uses a time-grace +
 # verdict-poll model instead). jq parses the agent list (codebase-standard;
 # avoids a python3 runtime dependency); a parse failure or empty list yields
-# rc!=0 ("not busy"), the fail-safe default.
+# "not busy", the fail-safe default. The rc is normalised to exactly 0 (busy)
+# or 1 (not busy) — `jq -e` returns 1 on a `false` result but 2/5 on a parse
+# error, so the explicit if/return collapses every "not busy" cause (no match,
+# malformed JSON, claude failure) to a single rc 1 for a crisp caller contract.
 uberdev_goal_agent_busy_for_issue() {
   local n="$1"
   _uberdev_goal_validate_int "$n" || return 1
-  claude agents --json 2>/dev/null | jq -e --arg n "$n" '
+  if claude agents --json 2>/dev/null | jq -e --arg n "$n" '
     any(.[]?;
         (((.cwd // "") | rtrimstr("/")) | endswith("solve-issue-" + $n))
         and ((.status // "") | test("^(busy|running|starting|working)$")))' \
-    >/dev/null 2>&1
+    >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
 }
 
 # uberdev_goal_list_prs_in_state GOAL_ID STATE
@@ -692,8 +725,11 @@ uberdev_goal_list_prs_in_state() {
 uberdev_goal_read_merge_result() {
   local pr="$1"
   _uberdev_goal_validate_int "$pr" || return 1
-  # Tier 1 — gh state is authoritative for the success path.
-  if [ "$(uberdev_goal_pr_state_gh "$pr" 2>/dev/null)" = "MERGED" ]; then
+  # Tier 1 — gh state is authoritative for the success path. No inline
+  # 2>/dev/null: uberdev_goal_pr_state_gh already suppresses gh's own stderr and
+  # emits its own breadcrumb on failure, so letting its stderr through surfaces a
+  # gh outage here instead of silently falling through to the audit tier.
+  if [ "$(uberdev_goal_pr_state_gh "$pr")" = "MERGED" ]; then
     printf 'success\n'; return 0
   fi
   # Tier 2 — local audit classifies failures for PRs that did not merge.
@@ -734,8 +770,9 @@ uberdev_goal_read_merge_result() {
 # and dispatches via the standard small-tier path.
 #
 # B3 bound — per-PR attempt cap at ${_UBERDEV_GOAL_MAX_REVIEW_PR_ATTEMPTS:-3}.
-# Step 2a's stale|missing arm (SKILL.md line 280-283) calls this every 60s
-# while a PR sits in pushed-reviewing with a missing/stale audit; the cap
+# Phase 2b's stale|missing graced arm (issue #180) calls this after the
+# REVIEW_GRACE window lapses while a PR sits in pushed-reviewing with a
+# missing/stale audit; the cap
 # bounds total dispatches per PR across the entire goal run (worst case
 # was 240/PR over the 4h stuck_loop window — now 3/PR). On cap-exceeded:
 # print a stderr warning and return rc=0 so the step 2a loop continues

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -437,6 +437,13 @@ while true; do
         # /merge agent still in flight, OR stalled. If past MERGE_TIMEOUT with
         # no live agent, fall back to `green` so step 2c retries (bounded by the
         # per-PR merge-attempt cap). Otherwise keep waiting.
+        # NOTE the liveness probe is keyed on $pr (the PR number), not an issue
+        # number: _uberdev_goal_dispatch_merge dispatches via
+        # `uberdev_dispatch_one "$pr" …`, and uberdev_dispatch_one names every
+        # worktree `solve-issue-<key>` (lib/dispatch.sh) — so a merge agent's cwd
+        # is `solve-issue-<pr>` and `agent_busy_for_issue "$pr"` matches it
+        # correctly. (The function name says "for_issue" because the SHARED
+        # naming convention is solve-issue-<key>; the key here is a PR.)
         merge_ts="$(awk -v p="$pr" '$1==p && $2=="merging"{t=$3} END{print t+0}' \
           "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" 2>/dev/null)"
         if [ "$(( now - merge_ts ))" -ge "$_UBERDEV_GOAL_MERGE_TIMEOUT" ] \

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -9,7 +9,7 @@ This skill is invoked inline by `commands/goal.md`. It reads `$ARGUMENTS` from t
 
 `/goal` is the autonomous convergence orchestrator from RFC 0005: it loops `/turbo` → auto `/review-pr` → `/merge` if GREEN, recursing on BLOCKER/CRITICAL `review-pr-finding` issues filed by `/review-pr` Phase 2.5 until the queue is empty AND every PR landed in `{merged, merge-failed}`. YELLOW PRs are NEVER merged inside `/goal` — they are held for re-review. RED PRs are held with a `Blocks: #N` body annotation that wires unblock back into the cycle once the blocking issues close.
 
-> **You are an orchestrator, not an implementer.** You preflight, dispatch `/turbo` agents one per issue, watch their stdout transcripts for the `backgrounded · ` marker, drive PR state transitions from the `/review-pr` Phase 2.5 audit JSON, dispatch `/merge` for GREEN PRs, drive unblock checks on every successful merge, collect the next queue from `review-pr-finding` issues filed during the cycle, and halt deterministically via one of the five exit paths. You never write feature code yourself.
+> **You are an orchestrator, not an implementer.** You preflight, dispatch `/turbo` agents one per issue, detect each solver's pushed PR via GitHub (`gh pr list` `closingIssuesReferences` / `feat/N-` head — CLI-version-independent, issue #180), drive PR state transitions from the file-based `/review-pr` Phase 2.5 verdict JSON, dispatch `/merge` for GREEN PRs, confirm merge via `gh pr view <pr> --json state == MERGED`, drive unblock checks on every successful merge, collect the next queue from `review-pr-finding` issues filed during the cycle, and halt deterministically via one of the exit paths. You never write feature code yourself.
 
 ## Constants
 
@@ -26,6 +26,9 @@ _UBERDEV_GOAL_DEFAULT_MAX_CYCLES=5
 _UBERDEV_GOAL_POLL_SECS=60
 _UBERDEV_GOAL_STUCK_SECS=14400         # 4h
 _UBERDEV_GOAL_MAX_MERGE_ATTEMPTS=3
+_UBERDEV_GOAL_SOLVE_TIMEOUT=9000       # 150m — no PR AND no live agent => issue failed (issue #180)
+_UBERDEV_GOAL_REVIEW_GRACE=1800        # 30m — wait for the leaf solver's OWN /review-pr verdict before dispatching ours (issue #180)
+_UBERDEV_GOAL_MERGE_TIMEOUT=3600       # 60m — merging w/o MERGED AND agent idle => back to green for retry (issue #180)
 _UBERDEV_GOAL_BODY_CAP=65536           # 64 KiB
 FINDING_LABEL='review-pr-finding'
 FINDING_FINGERPRINT_REGEX='<!-- uberdev:review-pr-finding fingerprint=([a-f0-9]{16}) -->'
@@ -44,6 +47,20 @@ Notes on the enums:
 - **`FINDING_FINGERPRINT_REGEX`** is the marker shape `agents/findings-to-issues.md` injects into every BLOCKER/CRITICAL `review-pr-finding` issue body; Phase 3 extracts it via `_uberdev_goal_extract_fingerprint` to drive the repeat-cycle detector.
 
 ## Phase 0 — Preflight
+
+0. **bash ≥ 4 preflight guard (issue #180, defect #8).** Evaluated FIRST — before arg parsing, backend resolution, or any `gh` call. The watch loop's verdict locator (`uberdev_goal_locate_review_pr_audit_by_pr`) iterates unquoted globs that rely on bash's "unmatched glob → literal" semantics (zsh fatals with `no matches found`), and macOS's default `/bin/bash` is 3.2 (no `declare -A`, no `mapfile`). Refuse anything below bash 4 with a clear, actionable error rather than letting the loop misbehave silently.
+
+   ```bash
+   # Two-arm detection: the first arm catches non-bash shells (zsh, the Bash-tool
+   # default, leaves BASH_VERSINFO unset); the second catches bash 3.2. Either way
+   # the watch loop's glob + array semantics are unsafe — fail fast.
+   if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+     echo "goal: requires bash >= 4 (macOS default /bin/bash is 3.2, and zsh fatals on the watch loop's unmatched-glob verdict locator)." >&2
+     echo "  - install a modern bash:  brew install bash      # -> /opt/homebrew/bin/bash 5.x" >&2
+     echo "  - then re-run /uberdev:goal under bash >= 4." >&2
+     exit 2
+   fi
+   ```
 
 1. **Parse positional issue numbers + flags.** The parser scans `$ARGUMENTS` and collects every token matching `^[0-9]+$` into the input queue; recognised flag tokens are `--max-cycles=N`, `--only-mine`, `--dry-run`, `--backend=<name>`. Empty input prints the usage line and exits.
 
@@ -125,7 +142,7 @@ Notes on the enums:
    uberdev_goal_write_run_state || { echo "goal: failed to persist run-state" >&2; exit 3; }
    ```
 
-8. **If `--dry-run`: print planned cycle-1 dispatch list + watch-loop outline, exit 0** (D16, S9). The dry-run path is the audit/preview surface — no `gh` calls, no agent spawns, no merges, **no audit events emitted** (S9 — `goal_dispatched` must NOT fire on dry-run so the audit log only carries real runs). Emit the resolved `MAX_CYCLES`, the resolved `UBERDEV_RESOLVED_BACKEND`, the issue queue, and the planned audit events ("would emit goal_dispatched", "would dispatch /turbo for issues …", "would poll solve-bg-stdout-N.log per issue"), then exit 0 cleanly. This step runs BEFORE the real `goal_dispatched` emit in step 9 — order matters.
+8. **If `--dry-run`: print planned cycle-1 dispatch list + watch-loop outline, exit 0** (D16, S9). The dry-run path is the audit/preview surface — no `gh` calls, no agent spawns, no merges, **no audit events emitted** (S9 — `goal_dispatched` must NOT fire on dry-run so the audit log only carries real runs). Emit the resolved `MAX_CYCLES`, the resolved `UBERDEV_RESOLVED_BACKEND`, the issue queue, and the planned audit events ("would emit goal_dispatched", "would dispatch /turbo for issues …", "would poll GitHub (gh pr list) for each issue's PR"), then exit 0 cleanly. This step runs BEFORE the real `goal_dispatched` emit in step 9 — order matters.
 
 9. **Emit `goal_dispatched` event** with `{goal_id, cycle: 0, issues, dry_run, backend}` payload (real runs only — dry-run exits in step 8 before reaching here). This is the audit anchor — `cycle: 0` distinguishes the initial dispatch from the Phase 1 per-cycle dispatch:
 
@@ -251,96 +268,121 @@ while true; do
 
   any_active=0
 
-  # 2a. Poll each dispatched /turbo agent's stdout log
-  # F13 simplify-lens — the `backgrounded · ` marker is terminal (emitted once
-  # at session end by every dispatch.sh backend), so `tail -c 65536` bounds
-  # per-poll grep cost to O(1) regardless of uncapped log growth. Identical
-  # semantics for a contract that promises a terminal-marker; cheaper polling.
+  # 2a. Detect each solver's pushed PR via GitHub (issue #180 — CLI-version-
+  # independent). The pre-2.1.150 stdout-marker probe (`backgrounded ·` +
+  # `pushed PR #N`) is retired: on CLI 2.1.150 `claude --bg` detaches with a
+  # banner-only stdout and `pushed PR #N` has zero producers, so the loop keying
+  # on it never advanced. Authoritative completion signal = a PR that closes
+  # issue N exists on GitHub (`closingIssuesReferences` / `feat/N-` head). When
+  # no PR exists yet, `uberdev_goal_agent_busy_for_issue` disambiguates "solver
+  # still working" from "solver died", bounded by _UBERDEV_GOAL_SOLVE_TIMEOUT.
   for issue in "${active_issues[@]}"; do
-    log="$UBERDEV_TMPDIR/solve-bg-stdout-$issue.log"
-    if [ -f "$log" ] && tail -c 65536 "$log" 2>/dev/null | grep -q 'backgrounded · '; then
-      audit_json="$(uberdev_goal_locate_review_pr_audit "$issue")"
-      signal="$(uberdev_goal_read_trust_signal "$audit_json")"
-      pr_num="$(uberdev_goal_extract_pr_num_from_log "$log")"
-      # F11 simplify-lens — surface the missing-marker case (no `pushed PR #N`
-      # line in the solve-bg stdout transcript yet) instead of letting it fall
-      # through to a silent `uberdev_goal_pr_state_transition` validate-fail.
-      # Treat as in-flight: keep the issue active so the next poll retries.
-      if [ -z "$pr_num" ]; then
-        printf 'goal-pipeline: issue %s: no `pushed PR #N` marker in stdout yet; deferring to next poll\n' \
-          "$issue" >&2
-        any_active=1
-        continue
+    istate="$(awk -v i="$issue" '{s[$1]=$2} END{print s[i]}' \
+      "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
+    case "$istate" in pr-pushed|resolved|failed) continue ;; esac
+    pr_num="$(uberdev_goal_find_pr_for_issue "$issue")"
+    if [ -n "$pr_num" ]; then
+      uberdev_goal_issue_state_transition "$GOAL_ID" "$issue" solving pr-pushed
+      uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" dispatched pushed-reviewing
+      if uberdev_goal_pr_is_merged "$pr_num"; then
+        # Resume / human-merged: the PR already landed. Pre-stage it through the
+        # valid path so step 2d finalizes it to `merged` next pass — no wasteful
+        # /review-pr or /merge dispatch against an already-merged PR.
+        uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" pushed-reviewing green
+        uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" green merging
       fi
-      case "$signal" in
-        green)
-          uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" pushed-reviewing green
-          ;;
-        yellow)
-          uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" pushed-reviewing yellow-held
-          # Record the audit that put this PR in held so step 2e's poll loop
-          # has a baseline — when a NEWER audit appears (re-review fired),
-          # the poll loop applies the next state transition (#159).
-          uberdev_goal_record_held_audit "$GOAL_ID" "$pr_num" "$audit_json"
-          ;;
-        red)
-          uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" pushed-reviewing red-held
-          # Record audit baseline for the step 2e poll loop (mirrors yellow case).
-          uberdev_goal_record_held_audit "$GOAL_ID" "$pr_num" "$audit_json"
-          # B6 — Blocker-overflow handler (D13). Reads the per-PR audit JSON
-          # while $audit_json and $pr_num are still in scope (the Phase 3
-          # site previously held this block but those variables don't exist
-          # there, so the check silently no-op'd). Setting overflow_detected
-          # here gates the Phase 3 first-10 truncation below.
-          #
-          # M14 — explicit branch on gh_jq_or_jq rc. If the audit JSON is
-          # corrupted, the old `halted_overflow="$(gh_jq_or_jq …)"` swallowed
-          # jq's rc and left $halted_overflow empty — `[ "" = "true" ]` is
-          # false so the overflow check silently skipped. Surface to stderr;
-          # default to "no overflow" (safer than spuriously truncating the
-          # next cycle's candidate queue on an unreadable audit).
-          if halted_overflow="$(gh_jq_or_jq "$audit_json" '.phases.phase2_5.halted_due_to_overflow // false')"; then
-            if [ "$halted_overflow" = "true" ]; then
-              overflow_detected=1
-              # Q4 — accumulate per-cycle PR-overflow count for the
-              # goal_cycle_completed audit payload (the prose at line ~381
-              # promises {overflow_count: N} in the summary).
-              overflow_count=$(( ${overflow_count:-0} + 1 ))
-              uberdev_goal_write_run_state || echo "goal: warning: run-state flush failed in Phase 2a" >&2
-            fi
-          else
-            printf 'goal-pipeline: overflow check failed to read audit %s for PR %s; treating as no overflow this cycle\n' \
-              "$audit_json" "$pr_num" >&2
-          fi
-          ;;
-        stale|missing)
-          # D17: never assume GREEN on missing phase2_5 — re-dispatch /review-pr.
-          # B3 bound — _uberdev_goal_dispatch_review_pr enforces a per-PR cap
-          # at ${_UBERDEV_GOAL_MAX_REVIEW_PR_ATTEMPTS:-3} dispatches across the
-          # entire goal run (TSV at goal-<id>-review-pr-attempts.tsv mirrors
-          # the merge-attempts pattern). The cap returns rc=0 with a stderr
-          # warning when exceeded — the watch loop's 60s cadence cannot fire
-          # >3 /review-pr dispatches per PR over the 4h stuck_loop window
-          # (was unbounded at 240/PR). NOT a circuit breaker: the goal does
-          # not halt; subsequent cycles skip re-dispatch in-place.
-          _uberdev_goal_dispatch_review_pr "$pr_num"
-          ;;
-      esac
-    else
       any_active=1
+      continue
+    fi
+    # No PR yet — is the solver still alive, or did it die?
+    if uberdev_goal_agent_busy_for_issue "$issue"; then
+      any_active=1
+    else
+      dispatch_ts="$(awk -v i="$issue" '$1==i && $2=="solving"{t=$3} END{print t+0}' \
+        "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
+      if [ "$(( now - dispatch_ts ))" -lt "$_UBERDEV_GOAL_SOLVE_TIMEOUT" ]; then
+        any_active=1
+      else
+        printf 'goal-pipeline: issue %s FAILED (no PR, agent idle, %ss elapsed)\n' \
+          "$issue" "$(( now - dispatch_ts ))" >&2
+        uberdev_goal_issue_state_transition "$GOAL_ID" "$issue" solving failed
+      fi
     fi
   done
 
-  # 2b. Dispatch /merge for any new GREEN PRs
-  # B2 — Only transition to `merging` on dispatch rc=0 (mirrors Phase 1's
-  # `if uberdev_dispatch_one …` branching at lines ~166-189). Failed dispatch
-  # (mktemp fails, prompt write fails, claude-bg session refuse, etc.) used
-  # to transition the PR to `merging` anyway, then the watch loop would
-  # poll for a backgrounded · marker that would never appear, stalling
-  # until the 4h stuck_loop circuit breaker fired. Now: rc!=0 logs to
-  # stderr and leaves the PR in `green` so the next watch iteration
-  # retries; the per-PR attempt counter (cap 3) bounds runaway retries.
+  # 2b. Read the leaf /review-pr verdict for PRs in pushed-reviewing (file-based
+  # verdict locator + trust signal — the unchanged, version-independent contract).
+  # TIME-GRACED (issue #180): the leaf solver runs its OWN /review-pr ~20m after
+  # pushing and frequently goes idle in that window, so "agent idle ⇒ review
+  # done" is false (keying re-review on liveness fired 3 redundant reviews in
+  # 4 min and prematurely red-held a PR whose GREEN verdict had not landed).
+  # Instead wait _UBERDEV_GOAL_REVIEW_GRACE for the leaf's verdict, re-reading
+  # the verdict JSON every poll — it advances the instant the verdict lands,
+  # with zero redundant reviews on the happy path; only after the grace lapses
+  # do we dispatch our own /review-pr (bounded ×3).
+  for pr_num in $(uberdev_goal_list_prs_in_state "$GOAL_ID" pushed-reviewing); do
+    audit_json="$(uberdev_goal_locate_review_pr_audit_by_pr "$pr_num")"
+    signal="$(uberdev_goal_read_trust_signal "$audit_json")"
+    case "$signal" in
+      green)
+        uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" pushed-reviewing green
+        ;;
+      yellow)
+        uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" pushed-reviewing yellow-held
+        # Baseline audit for step 2e's poll loop — a NEWER audit means a
+        # re-review fired, so the poll loop applies the next transition (#159).
+        uberdev_goal_record_held_audit "$GOAL_ID" "$pr_num" "$audit_json"
+        ;;
+      red)
+        uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" pushed-reviewing red-held
+        uberdev_goal_record_held_audit "$GOAL_ID" "$pr_num" "$audit_json"
+        # B6/M14 — blocker-overflow handler (D13). Explicit branch on
+        # gh_jq_or_jq rc so a corrupted audit defaults to "no overflow" rather
+        # than silently skipping; sets overflow_detected (gates the Phase 3
+        # first-10 truncation) and accumulates the per-cycle count.
+        if halted_overflow="$(gh_jq_or_jq "$audit_json" '.phases.phase2_5.halted_due_to_overflow // false')"; then
+          if [ "$halted_overflow" = "true" ]; then
+            overflow_detected=1
+            overflow_count=$(( ${overflow_count:-0} + 1 ))
+            uberdev_goal_write_run_state || echo "goal: warning: run-state flush failed in Phase 2b" >&2
+          fi
+        else
+          printf 'goal-pipeline: overflow check failed to read audit %s for PR %s; treating as no overflow this cycle\n' \
+            "$audit_json" "$pr_num" >&2
+        fi
+        ;;
+      stale|missing)
+        # No verdict yet. Wait REVIEW_GRACE for the leaf's OWN /review-pr before
+        # dispatching ours. seen_ts = the FIRST pushed-reviewing transition for
+        # this PR (durable in the pr-states TSV). D17: never assume GREEN.
+        seen_ts="$(awk -v p="$pr_num" '$1==p && $2=="pushed-reviewing" && !t{t=$3} END{print t+0}' \
+          "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" 2>/dev/null)"
+        if [ "$(( now - seen_ts ))" -lt "$_UBERDEV_GOAL_REVIEW_GRACE" ]; then
+          any_active=1   # still waiting for the leaf's own review verdict
+        else
+          # Grace lapsed — dispatch our own /review-pr. B3 bound:
+          # _uberdev_goal_dispatch_review_pr caps at
+          # ${_UBERDEV_GOAL_MAX_REVIEW_PR_ATTEMPTS:-3} dispatches per PR across
+          # the whole run (rc=0 + stderr warning when exceeded; NOT a breaker).
+          _uberdev_goal_dispatch_review_pr "$pr_num"
+          any_active=1
+        fi
+        ;;
+    esac
+  done
+
+  # 2c. Dispatch /merge for any new GREEN PRs.
+  # B2 — only transition to `merging` on dispatch rc=0; a failed dispatch
+  # (mktemp/prompt-write/session-refuse) leaves the PR in `green` for a
+  # next-cycle retry (per-PR attempt counter, cap 3, bounds runaway retries).
   for pr in $(uberdev_goal_list_prs_in_state "$GOAL_ID" green); do
+    if uberdev_goal_pr_is_merged "$pr"; then
+      # Already merged (resume / human-merged) — finalize via step 2d without
+      # re-dispatching /merge against an already-landed PR.
+      uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" green merging
+      any_active=1
+      continue
+    fi
     if uberdev_goal_should_automerge "$GOAL_ID" "$pr"; then
       if _uberdev_goal_dispatch_merge "$pr"; then
         uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" green merging
@@ -352,24 +394,38 @@ while true; do
     fi
   done
 
-  # 2c. Drive /merge transitions
+  # 2d. Drive merging → merged. Completion is authoritative via GitHub
+  # (`gh pr view <pr> --json state == MERGED`, issue #180 — the
+  # merge-bg-stdout-<pr>.log marker this step used to poll was NEVER written by
+  # any dispatch backend, so the gate could not fire). For PRs that did NOT
+  # merge, read_merge_result (gh-state-first, then the local audit) classifies
+  # the failure: conflict / hook_failed halt the goal; CLOSED-without-merge is
+  # a hard merge_failed; `missing` defers (re-poll) with a MERGE_TIMEOUT
+  # fallback to `green` when the merge agent stalled.
   for pr in $(uberdev_goal_list_prs_in_state "$GOAL_ID" merging); do
-    merge_log="$UBERDEV_TMPDIR/merge-bg-stdout-$pr.log"
-    # F13 simplify-lens — `tail -c 65536` bounds per-poll grep cost; the
-    # `backgrounded · ` marker is terminal so tail-of-file is equivalent.
-    [ -f "$merge_log" ] && tail -c 65536 "$merge_log" 2>/dev/null | grep -q 'backgrounded · ' || continue
+    if uberdev_goal_pr_is_merged "$pr"; then
+      uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" merging merged
+      # B4 — uberdev_goal_list_prs_in_state takes ONE state ($2); call twice
+      # and concatenate so BOTH held sets get the unblock check.
+      for held_pr in $(uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held; \
+                       uberdev_goal_list_prs_in_state "$GOAL_ID" red-held); do
+        _uberdev_goal_check_unblock "$held_pr"
+      done
+      continue
+    fi
+    # Not merged — a CLOSED-without-merge PR is a hard merge failure.
+    if [ "$(uberdev_goal_pr_state_gh "$pr")" = "CLOSED" ]; then
+      uberdev_goal_audit goal_circuit_breaker \
+        "{\"reason\":\"merge_failed\",\"pr\":$pr,\"detail\":\"closed\"}"
+      print_summary "$cycle"
+      exit 1
+    fi
     result="$(uberdev_goal_read_merge_result "$pr")"
     case "$result" in
       success)
-        uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" merging merged
-        # B4 — uberdev_goal_list_prs_in_state takes ONE state ($2); passing
-        # `yellow-held red-held` made `red-held` a positional no-op and the
-        # red-held PRs silently never got the unblock check. Call twice and
-        # concatenate, mirroring print_summary's pattern below.
-        for held_pr in $(uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held; \
-                         uberdev_goal_list_prs_in_state "$GOAL_ID" red-held); do
-          _uberdev_goal_check_unblock "$held_pr"
-        done
+        # Audit says success but gh has not flipped to MERGED yet — a brief
+        # write/state race; re-poll next iteration (pr_is_merged is the SSOT).
+        any_active=1
         ;;
       conflict|hook_failed)
         uberdev_goal_audit goal_circuit_breaker \
@@ -378,17 +434,23 @@ while true; do
         exit 1
         ;;
       missing)
-        # /merge hasn't appended an audit row for this PR yet (in-flight or
-        # the merge-bg-stdout marker fired before the audit write hit the
-        # disk). Defer to the next watch iteration — re-poll happens on the
-        # next sleep cycle. Do NOT halt.
+        # /merge agent still in flight, OR stalled. If past MERGE_TIMEOUT with
+        # no live agent, fall back to `green` so step 2c retries (bounded by the
+        # per-PR merge-attempt cap). Otherwise keep waiting.
+        merge_ts="$(awk -v p="$pr" '$1==p && $2=="merging"{t=$3} END{print t+0}' \
+          "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" 2>/dev/null)"
+        if [ "$(( now - merge_ts ))" -ge "$_UBERDEV_GOAL_MERGE_TIMEOUT" ] \
+           && ! uberdev_goal_agent_busy_for_issue "$pr"; then
+          printf 'goal-pipeline: PR %s merge stalled (%ss, agent idle) -> back to green for retry\n' \
+            "$pr" "$(( now - merge_ts ))" >&2
+          uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" merging green
+        fi
+        any_active=1
         ;;
       *)
-        # B7 — defensive default-case guard. uberdev_goal_read_merge_result
-        # is contracted to return `success|conflict|hook_failed|missing`; any
-        # other value indicates a contract drift (e.g., a future enum member
-        # not threaded through here). Halt loudly rather than fall through
-        # silently, which would leave the PR stuck in `merging` forever.
+        # B7 — defensive default. read_merge_result is contracted to return
+        # success|conflict|hook_failed|missing; any other value is contract
+        # drift — halt loudly rather than leave the PR stuck in `merging`.
         uberdev_goal_audit goal_circuit_breaker \
           "{\"reason\":\"unknown_merge_result\",\"pr\":$pr,\"result\":\"$result\"}"
         print_summary "$cycle"
@@ -398,7 +460,7 @@ while true; do
   done
 
   # 2e. Poll held PRs for re-review completion (RFC 0005 §3.2.3 hold-and-
-  # unblock completion-half; #159). When the unblock rule (step 2c) dispatches
+  # unblock completion-half; #159). When the unblock rule (step 2d) dispatches
   # a `/uberdev:review-pr` for a newly-unblocked PR, that re-review writes a
   # NEW audit JSON under `.uberdev/runs/<new-run-id>/`. Without this poll,
   # the dispatch is fire-and-forget — the held PR never exits the held state
@@ -437,10 +499,10 @@ while true; do
       green)
         uberdev_goal_pr_state_transition "$GOAL_ID" "$held_pr" "$held_current" green
         uberdev_goal_record_held_audit "$GOAL_ID" "$held_pr" "$new_audit"
-        # B1 — keep the watch loop alive for one more iteration so step 2b
+        # B1 — keep the watch loop alive for one more iteration so step 2c
         # (which runs ABOVE step 2e in cycle order) has a chance to pick this
         # freshly-green PR up on the next pass and dispatch /merge. Without
-        # this, the held→green transition is invisible to step 2d's
+        # this, the held→green transition is invisible to step 2f's
         # termination check on the SAME iteration: `any_active` could already
         # be 0 from the active-issues walk, the merging set is empty, and the
         # loop breaks with a near-merged PR that Phase 3 then mis-classifies
@@ -469,7 +531,7 @@ while true; do
     esac
   done
 
-  # 2d. Termination check (intra-cycle)
+  # 2f. Termination check (intra-cycle)
   if [ "$any_active" = "0" ] && \
      [ -z "$(uberdev_goal_list_prs_in_state "$GOAL_ID" merging)" ]; then
     break
@@ -479,7 +541,7 @@ while true; do
 done
 ```
 
-Why polling stdout transcripts instead of the (non-existent) `claude agents status <id>` API: R6 in the implementation plan — the dispatch-backend agent-status API is a known gap, and the `backgrounded · ` marker emitted by every `lib/dispatch.sh` backend's stdout transcript is the only authoritative completion signal. The marker is a stable contract (asserted by the shared test surface), so this is not a fragile screen-scrape — it is the documented backend completion signal.
+Why GitHub + the file-based verdict instead of agent stdout (issue #180): on Claude Code CLI 2.1.150 `claude --bg` detaches in ~4s and writes only a launch banner (`backgrounded · <id>`) to the captured `solve-bg-stdout-N.log` — the agent's real transcript goes to the detached session (`claude logs <id>`). So the old completion probes (`backgrounded · ` as a "terminal" marker; `pushed PR #N`, which has zero producers; `merge-bg-stdout-<pr>.log`, which is never written) could never reflect real state. The version-independent signals are: PR existence/number via `gh pr list --json number,closingIssuesReferences,headRefName` (every solver PR carries a `Closes #N` link and a `feat/N-` head), merge completion via `gh pr view <pr> --json state == MERGED`, and the trust verdict via the existing file-based locator (`uberdev_goal_locate_review_pr_audit_by_pr`) + `uberdev_goal_read_trust_signal`. Solver liveness, used only to distinguish "still working" from "died" (never to gate review-readiness), is `claude agents --json` filtered by cwd + status.
 
 ## Phase 3 — Collect Next Queue
 
@@ -560,10 +622,19 @@ if [ "$gh_rc" -ne 0 ]; then
 fi
 
 # `candidates_json` is already newline-separated raw integers (one number per
-# line) from the F14 filter shape above. Bash mapfile reads each line into the
-# array; empty input yields a 0-element array (the `${#new_candidates[@]}`
-# checks downstream behave identically to the prior map(.number)+jq -r path).
-mapfile -t new_candidates < <(printf '%s' "$candidates_json")
+# line) from the F14 filter shape above. Read each line into the array with a
+# portable while-read loop — NOT `mapfile`, which is bash-4-only and aborts on
+# macOS's default /bin/bash 3.2 (issue #180 defect #8); this mirrors the
+# run-state rehydration loop in lib/goal-state.sh. Empty input yields a
+# 0-element array, so the `${#new_candidates[@]}` checks downstream behave
+# identically. Each line is numeric-gated (the candidates are raw integers from
+# --jq; the gate drops any stray blank or non-integer line defensively).
+new_candidates=()
+while IFS= read -r _cand_line; do
+  [ -n "$_cand_line" ] || continue
+  case "$_cand_line" in ''|*[!0-9]*) continue ;; esac
+  new_candidates+=("$_cand_line")
+done < <(printf '%s' "$candidates_json")
 ```
 
 For each candidate, extract the fingerprint and check for repeat:
@@ -770,4 +841,4 @@ Called from Phase 2 step 2c on every `merging → merged` PR transition, for eac
 
 3. **YELLOW handling: YELLOW PRs are NEVER merged — they are held for re-review.** Standalone `/merge` (with `--accept-critical-deferred`) can land a YELLOW PR; inside `/goal` this is forbidden. The PR-state-machine valid-transitions table in `_uberdev_goal_pr_state_machine_valid` returns non-zero for `yellow-held → merging` (D17); the only way out of `yellow-held` is `→ green` (after a successful `/review-pr` re-review that resolves the CRITICAL findings).
 
-**Backend inheritance (D15).** Backend resolution is performed **once** by Phase 0 via `uberdev_dispatch_preflight`, which sets `UBERDEV_RESOLVED_BACKEND` for the whole run. The Phase 1 `/turbo` dispatch forwards `--backend=$UBERDEV_RESOLVED_BACKEND` explicitly (see the printf at line ~154); the Phase 2 `/merge` and `/review-pr` dispatches in `lib/goal-state.sh::_uberdev_goal_dispatch_{merge,review_pr}` do NOT thread the flag because the child commands do not accept `--backend` — those children re-resolve the backend in their own preflight from the same `UBERDEV_RESOLVED_BACKEND` env var that is exported by Phase 0 and inherited into every spawned shell. Per-cycle re-resolution at the orchestrator level is forbidden — it would let a transient `claude --version` flake mid-run silently swap backends and corrupt the agent-stdout polling contract (every backend emits the `backgrounded · ` marker, but the path conventions for `solve-bg-stdout-N.log` and `merge-bg-stdout-N.log` are backend-specific in a way that must remain stable across cycles). Wiring `--backend` through both downstream commands so the whole pipeline carries the flag explicitly is tracked as a follow-up (out of scope for v1).
+**Backend inheritance (D15).** Backend resolution is performed **once** by Phase 0 via `uberdev_dispatch_preflight`, which sets `UBERDEV_RESOLVED_BACKEND` for the whole run. The Phase 1 `/turbo` dispatch forwards `--backend=$UBERDEV_RESOLVED_BACKEND` explicitly (see the printf at line ~154); the Phase 2 `/merge` and `/review-pr` dispatches in `lib/goal-state.sh::_uberdev_goal_dispatch_{merge,review_pr}` do NOT thread the flag because the child commands do not accept `--backend` — those children re-resolve the backend in their own preflight from the same `UBERDEV_RESOLVED_BACKEND` env var that is exported by Phase 0 and inherited into every spawned shell. Per-cycle re-resolution at the orchestrator level is forbidden — it would let a transient `claude --version` flake mid-run silently swap backends, splitting a single goal's solvers across incompatible dispatch mechanisms. Each backend (`claude-bg` / `wezterm` / `background`) has its own session-management and worktree conventions that must stay stable across cycles so the gh + file detection signals (PR discovery via `closingIssuesReferences`, liveness via `claude agents --json` cwd matching, verdict via the file-based locator — issue #180) resolve consistently for every solver in the run. Wiring `--backend` through both downstream commands so the whole pipeline carries the flag explicitly is tracked as a follow-up (out of scope for v1).

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -38,11 +38,11 @@ BLOCKS_LINE_REGEX='^Blocks: #([0-9]+)$'
 Notes on the enums:
 
 - **`GOAL_AUDIT_EVENT_ENUM`** — the 6 events `lib/goal-state.sh::uberdev_goal_audit` accepts. Any other event name returns non-zero from the helper and is dropped on the floor; consumers grep these literals.
-- **`GOAL_CIRCUIT_BREAKER_REASONS`** — the 7 halt reasons emitted by Phase 2/3/4 inside the `goal_circuit_breaker` payload's `.reason` field. The four original reasons (`max_cycles`, `nonconvergence`, `stuck_loop`, `merge_failed`); two surfaced-failure reasons added during post-impl-review (`gh_api_failed` — Phase 3 `gh issue list` rc!=0 instead of falsely treating an empty candidates list as convergence; `unknown_merge_result` — Phase 2c case default arm for a `uberdev_goal_read_merge_result` value outside the documented `success|conflict|hook_failed|missing` set); and `queue_empty_not_converged` — Phase 3 deterministic halt when the candidate queue is empty but at least one PR is still in a non-terminal state (issue #160; deterministic alternative to the 4h `stuck_loop` wall-clock fallback). The set is closed; new reasons require an RFC amendment.
+- **`GOAL_CIRCUIT_BREAKER_REASONS`** — the 7 halt reasons emitted by Phase 2/3/4 inside the `goal_circuit_breaker` payload's `.reason` field. The four original reasons (`max_cycles`, `nonconvergence`, `stuck_loop`, `merge_failed`); two surfaced-failure reasons added during post-impl-review (`gh_api_failed` — Phase 3 `gh issue list` rc!=0 instead of falsely treating an empty candidates list as convergence; `unknown_merge_result` — Phase 2d case default arm for a `uberdev_goal_read_merge_result` value outside the documented `success|conflict|hook_failed|missing` set); and `queue_empty_not_converged` — Phase 3 deterministic halt when the candidate queue is empty but at least one PR is still in a non-terminal state (issue #160; deterministic alternative to the 4h `stuck_loop` wall-clock fallback). The set is closed; new reasons require an RFC amendment.
 - **`GOAL_PR_STATE_ENUM`** — the 8 states the PR machine in `_uberdev_goal_pr_state_machine_valid` recognises. `merged` and `merge-failed` are hard terminal (no further transitions); `yellow-held` and `red-held` are pseudo-terminal for convergence (Phase 3 counts them as terminal so the goal can converge cleanly with held PRs remaining, but the held-PR re-review poll loop in Phase 2 step 2e can still arc them to `green` once a re-review clears the findings, or cross-classify between `yellow-held`/`red-held` if a re-review's trust signal severity changed). `yellow-held → merging` and `red-held → merging` are hard-forbidden (D17 — never merge YELLOW/RED inside `/goal`).
 - **`GOAL_ISSUE_STATE_ENUM`** — the 5 states the issue machine recognises; `pr-pushed → resolved` and the two `→ failed` transitions are the only sinks.
 - **`TRUST_SIGNAL_ENUM`** — the 5 values `uberdev_goal_read_trust_signal` returns. `stale` (phase2_5 missing in audit JSON) and `missing` (audit JSON absent) both trigger `_uberdev_goal_dispatch_review_pr` rather than an assumed GREEN (D17).
-- **`GOAL_MERGE_RESULT_ENUM`** — the 4 values `uberdev_goal_read_merge_result` returns. Maps the merge-pipeline's audit-row events (`merge_executed` for `success`, `pr_parked` with `data.reason ∈ {refused, ambiguous, push-non-ff}` for `conflict`, `pr_parked` with `data.reason == test-fail-exhausted` for `hook_failed`) plus a sentinel `missing` for "no audit row appended yet". Phase 2c's case statement handles each value explicitly; the `*)` default arm emits `goal_circuit_breaker reason=unknown_merge_result` (B7 — defensive guard against future enum drift).
+- **`GOAL_MERGE_RESULT_ENUM`** — the 4 values `uberdev_goal_read_merge_result` returns. Maps the merge-pipeline's audit-row events (`merge_executed` for `success`, `pr_parked` with `data.reason ∈ {refused, ambiguous, push-non-ff}` for `conflict`, `pr_parked` with `data.reason == test-fail-exhausted` for `hook_failed`) plus a sentinel `missing` for "no audit row appended yet". Phase 2d's case statement handles each value explicitly; the `*)` default arm emits `goal_circuit_breaker reason=unknown_merge_result` (B7 — defensive guard against future enum drift).
 - **`BLOCKS_LINE_REGEX`** is the anchored ReDoS-safe shape (D9 + T1) used by `_uberdev_goal_parse_blocks_line` in `lib/goal-state.sh`. The Phase 3 prose and the Unblock rule both reference this constant by name; the literal `^Blocks: #([0-9]+)$` appears here once.
 - **`FINDING_FINGERPRINT_REGEX`** is the marker shape `agents/findings-to-issues.md` injects into every BLOCKER/CRITICAL `review-pr-finding` issue body; Phase 3 extracts it via `_uberdev_goal_extract_fingerprint` to drive the repeat-cycle detector.
 
@@ -127,7 +127,7 @@ Notes on the enums:
    uberdev_goal_state_init "$GOAL_ID" || exit 1
    ```
 
-7. **Initialize cycle counter + goal-level wall-clock anchor.** `cycle` is the per-cycle counter referenced by Phase 2/3/4 (audit payloads, MAX_CYCLES check, fingerprint repeat detector). `watch_start` is the **goal-level** wall-clock anchor — it must persist across cycle iterations so the 4h stuck-loop circuit breaker (`_UBERDEV_GOAL_STUCK_SECS`) measures total goal wall-clock, not per-cycle wall-clock (RFC §3.3 intent: the 4h cap is the goal-level safety net). `overflow_count` and `overflow_detected` are **per-cycle** accumulators set in Phase 2a and reset at the end of Phase 3 (so the `goal_cycle_completed` payload only reports overflows from the current cycle).
+7. **Initialize cycle counter + goal-level wall-clock anchor.** `cycle` is the per-cycle counter referenced by Phase 2/3/4 (audit payloads, MAX_CYCLES check, fingerprint repeat detector). `watch_start` is the **goal-level** wall-clock anchor — it must persist across cycle iterations so the 4h stuck-loop circuit breaker (`_UBERDEV_GOAL_STUCK_SECS`) measures total goal wall-clock, not per-cycle wall-clock (RFC §3.3 intent: the 4h cap is the goal-level safety net). `overflow_count` and `overflow_detected` are **per-cycle** accumulators set in Phase 2b (the red trust-signal case) and reset at the end of Phase 3 (so the `goal_cycle_completed` payload only reports overflows from the current cycle).
 
    ```bash
    cycle=1
@@ -236,7 +236,7 @@ uberdev_goal_write_run_state || { echo "goal: failed to persist run-state after 
 
 ## Phase 2 — Watch (per cycle, hard cap 4h wall-clock)
 
-**Concurrency model.** Phase 2 runs as a **single-threaded watcher** per iteration: each `sleep $_UBERDEV_GOAL_POLL_SECS` cycle walks the active-issues list once (step 2a), the green-PR list once (step 2b), and the merging-PR list once (step 2c) in deterministic order — a serial poll of every PR, never a fan-out. There is **no per-PR poll parallelism in v1** — the audit timeline (`goal_pr_transition` events in `goal-<id>.jsonl`) must remain a serial, replay-deterministic sequence for post-mortems and for the fingerprint-repeat detector in Phase 3. Per-PR poll parallelism is deferred to a future RFC (it would require an event-bus partition by PR number and a multi-writer audit framing that preserves a total order; neither lands in v1).
+**Concurrency model.** Phase 2 runs as a **single-threaded watcher** per iteration: each `sleep $_UBERDEV_GOAL_POLL_SECS` cycle walks the active-issues list once (step 2a — gh PR detection), the pushed-reviewing PR list once (step 2b — graced verdict read), the green-PR list once (step 2c — /merge dispatch), the merging-PR list once (step 2d — gh merge completion), and the held-PR list once (step 2e — re-review poll) in deterministic order — a serial poll of every PR, never a fan-out. There is **no per-PR poll parallelism in v1** — the audit timeline (`goal_pr_transition` events in `goal-<id>.jsonl`) must remain a serial, replay-deterministic sequence for post-mortems and for the fingerprint-repeat detector in Phase 3. Per-PR poll parallelism is deferred to a future RFC (it would require an event-bus partition by PR number and a multi-writer audit framing that preserves a total order; neither lands in v1).
 
 ```bash
 # #171 fresh-shell rehydration — re-source libs (idempotent via _UBERDEV_*_LOADED
@@ -403,7 +403,15 @@ while true; do
   # a hard merge_failed; `missing` defers (re-poll) with a MERGE_TIMEOUT
   # fallback to `green` when the merge agent stalled.
   for pr in $(uberdev_goal_list_prs_in_state "$GOAL_ID" merging); do
-    if uberdev_goal_pr_is_merged "$pr"; then
+    # Read gh state ONCE per PR per poll and branch on it locally — the MERGED
+    # gate and the CLOSED gate previously called uberdev_goal_pr_state_gh twice
+    # (once via pr_is_merged), a redundant `gh pr view` round-trip every poll
+    # while a /merge agent runs. Folding to one read cuts the steady-state merge
+    # poll cost and the gh-failure breadcrumb noise in half (the rate-limit
+    # exhaustion this loop is sensitive to). Behavior is identical: same MERGED /
+    # CLOSED / else branch decisions.
+    pr_state="$(uberdev_goal_pr_state_gh "$pr")"
+    if [ "$pr_state" = "MERGED" ]; then
       uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" merging merged
       # B4 — uberdev_goal_list_prs_in_state takes ONE state ($2); call twice
       # and concatenate so BOTH held sets get the unblock check.
@@ -414,7 +422,7 @@ while true; do
       continue
     fi
     # Not merged — a CLOSED-without-merge PR is a hard merge failure.
-    if [ "$(uberdev_goal_pr_state_gh "$pr")" = "CLOSED" ]; then
+    if [ "$pr_state" = "CLOSED" ]; then
       uberdev_goal_audit goal_circuit_breaker \
         "{\"reason\":\"merge_failed\",\"pr\":$pr,\"detail\":\"closed\"}"
       print_summary "$cycle"
@@ -741,9 +749,9 @@ uberdev_goal_write_run_state || { echo "goal: failed to persist run-state before
 # loop back to Phase 1
 ```
 
-**Blocker-overflow handler (D13).** When the upstream `/review-pr` run halted with too many BLOCKER findings (more than the file-issues cap), its audit JSON carries `halted_due_to_overflow: true` at the top level. **Detection lives in Phase 2a** (red signal case) where `$audit_json` and `$pr_num` are in scope; it sets `overflow_detected=1`. Phase 3's truncation step then:
+**Blocker-overflow handler (D13).** When the upstream `/review-pr` run halted with too many BLOCKER findings (more than the file-issues cap), its audit JSON carries `halted_due_to_overflow: true` at the top level. **Detection lives in Phase 2b** (red signal case) where `$audit_json` and `$pr_num` are in scope; it sets `overflow_detected=1`. Phase 3's truncation step then:
 
-- (Phase 2a already transitioned the PR to `red-held` for the red trust signal — overflow is functionally identical to RED, so the transition is shared);
+- (Phase 2b already transitioned the PR to `red-held` for the red trust signal — overflow is functionally identical to RED, so the transition is shared);
 - queues only the first 10 candidate issues for the next cycle (the upstream agent already truncated the issue-file list at the cap; the queue cap mirrors that ceiling);
 - surfaces the overflow count in the `goal_cycle_completed` summary `{overflow_count: N}`;
 - **does NOT halt the entire goal** — `halted_due_to_overflow` is a per-PR cycle-management signal, not a goal-level circuit breaker. The goal continues to its next cycle and may converge once the overflow PR's issues are resolved.
@@ -757,9 +765,9 @@ uberdev_goal_write_run_state || { echo "goal: failed to persist run-state before
 GOAL_ID="${UBERDEV_GOAL_ID:-${GOAL_ID:-}}"
 uberdev_goal_read_run_state || { echo "goal: cannot rehydrate run-state in Phase 3 (overflow check)" >&2; exit 3; }
 uberdev_dispatch_resolve_env || exit 1   # re-derive backend/env (idempotent, D8); not persisted
-# overflow_detected is set in Phase 2a's red case when any PR's /review-pr
+# overflow_detected is set in Phase 2b's red case when any PR's /review-pr
 # audit JSON carried halted_due_to_overflow:true. Here in Phase 3 we apply
-# the first-10 truncation (no PR transition — Phase 2a already did that).
+# the first-10 truncation (no PR transition — Phase 2b already did that).
 if [ "${overflow_detected:-0}" = "1" ]; then
   new_candidates=("${new_candidates[@]:0:10}")
   # surfaced in cycle summary; goal continues — do NOT halt.
@@ -779,7 +787,7 @@ Every exit path from this skill emits exactly one terminal audit event AND print
 | Non-convergence | `goal_circuit_breaker` with `reason=nonconvergence` | 1 | Fingerprint repeat detected by `uberdev_goal_check_fingerprint_repeat` (Phase 3 per-candidate loop). |
 | Queue-empty-not-converged | `goal_circuit_breaker` with `reason=queue_empty_not_converged` | 1 | `new_candidates` empty AND at least one PR still in a non-terminal in-flight state (`dispatched`, `pushed-reviewing`, `green`, `merging`) — deterministic Phase 3 halt that pre-empts the 4h `stuck_loop` fallback (#160). |
 | Stuck-loop | `goal_circuit_breaker` with `reason=stuck_loop` | 1 | `watch_secs >= _UBERDEV_GOAL_STUCK_SECS` (4h) at top of Phase 2 iteration. |
-| Merge-failed | `goal_circuit_breaker` with `reason=merge_failed` | 1 | `/merge` returned `conflict` or `hook_failed` (Phase 2 step 2c). |
+| Merge-failed | `goal_circuit_breaker` with `reason=merge_failed` | 1 | `/merge` returned `conflict` or `hook_failed`, or the PR was CLOSED without merging (Phase 2 step 2d). |
 
 **Human-readable summary line.** Print to stdout (NOT stderr — this is the operator's success-or-failure narrative) before exit:
 
@@ -825,7 +833,7 @@ print_summary() {
 
 ## Unblock rule
 
-Called from Phase 2 step 2c on every `merging → merged` PR transition, for each PR currently in `yellow-held` or `red-held`. The body of the rule is implemented by `lib/goal-state.sh::_uberdev_goal_check_unblock`; the 5-step contract:
+Called from Phase 2 step 2d on every `merging → merged` PR transition, for each PR currently in `yellow-held` or `red-held`. The body of the rule is implemented by `lib/goal-state.sh::_uberdev_goal_check_unblock`; the 5-step contract:
 
 1. **Fetch held PR body.** `gh pr view $held_pr --json body --jq '.body'`, capped at `_UBERDEV_GOAL_BODY_CAP` (64 KiB) via `head -c` to bound the regex-parse cost (R1 / T1 — without the cap, a 10 MB PR body could ReDoS the parse loop or starve memory).
 2. **Line-split and match against `BLOCKS_LINE_REGEX`.** Each line is fed to bash `[[ =~ ]]` against the anchored shape `^Blocks: #([0-9]+)$` — anchored, no quantifiers under user control, ReDoS-safe (D9 + T1). Non-matching lines are skipped silently (a held PR body need not contain a Blocks line — in which case nothing is unblocked).
@@ -833,13 +841,13 @@ Called from Phase 2 step 2c on every `merging → merged` PR transition, for eac
 4. **If all blocking issues are CLOSED, re-dispatch `/uberdev:review-pr $held_pr`** via `_uberdev_goal_dispatch_review_pr` (D18 full re-review — including Phase 3 CI Health re-evaluation; the no-shortcut path is mandatory because the upstream merge that triggered this unblock may have changed CI dependencies). If any blocking issue is still OPEN, do nothing this iteration; the unblock check will re-run on the next merged-PR transition.
 5. **Emit `goal_unblock_triggered` event** with payload `{pr, blocking_issues: […]}`. This event is the durable record that the unblock fired; consumers can replay it from `goal-<id>.jsonl` to reconstruct the held-PR DAG.
 
-**Completion half (Phase 2 step 2e — #159).** The unblock rule's `/review-pr` dispatch in step 4 is fire-and-forget; it is **Phase 2 step 2e**, the held-PR re-review poll, that closes the loop. On every Phase 2 iteration, step 2e walks every PR currently in `yellow-held` / `red-held`, compares the live latest audit (`uberdev_goal_locate_review_pr_audit_by_pr`) against the previously-consumed audit (`uberdev_goal_get_last_held_audit`), and — when they differ — applies the next state transition based on the new audit's trust signal: `green → green` (eligible for merge in next cycle's step 2b), severity-flip → `{yellow,red}-held → {red,yellow}-held` re-classification, or same-severity → no transition. Without step 2e, the dispatch in step 4 had no consumer, and the held PR was permanently orphaned (the bug issue #159 captured).
+**Completion half (Phase 2 step 2e — #159).** The unblock rule's `/review-pr` dispatch in step 4 is fire-and-forget; it is **Phase 2 step 2e**, the held-PR re-review poll, that closes the loop. On every Phase 2 iteration, step 2e walks every PR currently in `yellow-held` / `red-held`, compares the live latest audit (`uberdev_goal_locate_review_pr_audit_by_pr`) against the previously-consumed audit (`uberdev_goal_get_last_held_audit`), and — when they differ — applies the next state transition based on the new audit's trust signal: `green → green` (eligible for merge in next cycle's step 2c), severity-flip → `{yellow,red}-held → {red,yellow}-held` re-classification, or same-severity → no transition. Without step 2e, the dispatch in step 4 had no consumer, and the held PR was permanently orphaned (the bug issue #159 captured).
 
 ## Scoped relaxations
 
 `/goal` is the one place in UberDev where three otherwise-strict /uberdev conventions are deliberately relaxed (RFC §2.3). Every relaxation is scoped to `/goal` only — the relaxed behaviour does NOT leak to standalone `/turbo`, `/merge`, or `/review-pr` invocations.
 
-1. **`feedback_merge_independent`: `/merge` auto-chain allowed inside `/goal`.** The global rule "merge is a deliberate user-invoked command" still holds for standalone use. Inside `/goal`, Phase 2 step 2b auto-dispatches `/merge` for any PR that transitions to `green`, subject to:
+1. **`feedback_merge_independent`: `/merge` auto-chain allowed inside `/goal`.** The global rule "merge is a deliberate user-invoked command" still holds for standalone use. Inside `/goal`, Phase 2 step 2c auto-dispatches `/merge` for any PR that transitions to `green`, subject to:
    - `uberdev_goal_should_automerge` provenance check (UBERDEV_GOAL_ID env-var must be set — outside `/goal` it isn't, so the auto-merge refuses);
    - per-PR attempt counter cap (`_UBERDEV_GOAL_MAX_MERGE_ATTEMPTS=3` — after 3 attempts the same PR is held for human inspection);
    - YELLOW/RED PRs are NEVER auto-merged (D17 forbidden transitions).

--- a/plugins/uberdev/skills/merge-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/merge-pipeline/SKILL.md
@@ -693,7 +693,16 @@ Run `git merge-tree --write-tree <integration_branch> <headRefOid>`. Exit 0 = cl
 
 ### Step 3.2 — Clean-merge path
 
-If probe was clean: run `gh pr merge <N> --<strategy> --match-head-commit <headRefOid>`. The `--match-head-commit` flag is mandatory — it is the TOCTOU guard that fails fast if the PR HEAD moved between probe and merge. On `gh pr merge` failure: abort that PR, emit `merge_executed`+`error` events, continue with rest of queue.
+If probe was clean: run `gh pr merge <N> --<strategy> --match-head-commit <headRefOid>`. The `--match-head-commit` flag is mandatory — it is the TOCTOU guard that fails fast if the PR HEAD moved between probe and merge.
+
+**On success, emit a concrete `merge_executed` audit row** — this is the canonical shape downstream consumers depend on (notably `/goal`'s `uberdev_goal_read_merge_result`, which selects `.event=="merge_executed" | .data.pr`). Do NOT hand-improvise the JSON; emit exactly this template (the same one the Step 3.3vii conflict-resolve path uses after its successful `gh pr merge`):
+
+```bash
+printf '{"event":"merge_executed","run_id":"%s","ts":"%s","data":{"pr":%d,"strategy":"%s"}}\n' \
+  "$RUN_ID" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PR" "$strategy" >> ".uberdev/audit.jsonl"
+```
+
+`merge_executed` is emitted ONLY on a successful merge — it is the success contract. On `gh pr merge` **failure**: abort that PR, emit an `error` event (NOT `merge_executed` — a `merge_executed` row on a failed merge would falsely advance `/goal`'s state machine), and continue with the rest of the queue. (Belt-and-braces: `/goal` reads `gh pr view --json state == MERGED` first, so a stray failure-row is also caught there — but the producer must not emit it.)
 
 ### Step 3.3 — Conflict-resolve path
 
@@ -756,7 +765,7 @@ Commit message format: `chore(merge): resolve conflicts in <comma-separated-file
 
 Push: `git push origin HEAD:<headRefName>`. **Never `--force`. Never `--force-with-lease`** against a PR head ref **for `/merge`'s own writes**. Resolution is a NEW commit on top of existing head. **Sanctioned exception:** `/uberdev:review-pr` Phase 3's `ci-rebase-handler` agent is the **single sanctioned exception** — see `plugins/uberdev/agents/ci-rebase-handler.md` for the bounded exception (worktree lock + explicit-old-SHA lease form + `--force-if-includes`). The exception applies only inside Phase 3 stale_base remediation, not to `/merge`'s own conflict-resolution pushes. If push fails non-FF (the PR head moved during conflict-resolve — someone else pushed in between): emit `push_resolution`+`error` to audit log, **park THIS PR via `drop` strategy** with `PARK_REASON_ENUM` value `push-non-ff`, and **continue with the next PR**. The queue does NOT halt — the parked PR is dropped from THIS run; a future `/merge` invocation will re-evaluate it against the Phase 1.4 gate (`APPROVED` + CI-green) and pick it up if it still qualifies.
 
-vii. **Retry `gh pr merge`** with the new head SHA (re-fetch `headRefOid` after push).
+vii. **Retry `gh pr merge`** with the new head SHA (re-fetch `headRefOid` after push). On success, emit the canonical `merge_executed` audit row (the Step 3.2 template — success-only, `data.pr` integer); on failure emit `error` (never `merge_executed`).
 
 viii. **Tear down the scratch worktree** per `using-git-worktrees` protocol: `git worktree remove --force <path>`. On failure: `git worktree prune` retry. If still failing: surface manual cleanup instructions; **never `rm -rf`**.
 
@@ -821,7 +830,7 @@ done
 |---|---|---|
 | `test_fail` after exhausting (a)/(b)/(c) in Step 3.3v | park via `drop` (`data.reason="test-fail-exhausted"`) | continues |
 | `push_resolution` non-FF (Step 3.3vi) | park via `drop` (`data.reason="push-non-ff"`) | continues |
-| `gh pr merge` failure (Step 3.2 / 3.3vii) | abort that PR; emit `merge_executed`+`error` | continues |
+| `gh pr merge` failure (Step 3.2 / 3.3vii) | abort that PR; emit `error` (NOT `merge_executed` — success-only) | continues |
 | conflict-resolver `AMBIGUOUS` | park via `drop` (`data.reason="ambiguous"`) | continues |
 | conflict-resolver `REFUSED` | park via `drop` (`data.reason="refused"`) | continues |
 | dependency cycle (Phase 2.1) | break edges, fall back to createdAt order; emit cycle path to stderr | continues |

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -2013,6 +2013,82 @@ uberdev_goal_agent_busy_for_issue abc 2>/dev/null
 assert_rc "$?" "1" "BT68.agent-busy-non-numeric-rc-1"
 MOCK_CLAUDE_AGENTS_JSON='[]'   # reset to inert
 
+# ----- BT69-BT75 — issue #180 /review-pr fix-loop coverage -----
+# Closes the gaps surfaced by the post-impl review fanout: the merge-stall
+# state-machine arm (the one real correctness bug), gh-failure fail-open + the
+# new breadcrumbs, CLOSED-without-merge, and filter/cwd prefix isolation.
+
+# BT69 — state machine: merging->green is VALID (Phase 2d merge-stall recovery).
+# Regression guard for the review blocker — WITHOUT this arm the stall recovery
+# calls an invalid transition (rc=2), the PR is stranded in `merging`, and the
+# goal spins to the 4h stuck_loop: the exact failure mode #180 fixes.
+_uberdev_goal_pr_state_machine_valid merging green
+assert_rc "$?" "0" "BT69.state-machine-merging-to-green-valid"
+_uberdev_goal_pr_state_machine_valid merging merged
+assert_rc "$?" "0" "BT69.state-machine-merging-to-merged-still-valid"
+_uberdev_goal_pr_state_machine_valid merging yellow-held
+assert_rc "$?" "1" "BT69.state-machine-merging-to-yellow-still-invalid"
+
+# BT70 — find_pr_for_issue: a gh FAILURE (rc!=0) is fail-open (empty + rc 0 so
+# the caller keeps re-polling) BUT emits a stderr breadcrumb — it must NOT
+# masquerade silently as "no PR yet".
+MOCK_PR_LIST_JSON='[]'; MOCK_PR_LIST_RC=1
+_bt70_err="$_b12_tmpdir/bt70-stderr"; : > "$_bt70_err"
+_bt70_rc=0
+_bt70_out="$(uberdev_goal_find_pr_for_issue 100 2>"$_bt70_err")" || _bt70_rc=$?
+assert_eq "$_bt70_out" "" "BT70.find-pr-gh-failure-empty"
+assert_rc "$_bt70_rc" "0" "BT70.find-pr-gh-failure-rc-zero-failopen"
+if grep -q 'gh pr list failed' "$_bt70_err"; then
+  PASS=$((PASS + 1)); printf '  PASS  %s\n' "BT70.find-pr-gh-failure-breadcrumb"
+else
+  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "BT70.find-pr-gh-failure-breadcrumb" >&2
+fi
+MOCK_PR_LIST_RC=0; MOCK_PR_LIST_JSON='[]'
+
+# BT71 — pr_state_gh: gh FAILURE (rc!=0) -> empty + breadcrumb; pr_is_merged false.
+MOCK_PR_STATE="OPEN"; MOCK_PR_STATE_RC=1
+_bt71_err="$_b12_tmpdir/bt71-stderr"; : > "$_bt71_err"
+_bt71_out="$(uberdev_goal_pr_state_gh 42 2>"$_bt71_err")"
+assert_eq "$_bt71_out" "" "BT71.pr-state-gh-failure-empty"
+if grep -q 'gh pr view failed' "$_bt71_err"; then
+  PASS=$((PASS + 1)); printf '  PASS  %s\n' "BT71.pr-state-gh-failure-breadcrumb"
+else
+  FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "BT71.pr-state-gh-failure-breadcrumb" >&2
+fi
+uberdev_goal_pr_is_merged 42 2>/dev/null
+assert_rc "$?" "1" "BT71.pr-is-merged-false-on-gh-failure"
+MOCK_PR_STATE_RC=0; MOCK_PR_STATE=""
+
+# BT72 — pr_state_gh CLOSED-without-merge -> "CLOSED"; pr_is_merged false. Phase
+# 2d's hard merge_failed gate depends on this (a force-closed PR must surface
+# immediately, not loop until MERGE_TIMEOUT).
+MOCK_PR_STATE="CLOSED"
+assert_eq "$(uberdev_goal_pr_state_gh 42)" "CLOSED" "BT72.pr-state-gh-closed"
+uberdev_goal_pr_is_merged 42
+assert_rc "$?" "1" "BT72.pr-is-merged-false-on-closed"
+MOCK_PR_STATE=""
+
+# BT73 — find_pr_for_issue head-ref PREFIX ISOLATION: a PR whose head is
+# `feat/30-x` (issue 30) closing issue 999 must NOT match issue 300 (neither the
+# `^feat/300-` head arm nor the closingRefs arm) — guards feat/30 vs feat/300.
+MOCK_PR_LIST_JSON='[{"number":4242,"closingIssuesReferences":[{"number":999}],"headRefName":"feat/30-x"}]'
+assert_eq "$(uberdev_goal_find_pr_for_issue 300)" "" "BT73.find-pr-head-prefix-300-no-match"
+assert_eq "$(uberdev_goal_find_pr_for_issue 30)" "4242" "BT73.find-pr-head-prefix-30-matches"
+MOCK_PR_LIST_JSON='[]'
+
+# BT74 — agent_busy_for_issue: malformed claude JSON -> rc 1 (fail-safe "not busy").
+MOCK_CLAUDE_AGENTS_JSON='not valid json {{{'
+uberdev_goal_agent_busy_for_issue 77 2>/dev/null
+assert_rc "$?" "1" "BT74.agent-busy-malformed-json-not-busy"
+MOCK_CLAUDE_AGENTS_JSON='[]'
+
+# BT75 — agent_busy_for_issue cwd PREFIX ISOLATION: cwd `solve-issue-7` must NOT
+# satisfy a check for issue 77 (endswith isolation; inverse of BT67).
+MOCK_CLAUDE_AGENTS_JSON='[{"cwd":"/x/solve-issue-7","status":"busy"}]'
+uberdev_goal_agent_busy_for_issue 77
+assert_rc "$?" "1" "BT75.agent-busy-prefix-isolation-7-not-77"
+MOCK_CLAUDE_AGENTS_JSON='[]'
+
 # ----- H1-H6 — #156 goal_id path-traversal guard + #157 unwritable-tmpdir surfacing -----
 # Both findings target plugins/uberdev/lib/goal-state.sh. #156: goal_id was
 # interpolated into per-goal state filenames without the slug validation that

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -242,7 +242,9 @@ for fn in uberdev_goal_state_init uberdev_goal_pr_state_transition uberdev_goal_
           uberdev_goal_audit uberdev_goal_locate_review_pr_audit \
           uberdev_goal_locate_review_pr_audit_by_pr \
           uberdev_goal_get_pr_state uberdev_goal_record_held_audit uberdev_goal_get_last_held_audit \
-          uberdev_goal_extract_pr_num_from_log uberdev_goal_list_prs_in_state uberdev_goal_read_merge_result; do
+          uberdev_goal_find_pr_for_issue uberdev_goal_pr_state_gh uberdev_goal_pr_is_merged \
+          uberdev_goal_agent_busy_for_issue \
+          uberdev_goal_list_prs_in_state uberdev_goal_read_merge_result; do
   assert_grep "$GOAL_LIB" "^${fn}\\(\\)" "G19.public.${fn}"
 done
 # Internal function names (13 underscore-prefixed helpers — `_uberdev_goal_validate_id`
@@ -271,15 +273,43 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.33.8) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.8"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.8"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.8-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.8\]'        "G20.changelog"
+echo "== G20: version bump locked (0.33.9) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.9"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.9"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.9-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.9\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"
 assert_grep "$GOAL_SKILL" 'export AUTO_MODE=1'            "G20b.phase0-sets-AUTO_MODE (#175 turbo-parity)"
+
+echo
+echo "== G23: CLI-version-independent gh+file detection (issue #180) =="
+# The watch loop must key completion/PR/merge off gh + the file-based verdict,
+# NOT the captured claude --bg stdout (which on CLI 2.1.150 is a detached
+# banner only). These gates lock the fix in place against regression.
+# Positive: the gh signals are wired into the skill + lib.
+assert_grep "$GOAL_SKILL" 'uberdev_goal_find_pr_for_issue'  "G23.find-pr-in-skill"
+assert_grep "$GOAL_SKILL" 'uberdev_goal_pr_is_merged'       "G23.pr-is-merged-in-skill"
+assert_grep "$GOAL_LIB"   '^uberdev_goal_find_pr_for_issue\(\)'    "G23.lib-find-pr"
+assert_grep "$GOAL_LIB"   '^uberdev_goal_pr_state_gh\(\)'          "G23.lib-pr-state-gh"
+assert_grep "$GOAL_LIB"   '^uberdev_goal_pr_is_merged\(\)'         "G23.lib-pr-is-merged"
+assert_grep "$GOAL_LIB"   '^uberdev_goal_agent_busy_for_issue\(\)' "G23.lib-agent-busy"
+assert_grep "$GOAL_LIB"   'closingIssuesReferences'               "G23.lib-uses-closing-refs"
+# Phase 0 bash>=4 preflight guard (defect #8 — macOS /bin/bash is 3.2, and the
+# Bash-tool default zsh chokes on the unmatched-glob verdict locator).
+assert_grep "$GOAL_SKILL" 'BASH_VERSINFO'                  "G23.phase0-bash4-guard"
+# Anti-regression: the broken stdout-marker COMPLETION PROBES are gone from the
+# watch loop. These target the actual CODE constructs, not token mentions — the
+# explanatory prose legitimately NAMES the retired markers to document the fix.
+assert_no_grep "$GOAL_SKILL" "grep -q 'backgrounded"      "G23.no-backgrounded-completion-probe"
+assert_no_grep "$GOAL_SKILL" 'merge_log='                 "G23.no-merge-bg-stdout-read"
+assert_no_grep "$GOAL_SKILL" 'uberdev_goal_extract_pr_num_from_log' "G23.skill-no-extract-call"
+assert_no_grep "$GOAL_SKILL" 'mapfile -t'                 "G23.no-mapfile-bash4ism"
+# Anti-regression: the false-premise log parser is removed from the lib, and
+# the `pushed PR #N` grep it relied on is gone.
+assert_no_grep "$GOAL_LIB" '^uberdev_goal_extract_pr_num_from_log' "G23.lib-no-extract-pr-num"
+assert_no_grep "$GOAL_LIB" "grep -oE 'pushed PR"          "G23.lib-no-pushed-pr-grep"
 
 echo
 echo "== G21: held-PR re-review poll loop (issue #159) =="
@@ -557,6 +587,20 @@ MOCK_ISSUE_RC=0
 MOCK_ISSUE_STDERR=""
 MOCK_ISSUE_STATES=()
 DISPATCH_LOG=""
+# #180 — gh+file detection mocks. MOCK_PR_LIST_JSON is the raw JSON array a
+# `gh pr list --json ...` call would return; the mock applies the call's own
+# `--jq` filter to it (faithfully mirroring gh's in-process jq) so the filter
+# logic in uberdev_goal_find_pr_for_issue is exercised, not stubbed. MOCK_PR_STATE
+# is what `gh pr view <pr> --json state` returns (used by pr_state_gh / pr_is_merged
+# / read_merge_result's gh-first arm). MOCK_CLAUDE_AGENTS_JSON drives the claude()
+# mock for agent_busy_for_issue. All default to the inert "no PR / not merged /
+# no live agent" shape so pre-#180 behavioural tests (BT41-47 etc.) fall through
+# to their original file-based code paths unchanged.
+MOCK_PR_LIST_JSON="[]"
+MOCK_PR_LIST_RC=0
+MOCK_PR_STATE=""
+MOCK_PR_STATE_RC=0
+MOCK_CLAUDE_AGENTS_JSON="[]"
 
 gh() {
   local sub="$1"; shift
@@ -564,7 +608,31 @@ gh() {
     pr)
       local sub2="$1"; shift
       case "$sub2" in
-        view) printf '%s' "$MOCK_PR_BODY"; return "$MOCK_PR_RC" ;;
+        list)
+          # Apply the call's own --jq filter to MOCK_PR_LIST_JSON, mirroring
+          # gh's internal jq (raw output). uberdev_goal_find_pr_for_issue passes
+          # the closingIssuesReferences/headRefName filter; running it here means
+          # the test exercises the real filter, not a hand-computed answer.
+          local _filter='.'
+          while [ "$#" -gt 0 ]; do
+            case "$1" in
+              --jq) _filter="$2"; shift 2 ;;
+              *) shift ;;
+            esac
+          done
+          printf '%s' "$MOCK_PR_LIST_JSON" | jq -r "$_filter"
+          return "$MOCK_PR_LIST_RC"
+          ;;
+        view)
+          # Distinguish a state projection (`--json state`, used by pr_state_gh)
+          # from a body projection (`--json body`, used by unblock/fetch_pr_body).
+          local _want_state=0 _a
+          for _a in "$@"; do [ "$_a" = "state" ] && _want_state=1; done
+          if [ "$_want_state" = "1" ]; then
+            printf '%s' "$MOCK_PR_STATE"; return "$MOCK_PR_STATE_RC"
+          fi
+          printf '%s' "$MOCK_PR_BODY"; return "$MOCK_PR_RC"
+          ;;
       esac
       ;;
     issue)
@@ -595,6 +663,15 @@ gh() {
       esac
       ;;
   esac
+  return 0
+}
+
+# #180 — claude() mock for uberdev_goal_agent_busy_for_issue, which pipes
+# `claude agents --json` into jq. Returns MOCK_CLAUDE_AGENTS_JSON for the
+# `agents` subcommand; any other invocation is an inert no-op so a stray
+# `claude` call in a future test never spawns a real session.
+claude() {
+  if [ "$1" = "agents" ]; then printf '%s' "$MOCK_CLAUDE_AGENTS_JSON"; return 0; fi
   return 0
 }
 
@@ -778,11 +855,14 @@ _bt11c_rc=$?
 assert_rc "$_bt11c_rc" "0" "BT11c.n3-middle-open-returns-zero"
 assert_eq "$DISPATCH_LOG" "" "BT11c.n3-middle-open-no-dispatch"
 
-# Hygiene: drop the function-override + dispatch stubs before B12 ends
-# (spec Error handling section). No subsequent tests, so blast radius is
-# zero, but explicit unset documents intent and prevents a future BT12
-# appended below from silently inheriting any of these shadows.
-unset -f gh
+# Hygiene: drop the dispatch stubs before BT12 (spec Error handling section) so
+# a stray dispatch in a later test fails loudly instead of silently logging.
+# The gh() + claude() mocks are NOT unset — issue #180's gh+file detection tests
+# (BT24-28 find_pr, BT37-40/BT56 locate-via-find_pr, BT59-68 gh-state helpers,
+# and read_merge_result's gh-first arm at BT41-47/BT63-64) all route through gh,
+# so the override must persist. It stays inert for the file-only tests (BT12-23,
+# BT29-34) because their functions never call gh, and MOCK_PR_STATE/MOCK_PR_LIST_JSON
+# default to the "not merged / no PR" shape so BT41-47 fall through to the audit path.
 unset -f uberdev_dispatch_one
 unset -f _uberdev_goal_dispatch_review_pr
 
@@ -1248,59 +1328,46 @@ fi
 # from line 294-295, so solve-bg-stdout-<issue>.log fixtures land where
 # the function-under-test (locate_review_pr_audit) reads them.
 
-# ===== uberdev_goal_extract_pr_num_from_log (lines 377-381) =====
+# ===== uberdev_goal_find_pr_for_issue (issue #180 — gh closingIssuesReferences) =====
+# Replaces the retired uberdev_goal_extract_pr_num_from_log `pushed PR #N` log
+# parser: that marker has zero producers and `claude --bg` stdout is a detached
+# banner on CLI 2.1.150. Issue->PR resolution is now GitHub-native — a PR that
+# closes issue N (closingIssuesReferences) or whose head is `feat/N-…`.
 
-# BT24 — happy: `pushed PR #N` marker present -> outputs N.
-_bt24_log="$_b12_tmpdir/bt24.log"
-cat > "$_bt24_log" <<'EOF'
-[solve-bg] dispatched /solve 100
-[solve-bg] pushed PR #123 (issue #100)
-[solve-bg] done
-EOF
-assert_eq "$(uberdev_goal_extract_pr_num_from_log "$_bt24_log")" "123" \
-  "BT24.extract-pr-happy-path"
+# BT24 — happy: closingIssuesReferences match -> PR number.
+MOCK_PR_LIST_JSON='[{"number":123,"closingIssuesReferences":[{"number":100}],"headRefName":"feat/100-fix"}]'
+assert_eq "$(uberdev_goal_find_pr_for_issue 100)" "123" \
+  "BT24.find-pr-closes-match"
 
-# BT25 — missing file: `[ -f "$log" ] || return 0` short-circuits. Capture
-# the rc separately because the `$(...)` swallows it; assert both that the
-# function exited 0 (not an error) AND that stdout is empty (no garbage
-# output before the early return).
-_bt25_rc=0
-_bt25_out="$(uberdev_goal_extract_pr_num_from_log /nonexistent/path)" \
-  || _bt25_rc=$?
-assert_eq "$_bt25_out" "" "BT25.extract-missing-file-empty"
-assert_rc "$_bt25_rc" "0"  "BT25.extract-missing-file-rc-zero"
+# BT25 — non-numeric issue: validate_int rejects BEFORE any gh call -> rc=1
+# (the R3 gh-argument-injection guard; mirrors BT35/BT41).
+uberdev_goal_find_pr_for_issue abc 2>/dev/null
+assert_rc "$?" "1" "BT25.find-pr-non-numeric-rc-1"
 
-# BT26 — empty file: file exists but no marker -> empty output. Distinct
-# from BT25 because the [ -f ] guard passes here; the grep pipe is what
-# yields empty.
-_bt26_log="$_b12_tmpdir/bt26.log"
-: > "$_bt26_log"
-assert_eq "$(uberdev_goal_extract_pr_num_from_log "$_bt26_log")" "" \
-  "BT26.extract-empty-file-empty"
+# BT26 — no match: empty PR list -> empty output, rc=0 (a not-yet-pushed
+# solver must NOT be misread as an error).
+MOCK_PR_LIST_JSON='[]'
+_bt26_rc=0
+_bt26_out="$(uberdev_goal_find_pr_for_issue 9999)" || _bt26_rc=$?
+assert_eq "$_bt26_out" "" "BT26.find-pr-no-match-empty"
+assert_rc "$_bt26_rc" "0" "BT26.find-pr-no-match-rc-zero"
 
-# BT27 — multi-entry: multiple `pushed PR #N` markers -> first wins
-# (the `head -n 1` between the two greps locks "first match" semantics).
-# A regression that dropped `head -n 1` would emit all PR numbers and
-# this assertion (exact match against "5") would fail loudly.
-_bt27_log="$_b12_tmpdir/bt27.log"
-cat > "$_bt27_log" <<'EOF'
-[solve-bg] pushed PR #5
-[solve-bg] dispatched
-[solve-bg] pushed PR #99
-EOF
-assert_eq "$(uberdev_goal_extract_pr_num_from_log "$_bt27_log")" "5" \
-  "BT27.extract-multi-entry-first-wins"
+# BT27 — head-ref fallback: closingIssuesReferences empty, head `feat/N-` matches.
+# Covers the historical-PR shape where the Closes link was dropped but the
+# branch name still carries the issue number.
+MOCK_PR_LIST_JSON='[{"number":321,"closingIssuesReferences":[],"headRefName":"feat/200-thing"}]'
+assert_eq "$(uberdev_goal_find_pr_for_issue 200)" "321" \
+  "BT27.find-pr-head-ref-fallback"
 
-# BT28 — malformed input: no `pushed PR #N` marker -> empty (the trailing
-# `|| true` ensures rc=0 even when grep finds nothing; without it the
-# pipeline rc would be 1 and break callers).
-_bt28_log="$_b12_tmpdir/bt28.log"
-cat > "$_bt28_log" <<'EOF'
-[solve-bg] dispatched /solve 100
-[solve-bg] PR push failed: ENOSPC
-EOF
-assert_eq "$(uberdev_goal_extract_pr_num_from_log "$_bt28_log")" "" \
-  "BT28.extract-no-marker-empty"
+# BT28 — multiple matches + a distractor: highest PR wins (max), and a PR
+# closing a DIFFERENT issue is excluded. A regression that dropped the
+# `| max` or the `select(... == N)` filter would surface here.
+MOCK_PR_LIST_JSON='[{"number":5,"closingIssuesReferences":[{"number":300}],"headRefName":"feat/300-a"},{"number":99,"closingIssuesReferences":[{"number":300}],"headRefName":"feat/300-b"},{"number":1000,"closingIssuesReferences":[{"number":999}],"headRefName":"feat/999-z"}]'
+assert_eq "$(uberdev_goal_find_pr_for_issue 300)" "99" \
+  "BT28.find-pr-highest-wins-excludes-other-issue"
+
+# Reset the PR-list mock to inert before the file-based BTs below.
+MOCK_PR_LIST_JSON='[]'
 
 # ===== uberdev_goal_list_prs_in_state (lines 386-392) =====
 
@@ -1371,29 +1438,29 @@ assert_eq "$(uberdev_goal_list_prs_in_state test-bt34 merging)" "" \
 uberdev_goal_locate_review_pr_audit abc 2>/dev/null
 assert_rc "$?" "1" "BT35.locate-non-numeric-issue-rc-1"
 
-# BT36 — missing log: extract_pr_num_from_log returns "" for issue 9999
-# (no solve-bg-stdout-9999.log in $UBERDEV_TMPDIR), so the `[ -n "$pr" ]
-# || return 0` branch fires and the function emits nothing. Confirms the
-# function does NOT halt the goal-pipeline when a solve-bg log is missing.
-# Capture rc separately (mirrors BT25/BT29) — `$(...)` swallows it, so
-# we assert both the empty-stdout invariant AND that the function
-# returned 0 (the missing-log short-circuit must NOT raise an error).
+# BT36 — no PR for issue: find_pr_for_issue returns "" for issue 9999 (empty
+# gh PR list), so the `[ -n "$pr" ] || return 0` branch fires and the function
+# emits nothing. Confirms the function does NOT halt the goal-pipeline when a
+# solver has not yet pushed a PR. Capture rc separately (mirrors BT25/BT29) —
+# `$(...)` swallows it, so we assert both the empty-stdout invariant AND that
+# the function returned 0 (the no-PR short-circuit must NOT raise an error).
+MOCK_PR_LIST_JSON='[]'
 _bt36_rc=0
 _bt36_out="$(uberdev_goal_locate_review_pr_audit 9999)" || _bt36_rc=$?
-assert_eq "$_bt36_out" "" "BT36.locate-missing-log-empty"
-assert_rc "$_bt36_rc" "0" "BT36.locate-missing-log-rc-zero"
+assert_eq "$_bt36_out" "" "BT36.locate-no-pr-empty"
+assert_rc "$_bt36_rc" "0" "BT36.locate-no-pr-rc-zero"
 
-# BT37 — happy: log resolves PR=500, .uberdev/runs/<run>/review-pr-verdict.json
+# BT37 — happy: gh resolves issue 37 -> PR=500, .uberdev/runs/<run>/review-pr-verdict.json
 # carries matching .pr, run_id matches RUN_ID_REGEX. Function returns
 # the relative canonical path. The verdict.json uses `"pr": "500"`
-# (string form) because locate_review_pr_audit reads .pr via `jq -r`
+# (string form) because locate_review_pr_audit_by_pr reads .pr via `jq -r`
 # (NOT `jq --argjson`) and then string-compares against $pr, so either
 # `{"pr": "500"}` or `{"pr": 500}` works identically here. BT43's
 # read_merge_result counterpart MUST use integer form (see BT43) — the
 # asymmetry is intentional and reflects each fn's filter.
 _bt37_dir="$_b12_tmpdir/bt37-cwd"
 mkdir -p "$_bt37_dir/.uberdev/runs/20260521-120000-aaaa1111"
-printf '[solve-bg] pushed PR #500\n' > "$_b12_tmpdir/solve-bg-stdout-37.log"
+MOCK_PR_LIST_JSON='[{"number":500,"closingIssuesReferences":[{"number":37}],"headRefName":"feat/37-x"}]'
 cat > "$_bt37_dir/.uberdev/runs/20260521-120000-aaaa1111/review-pr-verdict.json" <<'EOF'
 {"pr": "500"}
 EOF
@@ -1415,7 +1482,7 @@ assert_eq "$_bt37_out" \
 _bt38_dir="$_b12_tmpdir/bt38-cwd"
 mkdir -p "$_bt38_dir/.uberdev/runs/20260521-100000-bbbb2222" \
          "$_bt38_dir/.uberdev/runs/20260521-200000-aaaa1111"
-printf '[solve-bg] pushed PR #600\n' > "$_b12_tmpdir/solve-bg-stdout-38.log"
+MOCK_PR_LIST_JSON='[{"number":600,"closingIssuesReferences":[{"number":38}],"headRefName":"feat/38-x"}]'
 for _d in 20260521-100000-bbbb2222 20260521-200000-aaaa1111; do
   printf '%s\n' '{"pr": "600"}' \
     > "$_bt38_dir/.uberdev/runs/$_d/review-pr-verdict.json"
@@ -1425,14 +1492,14 @@ assert_eq "$_bt38_out" \
   ".uberdev/runs/20260521-200000-aaaa1111/review-pr-verdict.json" \
   "BT38.locate-multi-run-newest-wins"
 
-# BT39 — PR mismatch: verdict.json's .pr is 999 but the solve-bg log says
+# BT39 — PR mismatch: verdict.json's .pr is 999 but gh resolves issue 39 to
 # PR=700. The `[ "$pr_field" = "$pr" ] || continue` filter rejects the
 # candidate; final output empty. Without this filter, the function would
 # return a path pointing to an UNRELATED PR's review-pr verdict, which
 # would silently misclassify the trust signal.
 _bt39_dir="$_b12_tmpdir/bt39-cwd"
 mkdir -p "$_bt39_dir/.uberdev/runs/20260521-130000-cccc3333"
-printf '[solve-bg] pushed PR #700\n' > "$_b12_tmpdir/solve-bg-stdout-39.log"
+MOCK_PR_LIST_JSON='[{"number":700,"closingIssuesReferences":[{"number":39}],"headRefName":"feat/39-x"}]'
 printf '%s\n' '{"pr": "999"}' \
   > "$_bt39_dir/.uberdev/runs/20260521-130000-cccc3333/review-pr-verdict.json"
 _bt39_out="$(cd "$_bt39_dir" && uberdev_goal_locate_review_pr_audit 39)"
@@ -1445,11 +1512,13 @@ assert_eq "$_bt39_out" "" "BT39.locate-pr-mismatch-empty"
 # the sort.
 _bt40_dir="$_b12_tmpdir/bt40-cwd"
 mkdir -p "$_bt40_dir/.uberdev/runs/not-a-run-id"
-printf '[solve-bg] pushed PR #800\n' > "$_b12_tmpdir/solve-bg-stdout-40.log"
+MOCK_PR_LIST_JSON='[{"number":800,"closingIssuesReferences":[{"number":40}],"headRefName":"feat/40-x"}]'
 printf '%s\n' '{"pr": "800"}' \
   > "$_bt40_dir/.uberdev/runs/not-a-run-id/review-pr-verdict.json"
 _bt40_out="$(cd "$_bt40_dir" && uberdev_goal_locate_review_pr_audit 40)"
 assert_eq "$_bt40_out" "" "BT40.locate-malformed-run-id-empty"
+# Reset the PR-list mock to inert before the read_merge_result BTs below.
+MOCK_PR_LIST_JSON='[]'
 
 # ===== uberdev_goal_read_merge_result (lines 410-438) =====
 
@@ -1723,11 +1792,12 @@ mkdir -p "$_bt56_scratch"
   mkdir -p .uberdev/runs/20260301-100000-deadbeef
   printf '{"pr":1234}\n' > .uberdev/runs/20260301-100000-deadbeef/review-pr-verdict.json
 )
-# Seed the solve-bg stdout log so extract_pr_num_from_log resolves issue→PR.
-printf 'some preamble\npushed PR #1234\nmore lines\n' > "$UBERDEV_TMPDIR/solve-bg-stdout-555.log"
+# gh resolves issue 555 -> PR 1234 (closingIssuesReferences), then _by_pr globs.
+MOCK_PR_LIST_JSON='[{"number":1234,"closingIssuesReferences":[{"number":555}],"headRefName":"feat/555-x"}]'
 _bt56_audit="$(cd "$_bt56_scratch" && uberdev_goal_locate_review_pr_audit 555)"
 assert_eq "$_bt56_audit" ".uberdev/runs/20260301-100000-deadbeef/review-pr-verdict.json" \
   "BT56.issue-keyed-locator-still-works"
+MOCK_PR_LIST_JSON='[]'
 rm -rf "$_bt56_scratch" 2>/dev/null || true
 
 # BT57 — stale|missing arm of the step 2e poll loop MUST be a no-op: held
@@ -1877,6 +1947,71 @@ else
   printf '        transitions after:  %s\n' "$_bt58_transitions_after" >&2
 fi
 rm -rf "$_bt58_scratch" 2>/dev/null || true
+
+# ----- BT59-BT68 — gh+file detection helpers (issue #180) -----
+# Functions under test: uberdev_goal_pr_state_gh, uberdev_goal_pr_is_merged,
+# uberdev_goal_read_merge_result (gh-first arm), uberdev_goal_agent_busy_for_issue.
+# These replace the CLI-version-dependent stdout-marker probes (`backgrounded ·`
+# + `merge-bg-stdout`) with GitHub-native / file-based signals.
+
+# BT59 — pr_state_gh returns the gh state verbatim.
+MOCK_PR_STATE="MERGED"
+assert_eq "$(uberdev_goal_pr_state_gh 42)" "MERGED" "BT59.pr-state-gh-returns-state"
+
+# BT60 — pr_state_gh non-numeric PR -> rc=1 BEFORE any gh call (R3 guard).
+uberdev_goal_pr_state_gh abc 2>/dev/null
+assert_rc "$?" "1" "BT60.pr-state-gh-non-numeric-rc-1"
+
+# BT61 — pr_is_merged: rc=0 when gh state == MERGED (authoritative completion).
+MOCK_PR_STATE="MERGED"
+uberdev_goal_pr_is_merged 42
+assert_rc "$?" "0" "BT61.pr-is-merged-true-on-merged"
+
+# BT62 — pr_is_merged: rc=1 when gh state == OPEN (NOT merged — must not finalize).
+MOCK_PR_STATE="OPEN"
+uberdev_goal_pr_is_merged 42
+assert_rc "$?" "1" "BT62.pr-is-merged-false-on-open"
+
+# BT63 — read_merge_result gh-first: gh MERGED -> 'success' even with NO audit row.
+# This is the defect-#5 robustness fix: the goal no longer depends on the
+# agent-improvised merge_executed audit shape — gh state is authoritative.
+MOCK_PR_STATE="MERGED"
+_bt63_dir="$_b12_tmpdir/bt63-cwd"; mkdir -p "$_bt63_dir"
+_bt63_out="$(cd "$_bt63_dir" && uberdev_goal_read_merge_result 905)"
+assert_eq "$_bt63_out" "success" "BT63.read-merge-gh-merged-no-audit-row"
+
+# BT64 — read_merge_result gh-first: gh MERGED OVERRIDES a stale conflict row.
+# A pr_parked(refused) row would map to 'conflict' on the audit path, but gh
+# says the PR actually merged afterward — gh wins.
+MOCK_PR_STATE="MERGED"
+_bt64_dir="$_b12_tmpdir/bt64-cwd"; mkdir -p "$_bt64_dir/.uberdev"
+printf '%s\n' '{"event":"pr_parked","data":{"pr":906,"reason":"refused"}}' \
+  > "$_bt64_dir/.uberdev/audit.jsonl"
+_bt64_out="$(cd "$_bt64_dir" && uberdev_goal_read_merge_result 906)"
+assert_eq "$_bt64_out" "success" "BT64.read-merge-gh-merged-overrides-conflict-row"
+MOCK_PR_STATE=""   # reset: subsequent tests must fall through to the audit path
+
+# BT65 — agent_busy_for_issue: rc=0 when a session cwd ends in solve-issue-N
+# AND status is busy. Disambiguates "solver still working" from "solver died".
+MOCK_CLAUDE_AGENTS_JSON='[{"cwd":"/x/.claude/worktrees/solve-issue-77","status":"busy"}]'
+uberdev_goal_agent_busy_for_issue 77
+assert_rc "$?" "0" "BT65.agent-busy-true-on-busy-matching-cwd"
+
+# BT66 — agent_busy_for_issue: rc=1 when the matching session is idle.
+MOCK_CLAUDE_AGENTS_JSON='[{"cwd":"/x/solve-issue-77","status":"idle"}]'
+uberdev_goal_agent_busy_for_issue 77
+assert_rc "$?" "1" "BT66.agent-busy-false-on-idle"
+
+# BT67 — agent_busy_for_issue: rc=1 when a busy session belongs to a DIFFERENT
+# issue (no solve-issue-7 / solve-issue-77 prefix confusion).
+MOCK_CLAUDE_AGENTS_JSON='[{"cwd":"/x/solve-issue-88","status":"busy"}]'
+uberdev_goal_agent_busy_for_issue 77
+assert_rc "$?" "1" "BT67.agent-busy-false-on-other-issue"
+
+# BT68 — agent_busy_for_issue: non-numeric issue -> rc=1 BEFORE any claude call.
+uberdev_goal_agent_busy_for_issue abc 2>/dev/null
+assert_rc "$?" "1" "BT68.agent-busy-non-numeric-rc-1"
+MOCK_CLAUDE_AGENTS_JSON='[]'   # reset to inert
 
 # ----- H1-H6 — #156 goal_id path-traversal guard + #157 unwritable-tmpdir surfacing -----
 # Both findings target plugins/uberdev/lib/goal-state.sh. #156: goal_id was

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.7 -> 0.33.8 propagated =="
+echo "== Version bump 0.33.8 -> 0.33.9 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.33.8"' \
-  "plugin.json bumped to 0.33.8"
+  '"version": "0.33.9"' \
+  "plugin.json bumped to 0.33.9"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.33.8"' \
-  "marketplace.json bumped to 0.33.8"
+  '"version": "0.33.9"' \
+  "marketplace.json bumped to 0.33.9"
 assert_grep "$README" \
-  "version-0\\.33\\.8-blue" \
-  "README version badge bumped to 0.33.8"
+  "version-0\\.33\\.9-blue" \
+  "README version badge bumped to 0.33.9"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.33\.8\]' \
-  "CHANGELOG has [0.33.8] section header"
+  '^## \[0\.33\.9\]' \
+  "CHANGELOG has [0.33.9] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary

Fixes #180 — `/uberdev:goal`'s Phase-2 watch loop never advanced on Claude Code CLI **2.1.150** and auto-merged nothing.

**Root cause (smoking gun):** the loop keyed solver-completion, PR discovery, and merge detection on stdout markers grepped from the captured `solve-bg-stdout-<N>.log`. On 2.1.150 `claude --bg` detaches in ~4s writing only a launch banner there, so:
- `backgrounded ·` was treated as a *terminal* marker but is a **startup** banner;
- `pushed PR #N` has **zero producers** (`finish-branch` prints `PR created: <url>`);
- the merge gate read `merge-bg-stdout-<pr>.log`, a file that is **never written** (dispatch always writes `solve-bg-stdout-<ISSUE>.log`).

The loop spun to the 4h `stuck_loop` breaker. Fix replaces stdout-marker signals with **`gh` + file** signals, exactly as proven end-to-end in the maintainer reference (`goal-cli-2.1.150-fix/`). This is the "patch source (option 1)" path from that guide; the file-based contracts that were already correct are left untouched.

## What changed

**`lib/goal-state.sh`** — four new version-independent helpers (all int-validated before any `gh` call; portable, no bash-4-isms):
- `uberdev_goal_find_pr_for_issue` — `gh pr list --json number,closingIssuesReferences,headRefName` → highest PR closing issue N or with a `feat/N-` head. (Uses `any(...)` so an empty `closingIssuesReferences` array doesn't collapse the `or` to jq `empty` — the head-ref fallback works.)
- `uberdev_goal_pr_state_gh` / `uberdev_goal_pr_is_merged` — authoritative merge completion via `gh pr view --json state == MERGED`.
- `uberdev_goal_agent_busy_for_issue` — `claude agents --json` liveness (cwd `solve-issue-N` + busy), used **only** to tell "still working" from "died".
- `uberdev_goal_read_merge_result` now consults **gh state first**, decoupling convergence from the (formerly agent-improvised) `merge_executed` audit shape.
- the issue→PR resolver (`uberdev_goal_locate_review_pr_audit`) is repointed to the gh finder; the false-premise `uberdev_goal_extract_pr_num_from_log` is **removed**.
- **Unchanged (do-not-touch) file-based contracts:** `uberdev_goal_locate_review_pr_audit_by_pr`, `uberdev_goal_read_trust_signal`, flat `.uberdev/audit.jsonl`.

**`skills/goal-pipeline/SKILL.md`**
- **Phase 0:** bash ≥ 4 preflight guard (defect #8 — macOS `/bin/bash` 3.2 and zsh can't run the verdict locator's unmatched-glob iteration). **Phase 3:** `mapfile` → portable `while read` loop.
- **Phase 2** rewritten to gh + file signals: 2a detect-PR (gh) + liveness; **2b time-graced verdict read** (`REVIEW_GRACE` 30m — the leaf solver runs its OWN `/review-pr` ~20m post-push and goes idle, so liveness-keyed re-review fired redundant reviews and prematurely red-held a not-yet-green PR); 2c green→merge (already-merged guard); 2d gh-based `merging→merged` + `MERGE_TIMEOUT` stall recovery; 2e held-PR poll **unchanged**.

**`skills/merge-pipeline/SKILL.md`** — concrete **success-only** `merge_executed` printf template (defect #5; a failed merge emits `error`, never `merge_executed`).

**Version → 0.33.9** everywhere (`plugin.json`, `marketplace.json`, README badge, CHANGELOG) + the two hidden test ratchets (`goal.test.sh` G20, `solve-claim.test.sh`).

## Tests

TDD. `tests/goal.test.sh`: **318 passing** — new `find_pr_for_issue`/`pr_state_gh`/`pr_is_merged`/`agent_busy_for_issue`/gh-first-`read_merge_result` behavioral coverage (BT24-28, BT59-68), BT35-40/BT56 migrated to the gh mock, plus a **G23 anti-regression gate** that fails if the stdout-marker probes (`grep -q 'backgrounded`, `merge_log=`, `mapfile -t`, the removed parser) ever return. Full local suite: **42/42 shell test files green** (bash; zsh for the zsh suite); lib clean under `bash -n` and `zsh -n`; all 18 SKILL bash blocks pass `bash -n`.

## Open questions answered by /turbo
- **Remove vs. keep the dead `extract_pr_num_from_log`** → removed (its input marker has zero producers; keeping it would be false-premise dead code). G19 swapped to the new helpers.
- **`jq` vs `python3` for agent liveness** → `jq` (codebase standard; avoids a new python3 runtime dependency).
- **Source patch vs. shipping the stopgap driver** → source patch (option 1 in the guide); `goal-cli-2.1.150-fix/` is left as historical reference.

## Deferred (lower-priority follow-ups noted in the issue)
- Claude Max usage-cap detection (`session_limited` — back off + fresh re-dispatch rather than red-hold on a quota stall).
- Auto-merge rebase for GREEN-but-conflicting sibling PRs on a shared base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.33.9

**Bug Fixes**
- Improved `/goal` command PR progress detection to use GitHub state queries instead of log parsing
- Added review verdict verification period in Phase 2 monitoring to wait for solver feedback before timing out
- Fixed `/merge` command to emit success audit records only when merges actually complete successfully
- Enhanced bash version preflight validation to require bash version 4 or higher

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->