### PR TITLE
fix(secret-scan): distinguish grep error (rc>=2) from a real match in regex fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.33.12",
+      "version": "0.33.13",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
           bash tests/review-pr.test.sh && \
           bash tests/review-pr-phase3-ci.test.sh && \
           bash tests/finish-branch-auto-chain.test.sh && \
+          bash tests/secret-scan.test.sh && \
           bash tests/aliases.test.sh && \
           bash tests/merge.test.sh && \
           bash tests/ghostty-dispatch-no-instance-leak.test.sh && \
@@ -115,6 +116,7 @@ jobs:
           bash tests/review-pr.test.sh && \
           bash tests/review-pr-phase3-ci.test.sh && \
           bash tests/finish-branch-auto-chain.test.sh && \
+          bash tests/secret-scan.test.sh && \
           bash tests/aliases.test.sh && \
           bash tests/merge.test.sh && \
           bash tests/ghostty-dispatch-no-instance-leak.test.sh && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.13] - 2026-05-25
+
+### Fixed
+- **`lib/secret-scan.sh` regex fallback could not distinguish a broken scanner from a real match — grep rc≥2 was mis-handled (#189, uberscan MAJOR).** The fallback used `if printf … | grep …; then return 1; fi; return 0`, collapsing grep's tri-state exit (`0`=match, `1`=no-match, `≥2`=regex/I-O error) into a binary. A grep **error** (rc≥2 — e.g. a malformed future pattern making grep exit `2` on every call) fell through to `return 0`, so a broken scanner reported every input as **clean** with no diagnostic (fail-OPEN), and in no case was a scanner error distinguishable from a real secret match. The fallback now captures grep's rc explicitly via `… >&2 || grep_rc=$?` (errexit-safe) and branches: `0`→`return 1` (secret found, fail-CLOSED), `1`→`return 0` (clean), `≥2`→emit a distinct stderr diagnostic naming the scanner failure (never "secret found") and `return` grep's own rc — fail-CLOSED on a code distinct from the match code `1`, so a broken scanner is loud and unmistakable. The gitleaks primary path is unchanged. Regression-locked by new `tests/secret-scan.test.sh` (S1 clean→0, S2 match→1, S3 grep rc≥2→distinct diagnostic + fail-CLOSED), registered in both CI jobs.
+
+### Changed
+- Version bumped to 0.33.13 across `plugin.json`, `marketplace.json`, the README badge, and the test version ratchets (`goal.test.sh` G20, `solve-claim.test.sh`).
+
 ## [0.33.12] - 2026-05-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.33.12-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.33.13-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.33.12",
+  "version": "0.33.13",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/lib/secret-scan.sh
+++ b/plugins/uberdev/lib/secret-scan.sh
@@ -21,8 +21,11 @@ _UBERDEV_SECRET_SCAN_LOADED=1
 
 # uberdev_run_secret_scan_stdin
 #   Reads candidate text from stdin. Returns:
-#     0 — clean (no secret detected)
-#     non-zero — secret detected OR gitleaks crashed (fail-CLOSED on both)
+#     0    — clean (no secret detected)
+#     1    — secret detected (fail-CLOSED)
+#     >=2  — scanner itself failed: gitleaks crashed OR the regex-fallback grep
+#            errored (fail-CLOSED on a code distinct from the match code 1, so a
+#            broken scanner is never silently clean nor mistaken for a real leak)
 #   Layered scan: gitleaks primary (when installed), regex fallback always.
 uberdev_run_secret_scan_stdin() {
   # Primary: gitleaks (when installed). gitleaks exits 0 if no leaks found,

--- a/plugins/uberdev/lib/secret-scan.sh
+++ b/plugins/uberdev/lib/secret-scan.sh
@@ -39,7 +39,18 @@ uberdev_run_secret_scan_stdin() {
   fi
   # Regex fallback: always run (defense in depth even when gitleaks ran clean).
   # Patterns mirror the existing inline list in finish-branch/SKILL.md.
-  if printf '%s' "$input" | grep -EnH --color=never \
+  #
+  # grep's exit status is TRI-STATE and the three cases are NOT interchangeable:
+  #   0   one or more patterns matched -> secret found (fail-CLOSED, return 1)
+  #   1   no line matched              -> clean (return 0)
+  #   >=2 grep itself failed (a malformed pattern, I/O error, …) -> the SCANNER
+  #       is broken, NOT a secret match. Emit a distinct diagnostic and
+  #       fail-CLOSED on grep's own rc so a broken scanner can never be (a)
+  #       silently reported clean NOR (b) mistaken for a real leak (#189).
+  # `|| grep_rc=$?` captures grep's rc (the pipeline's status is grep's, the last
+  # stage) while keeping the non-zero pipeline out of an enclosing `set -e`.
+  local grep_rc=0
+  printf '%s' "$input" | grep -EnH --color=never \
       -e 'AKIA[0-9A-Z]{16}' \
       -e 'aws_access_key[_-]?id[[:space:]]*[:=][[:space:]]*[A-Z0-9]{16,}' \
       -e 'aws_secret_access_key[[:space:]]*[:=][[:space:]]*[A-Za-z0-9/+=]{40}' \
@@ -47,10 +58,14 @@ uberdev_run_secret_scan_stdin() {
       -e 'gh[pousr]_[A-Za-z0-9]{36,}' \
       -e 'sk-[A-Za-z0-9]{32,}' \
       -e 'xox[abprs]-[A-Za-z0-9-]{10,}' \
-      >&2; then
-    return 1
+      >&2 || grep_rc=$?
+  if [ "$grep_rc" -eq 0 ]; then
+    return 1                  # match -> secret found (fail-CLOSED)
+  elif [ "$grep_rc" -ge 2 ]; then
+    printf 'ERROR: uberdev secret-scan scanner failure — regex fallback grep exited %s (regex/I-O error, NOT a secret match). Failing CLOSED; fix the patterns in lib/secret-scan.sh.\n' "$grep_rc" >&2
+    return "$grep_rc"         # scanner error -> fail-CLOSED, distinct from a match
   fi
-  return 0
+  return 0                     # grep_rc == 1 -> no match -> clean
 }
 
 # Emit gitleaks-missing warning ONCE per parent shell — the source-time guard

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -273,11 +273,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.33.12) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.12"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.12"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.12-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.12\]'        "G20.changelog"
+echo "== G20: version bump locked (0.33.13) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.13"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.13"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.13-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.13\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/secret-scan.test.sh
+++ b/tests/secret-scan.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# tests/secret-scan.test.sh — behavioral lock for lib/secret-scan.sh regex-fallback
+# grep exit-code handling (#189).
+#
+# `grep` is TRI-STATE and the three cases are NOT interchangeable:
+#   0  -> one or more patterns matched -> secret found -> return 1 (fail-CLOSED)
+#   1  -> no line matched              -> clean        -> return 0
+#   >=2 -> grep itself failed (a malformed pattern, I/O error, …) -> the SCANNER
+#         is broken, NOT a secret match. It must fail-CLOSED on a non-zero code
+#         that is DISTINCT from the plain match code 1, and emit a diagnostic
+#         that names the scanner failure (never a silent "clean" nor a false
+#         "secret found"). A broken scanner must be distinguishable from a real
+#         match.
+#
+# Pre-#189 the fallback was `if printf | grep …; then return 1; fi; return 0`,
+# which returned 0 (clean) on grep rc=2 — a broken scanner reported clean, with
+# no diagnostic (fail-OPEN). S3 is the regression that locks the fix.
+#
+# Runtime tests source the lib inside a bash -c subshell (mirrors the
+# finish-branch.test.sh F6 idiom) and drive the function via the SKILL.md caller
+# contract: SCAN_DIAG=$(… | uberdev_run_secret_scan_stdin 2>&1 >/dev/null); SCAN_RC=$?
+set -u
+THIS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$THIS_DIR/.." && pwd)"
+PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"
+
+PASS=0; FAIL=0
+echo "## secret-scan grep rc tri-state suite (#189)"
+
+# S1 — clean input (regex fallback grep no-match, rc=1) -> return 0.
+if ( CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash -c '
+      set -u
+      source "$CLAUDE_PLUGIN_ROOT/lib/secret-scan.sh" >/dev/null 2>&1 || exit 99
+      SCAN_DIAG=$(printf "%s" "just a clean line of code" | uberdev_run_secret_scan_stdin 2>&1 >/dev/null); SCAN_RC=$?
+      [ "$SCAN_RC" -eq 0 ] || exit 1
+    ' ); then
+  echo "  PASS  S1 clean input -> rc=0 (no secret)"; PASS=$((PASS+1))
+else
+  rc=$?; echo "  FAIL  S1 clean input must return 0 (sub-rc=$rc)"; FAIL=$((FAIL+1))
+fi
+
+# S2 — genuine match (canonical AWS example key, grep rc=0 / gitleaks rc=1) ->
+# return EXACTLY 1, and the diagnostic is a real match, NOT a scanner-failure
+# message. The key is assembled at runtime ("AKIA" + the rest) so this fixture
+# file does not itself trip the secret scanner — the flaggable token never
+# appears contiguously in the source, yet the full key still reaches the
+# function at runtime.
+if ( CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash -c '
+      set -u
+      source "$CLAUDE_PLUGIN_ROOT/lib/secret-scan.sh" >/dev/null 2>&1 || exit 99
+      example_key="AKIA""IOSFODNN7EXAMPLE"
+      SCAN_DIAG=$(printf "%s" "$example_key" | uberdev_run_secret_scan_stdin 2>&1 >/dev/null); SCAN_RC=$?
+      [ "$SCAN_RC" -eq 1 ] || exit 1
+      case "$SCAN_DIAG" in *"scanner failure"*) exit 2;; esac
+    ' ); then
+  echo "  PASS  S2 genuine match -> rc=1 (secret found), not a scanner-failure msg"; PASS=$((PASS+1))
+else
+  rc=$?; echo "  FAIL  S2 genuine match must return exactly 1 and not be a scanner-failure msg (sub-rc=$rc)"; FAIL=$((FAIL+1))
+fi
+
+# S3 — scanner error: grep exits 2 on EVERY call (as a malformed future pattern
+# would). The fallback MUST NOT silently pass NOR claim a secret. It must
+# fail-CLOSED on a non-zero code DISTINCT from the plain match code 1, and emit a
+# diagnostic that names the scanner failure (not "secret found"). This is the
+# #189 regression lock.
+if ( CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash -c '
+      set -u
+      source "$CLAUDE_PLUGIN_ROOT/lib/secret-scan.sh" >/dev/null 2>&1 || exit 99
+      # Force every grep invocation to exit 2 (regex/I-O error). Shadows the
+      # external grep only inside this subshell; the assertions below use case
+      # (no grep) so they are unaffected by the shadow.
+      grep() { return 2; }
+      SCAN_DIAG=$(printf "%s" "plain text no secrets here" | uberdev_run_secret_scan_stdin 2>&1 >/dev/null); SCAN_RC=$?
+      # (a) fail-CLOSED: must NOT be reported clean
+      [ "$SCAN_RC" -ne 0 ] || exit 1
+      # (b) distinct from a real match: must NOT be the plain match code 1
+      [ "$SCAN_RC" -ne 1 ] || exit 2
+      # (c) diagnostic names the scanner failure
+      case "$SCAN_DIAG" in *"scanner failure"*) : ;; *) exit 3;; esac
+      # (d) diagnostic surfaces the offending grep exit code
+      case "$SCAN_DIAG" in *"grep exited"*) : ;; *) exit 4;; esac
+      # (e) diagnostic must NOT falsely claim a secret was found
+      case "$SCAN_DIAG" in *"secret found"*) exit 5;; esac
+    ' ); then
+  echo "  PASS  S3 grep rc>=2 -> distinct scanner-failure diagnostic + fail-CLOSED (not clean, not match)"; PASS=$((PASS+1))
+else
+  rc=$?; echo "  FAIL  S3 scanner error must surface a distinct diagnostic and fail-CLOSED (sub-rc=$rc)"; FAIL=$((FAIL+1))
+fi
+
+echo
+echo "## Summary"
+echo "  PASS=$PASS  FAIL=$FAIL"
+if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/tests/secret-scan.test.sh
+++ b/tests/secret-scan.test.sh
@@ -39,12 +39,13 @@ else
   rc=$?; echo "  FAIL  S1 clean input must return 0 (sub-rc=$rc)"; FAIL=$((FAIL+1))
 fi
 
