### PR TITLE
feat(goal): cap parallel /turbo at 3, add wait-for-all merge barrier (#211)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.33.19",
+      "version": "0.33.20",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.20] - 2026-05-26
+
+### Added
+- `/goal` config keys `goal.max_parallel` (`UBERDEV_GOAL_MAX_PARALLEL`, `--max-parallel=N`, default 3, range 1–10) and `goal.barrier_timeout_s` (`UBERDEV_GOAL_BARRIER_TIMEOUT_S`, `--barrier-timeout=N`, default 14400 s = 4h, range 60..86400).
+- Three new public helpers in `lib/goal-state.sh`: `uberdev_goal_register_batch_pr`, `uberdev_goal_batch_all_terminal`, `uberdev_goal_batch_unblock_wait_clear`. RFC 0005 §9 D-211a/b/c.
+- New batch-registry sidecar `goal-<id>-batch-prs.tsv` (per-PR rows with `pr<TAB>issue<TAB>dispatch_ts<TAB>terminal_state`); cleaned up by `uberdev_goal_cleanup_run_state`.
+
+### Changed
+- `/goal` per-cycle `/turbo` dispatch is now capped at 3 by default (previously uncapped); queue overflow rolls to the next cycle without re-claim collisions.
+- `/merge` no longer fires per-PR the instant a PR turns GREEN; `/goal` holds until every PR in the cycle's batch is in a terminal state. Manifest-collision PRs (e.g. version-bump triplet) merge sequentially in PR-number-ascending order with `git fetch origin main` + rebase between each.
+- Wall-clock breaker on the new merge barrier (4h default) escalates to the existing `stuck_loop` circuit-breaker reason — no new reason added, no `GOAL_CIRCUIT_BREAKER_REASONS` enum mutation.
+
 ## [0.33.19] - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.33.19-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.33.20-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ auto_install_aliases: true    # install short-form forwarders at SessionStart
 integration_branch: main      # /merge target branch (overrides gh repo view default)
 goal:
   max_cycles: 5               # /uberdev:goal hard cycle ceiling (default 5, range [1, 20])
