### PR TITLE
ci: wire 10 orphaned tests into the CI matrix (#196)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.33.18",
+      "version": "0.33.19",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,24 @@ jobs:
         # needs the zsh binary, not the recommends graph).
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh
       - name: Run shape-check tests
-        # SYNC: this list MUST match the windows-latest job below, plus the
-        # zsh fixture, testers-pipeline, AND the uberscan trio
-        # (uberscan.test.sh / uberscan-report.test.sh / uberscan-chunk.test.sh)
-        # — all Unix-runtime fixtures the Windows job intentionally skips
-        # (they shell out to python3 -c with mktemp -d paths Git Bash on
-        # Windows mistranslates). When a test file is added or removed, update
-        # BOTH jobs by hand — there is no automated drift guard between the
-        # two lists.
+        # SYNC: this list MUST match the windows-latest job below, PLUS the
+        # ubuntu-only Unix-runtime fixtures the Windows job intentionally skips:
+        #   - solve-pipeline-zsh.test.sh         (needs zsh on PATH)
+        #   - testers-pipeline.test.sh           (python3 -c with mktemp -d paths
+        #                                         Git Bash on Windows mistranslates)
+        #   - uberscan.test.sh / uberscan-report.test.sh / uberscan-chunk.test.sh
+        #                                         (same python3 -c + path reason)
+        #   - merge-discovery-resilience.test.sh (executes the executable fake-gh
+        #                                         fixture via PATH + sources
+        #                                         lib/discover.sh — neither proven
+        #                                         on Git Bash; the fixture's +x bit
+        #                                         is not reliably preserved on a
+        #                                         Windows checkout) [#196]
+        #   - testers-agent-contract.test.sh / testers-rate-limit-audit.test.sh /
+        #     testers-rate-limit-wrapper.test.sh (python3 + PyYAML, same reason as
+        #                                         testers-pipeline) [#196]
+        # When a test file is added or removed, update BOTH jobs by hand — there
+        # is no automated drift guard between the two lists.
         run: |
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \
@@ -49,9 +59,14 @@ jobs:
           bash tests/audit-fixups.test.sh && \
           bash tests/review-pr.test.sh && \
           bash tests/review-pr-phase3-ci.test.sh && \
+          bash tests/code-fixer-dispatch.test.sh && \
+          bash tests/findings-to-issues.test.sh && \
+          bash tests/trust-trail-evaluator.test.sh && \
           bash tests/finish-branch-auto-chain.test.sh && \
+          bash tests/finish-branch.test.sh && \
           bash tests/secret-scan.test.sh && \
           bash tests/aliases.test.sh && \
+          bash tests/install.test.sh && \
           bash tests/merge.test.sh && \
           bash tests/ghostty-dispatch-no-instance-leak.test.sh && \
           bash tests/dispatch-claude-bg.test.sh && \
@@ -69,9 +84,14 @@ jobs:
           bash tests/dispatch-wezterm.test.sh && \
           bash tests/ubersimplify.test.sh && \
           bash tests/ubersimplify-aggregate.test.sh && \
+          bash tests/simplify.test.sh && \
           bash tests/uberscan.test.sh && \
           bash tests/uberscan-report.test.sh && \
           bash tests/uberscan-chunk.test.sh && \
+          bash tests/merge-discovery-resilience.test.sh && \
+          bash tests/testers-agent-contract.test.sh && \
+          bash tests/testers-rate-limit-audit.test.sh && \
+          bash tests/testers-rate-limit-wrapper.test.sh && \
           bash tests/goal-state-sidecar.test.sh && \
           bash tests/using-git-worktrees.test.sh && \
           bash tests/goal.test.sh
@@ -91,23 +111,29 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run shape-check tests
-        # No zsh on windows-latest Git Bash; solve-pipeline-zsh.test.sh is a
-        # Unix-runtime fixture and is intentionally skipped here. Every other
-        # test is a portable grep-and-assert shape-check.
+        # This list MUST match the ubuntu-latest job above MINUS the ubuntu-only
+        # Unix-runtime fixtures, which are intentionally skipped here because Git
+        # Bash on Windows can't run them reliably:
+        #   - solve-pipeline-zsh.test.sh         (no zsh on windows-latest)
+        #   - testers-pipeline.test.sh + testers-agent-contract.test.sh +
+        #     testers-rate-limit-audit.test.sh + testers-rate-limit-wrapper.test.sh
+        #                                         (python3 + PyYAML; the python3 -c
+        #                                         invocations embed mktemp -d paths
+        #                                         that resolve to /tmp/... strings
+        #                                         python.exe can't translate)
+        #   - uberscan.test.sh / uberscan-report.test.sh / uberscan-chunk.test.sh
+        #                                         (same python3 -c + path reason)
+        #   - merge-discovery-resilience.test.sh (executes the executable fake-gh
+        #                                         fixture via PATH + sources
+        #                                         lib/discover.sh — neither proven
+        #                                         on Git Bash) [#196]
         #
-        # testers-pipeline.test.sh is ALSO a Unix-runtime fixture — it shells
-        # out to python3 with `$SCRATCH/...` paths assembled by mktemp -d,
-        # which on Git Bash for Windows resolve to /tmp/... strings that
-        # python.exe can't translate when they're embedded inside `python3 -c`
-        # source code. The aggregator itself is portable, but the per-assertion
-        # python3 -c invocations are not — skipped here, runs on Linux.
-        #
-        # SYNC: this list MUST match the ubuntu-latest job above, minus the
-        # zsh fixture, testers-pipeline, AND the uberscan trio
-        # (uberscan.test.sh / uberscan-report.test.sh / uberscan-chunk.test.sh)
-        # — all Unix-runtime fixtures intentionally skipped here. When a test
-        # file is added or removed, update BOTH jobs by hand — there is no
-        # automated drift guard between the two lists.
+        # Every test below is a portable grep-and-assert shape-check OR a runtime
+        # fixture with an existing Windows-green precedent (the #196 additions
+        # code-fixer-dispatch / findings-to-issues / finish-branch / install /
+        # simplify / trust-trail-evaluator each mirror a lib/helper already
+        # exercised on this job). When a test file is added or removed, update
+        # BOTH jobs by hand — there is no automated drift guard between the lists.
         run: |
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \
@@ -116,9 +142,14 @@ jobs:
           bash tests/audit-fixups.test.sh && \
           bash tests/review-pr.test.sh && \
           bash tests/review-pr-phase3-ci.test.sh && \
+          bash tests/code-fixer-dispatch.test.sh && \
+          bash tests/findings-to-issues.test.sh && \
+          bash tests/trust-trail-evaluator.test.sh && \
           bash tests/finish-branch-auto-chain.test.sh && \
+          bash tests/finish-branch.test.sh && \
           bash tests/secret-scan.test.sh && \
           bash tests/aliases.test.sh && \
+          bash tests/install.test.sh && \
           bash tests/merge.test.sh && \
           bash tests/ghostty-dispatch-no-instance-leak.test.sh && \
           bash tests/dispatch-claude-bg.test.sh && \
@@ -135,6 +166,7 @@ jobs:
           bash tests/dispatch-wezterm.test.sh && \
           bash tests/ubersimplify.test.sh && \
           bash tests/ubersimplify-aggregate.test.sh && \
+          bash tests/simplify.test.sh && \
           bash tests/goal-state-sidecar.test.sh && \
           bash tests/using-git-worktrees.test.sh && \
           bash tests/goal.test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   shape-checks:
     name: shape-checks
     runs-on: ubuntu-latest
-    # 5 minutes is generous for ~70 grep-and-assert checks on the small repo.
+    # 5 minutes is generous for the ~330 grep-and-assert checks (44 test files).
     # Caps the default 360-min budget so a hung test from a fork PR can't burn
     # the public-repo Actions allowance. Bump if the suite legitimately grows.
     timeout-minutes: 5
@@ -129,11 +129,15 @@ jobs:
         #                                         on Git Bash) [#196]
         #
         # Every test below is a portable grep-and-assert shape-check OR a runtime
-        # fixture with an existing Windows-green precedent (the #196 additions
-        # code-fixer-dispatch / findings-to-issues / finish-branch / install /
-        # simplify / trust-trail-evaluator each mirror a lib/helper already
-        # exercised on this job). When a test file is added or removed, update
-        # BOTH jobs by hand — there is no automated drift guard between the lists.
+        # fixture whose mechanism already runs green on this job. The #196
+        # additions reuse: the _lib_assert_structural.sh awk-range lib
+        # (code-fixer-dispatch / findings-to-issues / finish-branch / simplify /
+        # trust-trail-evaluator); the `bash -c … uberdev_run_secret_scan_stdin`
+        # pattern (finish-branch, mirroring secret-scan.test.sh); lib/config-read.sh
+        # runtime (findings-to-issues, mirroring config-override.test.sh); and
+        # chmod+x-stub execution (install, mirroring solve-effort-flag.test.sh).
+        # When a test file is added or removed, update BOTH jobs by hand — there
+        # is no automated drift guard between the lists.
         run: |
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.19] - 2026-05-26
+
+### Added
+- **Wired the 10 orphaned `tests/*.test.sh` files into the CI matrix (`.github/workflows/test.yml`), so important surfaces that previously never ran in CI are now covered (#196, uberscan MAJOR).** A `/uberscan` whole-codebase pass found 10 test files present on disk but absent from both CI jobs — `code-fixer-dispatch`, `findings-to-issues`, `finish-branch`, `install`, `merge-discovery-resilience`, `simplify`, `testers-agent-contract`, `testers-rate-limit-audit`, `testers-rate-limit-wrapper`, `trust-trail-evaluator` — covering rate-limit enforcement, merge-discovery resilience, the code-fixer dispatch contract, findings→issues, trust-trail evaluation, and the installer bootstrap, none of which were regression-guarded by CI. Each test was **run locally and confirmed passing before wiring** (the PR's own CI then executes them). Job placement was decided by Git-Bash portability, mirroring the existing `solve-pipeline-zsh` / `testers-pipeline` / `uberscan`-trio precedent: 6 pure shape-check / proven-portable-runtime tests (`code-fixer-dispatch`, `findings-to-issues`, `finish-branch`, `install`, `simplify`, `trust-trail-evaluator`) run on **both** the ubuntu and windows shape-check jobs; 4 Unix-runtime tests run **ubuntu-only** — `merge-discovery-resilience` (executes an executable `fake-gh` fixture via PATH + sources `lib/discover.sh`, neither proven on Git Bash) and the three `testers-*` tests (`python3` + PyYAML, the same reason `testers-pipeline` is ubuntu-only). The `both`-job placements are each backed by an existing Windows-green precedent: `_lib_assert_structural.sh` (used by `review-pr.test.sh` et al.), `lib/config-read.sh` runtime (via `config-override.test.sh`), the `bash -c … uberdev_run_secret_scan_stdin` pattern (via `secret-scan.test.sh`), and chmod+x-stub execution (via `solve-effort-flag.test.sh`).
+- **Investigated and dismissed the issue's "orphaned test of a nonexistent `agents/code-fixer.md`" concern.** The uberscan finding flagged `code-fixer-dispatch.test.sh` as referencing a missing agent file; the test actually references `plugins/uberdev/agents/code-fixer.md` (present, 7979 bytes) and passes — the agent exists, so the test was wired normally with no fabricated file.
+
+### Changed
+- Version bumped to 0.33.19 across `plugin.json`, `marketplace.json`, the README badge, and the test version ratchets (`goal.test.sh` G20, `solve-claim.test.sh`).
+
 ## [0.33.18] - 2026-05-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.33.18-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.33.19-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.33.18",
+  "version": "0.33.19",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -273,11 +273,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.33.18) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.18"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.18"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.18-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.18\]'        "G20.changelog"
+echo "== G20: version bump locked (0.33.19) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.19"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.19"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.19-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.19\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.17 -> 0.33.18 propagated =="
+echo "== Version bump 0.33.18 -> 0.33.19 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.33.18"' \
-  "plugin.json bumped to 0.33.18"
+  '"version": "0.33.19"' \
+  "plugin.json bumped to 0.33.19"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.33.18"' \
-  "marketplace.json bumped to 0.33.18"
+  '"version": "0.33.19"' \
+  "marketplace.json bumped to 0.33.19"
 assert_grep "$README" \
