### PR TITLE
fix(testers): catch non-dict evidence per-finding so one bad agent can't kill the wave

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.33.14",
+      "version": "0.33.15",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.15] - 2026-05-25
+
+### Fixed
+- **`testers-pipeline/aggregate.py` crashed the entire wave when one persona emitted `evidence` as a truthy non-dict (#191, uberscan MAJOR).** `has_evidence()` deliberately raises `ValueError` on a string/list `evidence` (the schema deviation its own comment anticipates), but the per-finding loop in `main()` had no `try/except` — so a single malformed persona output (`evidence: "free text"` or `evidence: [..]`, which survives `f.get("evidence") or {}` as a truthy value and reaches the type guard) propagated an uncaught `ValueError`. The aggregator aborted at the first offending finding **before `wave-N.yaml` was ever written**, discarding the valid findings from all 8 agents in that wave (and, because the uncaught exception exits 1, the wave loop additionally mis-read it as a polite-rate breach). Persona output is untrusted free-form agent YAML, so a schema deviation is *expected*, not exceptional — the guard meant to surface bad input instead weaponized one bad agent into a wave-killer. Fix: wrap the per-finding `has_evidence` call in `try/except ValueError`, mirroring the file's existing malformed-YAML skip-and-continue — log a one-line `warning: skipping finding with non-dict evidence in <path>: <err>` to stderr and `continue` to the next finding. `has_evidence`'s raise-on-bad-shape contract is preserved (the deviation is still surfaced, now as a logged warning rather than a crash), and the documented drop-contract holds (evidence-less findings are dropped, not fatal). Regression-guarded by `tests/testers-pipeline.test.sh` P11 (string + list evidence across one persona; the two well-formed personas' findings survive, both offenders dropped with one stderr warning each).
+
+### Changed
+- Version bumped to 0.33.15 across `plugin.json`, `marketplace.json`, the README badge, and the test version ratchets (`goal.test.sh` G20, `solve-claim.test.sh`).
+
 ## [0.33.14] - 2026-05-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.33.14-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.33.15-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.33.14",
+  "version": "0.33.15",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/skills/testers-pipeline/aggregate.py
+++ b/plugins/uberdev/skills/testers-pipeline/aggregate.py
@@ -110,7 +110,8 @@ def main() -> int:
                 # and drop it (per SKILL.md's drop-contract for evidence-less
                 # findings) so a single bad agent can't crash the aggregation
                 # and discard the valid findings from the rest of the wave.
-                print(f"warning: skipping finding with non-dict evidence in {path}: {e}",
+                print(f"warning: skipping finding with non-dict evidence in {path} "
+                      f"(location={f.get('location') or '?'}, invariant={inv}): {e}",
                       file=sys.stderr)
                 continue
             if not keep:

--- a/plugins/uberdev/skills/testers-pipeline/aggregate.py
+++ b/plugins/uberdev/skills/testers-pipeline/aggregate.py
@@ -100,7 +100,20 @@ def main() -> int:
             inv = f.get("invariant_violated")
             if inv not in invariants:
                 continue
-            if not has_evidence(f.get("evidence") or {}):
+            try:
+                keep = has_evidence(f.get("evidence") or {})
+            except ValueError as e:
+                # Persona output is untrusted free-form agent YAML; a finding
+                # emitting evidence as a truthy non-dict (string/list) is an
+                # expected schema deviation, not a fatal condition. Mirror the
+                # malformed-YAML skip-and-continue above: log this one offender
+                # and drop it (per SKILL.md's drop-contract for evidence-less
+                # findings) so a single bad agent can't crash the aggregation
+                # and discard the valid findings from the rest of the wave.
+                print(f"warning: skipping finding with non-dict evidence in {path}: {e}",
+                      file=sys.stderr)
+                continue
+            if not keep:
                 continue
             persona = f.get("persona") or "unknown"
             location = f.get("location") or ""

--- a/tests/fixtures/testers-mock-outputs/wave-1-bad-evidence-shape.yaml
+++ b/tests/fixtures/testers-mock-outputs/wave-1-bad-evidence-shape.yaml
@@ -1,0 +1,28 @@
+# Schema-deviating persona output (issue #191): a persona emitting `evidence`
+# as a truthy non-dict (a bare string or a list) instead of the documented dict
+# shape. has_evidence() raises ValueError on these; the per-finding loop must
+# catch+skip them, NOT crash the whole wave. Both findings carry a VALID
+# invariant (no_5xx) so they pass the invariant gate and reach the evidence
+# guard — the exact path that triggered the wave-killer.
+verdict: AUDITED
+findings:
+  - severity: major
+    persona: chaos_engineer
+    location: /checkout
+    invariant_violated: no_5xx
+    summary: evidence emitted as a bare string
+    detail: Persona returned evidence as free text instead of the dict shape.
+    evidence: "I saw a 500 error on /checkout after clicking Pay twice"
+    confidence: low
+  - severity: critical
+    persona: chaos_engineer
+    location: /login
+    invariant_violated: no_5xx
+    summary: evidence emitted as a list
+    detail: Persona returned evidence as a list of strings instead of a dict.
+    evidence:
+      - navigate to /login
+      - submit empty form
+      - observe 503
+    confidence: medium
+confidence: low

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -273,11 +273,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.33.14) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.14"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.14"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.14-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.14\]'        "G20.changelog"
+echo "== G20: version bump locked (0.33.15) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.15"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.15"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.15-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.15\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.13 -> 0.33.14 propagated =="
+echo "== Version bump 0.33.14 -> 0.33.15 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.33.14"' \
-  "plugin.json bumped to 0.33.14"
+  '"version": "0.33.15"' \
+  "plugin.json bumped to 0.33.15"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.33.14"' \
-  "marketplace.json bumped to 0.33.14"
+  '"version": "0.33.15"' \
+  "marketplace.json bumped to 0.33.15"
 assert_grep "$README" \