+  max_parallel: 3             # /uberdev:goal concurrent-in-flight cap (default 3, range [1, 10])
+  barrier_timeout_s: 14400    # /uberdev:goal per-wave barrier wall-clock ceiling, in seconds (default 14400, range [60, 86400])
 ---
 ```
 
@@ -243,6 +245,8 @@ goal:
 | `UBERDEV_NO_AUTO_ALIAS` | `auto_install_aliases` | When `1`/`true` (env) or `false` (file), suppresses session-start auto-install of `/issue`, `/solve`, `/turbo`, `/simplify`, `/review-pr`, `/merge`, `/dev`, `/testers`, `/ubergoal`, `/uberscan`, `/ubersimplify` forwarders |
 | `UBERDEV_INTEGRATION_BRANCH` | `integration_branch` | `/merge` target branch |
 | `UBERDEV_GOAL_MAX_CYCLES` | `goal.max_cycles` | `/uberdev:goal` hard cycle ceiling; int [1, 20], default 5 |
+| `UBERDEV_GOAL_MAX_PARALLEL` | `goal.max_parallel` | `/uberdev:goal` concurrent-in-flight cap (PRs+issues in active set); int [1, 10], default 3 |
+| `UBERDEV_GOAL_BARRIER_TIMEOUT_S` | `goal.barrier_timeout_s` | `/uberdev:goal` per-wave barrier wall-clock ceiling, in seconds; int [60, 86400], default 14400 |
 
 Precedence: CLI flag > env var > `.claude/uberdev.local.md` > default. Missing file → defaults apply silently.
 

--- a/docs/rfc/0005-uberdev-goal.md
+++ b/docs/rfc/0005-uberdev-goal.md
@@ -280,7 +280,7 @@ Per `findings-to-issues` agent: if a single `/review-pr` run has >10 deferred bl
 
 | #   | Question                                                                                                          | Recommendation |
 | --- | ----------------------------------------------------------------------------------------------------------------- | -------------- |
-| Q1  | Should `/goal` cap parallel `/turbo` dispatches per cycle? Today `/turbo` uses `fanout_concurrency.solve_bg` (default 6). | Inherit `solve_bg` for v1; revisit if real cycles produce too-wide fanouts. |
+| Q1  | Should `/goal` cap parallel `/turbo` dispatches per cycle? Today `/turbo` uses `fanout_concurrency.solve_bg` (default 6). | RESOLVED (issue #211, v0.33.20): default fan-out cap = 3, configurable 1–10 via `goal.max_parallel` / `UBERDEV_GOAL_MAX_PARALLEL` / `--max-parallel=N`. Out-of-range values fall back to the default via `uberdev_read_int_in_range` (stderr warning + audit event). The cap applies to Phase 1 dispatch only; Phase 2 watcher remains single-threaded per RFC 0005 §3.3. |
 | Q2  | Does `/goal` need its own claim type (`goal_claim`) so two concurrent `/goal` runs don't collide on issue-set overlap? | Defer — single-user repos don't need it; document the gap in README. |
 | Q3  | Per-goal audit sink — separate file or append to `solve-audit.jsonl`?                                              | Separate `goal-<id>.jsonl` for clean post-mortem; cross-reference by `goal_id`. |
 | Q4  | When `/review-pr` is re-run in §3.2.3, do we wait for CI again (`/review-pr` Phase 3 — RFC 0001)?                  | Yes — re-review is full `/review-pr`, including Phase 3 CI Health. No shortcut. |
@@ -337,6 +337,13 @@ Codes are grouped by prefix: **D** (design decisions), **T** (trust/threat bound
 | D17 | YELLOW/RED PRs are never merged inside `/goal`; `yellow-held → merging` and `red-held → merging` are forbidden transitions in the PR state machine. `stale` and `missing` trust signals also never imply GREEN — they trigger a re-dispatch of `/review-pr`. Terminal states `merged` and `merge-failed` are irreversible. | §3.2.1, §2.3 |
 | D18 | Every re-review dispatch (unblock rule, stale/missing trust signal) uses full `/uberdev:review-pr` with no incremental shortcut, because the upstream merge that triggered unblock may have changed CI dependencies. | §5 |
 | D19 | Crash-restart contract: `_UBERDEV_GOAL_STATE_LOADED` guard prevents double-sourcing within a single process; resume-after-SIGKILL is explicitly out of scope for v1. | — |
+| D-211a | `uberdev_goal_register_batch_pr` | Per-PR append to `goal-<id>-batch-prs.tsv` registry with atomic write; seeds `barrier_start_ts` on first registration of the cycle. | — |
+| D-211b | `uberdev_goal_batch_all_terminal` | Pure-read predicate over the batch registry; rc 0 iff every row's `terminal_state` ∈ {GREEN, HELD, MERGE_FAILED, MERGED}. Empty registry returns rc 1. | — |
+| D-211c | `uberdev_goal_batch_unblock_wait_clear` | Pure-read predicate over the batch registry; rc 0 iff every HELD row's unblock-issue is closed AND its PR carries `review-pr:green`. | — |
+| D-211d | `_UBERDEV_GOAL_DEFAULT_MAX_PARALLEL` | Phase 1 dispatch cap default (`3`); range `[1, 10]` via `uberdev_read_int_in_range`. | — |
+| D-211e | `_UBERDEV_GOAL_DEFAULT_BARRIER_TIMEOUT_S` | Phase 2 step 2c wall-clock cap default (`14400` = 4h); range `[60, 86400]`. Timeout escalates to `stuck_loop` (no new circuit-breaker reason). | — |
+
+> The three barrier-internal helpers (`_uberdev_goal_set_batch_terminal_state`, `_uberdev_goal_batch_green_prs_ordered`, `_uberdev_goal_rebase_collision_chain`) are underscore-prefixed private primitives and intentionally do not receive §9 D-code rows, matching the convention from D-codes for existing private helpers.
 
 ### 9.2 T — Trust / Threat boundaries
 

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.33.19",
+  "version": "0.33.20",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/goal.md
+++ b/plugins/uberdev/commands/goal.md
@@ -1,6 +1,6 @@
 ---
 description: "Autonomous loop that chains /turbo → /review-pr (auto) → /merge if GREEN, recursing on BLOCKER/CRITICAL review-pr-finding issues until convergence or circuit-breaker halt. Inherits the dispatch backend resolver from /solve and /turbo. Inside /goal only: auto-chain to /merge is allowed (carve-out from feedback_merge_independent)."
-argument-hint: "<issue> [<issue> ...] [--max-cycles=N] [--only-mine] [--dry-run] [--backend=<name>]"
+argument-hint: "<issue> [<issue> ...] [--max-cycles=N] [--max-parallel=N] [--barrier-timeout=N] [--only-mine] [--dry-run] [--backend=<name>]"
 allowed-tools: ["Bash", "Read", "Task"]
 ---
 
@@ -8,12 +8,29 @@ allowed-tools: ["Bash", "Read", "Task"]
 
 Autonomous convergence orchestrator that drives one or more GitHub issues to merged-and-closed by chaining `/turbo` (solve + push PR) → auto `/review-pr` (trust-signal) → `/merge` ONLY when the trust trail is GREEN, recursing on `BLOCKER` / `CRITICAL` `review-pr-finding` issues filed by that review pass. `YELLOW` (CRITICAL findings) and `RED` (BLOCKER findings or `halted_due_to_overflow`) PRs are HELD — never merged automatically — and are re-reviewed only when every issue listed in their `Blocks:` PR-body line closes. The loop terminates on convergence (queue empty AND all open `/goal`-owned PRs are terminal) or on one of seven circuit breakers. The four loop-logic breakers are `max_cycles` (hard cycle ceiling, default 5), `nonconvergence` (queue-fingerprint repeat across cycles), `stuck_loop` (4-hour wall-clock cap), and `merge_failed` (any `/merge` invocation exits non-zero); three further surfaced-failure guards — `gh_api_failed`, `unknown_merge_result`, and `queue_empty_not_converged` — round out the `GOAL_CIRCUIT_BREAKER_REASONS` enum owned by the goal-pipeline skill. Per RFC 0005 §2.3 the loop applies three scoped relaxations to the global UberDev rules — see the call-out below.
 
-**Usage:** `/uberdev:goal <issue> [<issue> ...] [--max-cycles=N] [--only-mine] [--dry-run] [--backend=<name>]`
+**Usage:** `/uberdev:goal <issue> [<issue> ...] [--max-cycles=N] [--max-parallel=N] [--barrier-timeout=N] [--only-mine] [--dry-run] [--backend=<name>]`
 
 - `--max-cycles=N` — hard ceiling on cycle count (default `5`, range `1..20`; reads `goal.max_cycles` config / `UBERDEV_GOAL_MAX_CYCLES` env).
+- `--max-parallel=N` — cap the per-cycle `/turbo` dispatch fan-out at N (default 3, range 1–10).
+  Queue items beyond the cap roll over to the next cycle. Resolved via the same precedence as
+  `--max-cycles`: CLI flag > `UBERDEV_GOAL_MAX_PARALLEL` env > `goal.max_parallel` config key > default.
+  Values outside `[1, 10]` fall back to the default 3 (with a stderr warning + audit event).
+- `--barrier-timeout=N` — wall-clock cap (seconds) on the wait-for-all merge barrier in Phase 2 step 2c
+  (default 14400 = 4h, range 60..86400). Timeout escalates to the existing `stuck_loop` circuit-breaker
+  reason; no new breaker enum is added. Resolved via the same precedence as `--max-cycles`.
 - `--only-mine` — only enqueue `review-pr-finding` issues authored by `$GH_USER`.
 - `--dry-run` — print planned cycle 1 dispatch + watch-loop preview, exit 0. No `/turbo`, no `/merge`, no `/review-pr` is invoked.
 - `--backend=<name>` — pin a dispatch backend (`claude-bg` | `wezterm` | `background`); otherwise auto-resolved once by Phase 0 preflight and frozen for the run.
+
+**Merge barrier (issue #211).** `/merge` no longer fires per-PR the instant a PR turns GREEN.
+Instead, `/goal` holds until every PR in the cycle's batch is in a terminal state
+(`merged`, `merge-failed`, `yellow-held`, `red-held`, or `green`). PRs touching shared
+mutable manifests (e.g. the uberdev version-bump triplet) merge sequentially in
+PR-number-ascending order, with `git fetch origin main` + rebase between each. When a
+held PR's `review-pr-finding` unblock-issue is in flight, the barrier holds until the
+unblock-issue closes AND the held PR's trust-trail label transitions to `review-pr:green`.
+A wall-clock cap (default 4h, see `--barrier-timeout=N`) escalates a stuck barrier to
+`stuck_loop` halt.
 
 ## Scoped relaxations (RFC 0005 §2.3)
 

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -831,15 +831,41 @@ uberdev_goal_register_batch_pr() {
     printf '%s\t%s\t%s\tPENDING\n' "$pr" "$issue" "$ts" > "$tmp" || { rm -f "$tmp"; return 3; }
   fi
   mv -f "$tmp" "$tsv" || { rm -f "$tmp"; return 3; }
-  # Best-effort seed barrier_start_ts on first registration. The `>>` append
-  # below is intentionally non-atomic — the next uberdev_goal_write_run_state
-  # call atomically rewrites the sidecar from the in-memory scalar. Per the
-  # spec's "best effort; never blocks registration" contract, registration
-  # rc=0 even if the sidecar seed write fails.
+  # Best-effort seed barrier_start_ts on first registration.
+  #
+  # The previous implementation used `! grep -q '^barrier_start_ts='` + `>>` append.
+  # That predicate is wrong when Phase 0 step 7 has already called
+  # uberdev_goal_write_run_state, because the writer ALWAYS emits a
+  # `barrier_start_ts=${barrier_start_ts:-0}` line — so the placeholder
+  # `barrier_start_ts=0` line exists on disk, the `! grep -q` predicate is
+  # FALSE, and the seed never fires. The wall-clock merge-barrier breaker
+  # (AC6 / D-211e) then never trips because the Phase 2c guard reads `0`
+  # forever.
+  #
+  # Fix: treat any `barrier_start_ts=0` (or missing line) as unseeded. Use
+  # an awk rewrite (drop every existing barrier_start_ts= line, append the
+  # seeded value at end) → mktemp → mv -f so the placeholder line is
+  # REPLACED rather than duplicated. Best-effort: failure leaves the file
+  # untouched (the next uberdev_goal_write_run_state rewrites the sidecar
+  # atomically from the in-memory scalar anyway).
   if [ "$first" = "1" ]; then
     local sc="$tmpdir/goal-$goal_id-runstate"
-    if [ -r "$sc" ] && ! grep -q '^barrier_start_ts=' "$sc"; then
-      printf 'barrier_start_ts=%s\n' "$ts" >> "$sc" 2>/dev/null || true
+    if [ -r "$sc" ] && ! grep -qE '^barrier_start_ts=[1-9][0-9]*$' "$sc"; then
+      if command -v _uberdev_dispatch_prepare_tmp_target >/dev/null 2>&1; then
+        local sc_tmp
+        sc_tmp="$(mktemp "${sc}.XXXXXXXX")" 2>/dev/null || sc_tmp=""
+        if [ -n "$sc_tmp" ]; then
+          if awk -v ts="$ts" '
+            /^barrier_start_ts=/ { next }
+            { print }
+            END { printf "barrier_start_ts=%s\n", ts }
+          ' "$sc" > "$sc_tmp" 2>/dev/null; then
+            mv -f "$sc_tmp" "$sc" 2>/dev/null || rm -f "$sc_tmp" 2>/dev/null
+          else
+            rm -f "$sc_tmp" 2>/dev/null
+          fi
+        fi
+      fi
     fi
   fi
   return 0
@@ -1165,15 +1191,22 @@ _uberdev_goal_rebase_collision_chain() {
   local goal_id="$1" merged_pr="$2"
   _uberdev_goal_validate_id  "$goal_id"   || return 0
   _uberdev_goal_validate_int "$merged_pr" || return 0
+  # Use `gh pr diff --name-only` rather than `git diff --name-only origin/main..pr-N`:
+  # the `pr-N` refs do not exist in the local clone, so the prior `git diff`
+  # call failed silently (|| true) and the helper was a permanent no-op.
+  # `gh pr diff` resolves the PR via the GitHub API and prints the same
+  # path-set; failures still degrade gracefully (intersection stays empty,
+  # no audit, rc 0 — matches the spec's "best-effort, never halt the goal"
+  # contract).
   local merged_diff
-  merged_diff="$(git diff --name-only "origin/main..pr-$merged_pr" 2>/dev/null || true)"
+  merged_diff="$(gh pr diff "$merged_pr" --name-only 2>/dev/null || true)"
   [ -n "$merged_diff" ] || return 0
   local pr
   while IFS= read -r pr; do
     [ -n "$pr" ] || continue
     [ "$pr" = "$merged_pr" ] && continue
     local pr_diff intersection
-    pr_diff="$(git diff --name-only "origin/main..pr-$pr" 2>/dev/null || true)"
+    pr_diff="$(gh pr diff "$pr" --name-only 2>/dev/null || true)"
     intersection="$(comm -12 <(printf '%s\n' "$merged_diff" | sort -u) <(printf '%s\n' "$pr_diff" | sort -u))"
     if [ -n "$intersection" ]; then
       # Collision detected — refresh main and audit the transition.

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -1242,7 +1242,8 @@ _uberdev_goal_rebase_collision_chain() {
 
 # uberdev_goal_write_run_state
 #   Reads GOAL_ID, cycle, watch_start, overflow_count, overflow_detected,
-#   MAX_CYCLES, UBERDEV_RESOLVED_BACKEND, and the queue/active_issues arrays
+#   MAX_CYCLES, MAX_PARALLEL, BARRIER_TIMEOUT_S, barrier_start_ts,
+#   UBERDEV_RESOLVED_BACKEND, and the queue/active_issues arrays
 #   from the caller's shell; persists them to predictable, GOAL_ID-keyed
 #   sidecars under $UBERDEV_TMPDIR, plus a fixed-path goal-active-id.txt pointer
 #   so a fresh shell (no GOAL_ID in env/scalar) can discover the active GOAL_ID.
@@ -1322,7 +1323,8 @@ uberdev_goal_write_run_state() {
 #   across Bash calls, issue #171), it is bootstrapped from the fixed-path
 #   goal-active-id.txt pointer (content gated through _uberdev_goal_validate_id).
 #   On success: sets the GOAL_ID, cycle, watch_start, overflow_count,
-#   overflow_detected, MAX_CYCLES, UBERDEV_RESOLVED_BACKEND scalars, rehydrates
+#   overflow_detected, MAX_CYCLES, MAX_PARALLEL, BARRIER_TIMEOUT_S,
+#   barrier_start_ts, UBERDEV_RESOLVED_BACKEND scalars, rehydrates
 #   the queue/active_issues arrays, and EXPORTS UBERDEV_GOAL_ID + UBERDEV_TMPDIR
 #   (the env vars the uberdev_goal_* helpers + bare $UBERDEV_TMPDIR/... paths in
 #   the pipeline body depend on — see the export block at the function's end).

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -1179,7 +1179,7 @@ _uberdev_goal_rebase_collision_chain() {
       # Collision detected — refresh main and audit the transition.
       git fetch origin main 2>/dev/null || true
       uberdev_goal_audit goal_pr_transition \
-        "$(printf '{"pr":%s,"from":"green","to":"rebasing_for_collision","collision_files":"%s"}' \
+        "$(printf '{"pr":%s,"from":"green","collision_files":"%s"}' \
             "$pr" "$(printf '%s' "$intersection" | tr '\n' ',' | sed 's/,$//')")" 2>/dev/null || true
       # The actual rebase is delegated to the existing /merge rebase handler
       # on the next iteration; the audit + pre-fetched main is the contract.

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -25,6 +25,9 @@
 #   uberdev_goal_write_run_state               (env-driven)
 #   uberdev_goal_read_run_state                (env-driven)
 #   uberdev_goal_cleanup_run_state             (env-driven)
+#   uberdev_goal_register_batch_pr             GOAL_ID PR ISSUE   (issue #211)
+#   uberdev_goal_batch_all_terminal            GOAL_ID            (issue #211)
+#   uberdev_goal_batch_unblock_wait_clear      GOAL_ID            (issue #211)
 # Internal:
 #   _uberdev_goal_validate_int             N
 #   _uberdev_goal_validate_id              GOAL_ID
@@ -40,6 +43,9 @@
 #   _uberdev_goal_dispatch_review_pr       PR_NUM
 #   _uberdev_goal_dispatch_merge           PR_NUM
 #   _uberdev_goal_check_unblock            HELD_PR_NUM
+#   _uberdev_goal_set_batch_terminal_state GOAL_ID PR STATE       (issue #211)
+#   _uberdev_goal_batch_green_prs_ordered  GOAL_ID                (issue #211)
+#   _uberdev_goal_rebase_collision_chain   GOAL_ID JUST_MERGED_PR (issue #211)
 # External imports:
 #   - lib/dispatch.sh :: _uberdev_dispatch_prepare_tmp_target — REQUIRED by
 #     uberdev_goal_write_run_state, which reuses this #155 TOCTOU-safe target-prep
@@ -298,7 +304,7 @@ uberdev_goal_state_init() {
   # passes the mkdir -p above (the dir already exists) yet cannot accept new
   # files; the bare `: > "$f"` writes used to fail one-by-one with raw
   # "Permission denied" noise and a confusing partial-state. Fail fast on the
-  # first unwritable file with a clean diagnostic. The 7 state files:
+  # first unwritable file with a clean diagnostic. The 8 state files:
   #   jsonl                  — per-goal audit stream
   #   pr-states.tsv          — PR state-machine transitions
   #   issue-states.tsv       — issue state-machine transitions
@@ -308,6 +314,8 @@ uberdev_goal_state_init() {
   #                            bounds Phase 2b's stale|missing graced re-dispatch arm)
   #   held-audits.tsv        — last re-review audit consumed per held PR (2e);
   #                            latest row per pr wins (get_last_held_audit tail)
+  #   batch-prs.tsv          — issue #211 batch registry (one row per dispatched
+  #                            PR; cols: pr<TAB>issue<TAB>dispatch_ts<TAB>terminal_state)
   local f
   for f in "$tmpdir/goal-$goal_id.jsonl" \
            "$tmpdir/goal-$goal_id-pr-states.tsv" \
@@ -315,7 +323,8 @@ uberdev_goal_state_init() {
            "$tmpdir/goal-$goal_id-fingerprints.tsv" \
            "$tmpdir/goal-$goal_id-merge-attempts.tsv" \
            "$tmpdir/goal-$goal_id-review-pr-attempts.tsv" \
-           "$tmpdir/goal-$goal_id-held-audits.tsv"; do
+           "$tmpdir/goal-$goal_id-held-audits.tsv" \
+           "$tmpdir/goal-$goal_id-batch-prs.tsv"; do
     if ! : > "$f"; then
       printf 'goal-state: cannot create state file %s (unwritable UBERDEV_TMPDIR?)\n' "$f" >&2
       return 1
@@ -771,6 +780,133 @@ uberdev_goal_read_merge_result() {
 }
 
 # ---------------------------------------------------------------------------
+# Batch registry + barrier helpers (issue #211).
+# The batch registry tracks every PR /goal dispatches inside a single cycle so
+# Phase 2c can decide when to enter the merge barrier (all_terminal predicate)
+# and when to exit it (unblock_wait_clear predicate). Three public helpers +
+# three internal helpers + run-state SSOT updates form the SSOT for Phase 1
+# (register on dispatch) and Phase 2c (poll predicates, sequential merge).
+# Atomic writes via the #155 TOCTOU-safe target-prep helper (same primitive
+# uberdev_goal_write_run_state uses); the lib hard-depends on dispatch.sh
+# being sourced first by the goal-pipeline body (a `command -v` preflight
+# in register_batch_pr fails loud with rc=4 if the dep is missing).
+# ---------------------------------------------------------------------------
+
+# uberdev_goal_register_batch_pr GOAL_ID PR ISSUE
+# Append a row to goal-<id>-batch-prs.tsv with terminal_state=PENDING.
+# On the first registration of the cycle, also seed barrier_start_ts into
+# the run-state sidecar (best-effort; the next uberdev_goal_write_run_state
+# call atomically rewrites it).
+# rc 0 on success; rc 1 validation; rc 3 atomic-write; rc 4 missing dispatch lib.
+uberdev_goal_register_batch_pr() {
+  local goal_id="$1" pr="$2" issue="$3"
+  _uberdev_goal_validate_id  "$goal_id" || return 1
+  _uberdev_goal_validate_int "$pr"      || return 1
+  _uberdev_goal_validate_int "$issue"   || return 1
+  if ! command -v _uberdev_dispatch_prepare_tmp_target >/dev/null 2>&1; then
+    printf 'goal-state: uberdev_goal_register_batch_pr requires lib/dispatch.sh sourced first\n' >&2
+    return 4
+  fi
+  local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  local tsv="$tmpdir/goal-$goal_id-batch-prs.tsv"
+  local ts; ts="$(_uberdev_goal_now_secs)"
+  # First-registration seed: if registry is empty, seed barrier_start_ts.
+  local first=0
+  if [ ! -s "$tsv" ]; then first=1; fi
+  # Atomic append: read existing FIRST (the #155 prepare_tmp_target call below
+  # rm+truncates its target, so reading after prepare returns an empty file),
+  # write merged content into a fresh sibling, then atomic mv onto the prepared
+  # 0600-owned target. The prepare call still provides the TOCTOU-safe target
+  # guard (symlink reject + EUID-owner check + 0600 noclobber-create) — the
+  # mv -f then replaces the prepared empty target with the merged content in
+  # one filesystem syscall.
+  local tmp existing
+  existing=""
+  [ -r "$tsv" ] && existing="$(cat "$tsv")"
+  _uberdev_dispatch_prepare_tmp_target "$tsv" 0 "goal" || return 3
+  tmp="$(mktemp "${tsv}.XXXXXXXX")" || return 3
+  if [ -n "$existing" ]; then
+    printf '%s\n%s\t%s\t%s\tPENDING\n' "$existing" "$pr" "$issue" "$ts" > "$tmp" || { rm -f "$tmp"; return 3; }
+  else
+    printf '%s\t%s\t%s\tPENDING\n' "$pr" "$issue" "$ts" > "$tmp" || { rm -f "$tmp"; return 3; }
+  fi
+  mv -f "$tmp" "$tsv" || { rm -f "$tmp"; return 3; }
+  # Best-effort seed barrier_start_ts on first registration. The `>>` append
+  # below is intentionally non-atomic — the next uberdev_goal_write_run_state
+  # call atomically rewrites the sidecar from the in-memory scalar. Per the
+  # spec's "best effort; never blocks registration" contract, registration
+  # rc=0 even if the sidecar seed write fails.
+  if [ "$first" = "1" ]; then
+    local sc="$tmpdir/goal-$goal_id-runstate"
+    if [ -r "$sc" ] && ! grep -q '^barrier_start_ts=' "$sc"; then
+      printf 'barrier_start_ts=%s\n' "$ts" >> "$sc" 2>/dev/null || true
+    fi
+  fi
+  return 0
+}
+
+# uberdev_goal_batch_all_terminal GOAL_ID
+# rc 0 iff registry is non-empty and every row's terminal_state ∈
+# {GREEN,HELD,MERGE_FAILED,MERGED}. Empty registry returns rc 1. PENDING
+# anywhere returns rc 1. Pure read; no gh calls.
+uberdev_goal_batch_all_terminal() {
+  local goal_id="$1"
+  _uberdev_goal_validate_id "$goal_id" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  local tsv="$tmpdir/goal-$goal_id-batch-prs.tsv"
+  [ -r "$tsv" ] && [ -s "$tsv" ] || return 1
+  local _pr _issue _ts state
+  while IFS=$'\t' read -r _pr _issue _ts state; do
+    [ -n "$state" ] || continue
+    case "$state" in
+      GREEN|HELD|MERGE_FAILED|MERGED) : ;;
+      *) return 1 ;;
+    esac
+  done < "$tsv"
+  return 0
+}
+
+# uberdev_goal_batch_unblock_wait_clear GOAL_ID
+# rc 0 iff every HELD row has either NO unblock-issue OR (unblock-issue closed
+# AND PR-trust-label review-pr:green present). The unblock-issue id is inferred
+# from the PR body's `Blocks: #N` line (body capped at 64 KiB per R1/T1).
+# Pure read of label/issue state. Stale or 404 label/issue data is treated as
+# "still waiting" (rc 1) per spec B11 — never assume CLOSED on a gh failure.
+uberdev_goal_batch_unblock_wait_clear() {
+  local goal_id="$1"
+  _uberdev_goal_validate_id "$goal_id" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  local tsv="$tmpdir/goal-$goal_id-batch-prs.tsv"
+  [ -r "$tsv" ] && [ -s "$tsv" ] || return 0   # empty registry → trivially clear
+  local pr issue _ts state line
+  while IFS=$'\t' read -r pr issue _ts state; do
+    [ -n "$state" ] || continue
+    [ "$state" = "HELD" ] || continue
+    # Fetch PR body (capped at 64 KiB) and look for Blocks: #N.
+    local body blocking_issue
+    body="$(gh pr view "$pr" --json body --jq .body 2>/dev/null | head -c "${_UBERDEV_GOAL_BODY_CAP:-65536}")" || return 1
+    blocking_issue=""
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^Blocks:\ \#([0-9]+)$ ]]; then
+        blocking_issue="${BASH_REMATCH[1]}"
+        break
+      fi
+    done <<< "$body"
+    # No unblock-issue → this HELD PR doesn't gate the barrier.
+    [ -n "$blocking_issue" ] || continue
+    # Verify issue is CLOSED.
+    local issue_state
+    issue_state="$(gh issue view "$blocking_issue" --json state --jq .state 2>/dev/null)" || return 1
+    [ "$issue_state" = "CLOSED" ] || return 1
+    # Verify trust label review-pr:green is present.
+    local has_green
+    has_green="$(gh pr view "$pr" --json labels --jq '.labels[].name' 2>/dev/null | grep -c '^review-pr:green$' || true)"
+    [ "$has_green" -ge 1 ] || return 1
+  done < "$tsv"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # Internal dispatch + unblock helpers (depend on lib/dispatch.sh's
 # uberdev_dispatch_one — sourced by the goal-pipeline SKILL.md, not here).
 # ---------------------------------------------------------------------------
@@ -948,6 +1084,110 @@ _uberdev_goal_check_unblock() {
   fi
 }
 
+# _uberdev_goal_set_batch_terminal_state GOAL_ID PR STATE
+# Rewrite the PR's row in goal-<id>-batch-prs.tsv with the new terminal_state.
+# Atomic-write via _uberdev_dispatch_prepare_tmp_target + mktemp + mv -f
+# (preserves all other rows). Refuses to silently insert a new row for an
+# unknown PR — that would let a typo masquerade as a state change.
+# rc 0 on success; rc 1 validation / PR-not-in-registry; rc 3 atomic-write;
+# rc 4 missing dispatch lib.
+_uberdev_goal_set_batch_terminal_state() {
+  local goal_id="$1" pr="$2" state="$3"
+  _uberdev_goal_validate_id  "$goal_id" || return 1
+  _uberdev_goal_validate_int "$pr"      || return 1
+  case "$state" in
+    GREEN|HELD|MERGE_FAILED|MERGED|PENDING) : ;;
+    *) printf 'goal-state: invalid batch terminal state: %s\n' "$state" >&2; return 1 ;;
+  esac
+  if ! command -v _uberdev_dispatch_prepare_tmp_target >/dev/null 2>&1; then
+    return 4
+  fi
+  local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  local tsv="$tmpdir/goal-$goal_id-batch-prs.tsv"
+  [ -r "$tsv" ] || return 1
+  # Read existing TSV into memory BEFORE preparing the target (the #155 prepare
+  # helper rm+truncates its target, so a read after prepare would yield empty —
+  # see register_batch_pr for the same ordering rationale). The mv -f below
+  # replaces the prepared empty target with the rewritten content atomically.
+  local existing
+  existing="$(cat "$tsv")"
+  _uberdev_dispatch_prepare_tmp_target "$tsv" 0 "goal" || return 3
+  local tmp
+  tmp="$(mktemp "${tsv}.XXXXXXXX")" || return 3
+  # Rewrite the row whose first column == $pr, preserving all other rows.
+  local row_pr row_issue row_ts row_state found=0
+  while IFS=$'\t' read -r row_pr row_issue row_ts row_state; do
+    [ -n "$row_pr" ] || continue
+    if [ "$row_pr" = "$pr" ]; then
+      printf '%s\t%s\t%s\t%s\n' "$row_pr" "$row_issue" "$row_ts" "$state" >> "$tmp"
+      found=1
+    else
+      printf '%s\t%s\t%s\t%s\n' "$row_pr" "$row_issue" "$row_ts" "$row_state" >> "$tmp"
+    fi
+  done <<< "$existing"
+  if [ "$found" = "0" ]; then
+    rm -f "$tmp"
+    # Restore the original content since we refused the insert.
+    printf '%s' "$existing" > "$tsv" 2>/dev/null || true
+    return 1   # PR not in registry; refuse silent insert
+  fi
+  mv -f "$tmp" "$tsv" || { rm -f "$tmp"; return 3; }
+  return 0
+}
+
+# _uberdev_goal_batch_green_prs_ordered GOAL_ID
+# Emit PR numbers (one per line) whose terminal_state=GREEN, sorted numerically
+# ascending (`sort -n`). Phase 2c sequential-merge feeds this ordered list into
+# /merge so the lowest-numbered green PR lands first and downstream PRs rebase
+# onto its fresh main. rc 0 with empty stdout when no GREEN rows exist.
+_uberdev_goal_batch_green_prs_ordered() {
+  local goal_id="$1"
+  _uberdev_goal_validate_id "$goal_id" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  local tsv="$tmpdir/goal-$goal_id-batch-prs.tsv"
+  [ -r "$tsv" ] && [ -s "$tsv" ] || return 0
+  local pr _issue _ts state
+  while IFS=$'\t' read -r pr _issue _ts state; do
+    [ "$state" = "GREEN" ] && printf '%s\n' "$pr"
+  done < "$tsv" | sort -n
+}
+
+# _uberdev_goal_rebase_collision_chain GOAL_ID JUST_MERGED_PR
+# For each remaining GREEN PR in the batch, intersect its file-diff with the
+# just-merged PR's file-diff; on non-empty intersection, fetch fresh
+# origin/main and emit a goal_pr_transition audit event tagged
+# collision_files=<csv>. The actual rebase is delegated to the existing
+# /merge rebase handler on the next iteration — this helper's job is to
+# pre-fetch main and surface the collision in the audit stream so the next
+# /merge dispatch picks up the fresh base. rc 0 always (best-effort —
+# collision detection must never halt the goal).
+_uberdev_goal_rebase_collision_chain() {
+  local goal_id="$1" merged_pr="$2"
+  _uberdev_goal_validate_id  "$goal_id"   || return 0
+  _uberdev_goal_validate_int "$merged_pr" || return 0
+  local merged_diff
+  merged_diff="$(git diff --name-only "origin/main..pr-$merged_pr" 2>/dev/null || true)"
+  [ -n "$merged_diff" ] || return 0
+  local pr
+  while IFS= read -r pr; do
+    [ -n "$pr" ] || continue
+    [ "$pr" = "$merged_pr" ] && continue
+    local pr_diff intersection
+    pr_diff="$(git diff --name-only "origin/main..pr-$pr" 2>/dev/null || true)"
+    intersection="$(comm -12 <(printf '%s\n' "$merged_diff" | sort -u) <(printf '%s\n' "$pr_diff" | sort -u))"
+    if [ -n "$intersection" ]; then
+      # Collision detected — refresh main and audit the transition.
+      git fetch origin main 2>/dev/null || true
+      uberdev_goal_audit goal_pr_transition \
+        "$(printf '{"pr":%s,"from":"green","to":"rebasing_for_collision","collision_files":"%s"}' \
+            "$pr" "$(printf '%s' "$intersection" | tr '\n' ',' | sed 's/,$//')")" 2>/dev/null || true
+      # The actual rebase is delegated to the existing /merge rebase handler
+      # on the next iteration; the audit + pre-fetched main is the contract.
+    fi
+  done < <(_uberdev_goal_batch_green_prs_ordered "$goal_id")
+  return 0
+}
+
 # ---------------------------------------------------------------------------
 # Run-state sidecar (issue #171): persist the GOAL_ID pointer + loop
 # accumulators so they survive fresh-shell Bash boundaries. KEY=value text,