-  "version-0\\.33\\.18-blue" \
-  "README version badge bumped to 0.33.18"
+  "version-0\\.33\\.19-blue" \
+  "README version badge bumped to 0.33.19"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.33\.18\]' \
-  "CHANGELOG has [0.33.18] section header"
+  '^## \[0\.33\.19\]' \
+  "CHANGELOG has [0.33.19] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary
- Wires the **10 orphaned `tests/*.test.sh` files** into `.github/workflows/test.yml` so they actually run in CI (#196). They existed on disk but were absent from both jobs, leaving rate-limit enforcement, merge-discovery resilience, the code-fixer dispatch contract, findings→issues, trust-trail evaluation, and the installer bootstrap with **zero CI coverage**.
- **Job placement by Git-Bash portability**, mirroring the existing `solve-pipeline-zsh` / `testers-pipeline` / `uberscan`-trio precedent:
  - **both jobs (cross-platform)** — `code-fixer-dispatch`, `findings-to-issues`, `finish-branch`, `install`, `simplify`, `trust-trail-evaluator`. Each is backed by an existing **Windows-green precedent** (the `_lib_assert_structural.sh` awk-range lib, the `bash -c … uberdev_run_secret_scan_stdin` pattern, chmod+x-stub execution, and `lib/config-read.sh` runtime are all already exercised on the windows job).
  - **ubuntu-only (Unix-runtime)** — `merge-discovery-resilience` (executes the executable `fake-gh` fixture via PATH + sources `lib/discover.sh`, neither proven on Git Bash; the fixture's `+x` bit is not reliably preserved on a Windows checkout) and the 3 `testers-*` tests (`python3` + PyYAML, the same reason `testers-pipeline` is ubuntu-only).
- Bumps version **0.33.18 → 0.33.19** across all six locations (`plugin.json`, `marketplace.json`, README badge, CHANGELOG, `goal.test.sh` G20, `solve-claim.test.sh`).

## Test Plan
- [x] Ran each of the 10 orphaned tests **locally and confirmed passing before wiring** (the requirement that this PR's own CI not go red).
- [x] Ran the **full ubuntu chain** (all 44 tests, extracted from the YAML and run exactly as CI including the `zsh` line) — **exit 0 in 25s**, well under the 5-min budget.
- [x] Verified the wired set programmatically: **0 unwired**, ubuntu = 44 / windows = 35, ubuntu-only = exactly the 9 expected, no windows-only drift, YAML parses.
- [ ] **CI green on this PR** — both `shape-checks` (ubuntu) and `shape-checks-windows` jobs, with the new tests actually executing. Monitored by the chained `/review-pr` Phase 3.

## Notes
- The issue's "**orphaned test of a missing `agents/code-fixer.md`**" concern was a **stale uberscan finding**: `code-fixer-dispatch.test.sh` references `plugins/uberdev/agents/code-fixer.md` (present, 7979 bytes), not a top-level `agents/code-fixer.md`. The agent exists and the test passes, so it was wired normally — **no agent file was fabricated**.
- Both `SYNC` comments in `test.yml` were updated to document the expanded ubuntu-only fixture set.

Closes #196