-  "version-0\\.33\\.14-blue" \
-  "README version badge bumped to 0.33.14"
+  "version-0\\.33\\.15-blue" \
+  "README version badge bumped to 0.33.15"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.33\.14\]' \
-  "CHANGELOG has [0.33.14] section header"
+  '^## \[0\.33\.15\]' \
+  "CHANGELOG has [0.33.15] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/testers-pipeline.test.sh
+++ b/tests/testers-pipeline.test.sh
@@ -220,4 +220,50 @@ head -c 128 "$P10/agg.md" | grep -q '<external-untrusted-input source="testers-a
   || { echo "P10: close marker is not the trailer"; exit 1; }
 echo "PASS P10: testers aggregate carries spotlighting envelope + hardened cell()"
 
+# ----------------------------------------------------------------------
+# P11 (issue #191): a persona emitting `evidence` as a truthy non-dict
+#   (a bare string or a list) is a schema deviation has_evidence() flags
+#   with ValueError. The per-finding loop must catch+skip the offender and
+#   keep aggregating — one bad agent must NOT become a wave-killer that
+#   discards the valid findings from the other agents in the wave.
+#   Regression guard: try/except ValueError around the has_evidence call in
+#   aggregate.py main loop (mirrors the malformed-YAML skip-and-continue).
+# ----------------------------------------------------------------------
+P11="$SCRATCH/p11"
+mkdir -p "$P11/scratch/panicked-grandma" \
+         "$P11/scratch/power-user" \
+         "$P11/scratch/chaos-engineer"
+cp "$FIX/wave-1-grandma.yaml"            "$P11/scratch/panicked-grandma/out.yaml"
+cp "$FIX/wave-1-power-user.yaml"         "$P11/scratch/power-user/out.yaml"
+cp "$FIX/wave-1-bad-evidence-shape.yaml" "$P11/scratch/chaos-engineer/out.yaml"
+
+P11_ERR="$P11/stderr.log"
+# Running to completion under `set -e` is itself the core assertion: pre-fix,
+# the uncaught ValueError aborted aggregate.py before wave-1.yaml was written.
+python3 "$AGG" --run-id smoke --wave 1 --scratch-dir "$P11/scratch" \
+  --invariants "$INV" --rps-cap 10 --out "$P11/wave-1.yaml" 2> "$P11_ERR"
+
+[ -f "$P11/wave-1.yaml" ] || { echo "P11: aggregator produced no output (whole wave lost)"; exit 1; }
+python3 -c "import yaml; yaml.safe_load(open('$P11/wave-1.yaml'))" \
+  || { echo "P11: aggregator output is itself malformed"; exit 1; }
+
+# The two well-formed findings (grandma + power-user) survive; both bad-shape
+# chaos_engineer findings are dropped.
+COUNT_P11="$(python3 -c "import yaml; print(len(yaml.safe_load(open('$P11/wave-1.yaml'))['findings']))")"
+[ "$COUNT_P11" = "2" ] || {
+  echo "P11: expected 2 surviving findings (grandma + power-user), got $COUNT_P11"
+  echo "P11:   personas in output: $(python3 -c "import yaml; print([f.get('persona') for f in yaml.safe_load(open('$P11/wave-1.yaml'))['findings']])")"
+  exit 1
+}
+
+LEAKED_P11="$(python3 -c "import yaml; ff=yaml.safe_load(open('$P11/wave-1.yaml'))['findings']; print(any(f.get('persona')=='chaos_engineer' for f in ff))")"
+[ "$LEAKED_P11" = "False" ] || { echo "P11: bad-evidence finding leaked into output"; exit 1; }
+
+# Each dropped offender is logged once (string + list = 2 warnings).
+WARN_P11="$(grep -c "warning: skipping finding with non-dict evidence" "$P11_ERR" || true)"
+[ "$WARN_P11" = "2" ] || {
+  echo "P11: expected 2 'skipping finding with non-dict evidence' warnings, got $WARN_P11; stderr:"; cat "$P11_ERR"; exit 1;
+}
+echo "PASS P11: non-dict evidence skipped per-finding; valid findings in the wave survive"
+
 echo "ALL TESTS PASS"