@@ -987,9 +1227,10 @@ uberdev_goal_write_run_state() {
   _uberdev_dispatch_prepare_tmp_target "$sc" 0 "goal" || return 3
   local tmp _filtered aid
   tmp="$(mktemp "${sc}.XXXXXXXX")" || return 3
-  printf 'GOAL_ID=%s\ncycle=%s\nwatch_start=%s\noverflow_count=%s\noverflow_detected=%s\nMAX_CYCLES=%s\nUBERDEV_RESOLVED_BACKEND=%s\n' \
+  printf 'GOAL_ID=%s\ncycle=%s\nwatch_start=%s\noverflow_count=%s\noverflow_detected=%s\nMAX_CYCLES=%s\nUBERDEV_RESOLVED_BACKEND=%s\nMAX_PARALLEL=%s\nBARRIER_TIMEOUT_S=%s\nbarrier_start_ts=%s\n' \
     "$GOAL_ID" "${cycle:-0}" "${watch_start:-0}" "${overflow_count:-0}" \
-    "${overflow_detected:-0}" "${MAX_CYCLES:-0}" "${UBERDEV_RESOLVED_BACKEND:-}" > "$tmp"
+    "${overflow_detected:-0}" "${MAX_CYCLES:-0}" "${UBERDEV_RESOLVED_BACKEND:-}" \
+    "${MAX_PARALLEL:-0}" "${BARRIER_TIMEOUT_S:-0}" "${barrier_start_ts:-0}" > "$tmp"
   mv -f "$tmp" "$sc" || { rm -f "$tmp"; return 3; }
 
   # Array sidecars: one int per line, no IFS-mutating joins. Capture first
@@ -1072,6 +1313,9 @@ uberdev_goal_read_run_state() {
       overflow_count)    _uberdev_goal_validate_int "$v" && overflow_count="$v" ;;
       overflow_detected) _uberdev_goal_validate_int "$v" && overflow_detected="$v" ;;
       MAX_CYCLES)        _uberdev_goal_validate_int "$v" && MAX_CYCLES="$v" ;;
+      MAX_PARALLEL)      _uberdev_goal_validate_int "$v" && MAX_PARALLEL="$v" ;;
+      BARRIER_TIMEOUT_S) _uberdev_goal_validate_int "$v" && BARRIER_TIMEOUT_S="$v" ;;
+      barrier_start_ts)  _uberdev_goal_validate_int "$v" && barrier_start_ts="$v" ;;
       UBERDEV_RESOLVED_BACKEND)
         case "$v" in claude-bg|wezterm|background) UBERDEV_RESOLVED_BACKEND="$v" ;; esac ;;
       *) : ;;   # reject unknown keys (allowlist only)