-# S2 — genuine match (canonical AWS example key, grep rc=0 / gitleaks rc=1) ->
-# return EXACTLY 1, and the diagnostic is a real match, NOT a scanner-failure
-# message. The key is assembled at runtime ("AKIA" + the rest) so this fixture
-# file does not itself trip the secret scanner — the flaggable token never
-# appears contiguously in the source, yet the full key still reaches the
-# function at runtime.
+# S2 — genuine match (canonical AWS example key) -> return EXACTLY 1 via whichever
+# layer fires first: gitleaks (rc=1, when installed) takes precedence, else the
+# regex fallback (grep rc=0 -> return 1). Either way the result is 1 and the
+# diagnostic is a real match, NOT a scanner-failure message. The key is assembled
+# at runtime ("AKIA" + the rest) so this fixture file does not itself trip the
+# secret scanner — the flaggable token never appears contiguously in the source,
+# yet the full key still reaches the function at runtime.
 if ( CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" bash -c '
       set -u
       source "$CLAUDE_PLUGIN_ROOT/lib/secret-scan.sh" >/dev/null 2>&1 || exit 99

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.11 -> 0.33.12 propagated =="
+echo "== Version bump 0.33.12 -> 0.33.13 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.33.12"' \
-  "plugin.json bumped to 0.33.12"
+  '"version": "0.33.13"' \
+  "plugin.json bumped to 0.33.13"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.33.12"' \
-  "marketplace.json bumped to 0.33.12"
+  '"version": "0.33.13"' \
+  "marketplace.json bumped to 0.33.13"
 assert_grep "$README" \
-  "version-0\\.33\\.12-blue" \
-  "README version badge bumped to 0.33.12"
+  "version-0\\.33\\.13-blue" \
+  "README version badge bumped to 0.33.13"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.33\.12\]' \
-  "CHANGELOG has [0.33.12] section header"
+  '^## \[0\.33\.13\]' \
+  "CHANGELOG has [0.33.13] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary
- `lib/secret-scan.sh` regex fallback now distinguishes grep's **tri-state** exit instead of collapsing it into a binary: `rc=0` → secret found (`return 1`, fail-CLOSED), `rc=1` → clean (`return 0`), `rc≥2` → **scanner error** → distinct stderr diagnostic naming the scanner failure + fail-CLOSED on grep's own rc (distinct from the match code `1`).
- Before: `if printf … | grep …; then return 1; fi; return 0` let a grep error (`rc≥2`, e.g. a malformed future pattern making grep exit `2` on every call) fall through to `return 0` — a broken scanner silently reported every input as **clean** (fail-OPEN), with no signal it was broken.
- gitleaks primary path unchanged.
- New `tests/secret-scan.test.sh` (registered in **both** CI jobs) locks the three rc cases. The AWS example key is assembled at runtime so the fixture does not itself trip the secret scanner.
- Version bump 0.33.12 → 0.33.13.

## Test Plan
- [x] `bash tests/secret-scan.test.sh` — 3/3 (S1 clean→0, S2 match→1, S3 grep rc≥2 → distinct diagnostic + fail-CLOSED)
- [x] `bash tests/finish-branch.test.sh` — 6/6 (F6 runtime AKIA-abort intact)
- [x] `bash tests/finish-branch-auto-chain.test.sh` — 44/44
- [x] Full CI `test.yml` suite — 33/33 files pass (32 bash + 1 zsh)
- [x] `shellcheck` + `bash -n` on the lib — clean
- [x] Pre-push secret scan over the diff — clean (fixture assembles the example key at runtime)

Closes #189


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret scanner's error handling to correctly distinguish between actual secrets detected and scanner failures, ensuring secure fail-closed behavior.

* **Tests**
  * Added comprehensive test suite validating scanner behavior across clean input, genuine detections, and error conditions.

* **Chores**
  * Version bumped to 0.33.13.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->