### PR TITLE
fix(testers): harden per-host RPS cap + audit (rate-limit cluster #184-#188)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.33.11",
+      "version": "0.33.12",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.12] - 2026-05-25
+
+### Fixed
+- **`/uberdev:testers` per-host RPS cap was bypassable and its audit blind to the bypass — rate-limit cluster (#184, #185, #186, #187, #188; uberscan MAJOR ×5).** The runtime wrapper (`lib/rate-limit-curl.sh`) and the post-hoc auditor (`lib/rate-cap-audit.sh`) both keyed per-host buckets/groups on a naive `scheme://([^/?#]+)` authority capture, so `a@host` / `b@host` / `Host` / `host:443` / `host.` each got a DISTINCT bucket — defeating the cap (#184) and letting the same variants evade the audit meant to detect the bypass (#186). Five coherent fixes:
+  - **#184 + #186 (shared root cause).** Introduced one canonical host normalizer, `lib/normalize_host.py`, built on `urllib.parse.urlsplit().hostname` (the hardened stdlib URL parser — lowercases, strips userinfo + `:port`, de-brackets IPv6) plus a trailing-dot drop and the historic `..`/`/` scope-escape reject. Both files now key on it (the wrapper calls it as a subprocess; the audit imports it), so all authority variants of one host collapse to a single bucket/group. No more duplicated, drift-prone host parsing.
+  - **#185.** `DELAY_MS=$(( (1000 / RPS_CAP) - … ))` truncated `1000/RPS_CAP` to an integer before subtracting elapsed time, under-delaying for any non-integral interval (cap=600 → 1ms instead of 1.667ms, ~67% over cap). The interval is now computed in float (folded into the awk math) and gated on `> 0`.
+  - **#187.** The auditor did `cap = int(cap_str)` with no range check (cap=0 flagged every request; a negative cap flagged everything) and raised an uncaught `ValueError` (cryptic traceback) on non-numeric input. It now validates to `[1, 1000]` like the runtime wrapper and exits non-zero with a clear stderr message — no traceback.
+  - **#188.** `printf … > "$STATE.tmp" && mv -f …` ignored the `printf` return code; on a failed write the `&&` short-circuited, the state file kept a stale timestamp, and the next call silently re-paced from it. The write rc is now checked and the wrapper fails loud (exit 2) rather than corrupting the rate gate silently.
+  - Regression-locked by new assertions in `tests/testers-rate-limit-wrapper.test.sh` (normalizer collapses `a@host`/`Host`/`host:443` identically; wrapper buckets variants into one state dir; cap=600 yields the float delay; a state-write failure surfaces) and `tests/testers-rate-limit-audit.test.sh` (variants group as one host → breach; cap=0/-5/non-numeric rejected). These two suites remain orphaned from CI (tracked separately by #196).
+
+### Changed
+- Version bumped to 0.33.12 across `plugin.json`, `marketplace.json`, the README badge, and the test version ratchets (`goal.test.sh` G20, `solve-claim.test.sh`).
+
 ## [0.33.11] - 2026-05-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.33.11-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.33.12-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.33.11",
+  "version": "0.33.12",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/lib/normalize_host.py
+++ b/plugins/uberdev/lib/normalize_host.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Canonical URL -> bare-host normalizer for the testers rate-limit machinery.
+
+SINGLE SOURCE OF TRUTH for how a URL maps to a per-host rate bucket. Both consumers
+MUST key on the SAME normalized host, or a host split across userinfo / ASCII-case /
+:port / trailing-dot variants escapes the per-host RPS cap (issue #184) and slips past
+the post-hoc audit meant to detect that bypass (issue #186):
+
+  * lib/rate-limit-curl.sh -> calls this as a subprocess: ``python3 normalize_host.py URL``
+  * lib/rate-cap-audit.sh  -> imports ``normalize_host`` (this dir is put on sys.path)
+
+Do NOT reimplement host parsing in either consumer; change it here only.
+
+Normalization leans on ``urllib.parse.urlsplit().hostname`` -- the hardened stdlib URL
+parser, which already lowercases the host and strips userinfo and ``:port`` (and removes
+the brackets from IPv6 literals) -- rather than a hand-rolled authority regex, which is
+exactly the naive ``scheme://([^/?#]+)`` capture both issues are about. On top of that we
+drop a single trailing FQDN dot and reject hosts that could escape per-host filesystem
+scoping (a ``..`` segment or a ``/``).
+
+CLI contract: ``normalize_host.py URL``
+  * prints the normalized host and exits 0 when the URL yields a safe bare host
+  * prints nothing and exits 3 when it cannot (no host, or scope-escape), so a shell
+    caller can branch on the non-zero return code
+"""
+from urllib.parse import urlsplit
+
+
+def normalize_host(url):
+    """Return the canonical bare host for ``url`` to use as a per-host bucket key,
+    or ``None`` if the URL has no parseable host or the host could escape per-host
+    scoping (contains ``..`` or ``/``)."""
+    if not isinstance(url, str) or not url:
+        return None
+    try:
+        # hostname: lowercased, userinfo + :port stripped, IPv6 literal de-bracketed.
+        host = urlsplit(url).hostname
+    except ValueError:
+        # Malformed authority (e.g. bad IPv6 literal / invalid port) -> not a usable host.
+        return None
+    if not host:
+        return None
+    # Scope-escape guard (mirrors the historic ``*..*|*/*`` reject). Check BEFORE the
+    # trailing-dot strip so a trailing ``..`` is rejected, not silently halved to ``.``.
+    if ".." in host or "/" in host:
+        return None
+    if host.endswith("."):
+        # Drop the FQDN root label so "host." and "host" share one bucket.
+        host = host[:-1]
+    if not host:
+        return None
+    return host
+
+
+def _main(argv):
+    url = argv[1] if len(argv) > 1 else ""
+    host = normalize_host(url)
+    if host is None:
+        return 3
+    print(host)
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(_main(sys.argv))

--- a/plugins/uberdev/lib/normalize_host.py
+++ b/plugins/uberdev/lib/normalize_host.py
@@ -50,7 +50,7 @@ def normalize_host(url: str) -> str | None:
         # Drop the FQDN root label so "host." and "host" share one bucket.
         host = host[:-1]
     if not host:
-        return None
+        return None  # host was a bare "." (root) — no usable bucket key
     return host
 
 

--- a/plugins/uberdev/lib/normalize_host.py
+++ b/plugins/uberdev/lib/normalize_host.py
@@ -23,10 +23,12 @@ CLI contract: ``normalize_host.py URL``
   * prints nothing and exits 3 when it cannot (no host, or scope-escape), so a shell
     caller can branch on the non-zero return code
 """
+from __future__ import annotations  # lazy annotations so `str | None` is safe on py3.8/3.9
+
 from urllib.parse import urlsplit
 
 
-def normalize_host(url):
+def normalize_host(url: str) -> str | None:
     """Return the canonical bare host for ``url`` to use as a per-host bucket key,
     or ``None`` if the URL has no parseable host or the host could escape per-host
     scoping (contains ``..`` or ``/``)."""

--- a/plugins/uberdev/lib/rate-cap-audit.sh
+++ b/plugins/uberdev/lib/rate-cap-audit.sh
@@ -12,6 +12,13 @@ uberdev_rate_cap_audit() {
   # Absolute dir of this lib so the embedded python can import the shared host normalizer
   # (normalize_host.py — the same single source of truth the runtime wrapper uses).
   local LIBDIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+  # Fail loud if the shared normalizer can't be located — an empty LIBDIR would otherwise
+  # `sys.path.insert(0, "")` (cwd) and silently import the wrong module or raise a cryptic
+  # ImportError inside the heredoc.
+  if [ -z "$LIBDIR" ] || [ ! -f "$LIBDIR/normalize_host.py" ]; then
+    echo "error: rate-cap-audit: normalize_host.py not found (lib dir: ${LIBDIR:-unset})" >&2
+    return 2
+  fi
   python3 - "$WAVE_YAML" "$CAP" "$OUT_YAML" "$LIBDIR" <<'PY'
 import sys, yaml, hashlib
 from collections import defaultdict

--- a/plugins/uberdev/lib/rate-cap-audit.sh
+++ b/plugins/uberdev/lib/rate-cap-audit.sh
@@ -9,11 +9,30 @@ set -eu
 
 uberdev_rate_cap_audit() {
   local WAVE_YAML="$1" CAP="$2" OUT_YAML="$3"
-  python3 - "$WAVE_YAML" "$CAP" "$OUT_YAML" <<'PY'
-import sys, yaml, hashlib, re
+  # Absolute dir of this lib so the embedded python can import the shared host normalizer
+  # (normalize_host.py — the same single source of truth the runtime wrapper uses).
+  local LIBDIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+  python3 - "$WAVE_YAML" "$CAP" "$OUT_YAML" "$LIBDIR" <<'PY'
+import sys, yaml, hashlib
 from collections import defaultdict
-wave_path, cap_str, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
-cap = int(cap_str)
+wave_path, cap_str, out_path, libdir = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+# Import the canonical host normalizer (the same one lib/rate-limit-curl.sh calls) so the
+# audit groups observed requests by the SAME bare host the runtime cap buckets on — else a
+# host split across userinfo/case/port/trailing-dot variants evades the audit too (#186).
+sys.path.insert(0, libdir)
+from normalize_host import normalize_host
+# Validate the cap to [1, 1000] like the runtime wrapper (rate-limit-curl.sh:44-45). The
+# caller (aggregate.py) only enforces type=int, so cap<=0 would flag every request (1 > 0)
+# and a non-numeric cap would raise an uncaught ValueError -> cryptic traceback (#187).
+# Fail loud with a clear message and a non-zero exit instead.
+try:
+    cap = int(cap_str)
+except (TypeError, ValueError):
+    print(f"error: rate-cap-audit: --rps-cap must be an integer; got {cap_str!r}", file=sys.stderr)
+    sys.exit(2)
+if cap < 1 or cap > 1000:
+    print(f"error: rate-cap-audit: --rps-cap must be in [1, 1000]; got {cap}", file=sys.stderr)
+    sys.exit(2)
 with open(wave_path) as fh:
     doc = yaml.safe_load(fh) or {}
 findings = doc.get("findings") or []
@@ -35,11 +54,8 @@ for f in findings:
     except Exception as e:
         print(f"warning: rate-cap-audit skipping finding {f.get('id', '?')!r} with unparseable timestamp {ts!r}: {e}", file=sys.stderr)
         continue
-    m = re.match(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://([^/?#]+)", url)
-    if not m:
-        continue
-    host = m.group(1)
-    if ".." in host or "/" in host:
+    host = normalize_host(url)  # shared canonical normalizer (see import above) — #186
+    if host is None:
         continue
     by_host[host].append((ts_ms, f.get("persona") or "unknown", url))
 # For each host, compute the max rolling 1-second window count

--- a/plugins/uberdev/lib/rate-limit-curl.sh
+++ b/plugins/uberdev/lib/rate-limit-curl.sh
@@ -70,7 +70,7 @@ uberdev_rate_limit_curl() {
   until mkdir "$LOCK" 2>/dev/null; do sleep 0.01; done
   trap 'rmdir "$LOCK" 2>/dev/null || true' RETURN
 
-  local NOW_MS LAST_MS DELAY_S
+  local NOW_MS LAST_MS DELAY_S RELEASE_MS SLEPT
   # GNU date supports %3N (ms); BSD date (macOS) silently emits literal "3N".
   # Fall back to python3 when output is not purely numeric (handles both EXIT-fail and quiet-misformat).
   NOW_MS="$(date +%s%3N 2>/dev/null || true)"
@@ -80,22 +80,25 @@ uberdev_rate_limit_curl() {
   LAST_MS="$(cat "$STATE" 2>/dev/null || echo 0)"
   # Defensive: corruption in state file -> re-pace from zero rather than crash on arithmetic.
   [[ "$LAST_MS" =~ ^[0-9]+$ ]] || LAST_MS=0
-  # Per-call interval is 1000/RPS_CAP ms. Compute the delay in FLOAT (fold the division
-  # into the awk math) so a non-integral 1000/RPS_CAP is not truncated before subtracting
-  # the elapsed time. Integer truncation under-delays and exceeds the cap (#185, e.g.
-  # cap=600 -> 1.667ms, not 1ms ~= 67% over). Sleep only when the float delay is > 0.
-  DELAY_S="$(awk -v cap="$RPS_CAP" -v now="$NOW_MS" -v last="$LAST_MS" \
-    'BEGIN{ d = (1000.0 / cap) - (now - last); if (d < 0) d = 0; printf "%.6f", d / 1000.0 }')"
-  if awk -v s="$DELAY_S" 'BEGIN{ exit !(s > 0) }'; then
+  # Per-call interval is 1000/RPS_CAP ms. ONE awk pass computes everything in FLOAT (the division
+  # folded in) so a non-integral 1000/RPS_CAP is not truncated before subtracting the elapsed time —
+  # integer truncation under-delays and exceeds the cap (#185, e.g. cap=600 -> 1.667ms not 1ms,
+  # ~67% over). It emits three fields: sleep seconds, the rounded release timestamp, and a 0/1 sleep
+  # flag (awk owns the float `> 0` test, so the shell never mis-reads "0.000000" as truthy).
+  # release = max(now, last + interval) keeps cumulative pacing exact under back-to-back calls; %.0f
+  # is round-half-to-even (can land ~0.5ms either side) but the max(now, ...) re-syncs to the real
+  # clock next call, so sub-ms rounding never accumulates into a cap violation.
+  read -r DELAY_S RELEASE_MS SLEPT <<EOF
+$(awk -v cap="$RPS_CAP" -v now="$NOW_MS" -v last="$LAST_MS" 'BEGIN{
+  interval = 1000.0 / cap
+  d = interval - (now - last); if (d < 0) d = 0
+  rel = last + interval; if (now > rel) rel = now
+  printf "%.6f %.0f %d", d / 1000.0, rel, (d > 0)
+}')
+EOF
+  if [ "$SLEPT" -eq 1 ]; then
     sleep "$DELAY_S"
-    # Advance the virtual release clock by the (float) interval so cumulative pacing stays
-    # exact under back-to-back calls: release = max(now, last + interval). Round to integer ms
-    # for the state file. awk's %.0f is round-half-to-even, so the stored release can land at
-    # most ~0.5ms either side of the true value; the max(now, last + interval) above re-syncs
-    # to the real clock on the next call, so this sub-ms rounding never accumulates into a cap
-    # violation.
-    NOW_MS="$(awk -v cap="$RPS_CAP" -v now="$NOW_MS" -v last="$LAST_MS" \
-      'BEGIN{ rel = last + (1000.0 / cap); if (now > rel) rel = now; printf "%.0f", rel }')"
+    NOW_MS="$RELEASE_MS"
   fi
   # Persist the release timestamp atomically. Check the write rc and fail LOUD: a swallowed
   # failure (full disk / RO fs / lost permission) leaves a stale timestamp that the next call

--- a/plugins/uberdev/lib/rate-limit-curl.sh
+++ b/plugins/uberdev/lib/rate-limit-curl.sh
@@ -48,13 +48,18 @@ uberdev_rate_limit_curl() {
   # normalize_host.py, also imported by rate-cap-audit.sh). It lowercases, strips
   # userinfo + :port, drops a trailing dot, and rejects scope-escape hosts (`..`/`/`) —
   # so a@host / Host / host:443 / host. all map to ONE bucket and the cap can't be
-  # bypassed by varying the authority (#184). A non-zero rc (incl. python3 absent) or an
-  # empty host means the URL has no usable host.
-  local HOST
-  if ! HOST="$(python3 "$_UBERDEV_RATE_LIMIT_LIBDIR/normalize_host.py" "$URL" 2>/dev/null)" || [ -z "$HOST" ]; then
-    echo "rate-limit-curl: cannot parse host from URL: $URL" >&2
-    return 2
+  # bypassed by varying the authority (#184).
+  [ -n "$_UBERDEV_RATE_LIMIT_LIBDIR" ] && [ -f "$_UBERDEV_RATE_LIMIT_LIBDIR/normalize_host.py" ] || {
+    echo "rate-limit-curl: normalize_host.py not found (lib dir: ${_UBERDEV_RATE_LIMIT_LIBDIR:-unset})" >&2; return 2; }
+  local HOST HOST_RC=0
+  HOST="$(python3 "$_UBERDEV_RATE_LIMIT_LIBDIR/normalize_host.py" "$URL" 2>/dev/null)" || HOST_RC=$?
+  # normalize_host.py contract: rc 0 + nonempty host = ok; rc 3 = URL has no usable host.
+  # Any OTHER rc (python3 absent, import/runtime error) is a TOOL failure — surface it
+  # distinctly so it is never silently mistaken for a bad URL (fail loud, mirrors #188).
+  if [ "$HOST_RC" -ne 0 ] && [ "$HOST_RC" -ne 3 ]; then
+    echo "rate-limit-curl: host normalizer failed (python3 rc=$HOST_RC) for URL: $URL" >&2; return 2
   fi
+  [ "$HOST_RC" -eq 0 ] && [ -n "$HOST" ] || { echo "rate-limit-curl: cannot parse host from URL: $URL" >&2; return 2; }
 
   local HOST_DIR="$RATE_STATE_DIR/$HOST"
   mkdir -p "$HOST_DIR"
@@ -84,9 +89,11 @@ uberdev_rate_limit_curl() {
   if awk -v s="$DELAY_S" 'BEGIN{ exit !(s > 0) }'; then
     sleep "$DELAY_S"
     # Advance the virtual release clock by the (float) interval so cumulative pacing stays
-    # exact under back-to-back calls: release = max(now, last + interval). Round to integer
-    # ms for the state file (a half-ms-conservative round only ever over-delays, staying
-    # under the cap — the safe direction for a rate gate).
+    # exact under back-to-back calls: release = max(now, last + interval). Round to integer ms
+    # for the state file. awk's %.0f is round-half-to-even, so the stored release can land at
+    # most ~0.5ms either side of the true value; the max(now, last + interval) above re-syncs
+    # to the real clock on the next call, so this sub-ms rounding never accumulates into a cap
+    # violation.
     NOW_MS="$(awk -v cap="$RPS_CAP" -v now="$NOW_MS" -v last="$LAST_MS" \
       'BEGIN{ rel = last + (1000.0 / cap); if (now > rel) rel = now; printf "%.0f", rel }')"
   fi

--- a/plugins/uberdev/lib/rate-limit-curl.sh
+++ b/plugins/uberdev/lib/rate-limit-curl.sh
@@ -3,6 +3,10 @@
 if [ "${_UBERDEV_RATE_LIMIT_LOADED:-0}" = "1" ]; then return 0 2>/dev/null || true; fi
 _UBERDEV_RATE_LIMIT_LOADED=1
 
+# Absolute dir of this lib so the wrapper can find its sibling normalize_host.py — the
+# SINGLE SOURCE OF TRUTH for per-host bucket keys, shared with lib/rate-cap-audit.sh.
+_UBERDEV_RATE_LIMIT_LIBDIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+
 # uberdev_rate_limit_curl URL [curl-args...]
 #
 # Enforces $RPS_CAP (already validated by the caller in SKILL.md before export) for the host extracted
@@ -11,12 +15,14 @@ _UBERDEV_RATE_LIMIT_LOADED=1
 # Algorithm: serial gate with per-host bucket (mutex held during sleep — trades
 # concurrency for simplicity; under N-agent contention real RPS is bounded but
 # tail latency rises). Each call:
-#   1. Extracts <host> from URL (scheme://host[:port]/path).
+#   1. Normalizes <host> from URL via the shared normalize_host.py (lowercases; strips
+#      userinfo + :port; drops a trailing dot) so a@host / Host / host:443 / host. all
+#      share ONE bucket — the per-host cap can't be bypassed by varying the authority.
 #   2. Acquires mkdir-mutex on $RATE_STATE_DIR/<host>/.lock (trap on RETURN releases).
 #   3. Reads $RATE_STATE_DIR/<host>/last_release (epoch-ms, default 0).
-#   4. Computes inter-call delay = max(0, (1000 / $RPS_CAP) - (now_ms - last_release_ms)).
-#   5. If delay > 0, sleeps (`sleep "$delay_s"` where delay_s is delay/1000 with bc).
-#   6. Writes now_ms to last_release atomically (mktemp + mv).
+#   4. Computes inter-call delay (FLOAT) = max(0, (1000 / $RPS_CAP) - (now_ms - last_ms)).
+#   5. If delay > 0, sleeps (`sleep "$delay_s"` where delay_s is delay/1000 via awk).
+#   6. Writes now_ms to last_release atomically (tmp + mv), failing loud if the write fails.
 #   7. Releases mutex.
 #   8. Execs `command curl --fail-with-body --silent --show-error <args> -- "$URL"`.
 #
@@ -27,7 +33,8 @@ _UBERDEV_RATE_LIMIT_LOADED=1
 #     On bad value, exit 2.
 #   - mkdir-mutex contention -> retry every 10ms with no upper bound (per-host buckets
 #     mean contention is bounded by the number of agents hitting the same host, max 6).
-#   - URL parse fails (no scheme://host) -> exit 2 with stderr.
+#   - URL parse fails (no host, or scope-escape host) -> exit 2 with stderr.
+#   - state-file write fails (full disk / RO fs) -> exit 2 with stderr (never silent).
 
 uberdev_rate_limit_curl() {
   local URL="$1"; shift
@@ -37,15 +44,17 @@ uberdev_rate_limit_curl() {
   [[ "${RPS_CAP:-}" =~ ^[1-9][0-9]*$ ]] || { echo "rate-limit-curl: RPS_CAP malformed" >&2; return 2; }
   [ "$RPS_CAP" -le 1000 ] || { echo "rate-limit-curl: RPS_CAP out of range" >&2; return 2; }
 
-  # Extract host (scheme://host[:port]/path -> host[:port]).
+  # Normalize the host via the shared single-source-of-truth parser (sibling
+  # normalize_host.py, also imported by rate-cap-audit.sh). It lowercases, strips
+  # userinfo + :port, drops a trailing dot, and rejects scope-escape hosts (`..`/`/`) —
+  # so a@host / Host / host:443 / host. all map to ONE bucket and the cap can't be
+  # bypassed by varying the authority (#184). A non-zero rc (incl. python3 absent) or an
+  # empty host means the URL has no usable host.
   local HOST
-  HOST="$(printf '%s' "$URL" | sed -nE 's#^[a-zA-Z][a-zA-Z0-9+.-]*://([^/?#]+).*$#\1#p')"
-  [ -n "$HOST" ] || { echo "rate-limit-curl: cannot parse host from URL: $URL" >&2; return 2; }
-  # Reject hosts that could escape per-host scoping via path traversal or
-  # slash injection (the regex above filters `/?#` but allows `..`).
-  case "$HOST" in
-    *..* | */*) echo "rate-limit-curl: host contains path-escape characters: $HOST" >&2; return 2 ;;
-  esac
+  if ! HOST="$(python3 "$_UBERDEV_RATE_LIMIT_LIBDIR/normalize_host.py" "$URL" 2>/dev/null)" || [ -z "$HOST" ]; then
+    echo "rate-limit-curl: cannot parse host from URL: $URL" >&2
+    return 2
+  fi
 
   local HOST_DIR="$RATE_STATE_DIR/$HOST"
   mkdir -p "$HOST_DIR"
@@ -56,7 +65,7 @@ uberdev_rate_limit_curl() {
   until mkdir "$LOCK" 2>/dev/null; do sleep 0.01; done
   trap 'rmdir "$LOCK" 2>/dev/null || true' RETURN
 
-  local NOW_MS LAST_MS DELAY_MS DELAY_S
+  local NOW_MS LAST_MS DELAY_S
   # GNU date supports %3N (ms); BSD date (macOS) silently emits literal "3N".
   # Fall back to python3 when output is not purely numeric (handles both EXIT-fail and quiet-misformat).
   NOW_MS="$(date +%s%3N 2>/dev/null || true)"
@@ -66,13 +75,29 @@ uberdev_rate_limit_curl() {
   LAST_MS="$(cat "$STATE" 2>/dev/null || echo 0)"
   # Defensive: corruption in state file -> re-pace from zero rather than crash on arithmetic.
   [[ "$LAST_MS" =~ ^[0-9]+$ ]] || LAST_MS=0
-  DELAY_MS=$(( (1000 / RPS_CAP) - (NOW_MS - LAST_MS) ))
-  if [ "$DELAY_MS" -gt 0 ]; then
-    DELAY_S="$(awk -v ms="$DELAY_MS" 'BEGIN{ printf "%.3f", ms/1000 }')"
+  # Per-call interval is 1000/RPS_CAP ms. Compute the delay in FLOAT (fold the division
+  # into the awk math) so a non-integral 1000/RPS_CAP is not truncated before subtracting
+  # the elapsed time. Integer truncation under-delays and exceeds the cap (#185, e.g.
+  # cap=600 -> 1.667ms, not 1ms ~= 67% over). Sleep only when the float delay is > 0.
+  DELAY_S="$(awk -v cap="$RPS_CAP" -v now="$NOW_MS" -v last="$LAST_MS" \
+    'BEGIN{ d = (1000.0 / cap) - (now - last); if (d < 0) d = 0; printf "%.6f", d / 1000.0 }')"
+  if awk -v s="$DELAY_S" 'BEGIN{ exit !(s > 0) }'; then
     sleep "$DELAY_S"
-    NOW_MS=$(( NOW_MS + DELAY_MS ))
+    # Advance the virtual release clock by the (float) interval so cumulative pacing stays
+    # exact under back-to-back calls: release = max(now, last + interval). Round to integer
+    # ms for the state file (a half-ms-conservative round only ever over-delays, staying
+    # under the cap — the safe direction for a rate gate).
+    NOW_MS="$(awk -v cap="$RPS_CAP" -v now="$NOW_MS" -v last="$LAST_MS" \
+      'BEGIN{ rel = last + (1000.0 / cap); if (now > rel) rel = now; printf "%.0f", rel }')"
   fi
-  printf '%s' "$NOW_MS" > "$STATE.tmp" && mv -f "$STATE.tmp" "$STATE"
+  # Persist the release timestamp atomically. Check the write rc and fail LOUD: a swallowed
+  # failure (full disk / RO fs / lost permission) leaves a stale timestamp that the next call
+  # re-paces from, silently corrupting the rate gate while the caller keeps requesting (#188).
+  if ! { printf '%s' "$NOW_MS" > "$STATE.tmp" && mv -f "$STATE.tmp" "$STATE"; }; then
+    rm -f "$STATE.tmp" 2>/dev/null || true
+    echo "rate-limit-curl: failed to persist rate state to $STATE (refusing to proceed with stale pacing)" >&2
+    return 2  # RETURN trap releases the mutex
+  fi
 
   rmdir "$LOCK" 2>/dev/null || true
   trap - RETURN

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -273,11 +273,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.33.11) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.11"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.11"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.11-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.11\]'        "G20.changelog"
+echo "== G20: version bump locked (0.33.12) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.12"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.12"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.12-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.12\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.10 -> 0.33.11 propagated =="
+echo "== Version bump 0.33.11 -> 0.33.12 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.33.11"' \
-  "plugin.json bumped to 0.33.11"
+  '"version": "0.33.12"' \
+  "plugin.json bumped to 0.33.12"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.33.11"' \
-  "marketplace.json bumped to 0.33.11"
+  '"version": "0.33.12"' \
+  "marketplace.json bumped to 0.33.12"
 assert_grep "$README" \
-  "version-0\\.33\\.11-blue" \
-  "README version badge bumped to 0.33.11"
+  "version-0\\.33\\.12-blue" \
+  "README version badge bumped to 0.33.12"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.33\.11\]' \
-  "CHANGELOG has [0.33.11] section header"
+  '^## \[0\.33\.12\]' \
+  "CHANGELOG has [0.33.12] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/testers-rate-limit-audit.test.sh
+++ b/tests/testers-rate-limit-audit.test.sh
@@ -104,4 +104,81 @@ EOF
 }
 test_audit_per_host_scoping_no_breach
 
+# Same host split across userinfo/case/port/trailing-dot must group into ONE host (#186).
+# 18 requests in a 1s window, cap=10: correct normalization -> 18 > 10 -> breach; the pre-fix
+# full-authority grouping splits them into 6 groups of 3 (<= cap) -> no breach. Fails on the bug.
+test_audit_groups_authority_variants_as_one_host() {
+  WAVE="$TEST_TMPDIR/wave-variants.yaml"
+  python3 - "$WAVE" <<'EOF'
+import yaml, sys
+base = 1763729400000
+variants = [
+    "https://api.example.test/p",
+    "https://a@api.example.test/p",
+    "https://b@api.example.test/p",
+    "https://API.EXAMPLE.TEST/p",
+    "https://api.example.test:443/p",
+    "https://api.example.test./p",
+]
+findings = []
+for i in range(18):
+    findings.append({
+        "id": f"f{i}", "severity": "high", "persona": "adversarial_security",
+        "evidence": {"network_request": {
+            "url": variants[i % len(variants)], "method": "GET", "status": 200,
+            "timestamp": base + i * 50}}})
+with open(sys.argv[1], "w") as fh:
+    yaml.safe_dump({"findings": findings}, fh)
+EOF
+  OUT="$TEST_TMPDIR/wave-variants.audited.yaml"
+  . "$REPO_ROOT/plugins/uberdev/lib/rate-cap-audit.sh"
+  uberdev_rate_cap_audit "$WAVE" 10 "$OUT" && { fail "$FUNCNAME" "expected exit 1 (breach across normalized host)"; return; }
+  rc=$?
+  [ "$rc" -eq 1 ] || { fail "$FUNCNAME" "expected exit 1, got $rc"; return; }
+  grep -q "invariant_violated: polite_rate_cap" "$OUT" || { fail "$FUNCNAME" "variants not grouped -> no breach (#186 not fixed)"; return; }
+  grep -q "location: api.example.test" "$OUT" || { fail "$FUNCNAME" "breach not keyed on normalized host 'api.example.test'"; return; }
+  pass "$FUNCNAME"
+}
+test_audit_groups_authority_variants_as_one_host
+
+# cap=0 must be rejected with a clear range error, not silently flag every request (#187).
+test_audit_rejects_cap_zero() {
+  WAVE="$TEST_TMPDIR/wave-cap0.yaml"; printf 'findings: []\n' > "$WAVE"
+  OUT="$TEST_TMPDIR/wave-cap0.audited.yaml"
+  . "$REPO_ROOT/plugins/uberdev/lib/rate-cap-audit.sh"
+  out=$(uberdev_rate_cap_audit "$WAVE" 0 "$OUT" 2>&1) && { fail "$FUNCNAME" "expected non-zero exit for cap=0"; return; }
+  rc=$?
+  [ "$rc" -ne 0 ] || { fail "$FUNCNAME" "cap=0 must be rejected, got rc $rc"; return; }
+  echo "$out" | grep -q "\[1, 1000\]" || { fail "$FUNCNAME" "stderr lacks range message: $out"; return; }
+  pass "$FUNCNAME"
+}
+test_audit_rejects_cap_zero
+
+# cap=-5 must be rejected (negative cap would flag everything) (#187).
+test_audit_rejects_cap_negative() {
+  WAVE="$TEST_TMPDIR/wave-capneg.yaml"; printf 'findings: []\n' > "$WAVE"
+  OUT="$TEST_TMPDIR/wave-capneg.audited.yaml"
+  . "$REPO_ROOT/plugins/uberdev/lib/rate-cap-audit.sh"
+  out=$(uberdev_rate_cap_audit "$WAVE" -5 "$OUT" 2>&1) && { fail "$FUNCNAME" "expected non-zero exit for cap=-5"; return; }
+  rc=$?
+  [ "$rc" -ne 0 ] || { fail "$FUNCNAME" "cap=-5 must be rejected, got rc $rc"; return; }
+  echo "$out" | grep -q "\[1, 1000\]" || { fail "$FUNCNAME" "stderr lacks range message: $out"; return; }
+  pass "$FUNCNAME"
+}
+test_audit_rejects_cap_negative
+
+# Non-numeric cap must fail with a clear message, not an uncaught ValueError traceback (#187).
+test_audit_rejects_cap_non_numeric() {
+  WAVE="$TEST_TMPDIR/wave-capnan.yaml"; printf 'findings: []\n' > "$WAVE"
+  OUT="$TEST_TMPDIR/wave-capnan.audited.yaml"
+  . "$REPO_ROOT/plugins/uberdev/lib/rate-cap-audit.sh"
+  out=$(uberdev_rate_cap_audit "$WAVE" abc "$OUT" 2>&1) && { fail "$FUNCNAME" "expected non-zero exit for cap=abc"; return; }
+  rc=$?
+  [ "$rc" -ne 0 ] || { fail "$FUNCNAME" "cap=abc must be rejected, got rc $rc"; return; }
+  echo "$out" | grep -qi "integer" || { fail "$FUNCNAME" "stderr lacks a clear integer error: $out"; return; }
+  echo "$out" | grep -q "Traceback" && { fail "$FUNCNAME" "raw Python traceback leaked: $out"; return; }
+  pass "$FUNCNAME"
+}
+test_audit_rejects_cap_non_numeric
+
 exit "$FAILS"

--- a/tests/testers-rate-limit-wrapper.test.sh
+++ b/tests/testers-rate-limit-wrapper.test.sh
@@ -86,40 +86,49 @@ test_parse_leading_zero() {
 }
 test_parse_leading_zero
 
-# Case 6: wrapper paces calls per --rps-cap
+# Case 6: wrapper paces calls per --rps-cap. Deterministic + load-independent: stub `date`
+# (virtual clock read from a file) and `sleep` (records its arg and advances that clock by it,
+# WITHOUT actually sleeping). The only time that "passes" is the wrapper's own computed delay,
+# so the recorded delays are exact regardless of machine load — the wrapper's job is to ISSUE
+# correct paced delays; real sleeping is a trusted OS primitive. (A prior wall-clock version
+# flaked under heavy parallel load.)
 test_wrapper_pacing_50_calls_at_5rps() {
   export RATE_STATE_DIR="$TEST_TMPDIR/state-$RANDOM"
   mkdir -p "$RATE_STATE_DIR"
-  export RPS_CAP=10
-  # Stub curl to no-op (avoids real HTTP)
-  SHIM="$TEST_TMPDIR/curl-shim"; mkdir -p "$SHIM"
+  export RPS_CAP=10  # interval = 1000/10 = 100ms exactly
+  SHIM="$TEST_TMPDIR/pace-shim-$RANDOM"; mkdir -p "$SHIM"
+  export PACE_VCFILE="$TEST_TMPDIR/pace-vc-$RANDOM"; printf '%s' 1700000000000 > "$PACE_VCFILE"
+  export PACE_SLEEPLOG="$TEST_TMPDIR/pace-sleep-$RANDOM.log"; : > "$PACE_SLEEPLOG"
   cat > "$SHIM/curl" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-  chmod +x "$SHIM/curl"
+  # date: echo the virtual clock verbatim (pure integer ms -> wrapper takes no python fallback).
+  cat > "$SHIM/date" <<'EOF'
+#!/usr/bin/env bash
+cat "$PACE_VCFILE"
+EOF
+  # sleep: record the requested delay and advance the virtual clock by it; never actually sleep.
+  cat > "$SHIM/sleep" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >> "$PACE_SLEEPLOG"
+cur="$(cat "$PACE_VCFILE")"
+add="$(awk -v s="$1" 'BEGIN{ printf "%.0f", s*1000 }')"
+printf '%s' "$((cur + add))" > "$PACE_VCFILE"
+EOF
+  chmod +x "$SHIM/curl" "$SHIM/date" "$SHIM/sleep"
   OLD_PATH="$PATH"; export PATH="$SHIM:$PATH"
   . "$REPO_ROOT/plugins/uberdev/lib/rate-limit-curl.sh"
-  # GNU date supports %3N; BSD date (macOS) silently emits literal "3N". Fall back to python3
-  # when the output is not purely numeric so the arithmetic below works on either platform.
-  _ms_now() {
-    local v
-    v="$(date +%s%3N 2>/dev/null || true)"
-    if ! [[ "$v" =~ ^[0-9]+$ ]]; then
-      v="$(python3 -c 'import time;print(int(time.time()*1000))')"
-    fi
-    printf '%s' "$v"
-  }
-  start_ms=$(_ms_now)
   for i in $(seq 1 10); do
     uberdev_rate_limit_curl "http://example.test/$i" >/dev/null
   done
-  end_ms=$(_ms_now)
-  elapsed=$(( end_ms - start_ms ))
   export PATH="$OLD_PATH"
-  # 10 calls at 10rps: first instant, next 9 paced at 100ms each = >=900ms
-  [ "$elapsed" -ge 850 ] || { fail "$FUNCNAME" "elapsed $elapsed ms (<850)"; return; }
-  [ "$elapsed" -le 2000 ] || { fail "$FUNCNAME" "elapsed $elapsed ms (>2000)"; return; }
+  # 10 calls at 10rps: first instant (no prior release), next 9 paced at exactly 100ms each.
+  n_sleeps="$(wc -l < "$PACE_SLEEPLOG" | tr -d ' ')"
+  total_ms="$(awk '{ s += $1 } END { printf "%.0f", s*1000 }' "$PACE_SLEEPLOG")"
+  unset PACE_VCFILE PACE_SLEEPLOG
+  [ "$n_sleeps" -eq 9 ] || { fail "$FUNCNAME" "expected 9 paced sleeps, got $n_sleeps"; return; }
+  { [ "$total_ms" -ge 850 ] && [ "$total_ms" -le 1000 ]; } || { fail "$FUNCNAME" "paced total ${total_ms}ms not ~900 (9x100)"; return; }
   pass "$FUNCNAME"
 }
 test_wrapper_pacing_50_calls_at_5rps
@@ -234,5 +243,134 @@ EOF
   pass "$FUNCNAME"
 }
 test_trap_release_on_curl_failure
+
+# Case 15: shared host normalizer collapses authority variants to ONE bare host (#184/#186 root cause).
+# userinfo (a@/b@), ASCII case, :port and a trailing dot must all map to the same key.
+test_normalizer_collapses_authority_variants() {
+  NORM="$REPO_ROOT/plugins/uberdev/lib/normalize_host.py"
+  expected="target.test"
+  for u in \
+    "https://target.test/" \
+    "https://a@target.test/" \
+    "https://b@target.test/" \
+    "https://TARGET.test/" \
+    "https://target.test:443/" \
+    "https://target.test./" \
+    "https://user:pass@Target.test:8443/path?q=1"; do
+    got="$(python3 "$NORM" "$u" 2>/dev/null)" || { fail "$FUNCNAME" "normalizer rejected '$u'"; return; }
+    [ "$got" = "$expected" ] || { fail "$FUNCNAME" "'$u' -> '$got' (want '$expected')"; return; }
+  done
+  pass "$FUNCNAME"
+}
+test_normalizer_collapses_authority_variants
+
+# Case 16: normalizer rejects scope-escape (`..`) and unparseable (no-host) inputs.
+test_normalizer_rejects_unsafe_inputs() {
+  NORM="$REPO_ROOT/plugins/uberdev/lib/normalize_host.py"
+  for bad in \
+    "https://a..b/" \
+    "https://evil../x" \
+    "-fOJ /etc/passwd" \
+    "not a url" \
+    "https:///nohost"; do
+    if python3 "$NORM" "$bad" >/dev/null 2>&1; then
+      fail "$FUNCNAME" "normalizer accepted unsafe input: '$bad'"; return
+    fi
+  done
+  pass "$FUNCNAME"
+}
+test_normalizer_rejects_unsafe_inputs
+
+# Case 17: wrapper buckets userinfo/case/port/trailing-dot variants of one host into a SINGLE
+# state dir (end-to-end proof of #184 — pre-fix these split into distinct buckets, defeating the cap).
+test_wrapper_buckets_authority_variants_identically() {
+  export RATE_STATE_DIR="$TEST_TMPDIR/bucket-$RANDOM"
+  mkdir -p "$RATE_STATE_DIR"
+  export RPS_CAP=1000  # ~1ms interval -> negligible pacing
+  SHIM="$TEST_TMPDIR/bucket-shim"; mkdir -p "$SHIM"
+  cat > "$SHIM/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$SHIM/curl"
+  OLD_PATH="$PATH"; export PATH="$SHIM:$PATH"
+  . "$REPO_ROOT/plugins/uberdev/lib/rate-limit-curl.sh"
+  for u in \
+    "https://bucket.test/" \
+    "https://x@bucket.test/" \
+    "https://BUCKET.test/" \
+    "https://bucket.test:443/" \
+    "https://bucket.test./"; do
+    uberdev_rate_limit_curl "$u" >/dev/null
+  done
+  export PATH="$OLD_PATH"
+  dirs="$(find "$RATE_STATE_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  [ "$dirs" = "1" ] || { fail "$FUNCNAME" "expected 1 host bucket, got $dirs: $(find "$RATE_STATE_DIR" -mindepth 1 -maxdepth 1 -type d | tr '\n' ' ')"; return; }
+  [ -d "$RATE_STATE_DIR/bucket.test" ] || { fail "$FUNCNAME" "normalized bucket dir 'bucket.test' missing"; return; }
+  pass "$FUNCNAME"
+}
+test_wrapper_buckets_authority_variants_identically
+
+# Case 18: non-integral 1000/RPS_CAP uses a FLOAT delay, not integer truncation (#185).
+# RPS_CAP=600 -> interval 1000/600 = 1.667ms; the pre-fix integer math truncated to 1ms (~67% over cap).
+# Stub date+state so elapsed is exactly 0 (delay == full interval) and stub sleep to capture the value.
+test_float_delay_non_integral_cap() {
+  export RATE_STATE_DIR="$TEST_TMPDIR/float-$RANDOM"
+  mkdir -p "$RATE_STATE_DIR/sixhundred.test"
+  export RPS_CAP=600
+  FIXED=1700000000000
+  printf '%s' "$FIXED" > "$RATE_STATE_DIR/sixhundred.test/last_release"  # prime LAST_MS == NOW_MS
+  SHIM="$TEST_TMPDIR/float-shim"; mkdir -p "$SHIM"
+  SLEEPLOG="$TEST_TMPDIR/float-sleep-$RANDOM.log"; : > "$SLEEPLOG"
+  cat > "$SHIM/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  cat > "$SHIM/date" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "$FIXED"
+EOF
+  cat > "$SHIM/sleep" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$1" >> "$SLEEPLOG"
+exit 0
+EOF
+  chmod +x "$SHIM/curl" "$SHIM/date" "$SHIM/sleep"
+  OLD_PATH="$PATH"; export PATH="$SHIM:$PATH"
+  . "$REPO_ROOT/plugins/uberdev/lib/rate-limit-curl.sh"
+  uberdev_rate_limit_curl "http://sixhundred.test/probe" >/dev/null
+  export PATH="$OLD_PATH"
+  last_sleep="$(tail -1 "$SLEEPLOG" 2>/dev/null)"
+  [ -n "$last_sleep" ] || { fail "$FUNCNAME" "wrapper did not sleep (no delay captured)"; return; }
+  # delay must be ~1.667ms (float), NOT the 1.0ms an integer-truncated 1000/600 would yield.
+  awk -v s="$last_sleep" 'BEGIN{ ms = s*1000; exit !(ms > 1.5 && ms < 1.8) }' \
+    || { fail "$FUNCNAME" "delay ${last_sleep}s ($(awk -v s="$last_sleep" 'BEGIN{printf "%.4f", s*1000}')ms) is not the float interval ~1.667ms (#185)"; return; }
+  pass "$FUNCNAME"
+}
+test_float_delay_non_integral_cap
+
+# Case 19: a state-file write failure is surfaced loudly, not swallowed by `&& mv` (#188).
+# Force `printf > "$STATE.tmp"` to fail by pre-creating last_release.tmp as a directory.
+test_state_write_failure_surfaces() {
+  export RATE_STATE_DIR="$TEST_TMPDIR/wfail-$RANDOM"
+  mkdir -p "$RATE_STATE_DIR/wfail.test"
+  mkdir "$RATE_STATE_DIR/wfail.test/last_release.tmp"  # redirection to a dir fails -> printf rc != 0
+  export RPS_CAP=1000
+  SHIM="$TEST_TMPDIR/wfail-shim"; mkdir -p "$SHIM"
+  cat > "$SHIM/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$SHIM/curl"
+  OLD_PATH="$PATH"; export PATH="$SHIM:$PATH"
+  . "$REPO_ROOT/plugins/uberdev/lib/rate-limit-curl.sh"
+  out=$(uberdev_rate_limit_curl "http://wfail.test/x" 2>&1) && { export PATH="$OLD_PATH"; fail "$FUNCNAME" "expected non-zero exit on state write failure"; return; }
+  rc=$?
+  export PATH="$OLD_PATH"
+  [ "$rc" -ne 0 ] || { fail "$FUNCNAME" "expected non-zero exit, got $rc"; return; }
+  echo "$out" | grep -qi "state" || { fail "$FUNCNAME" "stderr lacks a state-write error: $out"; return; }
+  pass "$FUNCNAME"
+}
+test_state_write_failure_surfaces
 
 exit "$FAILS"

--- a/tests/testers-rate-limit-wrapper.test.sh
+++ b/tests/testers-rate-limit-wrapper.test.sh
@@ -373,4 +373,34 @@ EOF
 }
 test_state_write_failure_surfaces
 
+# Case 20: a normalizer TOOL failure (python3 absent / crashes, rc not in {0,3}) surfaces a
+# DISTINCT loud error, not the generic "cannot parse host" — so an env failure is never
+# silently mistaken for a bad URL (post-impl-review hardening; mirrors #188 fail-loud).
+test_normalizer_tool_failure_surfaces() {
+  export RATE_STATE_DIR="$TEST_TMPDIR/toolfail-$RANDOM"
+  mkdir -p "$RATE_STATE_DIR"
+  export RPS_CAP=10
+  SHIM="$TEST_TMPDIR/toolfail-shim"; mkdir -p "$SHIM"
+  # python3 stub that fails like a missing/broken interpreter (rc 1, NOT the normalizer's reject rc 3)
+  cat > "$SHIM/python3" <<'EOF'
+#!/usr/bin/env bash
+echo "simulated python3 failure" >&2
+exit 1
+EOF
+  cat > "$SHIM/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$SHIM/python3" "$SHIM/curl"
+  OLD_PATH="$PATH"; export PATH="$SHIM:$PATH"
+  . "$REPO_ROOT/plugins/uberdev/lib/rate-limit-curl.sh"
+  out=$(uberdev_rate_limit_curl "http://toolfail.test/x" 2>&1) && { export PATH="$OLD_PATH"; fail "$FUNCNAME" "expected non-zero exit when normalizer tool fails"; return; }
+  rc=$?
+  export PATH="$OLD_PATH"
+  [ "$rc" -ne 0 ] || { fail "$FUNCNAME" "expected non-zero exit, got $rc"; return; }
+  echo "$out" | grep -qi "normalizer failed" || { fail "$FUNCNAME" "stderr lacks distinct tool-failure message (got: $out)"; return; }
+  pass "$FUNCNAME"
+}
+test_normalizer_tool_failure_surfaces
+
 exit "$FAILS"


### PR DESCRIPTION
## Summary

Fixes the `/uberdev:testers` rate-limit cluster (#184–#188) as one coherent change. The runtime wrapper (`lib/rate-limit-curl.sh`) and the post-hoc auditor (`lib/rate-cap-audit.sh`) both keyed per-host buckets/groups on a naive `scheme://([^/?#]+)` authority capture, so `a@host` / `b@host` / `Host` / `host:443` / `host.` each produced a **distinct** bucket — bypassing the per-host RPS cap (#184) and letting the same variants evade the audit meant to catch the bypass (#186).

## Fixes

- **#184 + #186 (shared root cause)** — new canonical host normalizer `plugins/uberdev/lib/normalize_host.py`, the **single source of truth** for per-host bucket keys. It is built on `urllib.parse.urlsplit().hostname` (the hardened stdlib URL parser — lowercases, strips userinfo + `:port`, de-brackets IPv6) plus a trailing-dot drop and the historic `..`/`/` scope-escape reject. The wrapper calls it as a subprocess; the auditor imports it. No more drift-prone duplicate host parsing.
- **#185** — the per-call interval is now computed in **float** (folded into the `awk` math) instead of integer-truncating `1000/RPS_CAP` before subtracting elapsed time. `cap=600` now delays 1.667ms, not the 1ms that ran ~67% over the cap. Sleep is gated on `> 0`.
- **#187** — the auditor validates `--rps-cap` to `[1,1000]` like the runtime wrapper and exits non-zero with a clear stderr message. `cap=0` no longer flags every request, and a non-numeric cap no longer raises an uncaught `ValueError` traceback.
- **#188** — the state-file write return code is checked; a failed write (full disk / read-only fs / lost permission) fails loud (exit 2) instead of silently re-pacing from a stale timestamp via the swallowing `&& mv` short-circuit.

## Test plan

- `bash tests/testers-rate-limit-wrapper.test.sh` — 16/16 pass; new cases prove the normalizer collapses `a@host`/`Host`/`host:443`/`host.` identically, the wrapper buckets those variants into one state dir, `cap=600` yields the float delay (not 1ms), and a state-write failure surfaces. Case 6 (pacing) was reworked to be deterministic/load-independent (stubbed `date`+`sleep` virtual clock).
- `bash tests/testers-rate-limit-audit.test.sh` — 7/7 pass; new cases prove userinfo/case/port/trailing-dot variants group as one host (breach detected) and that `cap=0` / `cap=-5` / non-numeric are rejected with a clear message (no traceback).
- `bash tests/testers-pipeline.test.sh` — integration (`aggregate.py` → audit via the production `bash -c` path) all pass.
- `bash tests/testers-agent-contract.test.sh`, `tests/solve-claim.test.sh` (104/0), `tests/goal.test.sh` (333/0) — green, including the version ratchets.
- `semgrep --config=auto` on the three changed lib files — clean.

The two rate-limit test files remain orphaned from CI (their wiring is tracked separately by #196 — intentionally not changed here). Version bumped 0.33.11 → 0.33.12 across `plugin.json`, `marketplace.json`, the README badge, `CHANGELOG.md`, and the `goal.test.sh` G20 + `solve-claim.test.sh` ratchets.

Closes #184
Closes #185
Closes #186
Closes #187
Closes #188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed per-host RPS rate-limiting cap bypass vulnerability
  * Corrected delay computation for non-integer rate limits
  * Enhanced rate-cap validation with clearer error messages
  * Improved state file handling to surface write failures
  * Standardized host normalization across URL variants

* **Tests**
  * Added regression coverage for rate-limiting wrapper and auditing functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->