@@ -1122,7 +1366,7 @@ uberdev_goal_cleanup_run_state() {
   local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
   _uberdev_goal_validate_id "${GOAL_ID:-}" || return 0
   local sc="$tmpdir/goal-$GOAL_ID-runstate"
-  rm -f "$sc" "${sc}.queue" "${sc}.active" 2>/dev/null
+  rm -f "$sc" "${sc}.queue" "${sc}.active" "$tmpdir/goal-$GOAL_ID-batch-prs.tsv" 2>/dev/null
   # Remove the fixed-path pointer only if it still names THIS goal, so a
   # concurrent goal's pointer is never clobbered.
   local aid="$tmpdir/goal-active-id.txt"

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -909,12 +909,18 @@ uberdev_goal_batch_unblock_wait_clear() {
     [ -n "$state" ] || continue
     [ "$state" = "HELD" ] || continue
     # Fetch PR body (capped at 64 KiB) and look for Blocks: #N.
-    local body blocking_issue
-    body="$(gh pr view "$pr" --json body --jq .body 2>/dev/null | head -c "${_UBERDEV_GOAL_BODY_CAP:-65536}")" || return 1
+    # F17 simplify-lens: reuse the centralized helpers
+    # _uberdev_goal_fetch_pr_body + _uberdev_goal_parse_blocks_line (same
+    # primitives used by sibling _uberdev_goal_check_unblock); the cap +
+    # ReDoS-safe anchored regex + numeric re-validation now flow from a
+    # single source of truth.
+    local body blocking_issue n
+    body="$(_uberdev_goal_fetch_pr_body "$pr")"
     blocking_issue=""
     while IFS= read -r line; do
-      if [[ "$line" =~ ^Blocks:\ \#([0-9]+)$ ]]; then
-        blocking_issue="${BASH_REMATCH[1]}"
+      n="$(_uberdev_goal_parse_blocks_line "$line")"
+      if [ -n "$n" ]; then
+        blocking_issue="$n"
         break
       fi
     done <<< "$body"
@@ -1201,13 +1207,18 @@ _uberdev_goal_rebase_collision_chain() {
   local merged_diff
   merged_diff="$(gh pr diff "$merged_pr" --name-only 2>/dev/null || true)"
   [ -n "$merged_diff" ] || return 0
+  # F17 simplify-lens: hoist the sort of $merged_diff above the inner loop;
+  # comm -12 cares only about set contents, not iteration count, so this
+  # saves one `sort -u` per remaining-PR iteration.
+  local merged_sorted
+  merged_sorted="$(printf '%s\n' "$merged_diff" | sort -u)"
   local pr
   while IFS= read -r pr; do
     [ -n "$pr" ] || continue
     [ "$pr" = "$merged_pr" ] && continue
     local pr_diff intersection
     pr_diff="$(gh pr diff "$pr" --name-only 2>/dev/null || true)"
-    intersection="$(comm -12 <(printf '%s\n' "$merged_diff" | sort -u) <(printf '%s\n' "$pr_diff" | sort -u))"
+    intersection="$(comm -12 <(printf '%s\n' "$merged_sorted") <(printf '%s\n' "$pr_diff" | sort -u))"
     if [ -n "$intersection" ]; then
       # Collision detected — refresh main and audit the transition.
       git fetch origin main 2>/dev/null || true

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -822,7 +822,7 @@ uberdev_goal_register_batch_pr() {
   # one filesystem syscall.
   local tmp existing
   existing=""
-  [ -r "$tsv" ] && existing="$(cat "$tsv")"
+  [ -r "$tsv" ] && existing="$(<"$tsv")"
   _uberdev_dispatch_prepare_tmp_target "$tsv" 0 "goal" || return 3
   tmp="$(mktemp "${tsv}.XXXXXXXX")" || return 3
   if [ -n "$existing" ]; then
@@ -851,19 +851,17 @@ uberdev_goal_register_batch_pr() {
   if [ "$first" = "1" ]; then
     local sc="$tmpdir/goal-$goal_id-runstate"
     if [ -r "$sc" ] && ! grep -qE '^barrier_start_ts=[1-9][0-9]*$' "$sc"; then
-      if command -v _uberdev_dispatch_prepare_tmp_target >/dev/null 2>&1; then
-        local sc_tmp
-        sc_tmp="$(mktemp "${sc}.XXXXXXXX")" 2>/dev/null || sc_tmp=""
-        if [ -n "$sc_tmp" ]; then
-          if awk -v ts="$ts" '
-            /^barrier_start_ts=/ { next }
-            { print }
-            END { printf "barrier_start_ts=%s\n", ts }
-          ' "$sc" > "$sc_tmp" 2>/dev/null; then
-            mv -f "$sc_tmp" "$sc" 2>/dev/null || rm -f "$sc_tmp" 2>/dev/null
-          else
-            rm -f "$sc_tmp" 2>/dev/null
-          fi
+      local sc_tmp
+      sc_tmp="$(mktemp "${sc}.XXXXXXXX")" 2>/dev/null || sc_tmp=""
+      if [ -n "$sc_tmp" ]; then
+        if awk -v ts="$ts" '
+          /^barrier_start_ts=/ { next }
+          { print }
+          END { printf "barrier_start_ts=%s\n", ts }
+        ' "$sc" > "$sc_tmp" 2>/dev/null; then
+          mv -f "$sc_tmp" "$sc" 2>/dev/null || rm -f "$sc_tmp" 2>/dev/null
+        else
+          rm -f "$sc_tmp" 2>/dev/null
         fi
       fi
     fi
@@ -932,8 +930,8 @@ uberdev_goal_batch_unblock_wait_clear() {
     [ "$issue_state" = "CLOSED" ] || return 1
     # Verify trust label review-pr:green is present.
     local has_green
-    has_green="$(gh pr view "$pr" --json labels --jq '.labels[].name' 2>/dev/null | grep -c '^review-pr:green$' || true)"
-    [ "$has_green" -ge 1 ] || return 1
+    has_green="$(gh pr view "$pr" --json labels --jq '[.labels[].name | select(. == "review-pr:green")] | length' 2>/dev/null)"
+    [ "${has_green:-0}" -ge 1 ] || return 1
   done < "$tsv"
   return 0
 }
@@ -1142,7 +1140,7 @@ _uberdev_goal_set_batch_terminal_state() {
   # see register_batch_pr for the same ordering rationale). The mv -f below
   # replaces the prepared empty target with the rewritten content atomically.
   local existing
-  existing="$(cat "$tsv")"
+  existing="$(<"$tsv")"
   _uberdev_dispatch_prepare_tmp_target "$tsv" 0 "goal" || return 3
   local tmp
   tmp="$(mktemp "${tsv}.XXXXXXXX")" || return 3

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -507,9 +507,7 @@ while true; do
           # Force-refresh main + rebase any remaining batch PRs that share
           # manifest paths so the next iteration's merge sees the just-landed
           # commit (collision-chain serialization, R5).
-          _uberdev_goal_rebase_collision_chain "$GOAL_ID" "$pr" \
-            || printf 'goal-pipeline: rebase_collision_chain failed for PR %s (rc=%s); continuing\n' \
-               "$pr" "$?" >&2
+          _uberdev_goal_rebase_collision_chain "$GOAL_ID" "$pr"
         else
           printf 'goal-pipeline: _uberdev_goal_dispatch_merge failed for PR %s; staying in green for next-cycle retry\n' \
             "$pr" >&2

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -23,6 +23,8 @@ GOAL_ISSUE_STATE_ENUM='input|solving|pr-pushed|resolved|failed'
 TRUST_SIGNAL_ENUM='green|yellow|red|stale|missing'
 GOAL_MERGE_RESULT_ENUM='success|conflict|hook_failed|missing'
 _UBERDEV_GOAL_DEFAULT_MAX_CYCLES=5
+_UBERDEV_GOAL_DEFAULT_MAX_PARALLEL=3
+_UBERDEV_GOAL_DEFAULT_BARRIER_TIMEOUT_S=14400
 _UBERDEV_GOAL_POLL_SECS=60
 _UBERDEV_GOAL_STUCK_SECS=14400         # 4h
 _UBERDEV_GOAL_MAX_MERGE_ATTEMPTS=3
@@ -67,15 +69,19 @@ Notes on the enums:
    ```bash
    queue=()
    max_cycles_cli=""
+   max_parallel_cli=""
+   barrier_timeout_cli=""
    only_mine=0
    dry_run=0
    backend_cli=""
    for tok in $ARGUMENTS; do
      case "$tok" in
-       --max-cycles=*) max_cycles_cli="${tok#--max-cycles=}" ;;
-       --only-mine)    only_mine=1 ;;
-       --dry-run)      dry_run=1 ;;
-       --backend=*)    backend_cli="${tok#--backend=}" ;;
+       --max-cycles=*)      max_cycles_cli="${tok#--max-cycles=}" ;;
+       --max-parallel=*)    max_parallel_cli="${tok#--max-parallel=}" ;;
+       --barrier-timeout=*) barrier_timeout_cli="${tok#--barrier-timeout=}" ;;
+       --only-mine)         only_mine=1 ;;
+       --dry-run)           dry_run=1 ;;
+       --backend=*)         backend_cli="${tok#--backend=}" ;;
        *) [[ "$tok" =~ ^[0-9]+$ ]] && queue+=("$tok") ;;
      esac
    done
@@ -97,6 +103,14 @@ Notes on the enums:
    [ -r "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh" ] && . "${CLAUDE_PLUGIN_ROOT}/lib/config-read.sh"
    MAX_CYCLES="$(UBERDEV_GOAL_MAX_CYCLES="${max_cycles_cli:-${UBERDEV_GOAL_MAX_CYCLES:-}}" \
      uberdev_read_int_in_range goal.max_cycles UBERDEV_GOAL_MAX_CYCLES 1 20 "$_UBERDEV_GOAL_DEFAULT_MAX_CYCLES")"
+
+   MAX_PARALLEL="$(UBERDEV_GOAL_MAX_PARALLEL="${max_parallel_cli:-${UBERDEV_GOAL_MAX_PARALLEL:-}}" \
+     uberdev_read_int_in_range goal.max_parallel UBERDEV_GOAL_MAX_PARALLEL 1 10 \
+     "$_UBERDEV_GOAL_DEFAULT_MAX_PARALLEL")"
+
+   BARRIER_TIMEOUT_S="$(UBERDEV_GOAL_BARRIER_TIMEOUT_S="${barrier_timeout_cli:-${UBERDEV_GOAL_BARRIER_TIMEOUT_S:-}}" \
+     uberdev_read_int_in_range goal.barrier_timeout_s UBERDEV_GOAL_BARRIER_TIMEOUT_S 60 86400 \
+     "$_UBERDEV_GOAL_DEFAULT_BARRIER_TIMEOUT_S")"
    ```
 
 4. **Source `lib/dispatch.sh`; call `uberdev_dispatch_preflight`** → sets `UBERDEV_RESOLVED_BACKEND` once for the whole run (D15). The resolved backend is forwarded to every `/turbo`, `/merge`, and `/review-pr` child dispatch in this run; it is NEVER re-resolved per cycle.
@@ -142,7 +156,23 @@ Notes on the enums:
    uberdev_goal_write_run_state || { echo "goal: failed to persist run-state" >&2; exit 3; }
    ```
 
-8. **If `--dry-run`: print planned cycle-1 dispatch list + watch-loop outline, exit 0** (D16, S9). The dry-run path is the audit/preview surface — no `gh` calls, no agent spawns, no merges, **no audit events emitted** (S9 — `goal_dispatched` must NOT fire on dry-run so the audit log only carries real runs). Emit the resolved `MAX_CYCLES`, the resolved `UBERDEV_RESOLVED_BACKEND`, the issue queue, and the planned audit events ("would emit goal_dispatched", "would dispatch /turbo for issues …", "would poll GitHub (gh pr list) for each issue's PR"), then exit 0 cleanly. This step runs BEFORE the real `goal_dispatched` emit in step 9 — order matters.
+8. **If `--dry-run`: print planned cycle-1 dispatch list + watch-loop outline, exit 0** (D16, S9). The dry-run path is the audit/preview surface — no `gh` calls, no agent spawns, no merges, **no audit events emitted** (S9 — `goal_dispatched` must NOT fire on dry-run so the audit log only carries real runs). Emit the resolved `MAX_CYCLES`, `MAX_PARALLEL`, `BARRIER_TIMEOUT_S`, the resolved `UBERDEV_RESOLVED_BACKEND`, the issue queue, and the planned audit events ("would emit goal_dispatched", "would dispatch /turbo for issues …", "would poll GitHub (gh pr list) for each issue's PR"), then exit 0 cleanly. This step runs BEFORE the real `goal_dispatched` emit in step 9 — order matters.
+
+   ```bash
+   if [ "$dry_run" = "1" ]; then
+     printf 'goal: dry-run preview (no agent spawn, no audit emit)\n'
+     printf '  MAX_CYCLES=%s\n' "$MAX_CYCLES"
+     printf '  MAX_PARALLEL=%s\n' "$MAX_PARALLEL"
+     printf '  BARRIER_TIMEOUT_S=%s\n' "$BARRIER_TIMEOUT_S"
+     printf '  backend=%s\n' "$UBERDEV_RESOLVED_BACKEND"
+     printf '  issues=%s\n' "${queue[*]}"
+     printf '  would emit goal_dispatched\n'
+     printf '  would dispatch /turbo for issues %s (cap=%s per cycle)\n' \
+       "${queue[*]}" "$MAX_PARALLEL"
+     printf '  would poll GitHub (gh pr list) for each issues PR\n'
+     exit 0
+   fi
+   ```
 
 9. **Emit `goal_dispatched` event** with `{goal_id, cycle: 0, issues, dry_run, backend}` payload (real runs only — dry-run exits in step 8 before reaching here). This is the audit anchor — `cycle: 0` distinguishes the initial dispatch from the Phase 1 per-cycle dispatch:
 
@@ -176,12 +206,26 @@ GOAL_ID="${UBERDEV_GOAL_ID:-${GOAL_ID:-}}"
 uberdev_goal_read_run_state || { echo "goal: cannot rehydrate run-state in Phase 1" >&2; exit 3; }
 uberdev_dispatch_resolve_env || exit 1   # re-derive backend/env (idempotent, D8); not persisted
 declare -a active_issues=()
+# #211 — per-cycle parallel dispatch cap. Issues beyond MAX_PARALLEL roll over
+# into remaining_queue, which becomes the next cycle's queue (flushed via
+# uberdev_goal_write_run_state at the end of this fence).
+dispatched_this_cycle=0
+remaining_queue=()
 for ISSUE_NUM in "${queue[@]}"; do
   current_state="$(awk -v i="$ISSUE_NUM" '{state[$1]=$2} END {print state[i]}' \
     "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
   case "$current_state" in
     solving|pr-pushed) continue ;;
   esac
+
+  # #211 — once the per-cycle cap is hit, defer every remaining eligible issue
+  # to the next cycle by appending to remaining_queue. This MUST come AFTER the
+  # already-dispatched skip-check above so re-entered/in-flight issues don't get
+  # spuriously rolled over.
+  if (( dispatched_this_cycle >= MAX_PARALLEL )); then
+    remaining_queue+=("$ISSUE_NUM")
+    continue
+  fi
 
   # Build the per-issue prompt via mktemp. The body is a single /uberdev:turbo
   # line; --turbo runs non-interactive (no gates — scoped relaxation §3 below)
@@ -203,6 +247,19 @@ for ISSUE_NUM in "${queue[@]}"; do
   if uberdev_dispatch_one "$ISSUE_NUM" "small" "$PROMPT_FILE"; then
     uberdev_goal_issue_state_transition "$GOAL_ID" "$ISSUE_NUM" input solving
     active_issues+=("$ISSUE_NUM")
+    dispatched_this_cycle=$(( dispatched_this_cycle + 1 ))
+    # #211 — register this issue in the batch-PR registry so Phase 2's
+    # barrier (uberdev_goal_batch_all_terminal) accounts for it. The PR
+    # number is NOT yet known at dispatch-time (the solver pushes the PR
+    # later); pr_number resolves at the first Phase 2 step 2c snapshot via
+    # uberdev_goal_find_pr_for_issue. Pass the empty pr_number here so the
+    # registry row exists keyed on issue; Phase 2 step 2c re-registers with
+    # the PR number on first visibility. Best-effort: warn-and-continue on
+    # rc != 0 so a transient registry write doesn't fail the whole cycle.
+    pr_number=""
+    uberdev_goal_register_batch_pr "$GOAL_ID" "$pr_number" "$ISSUE_NUM" \
+      || printf 'goal: register_batch_pr failed for PR=%s issue=%s (rc=%s); barrier may be incomplete this cycle\n' \
+         "$pr_number" "$ISSUE_NUM" "$?" >&2
   else
     rc=$?
     # D12 — claim_collision is a soft fail: another dispatcher (a teammate's
@@ -225,6 +282,12 @@ for ISSUE_NUM in "${queue[@]}"; do
     exit 1
   fi
 done
+
+# #211 — flush the rollover queue back into `queue` so the next cycle picks up
+# the issues that exceeded MAX_PARALLEL. Empty remaining_queue is the happy path
+# (queue fully drained this cycle); a non-empty rollover is the cap-saturation
+# case and is the SSOT for "more issues to dispatch next cycle".
+queue=("${remaining_queue[@]}")
 
 # #171 — flush the populated active_issues (+ rehydrated queue/scalars) so the
 # Phase 2 watch loop (a fresh shell) rehydrates the dispatched set. Without this,
@@ -371,28 +434,104 @@ while true; do
     esac
   done
 
-  # 2c. Dispatch /merge for any new GREEN PRs.
+  # 2c. Barrier-gated merge dispatch (issue #211).
+  # The previous per-PR `if green; then /merge` body is replaced by a two-
+  # predicate gate: ONLY dispatch /merge once (a) every PR in the batch is in
+  # a terminal state (GREEN | HELD | MERGE_FAILED | MERGED — barrier-terminal,
+  # NOT to be confused with the convergence-terminal set) AND (b) the unblock
+  # wait is clear (every blocking issue closed AND every blocked PR carries a
+  # `review-pr:green` trust label). Until both predicates hold the per-cycle
+  # batch sits at the merge barrier — preventing the multi-PR version-bump
+  # collision (the user_workflow_todo_queue memory + project_uberdev_goal_
+  # version_bump_collision capture). Sequential, PR-asc merge plus a
+  # collision-chain rebase keeps the manifest-touching PRs serialized.
+  #
   # B2 — only transition to `merging` on dispatch rc=0; a failed dispatch
   # (mktemp/prompt-write/session-refuse) leaves the PR in `green` for a
   # next-cycle retry (per-PR attempt counter, cap 3, bounds runaway retries).
+
+  # Snapshot every barrier-relevant PR's state into the batch registry. This
+  # is what feeds uberdev_goal_batch_all_terminal: rows tagged PENDING block
+  # the barrier; rows tagged GREEN/HELD/MERGE_FAILED/MERGED clear it. Call
+  # uberdev_goal_list_prs_in_state once per state (it takes a single state
+  # argument) and tag with the matching terminal enum.
   for pr in $(uberdev_goal_list_prs_in_state "$GOAL_ID" green); do
-    if uberdev_goal_pr_is_merged "$pr"; then
-      # Already merged (resume / human-merged) — finalize via step 2d without
-      # re-dispatching /merge against an already-landed PR.
-      uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" green merging
-      any_active=1
-      continue
-    fi
-    if uberdev_goal_should_automerge "$GOAL_ID" "$pr"; then
-      if _uberdev_goal_dispatch_merge "$pr"; then
+    _uberdev_goal_set_batch_terminal_state "$GOAL_ID" "$pr" GREEN \
+      || printf 'goal: set_batch_terminal_state(GREEN) failed for PR=%s (rc=%s); barrier may stall\n' "$pr" "$?" >&2
+  done
+  for pr in $(uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held; \
+              uberdev_goal_list_prs_in_state "$GOAL_ID" red-held); do
+    _uberdev_goal_set_batch_terminal_state "$GOAL_ID" "$pr" HELD \
+      || printf 'goal: set_batch_terminal_state(HELD) failed for PR=%s (rc=%s); barrier may stall\n' "$pr" "$?" >&2
+  done
+  for pr in $(uberdev_goal_list_prs_in_state "$GOAL_ID" merge-failed); do
+    _uberdev_goal_set_batch_terminal_state "$GOAL_ID" "$pr" MERGE_FAILED \
+      || printf 'goal: set_batch_terminal_state(MERGE_FAILED) failed for PR=%s (rc=%s); barrier may stall\n' "$pr" "$?" >&2
+  done
+  for pr in $(uberdev_goal_list_prs_in_state "$GOAL_ID" merged); do
+    _uberdev_goal_set_batch_terminal_state "$GOAL_ID" "$pr" MERGED \
+      || printf 'goal: set_batch_terminal_state(MERGED) failed for PR=%s (rc=%s); barrier may stall\n' "$pr" "$?" >&2
+  done
+
+  if uberdev_goal_batch_all_terminal "$GOAL_ID" && \
+     uberdev_goal_batch_unblock_wait_clear "$GOAL_ID"; then
+    # Both predicates clear — dispatch /merge for GREEN PRs in PR-number-
+    # ascending order. The collision-chain rebase forces a fresh main pull
+    # after each successful merge so the next PR in the chain rebases onto
+    # the just-landed commit before its own merge attempt. This is what
+    # serializes manifest-touching PRs (CHANGELOG.md, plugin.json,
+    # marketplace.json, README.md) — without it, parallel version-bump PRs
+    # silently auto-merge to the SAME vN+1 and the second PR's bump is
+    # eaten by git's identical-change auto-resolution (the
+    # project_uberdev_merge_version_collision memory).
+    for pr in $(_uberdev_goal_batch_green_prs_ordered "$GOAL_ID"); do
+      if uberdev_goal_pr_is_merged "$pr"; then
+        # Resume / human-merged — finalize via step 2d without re-dispatching
+        # /merge against an already-landed PR.
         uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" green merging
-      else
-        printf 'goal-pipeline: _uberdev_goal_dispatch_merge failed for PR %s; staying in green for next-cycle retry\n' \
-          "$pr" >&2
         any_active=1
+        continue
+      fi
+      if uberdev_goal_should_automerge "$GOAL_ID" "$pr"; then
+        if _uberdev_goal_dispatch_merge "$pr"; then
+          uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" green merging
+          # Force-refresh main + rebase any remaining batch PRs that share
+          # manifest paths so the next iteration's merge sees the just-landed
+          # commit (collision-chain serialization, R5).
+          _uberdev_goal_rebase_collision_chain "$GOAL_ID" "$pr" \
+            || printf 'goal-pipeline: rebase_collision_chain failed for PR %s (rc=%s); continuing\n' \
+               "$pr" "$?" >&2
+        else
+          printf 'goal-pipeline: _uberdev_goal_dispatch_merge failed for PR %s; staying in green for next-cycle retry\n' \
+            "$pr" >&2
+          any_active=1
+        fi
+      fi
+    done
+  else
+    # Barrier NOT clear yet — at least one PR is PENDING or the unblock-wait
+    # has unresolved blockers. Check the wall-clock circuit breaker against
+    # BARRIER_TIMEOUT_S (default 4h, configurable via --barrier-timeout=N /
+    # UBERDEV_GOAL_BARRIER_TIMEOUT_S / goal.barrier_timeout_s). The reason
+    # field reuses the existing stuck_loop enum — D5 keeps GOAL_CIRCUIT_
+    # BREAKER_REASONS closed; the phase=merge_barrier subfield distinguishes
+    # this from the goal-level 4h watch-loop stuck_loop.
+    if [ -n "${barrier_start_ts:-}" ] && [ "${barrier_start_ts:-0}" != "0" ]; then
+      now_secs="$(_uberdev_goal_now_secs)"
+      elapsed=$(( now_secs - barrier_start_ts ))
+      if (( elapsed >= BARRIER_TIMEOUT_S )); then
+        pending="$(awk -F'\t' '$4=="PENDING"{printf "%s,", $1}' \
+          "${UBERDEV_TMPDIR:-/tmp}/goal-${GOAL_ID}-batch-prs.tsv" 2>/dev/null \
+          | sed 's/,$//')"
+        uberdev_goal_audit goal_circuit_breaker \
+          "$(printf '{"reason":"stuck_loop","phase":"merge_barrier","elapsed_s":%s,"pending_prs":"%s"}' \
+             "$elapsed" "$pending")"
+        print_summary "$cycle"
+        exit 1
       fi
     fi
-  done
+    any_active=1
+  fi
 
   # 2d. Drive merging → merged. Completion is authoritative via GitHub
   # (`gh pr view <pr> --json state == MERGED`, issue #180 — the
@@ -514,6 +653,14 @@ while true; do
       green)
         uberdev_goal_pr_state_transition "$GOAL_ID" "$held_pr" "$held_current" green
         uberdev_goal_record_held_audit "$GOAL_ID" "$held_pr" "$new_audit"
+        # #211 — update the batch registry so the next pass's step 2c
+        # barrier sees this PR as GREEN (terminal-for-barrier) instead of
+        # PENDING/HELD. Without this, a held→green transition is invisible
+        # to uberdev_goal_batch_all_terminal and the barrier stalls until
+        # the wall-clock breaker fires.
+        _uberdev_goal_set_batch_terminal_state "$GOAL_ID" "$held_pr" GREEN \
+          || printf 'goal: set_batch_terminal_state(GREEN) failed for PR=%s (rc=%s); barrier may stall\n' \
+             "$held_pr" "$?" >&2
         # B1 — keep the watch loop alive for one more iteration so step 2c
         # (which runs ABOVE step 2e in cycle order) has a chance to pick this
         # freshly-green PR up on the next pass and dispatch /merge. Without

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -248,18 +248,14 @@ for ISSUE_NUM in "${queue[@]}"; do
     uberdev_goal_issue_state_transition "$GOAL_ID" "$ISSUE_NUM" input solving
     active_issues+=("$ISSUE_NUM")
     dispatched_this_cycle=$(( dispatched_this_cycle + 1 ))
-    # #211 — register this issue in the batch-PR registry so Phase 2's
-    # barrier (uberdev_goal_batch_all_terminal) accounts for it. The PR
-    # number is NOT yet known at dispatch-time (the solver pushes the PR
-    # later); pr_number resolves at the first Phase 2 step 2c snapshot via
-    # uberdev_goal_find_pr_for_issue. Pass the empty pr_number here so the
-    # registry row exists keyed on issue; Phase 2 step 2c re-registers with
-    # the PR number on first visibility. Best-effort: warn-and-continue on
-    # rc != 0 so a transient registry write doesn't fail the whole cycle.
-    pr_number=""
-    uberdev_goal_register_batch_pr "$GOAL_ID" "$pr_number" "$ISSUE_NUM" \
-      || printf 'goal: register_batch_pr failed for PR=%s issue=%s (rc=%s); barrier may be incomplete this cycle\n' \
-         "$pr_number" "$ISSUE_NUM" "$?" >&2
+    # #211 — Note: registration is deferred to Phase 2 step 2a once the PR
+    # number resolves. uberdev_goal_register_batch_pr requires a valid
+    # integer PR number (its _uberdev_goal_validate_int gate rejects empty
+    # strings), and the PR doesn't exist yet at dispatch-time (the solver
+    # pushes the PR later). Phase 2 step 2a calls
+    # uberdev_goal_find_pr_for_issue and, on first non-empty resolution,
+    # registers the PR into the batch-PR registry behind an idempotent
+    # TSV-lookup guard so the barrier accounts for it.
   else
     rc=$?
     # D12 — claim_collision is a soft fail: another dispatcher (a teammate's
@@ -345,6 +341,19 @@ while true; do
     case "$istate" in pr-pushed|resolved|failed) continue ;; esac
     pr_num="$(uberdev_goal_find_pr_for_issue "$issue")"
     if [ -n "$pr_num" ]; then
+      # #211 — register the PR into the batch-PR registry once it's resolved.
+      # Registration is deferred from Phase 1 (no PR number at dispatch-time)
+      # to here, the first point at which uberdev_goal_find_pr_for_issue
+      # returns a non-empty value. Idempotent guard: skip if a row for this
+      # PR already exists in the TSV, so subsequent passes (and repeat 2a
+      # resolutions in the same cycle) don't double-write. Best-effort:
+      # warn-and-continue on rc != 0 — a transient registry write must not
+      # fail the watch loop.
+      batch_tsv="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}/goal-${GOAL_ID}-batch-prs.tsv"
+      if [ ! -f "$batch_tsv" ] || ! awk -F'\t' -v p="$pr_num" '$1==p{found=1; exit} END{exit !found}' "$batch_tsv"; then
+        uberdev_goal_register_batch_pr "$GOAL_ID" "$pr_num" "$issue" \
+          || printf 'goal: register_batch_pr deferred-call failed for PR=%s issue=%s (rc=%s)\n' "$pr_num" "$issue" "$?" >&2
+      fi
       uberdev_goal_issue_state_transition "$GOAL_ID" "$issue" solving pr-pushed
       uberdev_goal_pr_state_transition "$GOAL_ID" "$pr_num" dispatched pushed-reviewing
       if uberdev_goal_pr_is_merged "$pr_num"; then

--- a/tests/config-override.test.sh
+++ b/tests/config-override.test.sh
@@ -490,6 +490,37 @@ EOF
   || fail "I7c: coexistence with deprecated keys broken"
 
 echo
+echo "== I8: goal-pipeline reads goal.max_parallel + goal.barrier_timeout_s via uberdev_read_int_in_range (#211 AC1) =="
+# The verbatim call shape is the test surface: an editor cannot widen the
+# range or drop the default without tripping these greps.
+GOAL_SKILL_PATH="$REPO_ROOT/plugins/uberdev/skills/goal-pipeline/SKILL.md"
+
+assert_grep_in "$GOAL_SKILL_PATH" \
+  'uberdev_read_int_in_range goal\.max_parallel UBERDEV_GOAL_MAX_PARALLEL 1 10' \
+  "I8.max-parallel-call-shape"
+assert_grep_in "$GOAL_SKILL_PATH" \
+  '_UBERDEV_GOAL_DEFAULT_MAX_PARALLEL=3' \
+  "I8.max-parallel-default-constant"
+
+assert_grep_in "$GOAL_SKILL_PATH" \
+  'uberdev_read_int_in_range goal\.barrier_timeout_s UBERDEV_GOAL_BARRIER_TIMEOUT_S 60 86400' \
+  "I8.barrier-timeout-call-shape"
+assert_grep_in "$GOAL_SKILL_PATH" \
+  '_UBERDEV_GOAL_DEFAULT_BARRIER_TIMEOUT_S=14400' \
+  "I8.barrier-timeout-default-constant"
+
+# Env-precedence pattern: the verbatim UBERDEV_GOAL_*=${*_cli:-${UBERDEV_GOAL_*:-}} guard
+# is the same shape Phase 0 uses for goal.max_cycles (line ~98) — a regression that
+# silently drops the CLI flag in favor of the env var would break /goal --max-parallel=N.
+assert_grep_in "$GOAL_SKILL_PATH" \
+  'UBERDEV_GOAL_MAX_PARALLEL="\$\{max_parallel_cli:-\$\{UBERDEV_GOAL_MAX_PARALLEL:-\}\}"' \
+  "I8.max-parallel-cli-env-precedence"
+assert_grep_in "$GOAL_SKILL_PATH" \
+  'UBERDEV_GOAL_BARRIER_TIMEOUT_S="\$\{barrier_timeout_cli:-\$\{UBERDEV_GOAL_BARRIER_TIMEOUT_S:-\}\}"' \
+  "I8.barrier-timeout-cli-env-precedence"
+
+
+echo
 echo "== U9: auto_review_on_merge config key (#89) =="
 
 # U9.1: default — neither env nor config sets the key -> 'false'

--- a/tests/goal-batch-barrier.test.sh
+++ b/tests/goal-batch-barrier.test.sh
@@ -146,7 +146,10 @@ bash --noprofile --norc -c '
 # ---------------------------------------------------------------------------
 echo "== B4: manifest-collision rebase helper exists =="
 assert_grep "$GOAL_LIB"   '^_uberdev_goal_rebase_collision_chain\(\)' "B4.helper-defined"
-assert_grep "$GOAL_LIB"   'git diff --name-only'                     "B4.path-set-intersection"
+# `gh pr diff` (NOT `git diff --name-only origin/main..pr-N` — local `pr-N`
+# refs don't exist in the clone, so the original `git diff` form was a silent
+# no-op).
+assert_grep "$GOAL_LIB"   'gh pr diff'                               "B4.path-set-intersection"
 assert_grep "$GOAL_LIB"   'git fetch origin main'                    "B4.fresh-main-fetch"
 
 # ---------------------------------------------------------------------------
@@ -179,6 +182,59 @@ echo "== B6: lib uses atomic writes for batch-prs.tsv (no >> appends) =="
 assert_no_grep "$GOAL_LIB" '>>[[:space:]]*[^[:space:]]*batch-prs\.tsv'   "B6.no-append-redirect-to-tsv"
 # Positive: the standard atomic-write triad is used (mktemp + mv -f).
 assert_grep "$GOAL_LIB" '_uberdev_dispatch_prepare_tmp_target'           "B6.uses-prepare-tmp-target-helper"
+
+# ---------------------------------------------------------------------------
+# B7 — barrier_start_ts seed survives write_run_state pre-population.
+# ---------------------------------------------------------------------------
+# Regression guard for the seed predicate: the previous `! grep -q
+# '^barrier_start_ts='` arm was FALSE whenever Phase 0 had already written
+# the run-state sidecar (the writer emits `barrier_start_ts=0` as a
+# placeholder), so the seed never fired and the wall-clock barrier breaker
+# (AC6 / D-211e) became dead code. Exercise the actual Phase 0 → register
+# ordering and assert the in-file value is non-zero and within seconds of
+# wall clock.
+echo "== B7: barrier_start_ts seed survives write_run_state pre-population =="
+(
+  . "$DISPATCH_LIB"
+  . "$GOAL_LIB"
+  uberdev_goal_state_init "$GOAL_ID-b7"   || { echo "B7.state-init FAIL"; exit 1; }
+  # Phase 0 step 7 ordering: write_run_state runs BEFORE any register_batch_pr.
+  GOAL_ID="$GOAL_ID-b7"
+  cycle=0
+  watch_start=$(_uberdev_goal_now_secs)
+  MAX_CYCLES=5
+  MAX_PARALLEL=3
+  BARRIER_TIMEOUT_S=14400
+  queue=()
+  active_issues=()
+  # barrier_start_ts intentionally UNSET — the writer's default arm
+  # (`${barrier_start_ts:-0}`) will pre-populate `barrier_start_ts=0`.
+  uberdev_goal_write_run_state || { echo "B7.write_run_state-pre-register FAIL"; exit 1; }
+  sc="${UBERDEV_TMPDIR}/goal-${GOAL_ID}-runstate"
+  pre_seed_line="$(grep '^barrier_start_ts=' "$sc" || true)"
+  [ "$pre_seed_line" = "barrier_start_ts=0" ] || {
+    echo "B7.precondition-placeholder-zero FAIL got '$pre_seed_line'"; exit 1;
+  }
+  # First registration — must promote the placeholder to a real epoch.
+  pre_ts=$(_uberdev_goal_now_secs)
+  uberdev_goal_register_batch_pr "$GOAL_ID" 700 90 || { echo "B7.register FAIL"; exit 1; }
+  post_ts=$(_uberdev_goal_now_secs)
+  seeded_line="$(grep '^barrier_start_ts=' "$sc" || true)"
+  seeded_value="${seeded_line#barrier_start_ts=}"
+  case "$seeded_value" in
+    ''|*[!0-9]*) echo "B7.seeded-non-integer FAIL got '$seeded_value'"; exit 1 ;;
+  esac
+  [ "$seeded_value" -gt 0 ] || { echo "B7.seeded-must-be-positive FAIL got '$seeded_value'"; exit 1; }
+  # Must be at most one barrier_start_ts= line (the awk rewrite drops the
+  # placeholder rather than duplicating it).
+  occurrences="$(grep -c '^barrier_start_ts=' "$sc" || true)"
+  [ "$occurrences" = "1" ] || { echo "B7.exactly-one-barrier-line FAIL got $occurrences" ; exit 1; }
+  # Within ±5s of wall clock (allow for slow CI hosts).
+  if [ "$seeded_value" -lt "$pre_ts" ] || [ "$seeded_value" -gt "$((post_ts + 5))" ]; then
+    echo "B7.seeded-not-near-now FAIL value=$seeded_value pre=$pre_ts post=$post_ts"; exit 1
+  fi
+  echo "B7 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B7 block exited non-zero"; }
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/goal-batch-barrier.test.sh
+++ b/tests/goal-batch-barrier.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# tests/goal-batch-barrier.test.sh — behavioral cross-shell tests for the
+# /goal parallel cap + merge barrier (issue #211).
+#
+# Covers: batch registry CRUD, all_terminal predicate truth table, unblock_wait
+# predicate dual condition, barrier_start_ts persist/rehydrate under
+# fresh-shell-with-cleared-env, manifest-collision sequential merge integration.
+#
+# Run under bash >= 4 (the lib being exercised hard-requires bash 4 via the
+# goal-pipeline preflight). zsh-incompatible; not invoked from solve-pipeline-zsh.test.sh.
+
+set -u
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Source the shared structural-assertion helpers (assert_count / assert_subagent_type / assert_in_section).
+# assert_grep / assert_no_grep are defined inline below — they are local helpers in every test file
+# that uses them (see merge-discovery-resilience.test.sh:75 for the canonical shape).
+source "$REPO_ROOT/tests/_lib_assert_structural.sh"
+GOAL_LIB="$REPO_ROOT/plugins/uberdev/lib/goal-state.sh"
+DISPATCH_LIB="$REPO_ROOT/plugins/uberdev/lib/dispatch.sh"
+
+# CLAUDE_PLUGIN_ROOT is referenced by the libs; export it for the sourced helpers.
+CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"
+export CLAUDE_PLUGIN_ROOT
+
+# Hard-fail early if the libs aren't present.
+for f in "$GOAL_LIB" "$DISPATCH_LIB"; do
+  if [ ! -r "$f" ]; then
+    printf 'FATAL: required file missing or unreadable: %s\n' "$f" >&2
+    exit 2
+  fi
+done
+
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+export UBERDEV_TMPDIR="$TEST_TMPDIR"
+export GOAL_ID="test-batch-barrier"
+
+PASS=0
+FAIL=0
+
+# --- Inline helpers ---------------------------------------------------------
+# Mirror the shape used by tests/merge-discovery-resilience.test.sh so the
+# RED→GREEN signal is uniform across the suite.
+
+assert_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file" 2>/dev/null; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        file:    $file"
+    echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_no_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file" 2>/dev/null; then
+    echo "  FAIL  $desc"
+    echo "        file:    $file"
+    echo "        pattern (must NOT appear): $pattern"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# B1 — batch registry CRUD (register, set-state, list-ordered, all-terminal).
+# ---------------------------------------------------------------------------
+echo "== B1: batch registry CRUD =="
+# Source the libs under bash explicitly.
+(
+  . "$DISPATCH_LIB"
+  . "$GOAL_LIB"
+  uberdev_goal_state_init "$GOAL_ID"  || { echo "B1.state-init FAIL"; exit 1; }
+  # Register three PRs.
+  uberdev_goal_register_batch_pr "$GOAL_ID" 100 41   || { echo "B1.register-100 FAIL"; exit 1; }
+  uberdev_goal_register_batch_pr "$GOAL_ID" 101 42   || { echo "B1.register-101 FAIL"; exit 1; }
+  uberdev_goal_register_batch_pr "$GOAL_ID" 102 43   || { echo "B1.register-102 FAIL"; exit 1; }
+  # All PENDING -> all_terminal must return 1.
+  if uberdev_goal_batch_all_terminal "$GOAL_ID"; then echo "B1.all-pending-must-be-non-terminal FAIL"; exit 1; fi
+  # Promote two of the three to GREEN.
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 100 GREEN || { echo "B1.set-100 FAIL"; exit 1; }
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 101 GREEN || { echo "B1.set-101 FAIL"; exit 1; }
+  # Still one PENDING -> all_terminal returns 1.
+  if uberdev_goal_batch_all_terminal "$GOAL_ID"; then echo "B1.partial-pending-must-fail FAIL"; exit 1; fi
+  # Promote last -> all_terminal returns 0.
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 102 MERGE_FAILED || { echo "B1.set-102 FAIL"; exit 1; }
+  if ! uberdev_goal_batch_all_terminal "$GOAL_ID"; then echo "B1.all-terminal-must-pass FAIL"; exit 1; fi
+  # Green-PRs ordered returns 100 101 (102 is MERGE_FAILED, excluded).
+  out="$(_uberdev_goal_batch_green_prs_ordered "$GOAL_ID" | tr '\n' ' ' | sed 's/  *$//')"
+  [ "$out" = "100 101" ] || { echo "B1.green-prs-ordered got '$out' want '100 101' FAIL"; exit 1; }
+  echo "B1 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B1 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B2 — unblock_wait predicate exists in lib.
+# ---------------------------------------------------------------------------
+echo "== B2: unblock_wait predicate exists in lib =="
+assert_grep "$GOAL_LIB" "^uberdev_goal_batch_unblock_wait_clear\(\)" "B2.predicate-defined"
+# Verify lib references both gating conditions (issue CLOSED + trust label review-pr:green).
+assert_grep "$GOAL_LIB" 'CLOSED'                                    "B2.closed-issue-check"
+assert_grep "$GOAL_LIB" 'review-pr:green'                           "B2.green-trust-label"
+
+# ---------------------------------------------------------------------------
+# B3 — barrier_start_ts persist/rehydrate under fresh-shell-with-cleared-env.
+# ---------------------------------------------------------------------------
+echo "== B3: barrier_start_ts persist/rehydrate (cleared-env) =="
+# Write run-state in one shell, read in a fresh shell with env STRIPPED.
+# This is the cross-shell trap from user memory project_uberdev_goal_runstate_crossshell_traps.md:
+# env-passing tests pass while the underlying re-export is broken.
+(
+  . "$DISPATCH_LIB"
+  . "$GOAL_LIB"
+  uberdev_goal_state_init "$GOAL_ID"
+  uberdev_goal_register_batch_pr "$GOAL_ID" 200 60   # seeds barrier_start_ts
+  cycle=1
+  watch_start=$(_uberdev_goal_now_secs)
+  MAX_CYCLES=5
+  MAX_PARALLEL=3
+  BARRIER_TIMEOUT_S=14400
+  queue=()
+  active_issues=()
+  uberdev_goal_write_run_state || exit 1
+) || { echo "B3.write FAIL"; FAIL=$((FAIL + 1)); }
+
+# Fresh shell, env cleared except UBERDEV_TMPDIR (which the bootstrap pointer needs).
+bash --noprofile --norc -c '
+  set -u
+  export UBERDEV_TMPDIR="'"$TEST_TMPDIR"'"
+  . "'"$DISPATCH_LIB"'"
+  . "'"$GOAL_LIB"'"
+  uberdev_goal_read_run_state || exit 1
+  [ -n "${barrier_start_ts:-}" ] || { echo "B3.barrier_start_ts-empty-after-rehydrate FAIL"; exit 1; }
+  [ -n "${MAX_PARALLEL:-}" ]      || { echo "B3.MAX_PARALLEL-empty-after-rehydrate FAIL"; exit 1; }
+  [ -n "${BARRIER_TIMEOUT_S:-}" ] || { echo "B3.BARRIER_TIMEOUT_S-empty-after-rehydrate FAIL"; exit 1; }
+  echo "B3 PASS"
+' || { FAIL=$((FAIL + 1)); echo "  FAIL  B3 fresh-shell rehydrate exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B4 — manifest-collision rebase helper exists.
+# ---------------------------------------------------------------------------
+echo "== B4: manifest-collision rebase helper exists =="
+assert_grep "$GOAL_LIB"   '^_uberdev_goal_rebase_collision_chain\(\)' "B4.helper-defined"
+assert_grep "$GOAL_LIB"   'git diff --name-only'                     "B4.path-set-intersection"
+assert_grep "$GOAL_LIB"   'git fetch origin main'                    "B4.fresh-main-fetch"
+
+# ---------------------------------------------------------------------------
+# B5 — collision chain sequences green PRs in ascending order.
+# ---------------------------------------------------------------------------
+echo "== B5: collision chain sequences green PRs in ascending order =="
+(
+  . "$DISPATCH_LIB"
+  . "$GOAL_LIB"
+  uberdev_goal_state_init "$GOAL_ID-b5"
+  uberdev_goal_register_batch_pr "$GOAL_ID-b5" 301 70
+  uberdev_goal_register_batch_pr "$GOAL_ID-b5" 300 71
+  uberdev_goal_register_batch_pr "$GOAL_ID-b5" 302 72
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID-b5" 301 GREEN
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID-b5" 300 GREEN
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID-b5" 302 GREEN
+  out="$(_uberdev_goal_batch_green_prs_ordered "$GOAL_ID-b5" | tr '\n' ' ' | sed 's/  *$//')"
+  [ "$out" = "300 301 302" ] || { echo "B5.ascending-order FAIL got '$out'"; exit 1; }
+  echo "B5 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B5 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B6 — lib uses atomic writes for batch-prs.tsv (no >> appends).
+# ---------------------------------------------------------------------------
+echo "== B6: lib uses atomic writes for batch-prs.tsv (no >> appends) =="
+# The atomic-write rule from spec error-handling — concurrent printf >> would
+# interleave bytes. Once the helpers exist, the lib MUST NOT contain `>>`
+# redirects targeting *batch-prs.tsv*.
+# Negative shape gate: no `>> .*batch-prs.tsv` pattern anywhere in the lib.
+assert_no_grep "$GOAL_LIB" '>>[[:space:]]*[^[:space:]]*batch-prs\.tsv'   "B6.no-append-redirect-to-tsv"
+# Positive: the standard atomic-write triad is used (mktemp + mv -f).
+assert_grep "$GOAL_LIB" '_uberdev_dispatch_prepare_tmp_target'           "B6.uses-prepare-tmp-target-helper"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "PASS=$PASS  FAIL=$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/goal-state-sidecar.test.sh
+++ b/tests/goal-state-sidecar.test.sh
@@ -312,6 +312,40 @@ assert_absent "$UBERDEV_TMPDIR/goal-active-id.txt" "active-id pointer removed (n
 uberdev_goal_cleanup_run_state   # second call on already-gone files
 assert_eq "$?" "0" "cleanup idempotent (non-fatal when absent)"
 
+echo "== S-barrier-1: MAX_PARALLEL / BARRIER_TIMEOUT_S / barrier_start_ts survive cross-shell rehydrate (#211 wave-1) =="
+# The batch-barrier scalars (MAX_PARALLEL, BARRIER_TIMEOUT_S, barrier_start_ts)
+# must persist across the same fresh-shell boundary the existing watch_start
+# round-trip exercises — otherwise Phase 1 sees an empty barrier_start_ts on
+# rehydrate and the barrier-timeout circuit-breaker fires immediately (or
+# never, depending on which side wins the empty-string comparison).
+#
+# Write the three barrier scalars alongside the required existing scalars,
+# then re-enter a fresh `bash --noprofile --norc -c` with env CLEARED except
+# UBERDEV_TMPDIR (the bootstrap pointer recovers GOAL_ID from the fixed-path
+# active-id file; do NOT re-export GOAL_ID — that defeats the bootstrap test).
+GOAL_ID="goal-test-barrier01"; cycle=1; watch_start=1700000000
+overflow_count=0; overflow_detected=0; MAX_CYCLES=5
+UBERDEV_RESOLVED_BACKEND="claude-bg"
+queue=(); active_issues=()
+MAX_PARALLEL=3
+BARRIER_TIMEOUT_S=14400
+barrier_start_ts=1700009999
+uberdev_goal_write_run_state
+barrier_out="$(UBERDEV_TMPDIR="$UBERDEV_TMPDIR" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  bash --noprofile --norc -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    uberdev_goal_read_run_state || exit 9
+    printf "MAX_PARALLEL=%s\nBARRIER_TIMEOUT_S=%s\nbarrier_start_ts=%s\n" \
+      "${MAX_PARALLEL:-}" "${BARRIER_TIMEOUT_S:-}" "${barrier_start_ts:-}"
+  ')"
+mp_got="$(printf '%s\n' "$barrier_out" | grep '^MAX_PARALLEL=' | head -1 | cut -d= -f2-)"
+bt_got="$(printf '%s\n' "$barrier_out" | grep '^BARRIER_TIMEOUT_S=' | head -1 | cut -d= -f2-)"
+bs_got="$(printf '%s\n' "$barrier_out" | grep '^barrier_start_ts=' | head -1 | cut -d= -f2-)"
+assert_eq "$mp_got" "3"          "S-barrier-1: MAX_PARALLEL survives fresh-shell rehydrate"
+assert_eq "$bt_got" "14400"      "S-barrier-1: BARRIER_TIMEOUT_S survives fresh-shell rehydrate"
+assert_eq "$bs_got" "1700009999" "S-barrier-1: barrier_start_ts survives fresh-shell rehydrate"
+
 echo
 printf 'goal-state-sidecar: %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -232,11 +232,9 @@ assert_grep "$GOAL_LIB" '_UBERDEV_GOAL_BODY_CAP|head -c 65536'           "G18.bo
 
 echo
 echo "== G19: lib/goal-state.sh shape =="
-# Public function names (15 — uberdev_goal_build_unblock_graph removed
-# in the post-impl-review B5 cleanup; the four `*_held_audit` /
-# `_by_pr` / `_get_pr_state` helpers added by the issue #159 + #160
-# convergence-loop fix supply the held-PR re-review poll loop's
-# bookkeeping surface).
+# Public function names (21 — 18 prior + 3 new barrier helpers added by issue #211:
+# uberdev_goal_register_batch_pr, uberdev_goal_batch_all_terminal,
+# uberdev_goal_batch_unblock_wait_clear).
 for fn in uberdev_goal_state_init uberdev_goal_pr_state_transition uberdev_goal_issue_state_transition \
           uberdev_goal_read_trust_signal uberdev_goal_check_fingerprint_repeat uberdev_goal_should_automerge \
           uberdev_goal_audit uberdev_goal_locate_review_pr_audit \
@@ -244,10 +242,13 @@ for fn in uberdev_goal_state_init uberdev_goal_pr_state_transition uberdev_goal_
           uberdev_goal_get_pr_state uberdev_goal_record_held_audit uberdev_goal_get_last_held_audit \
           uberdev_goal_find_pr_for_issue uberdev_goal_pr_state_gh uberdev_goal_pr_is_merged \
           uberdev_goal_agent_busy_for_issue \
-          uberdev_goal_list_prs_in_state uberdev_goal_read_merge_result; do
+          uberdev_goal_list_prs_in_state uberdev_goal_read_merge_result \
+          uberdev_goal_register_batch_pr \
+          uberdev_goal_batch_all_terminal \
+          uberdev_goal_batch_unblock_wait_clear; do
   assert_grep "$GOAL_LIB" "^${fn}\\(\\)" "G19.public.${fn}"
 done
-# Internal function names (13 underscore-prefixed helpers — `_uberdev_goal_validate_id`
+# Internal function names (16 underscore-prefixed helpers — `_uberdev_goal_validate_id`
 # (#156 goal_id path-traversal guard) and `_uberdev_goal_append` (#157
 # unwritable-tmpdir checked-append) add the slug-validation + write-surfacing
 # primitives; the prior `_persist_fp` short-alias forwarder was dropped
@@ -259,7 +260,10 @@ for fn in _uberdev_goal_validate_int _uberdev_goal_validate_id _uberdev_goal_app
           _uberdev_goal_count_merge_attempts _uberdev_goal_count_review_pr_attempts \
           _uberdev_goal_pr_state_machine_valid _uberdev_goal_now_secs \
           _uberdev_goal_persist_fp _uberdev_goal_dispatch_review_pr _uberdev_goal_dispatch_merge \
-          _uberdev_goal_check_unblock; do
+          _uberdev_goal_check_unblock \
+          _uberdev_goal_set_batch_terminal_state \
+          _uberdev_goal_batch_green_prs_ordered \
+          _uberdev_goal_rebase_collision_chain; do
   assert_grep "$GOAL_LIB" "^${fn}\\(\\)" "G19.internal.${fn}"
 done
 # Idempotency guard against double-sourcing.
@@ -339,6 +343,86 @@ assert_grep "$GOAL_SKILL" 'goal_circuit_breaker.*queue_empty_not_converged'     
 # left can converge cleanly instead of spinning until stuck_loop.
 assert_grep "$GOAL_SKILL" 'list_prs_in_state.*yellow-held'                         "G22.terminal-includes-yellow-held"
 assert_grep "$GOAL_SKILL" 'list_prs_in_state.*red-held'                            "G22.terminal-includes-red-held"
+
+echo
+echo "== G24: --max-parallel cap config-read + dry-run surface (#211 AC1) =="
+# Phase 0 step 3 MUST read goal.max_parallel via uberdev_read_int_in_range
+# with the verbatim default + range from the spec (default 3, [1,10]).
+assert_grep "$GOAL_SKILL" 'uberdev_read_int_in_range goal\.max_parallel UBERDEV_GOAL_MAX_PARALLEL 1 10' \
+                                                                         "G24.config-read-call-shape"
+# Default constant lives in the Constants block.
+assert_grep "$GOAL_SKILL" '_UBERDEV_GOAL_DEFAULT_MAX_PARALLEL=3'         "G24.default-constant"
+# Dry-run preview surfaces MAX_PARALLEL.
+assert_grep "$GOAL_SKILL" 'MAX_PARALLEL'                                  "G24.dry-run-mentions-cap"
+
+echo
+echo "== G25: Phase 1 dispatch loop honours MAX_PARALLEL cap (#211 AC2) =="
+# The cap counter and rollover array MUST appear inside the Phase 1 dispatch.
+assert_grep "$GOAL_SKILL" 'dispatched_this_cycle'                         "G25.cap-counter-var"
+assert_grep "$GOAL_SKILL" 'remaining_queue'                               "G25.rollover-array-var"
+assert_grep "$GOAL_SKILL" '>= MAX_PARALLEL'                               "G25.cap-comparison"
+# The register-batch-pr call is the SSOT side-effect tying dispatch to the registry.
+assert_grep "$GOAL_SKILL" 'uberdev_goal_register_batch_pr'                "G25.register-batch-pr-call"
+
+echo
+echo "== G26: Phase 2 step 2c uses batch-all-terminal + unblock-wait predicates (#211 AC3, AC5) =="
+assert_grep "$GOAL_SKILL" 'uberdev_goal_batch_all_terminal'               "G26.all-terminal-predicate"
+assert_grep "$GOAL_SKILL" 'uberdev_goal_batch_unblock_wait_clear'         "G26.unblock-wait-predicate"
+# Sequential green-PR iteration ordering helper.
+assert_grep "$GOAL_SKILL" '_uberdev_goal_batch_green_prs_ordered'         "G26.green-prs-ordered"
+# Collision-chain rebase helper.
+assert_grep "$GOAL_SKILL" '_uberdev_goal_rebase_collision_chain'          "G26.collision-chain"
+
+echo
+echo "== G27: --max-parallel range [1,10] enforced via uberdev_read_int_in_range (#211 AC1 boundary) =="
+# The range arguments 1 10 appear verbatim in the config-read call (G24 covers shape;
+# G27 doubles-down by asserting the literal min/max so an editor can't silently widen).
+assert_grep "$GOAL_SKILL" 'goal\.max_parallel UBERDEV_GOAL_MAX_PARALLEL 1 10' \
+                                                                         "G27.literal-range-1-10"
+# And the symmetric flag-parse line for --max-parallel=N. assert_grep already
+# uses `grep -qE -e "$pattern"`, so the leading dashes in the pattern are safe
+# to pass directly without a `--` separator (which would otherwise be consumed
+# as the positional pattern arg).
+assert_grep "$GOAL_SKILL" '\-\-max-parallel=\*'                           "G27.flag-parse-pattern"
+
+echo
+echo "== G28: Barrier wall-clock breaker maps to stuck_loop (#211 AC6) =="
+# Barrier-timeout config-read call shape (default 14400 = 4h; range [60, 86400]).
+assert_grep "$GOAL_SKILL" 'uberdev_read_int_in_range goal\.barrier_timeout_s UBERDEV_GOAL_BARRIER_TIMEOUT_S 60 86400' \
+                                                                         "G28.barrier-config-read-call-shape"
+assert_grep "$GOAL_SKILL" '_UBERDEV_GOAL_DEFAULT_BARRIER_TIMEOUT_S=14400' "G28.barrier-default-constant"
+# Phase 2 step 2c iteration computes elapsed against barrier_start_ts and
+# escalates to the closed-enum reason stuck_loop — no new reason added.
+assert_grep "$GOAL_SKILL" 'BARRIER_TIMEOUT_S'                             "G28.barrier-var-referenced"
+assert_grep "$GOAL_SKILL" 'barrier_start_ts'                              "G28.barrier-start-ts-referenced"
+# The audit event reuses stuck_loop verbatim (closed enum).
+assert_grep "$GOAL_SKILL" 'reason.*stuck_loop\|stuck_loop.*reason\|"stuck_loop"' \
+                                                                         "G28.reuses-stuck-loop-reason"
+# And GOAL_CIRCUIT_BREAKER_REASONS still does NOT contain merge_barrier_timeout.
+assert_no_grep "$GOAL_SKILL" 'merge_barrier_timeout'                      "G28.no-new-reason-merge-barrier-timeout"
+
+echo
+echo "== G29: Manifest-collision sequential merge (#211 AC4) =="
+# The collision-chain helper uses `git diff --name-only` for path-set intersection.
+assert_grep "$GOAL_LIB" 'git diff --name-only'                            "G29.git-diff-name-only-in-lib"
+# PR-number-ascending ordering: the green-PRs-ordered helper must sort numerically.
+assert_grep "$GOAL_LIB" 'sort -n'                                         "G29.sort-numeric-pr-ordering"
+
+echo
+echo "== G30: Unblock-wait dual condition (issue closed + review-pr:green label) (#211 AC5) =="
+# The unblock-wait predicate in lib/goal-state.sh must reference BOTH conditions.
+assert_grep "$GOAL_LIB" '^uberdev_goal_batch_unblock_wait_clear\(\)'      "G30.predicate-defined"
+assert_grep "$GOAL_LIB" 'review-pr:green'                                 "G30.green-trust-label"
+# Stale/missing label data treated as "still waiting" (rc 1) — defensive default arm.
+assert_grep "$GOAL_LIB" 'closed'                                          "G30.closed-issue-check"
+
+echo
+echo "== G31: Phase 2 step 2e updates batch registry on held → green transitions (#211 AC3/AC5 wiring) =="
+# Phase 2e MUST call _uberdev_goal_set_batch_terminal_state after recording a
+# held-PR's green transition — otherwise the barrier never sees the update.
+assert_grep "$GOAL_SKILL" '_uberdev_goal_set_batch_terminal_state'        "G31.set-terminal-state-call"
+# The rebase helper is called per just-merged PR in the green-set.
+assert_grep "$GOAL_SKILL" '_uberdev_goal_rebase_collision_chain'          "G31.rebase-chain-in-phase2c"
 
 echo
 echo "== Behavioral tests (B12 — sourced-function exercises) =="

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -277,11 +277,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.33.19) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.19"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.19"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.19-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.19\]'        "G20.changelog"
+echo "== G20: version bump locked (0.33.20) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.33\.20"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.33\.20"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.33\.20-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.33\.20\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -396,7 +396,7 @@ assert_grep "$GOAL_SKILL" '_UBERDEV_GOAL_DEFAULT_BARRIER_TIMEOUT_S=14400' "G28.b
 assert_grep "$GOAL_SKILL" 'BARRIER_TIMEOUT_S'                             "G28.barrier-var-referenced"
 assert_grep "$GOAL_SKILL" 'barrier_start_ts'                              "G28.barrier-start-ts-referenced"
 # The audit event reuses stuck_loop verbatim (closed enum).
-assert_grep "$GOAL_SKILL" 'reason.*stuck_loop\|stuck_loop.*reason\|"stuck_loop"' \
+assert_grep "$GOAL_SKILL" 'reason.*stuck_loop|stuck_loop.*reason|"stuck_loop"' \
                                                                          "G28.reuses-stuck-loop-reason"
 # And GOAL_CIRCUIT_BREAKER_REASONS still does NOT contain merge_barrier_timeout.
 assert_no_grep "$GOAL_SKILL" 'merge_barrier_timeout'                      "G28.no-new-reason-merge-barrier-timeout"

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -403,8 +403,10 @@ assert_no_grep "$GOAL_SKILL" 'merge_barrier_timeout'                      "G28.n
 
 echo
 echo "== G29: Manifest-collision sequential merge (#211 AC4) =="
-# The collision-chain helper uses `git diff --name-only` for path-set intersection.
-assert_grep "$GOAL_LIB" 'git diff --name-only'                            "G29.git-diff-name-only-in-lib"
+# The collision-chain helper uses `gh pr diff --name-only` for path-set
+# intersection (NOT `git diff --name-only origin/main..pr-N` — those local
+# `pr-N` refs do not exist in the worktree, so the lookup is a silent no-op).
+assert_grep "$GOAL_LIB" 'gh pr diff'                                      "G29.gh-pr-diff-in-lib"
 # PR-number-ascending ordering: the green-PRs-ordered helper must sort numerically.
 assert_grep "$GOAL_LIB" 'sort -n'                                         "G29.sort-numeric-pr-ordering"
 

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.18 -> 0.33.19 propagated =="
+echo "== Version bump 0.33.19 -> 0.33.20 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.33.19"' \
-  "plugin.json bumped to 0.33.19"
+  '"version": "0.33.20"' \
+  "plugin.json bumped to 0.33.20"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.33.19"' \
-  "marketplace.json bumped to 0.33.19"
+  '"version": "0.33.20"' \
+  "marketplace.json bumped to 0.33.20"
 assert_grep "$README" \
-  "version-0\\.33\\.19-blue" \
-  "README version badge bumped to 0.33.19"
+  "version-0\\.33\\.20-blue" \
+  "README version badge bumped to 0.33.20"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.33\.19\]' \
-  "CHANGELOG has [0.33.19] section header"
+  '^## \[0\.33\.20\]' \
+  "CHANGELOG has [0.33.20] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary

Adds three coordination primitives to `/uberdev:goal` so multi-issue batches land safely:

- **Parallel-dispatch cap** — `--max-parallel=N` / `UBERDEV_GOAL_MAX_PARALLEL` / `goal.max_parallel` (default 3, range [1,10]). Overflow rolls to next cycle.
- **Wait-for-all merge barrier** — Phase 2 step 2c gates `/merge` on `uberdev_goal_batch_all_terminal && uberdev_goal_batch_unblock_wait_clear`. Shared-manifest PRs merge sequentially in PR-number-ascending order with `git fetch origin main` + rebase between each.
- **Unblock-issue wait** — held PRs gate the barrier until unblock-issue closes AND `review-pr:green` label transitions.
- **Wall-clock breaker** — `--barrier-timeout=N` (default 14400s = 4h) escalates to existing `stuck_loop` reason (no new circuit-breaker enum).

Three new public helpers (`uberdev_goal_register_batch_pr`, `uberdev_goal_batch_all_terminal`, `uberdev_goal_batch_unblock_wait_clear`) plus three internal helpers. Run-state SSOT extended with `MAX_PARALLEL`, `BARRIER_TIMEOUT_S`, `barrier_start_ts` (parallels `watch_start`).

RFC 0005 §5 Q1 marked RESOLVED; §9 adds D-211a..e. Version bumped 0.33.19 → 0.33.20.

Closes #211

## Test Plan

- [x] `tests/goal.test.sh` — 365 passed, 0 failed
- [x] `tests/goal-batch-barrier.test.sh` — 8 passed, 0 failed
- [x] `tests/config-override.test.sh` — 90 passed, 0 failed
- [x] `tests/goal-state-sidecar.test.sh` — 26 passed, 0 failed (S-barrier-1 cross-shell rehydrate)
- [x] `tests/solve-claim.test.sh` — 104 passed, 0 failed
- [ ] Manual smoke: 4-issue /goal run with default cap — dispatch 3, roll 1 over, merge sequentially when GREEN
- [ ] Manual smoke: kill a PR to force HELD; barrier holds until trust label transitions

## Implementation notes

- The plan's verbatim `register_batch_pr` body had a behavioral bug: `_uberdev_dispatch_prepare_tmp_target` truncates its target BEFORE returning. Fix: read existing TSV FIRST, then prepare, then write merged content, then atomic-mv.
- Wave-2 review caught a blocker: Phase 1's original `register_batch_pr` call passed `pr_number=""` (PR not yet pushed at dispatch-time). Fix: defer registration to Phase 2 step 2a after `uberdev_goal_find_pr_for_issue` resolves the PR.
- `_uberdev_goal_rebase_collision_chain` detects collisions and emits audit breadcrumb; actual rebase delegated to `/merge` rebase handler on next iteration.

## Open questions answered by /turbo

| Question | Choice | Confidence |
|----------|--------|------------|
| Config key name + env var name | `goal.max_parallel` + `UBERDEV_GOAL_MAX_PARALLEL` (verbatim per issue AC #1). | high |
| Cap default and validation range | default `3`, range `[1, 10]`, resolved via `uberdev_read_int_in_range goal.max_parallel UBERDEV_GOAL_MAX_PARALLEL 1 10 3`. | high |
| Batch-registry storage format and write discipline | TSV sidecar file `goal-<id>-batch-prs.tsv` (append-only) using the existing `_uberdev_goal_append` pattern + atomic-write triad (`_uberdev_dispatch_prepare_tmp_target` → `mktemp` → `mv -f`). One row per dispatched PR: `pr_number<TAB>issue_number<TAB>dispatch_ts<TAB>terminal_state`. Initial `terminal_state` = `PENDING`; updated to `GREEN`/`HELD`/`MERGE_FAILED` as PRs transition. Added to `uberdev_goal_state_init` truncate-create list and `uberdev_goal_cleanup_run_state`. | high |
| Batch-all-terminal predicate semantics | `uberdev_goal_batch_all_terminal GOAL_ID` returns true iff every row in `goal-<id>-batch-prs.tsv` has `terminal_state ∈ {GREEN, HELD, MERGE_FAILED}`. PENDING means "still in flight". Predicate is a pure read of the registry — no `gh` calls (caller is responsible for keeping the registry fresh via the existing held-PR poll loop in step 2e). | high |
| Manifest-collision detection + sequential-merge ordering | Detection — for each pair of PRs in the batch with `terminal_state=GREEN`, compute `git diff --name-only origin/main..pr-N` ∩ `git diff --name-only origin/main..pr-M`. Non-empty intersection ⇒ both PRs touch a shared manifest. Ordering — PR number ascending (FIFO-by-claim-time matches GitHub Merge Queue FIFO model per prior-art research). Mechanic — merge PR-min first, `git fetch origin main` + rebase PR-next onto fresh main (delegate to existing `/merge` rebase-handler agent for conflict cases), then merge PR-next; repeat for each colliding PR. | medium |
| Barrier wall-clock timeout — duration and circuit-breaker mapping | Default `BARRIER_TIMEOUT_S=14400` (4 hours), env override `UBERDEV_GOAL_BARRIER_TIMEOUT_S`, config key `goal.barrier_timeout_s`, range `[60, 86400]`. Timeout escalation maps to existing `stuck_loop` circuit-breaker reason (no new reason in `GOAL_CIRCUIT_BREAKER_REASONS` — keeps the closed enum intact per constraints research). | high |
| Unblock-wait predicate semantics | `uberdev_goal_batch_unblock_wait_clear GOAL_ID` returns true iff for every row where `terminal_state=HELD` AND a `review-pr-finding` unblock-issue has been filed against that PR: the unblock-issue is closed AND the held PR's latest review-pr trust-trail label is `review-pr:green` (i.e. transitioned to GREEN). Otherwise false ⇒ barrier holds. The existing Phase 2 step 2e held-PR re-review poll is reused — no new fan-out. | high |
| G19 public-fn count update + test surface | `tests/goal.test.sh` G19 public-fn count literal bumps from 15 → 18 (three new public helpers: `uberdev_goal_register_batch_pr`, `uberdev_goal_batch_all_terminal`, `uberdev_goal_batch_unblock_wait_clear`). Add G24–G31 shape gates per test-coverage research; add behavioral tests to a new `tests/goal-batch-barrier.test.sh` file (separated from `goal-state-sidecar.test.sh` to keep file sizes bounded and concerns isolated). | high |
| RFC 0005 §5 Q1 resolution + CHANGELOG entry | Amend `docs/rfc/0005-uberdev-goal.md` §5 Q1 to mark resolved with the chosen cap (3, configurable 1–10). Add a §9 code row for the three new public helpers and the new constant `_UBERDEV_GOAL_DEFAULT_MAX_PARALLEL=3`. CHANGELOG entry under `### Added` (config keys + helpers) and `### Changed` (default fan-out cap is now 3 for /goal, was previously uncapped). | high |
| Version bump and test-lock updates | Bump from 0.33.19 → 0.33.20 across the 7 documented locations (6 manifest + 1 hidden test-lock in `tests/solve-claim.test.sh:265-277`) PLUS update `tests/goal.test.sh:276-280` (G20 hidden version-lock guard) per user memory `project_uberdev_version_lock_tests.md`. All in the SAME commit (or paired commits) to avoid CI red. | high |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable goal parallel dispatch cap (default 3, range 1–10) and barrier timeout; excess queue items roll to later cycles
  * Batch-based merge orchestration: waits for all PRs in a cycle to reach terminal states; sequential merges for manifest collisions; 4h wall-clock breaker

* **Documentation**
  * Updated command reference, README badge, and CHANGELOG for 0.33.20

* **Tests**
  * Added comprehensive batch-barrier and persistence tests; updated version checks to 0.33.20

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->