--- a/tests/testers-pipeline.test.sh
+++ b/tests/testers-pipeline.test.sh
@@ -266,4 +266,31 @@ WARN_P11="$(grep -c "warning: skipping finding with non-dict evidence" "$P11_ERR
 }
 echo "PASS P11: non-dict evidence skipped per-finding; valid findings in the wave survive"
 
+# ----------------------------------------------------------------------
+# P12 (issue #191, edge): the most dangerous regression — a wave whose
+#   ONLY finding(s) carry non-dict evidence. The aggregator must still exit
+#   0 and emit a valid (empty-findings) wave file, NOT crash. P11 mixes
+#   good + bad personas; P12 isolates the all-bad case and asserts the exit
+#   code explicitly (not just via `set -e`).
+# ----------------------------------------------------------------------
+P12="$SCRATCH/p12"
+mkdir -p "$P12/scratch/chaos-engineer"
+cp "$FIX/wave-1-bad-evidence-shape.yaml" "$P12/scratch/chaos-engineer/out.yaml"
+
+P12_ERR="$P12/stderr.log"
+# Capture the exit code WITHOUT letting `set -e` abort: the explicit rc==0
+# assertion below is the point (addresses the "exit code only implicit" gap).
+P12_RC=0
+python3 "$AGG" --run-id smoke --wave 1 --scratch-dir "$P12/scratch" \
+  --invariants "$INV" --rps-cap 10 --out "$P12/wave-1.yaml" 2> "$P12_ERR" || P12_RC=$?
+
+[ "$P12_RC" = "0" ] || { echo "P12: aggregator exited $P12_RC (expected 0) on all-bad wave"; cat "$P12_ERR"; exit 1; }
+[ -f "$P12/wave-1.yaml" ] || { echo "P12: no output file for all-bad wave (whole wave lost)"; exit 1; }
+COUNT_P12="$(python3 -c "import yaml; print(len(yaml.safe_load(open('$P12/wave-1.yaml'))['findings']))")"
+[ "$COUNT_P12" = "0" ] || { echo "P12: expected 0 findings (all bad-shape dropped), got $COUNT_P12"; exit 1; }
+grep -q "warning: skipping finding with non-dict evidence" "$P12_ERR" || {
+  echo "P12: expected stderr warning for the dropped finding(s); got:"; cat "$P12_ERR"; exit 1;
+}
+echo "PASS P12: all-bad-evidence wave still exits 0 with valid (empty) output"
+
 echo "ALL TESTS PASS"


### PR DESCRIPTION
## Summary
- `testers-pipeline/aggregate.py`: wrap the per-finding `has_evidence()` call in `try/except ValueError` so a persona emitting `evidence` as a truthy non-dict (string/list) is logged + skipped instead of crashing the whole wave. Mirrors the file's existing malformed-YAML skip-and-continue; `has_evidence`'s raise-on-bad-shape contract and the documented drop-contract are both preserved.
- Root cause: `f.get("evidence") or {}` passes a truthy string straight through to the type guard, so the uncaught `ValueError` aborted aggregation before `wave-N.yaml` was ever written — discarding the valid findings from all 8 agents in that wave (and, because the crash exits 1, the SKILL.md wave loop additionally mis-read it as a polite-rate breach). Persona output is untrusted free-form agent YAML, so a schema deviation is expected, not exceptional.
- Version bumped 0.33.14 to 0.33.15 across plugin.json, marketplace.json, README badge, CHANGELOG, and the test ratchets (goal.test.sh G20, solve-claim.test.sh).

## Test Plan
- [x] `tests/testers-pipeline.test.sh` P11 (new, TDD): one persona emitting string + list evidence alongside two well-formed personas. aggregate.py exits 0, both offenders are dropped with one stderr warning each, and the two valid findings survive (the wave is preserved). Confirmed red pre-fix (uncaught ValueError, no output file), green post-fix.
- [x] Sibling testers tests green: testers-agent-contract, testers-rate-limit-audit, testers-rate-limit-wrapper.
- [x] Version ratchets green: goal.test.sh G20, solve-claim.test.sh version block.
- [x] Full CI test suite (33 files) green locally.

Closes #191
