### PR TITLE
ci: enforce tests/*.test.sh wiring as a CI invariant (#210)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "category": "workflow",
       "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
     }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,14 @@ jobs:
         #   - uberthink.test.sh / uberthink-report.test.sh
         #                                         (python3 -c + mktemp -d paths,
         #                                         same reason as uberscan-report)
-        # When a test file is added or removed, update BOTH jobs by hand — there
-        # is no automated drift guard between the two lists.
+        # When a test file is added or removed, update BOTH jobs by hand.
+        # tests/ci-wiring.test.sh (#210) enforces this convention as an
+        # invariant: it asserts every tests/*.test.sh on disk is wired into
+        # the ubuntu run: block AND that (ubuntu − windows) matches the
+        # `ci-wiring windows-skip-list` marker block in the windows job
+        # below. Ran first in both jobs so a wiring drift reds CI fast.
         run: |
+          bash tests/ci-wiring.test.sh && \
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \
           bash tests/post-impl-review.test.sh && \
@@ -145,9 +150,31 @@ jobs:
         # pattern (finish-branch, mirroring secret-scan.test.sh); lib/config-read.sh
         # runtime (findings-to-issues, mirroring config-override.test.sh); and
         # chmod+x-stub execution (install, mirroring solve-effort-flag.test.sh).
-        # When a test file is added or removed, update BOTH jobs by hand — there
-        # is no automated drift guard between the lists.
+        # When a test file is added or removed, update BOTH jobs by hand.
+        # tests/ci-wiring.test.sh (#210) enforces the convention as a hard
+        # invariant; the canonical Unix-only skip set is the marker block
+        # below — a runtime drift fails CI immediately.
+        #
+        # === BEGIN ci-wiring windows-skip-list ===
+        # Canonical SSOT of Unix-only fixtures intentionally skipped on
+        # windows-latest. ci-wiring.test.sh W4 asserts
+        # (ubuntu − windows) == this list. Update this block AND the run:
+        # block below in lockstep; a new Unix-only fixture needs an entry
+        # here AND its `bash tests/...` line in the ubuntu job above.
+        #   - solve-pipeline-zsh.test.sh
+        #   - testers-pipeline.test.sh
+        #   - testers-agent-contract.test.sh
+        #   - testers-rate-limit-audit.test.sh
+        #   - testers-rate-limit-wrapper.test.sh
+        #   - uberscan.test.sh
+        #   - uberscan-report.test.sh
+        #   - uberscan-chunk.test.sh
+        #   - uberthink.test.sh
+        #   - uberthink-report.test.sh
+        #   - merge-discovery-resilience.test.sh
+        # === END ci-wiring windows-skip-list ===
         run: |
+          bash tests/ci-wiring.test.sh && \
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \
           bash tests/post-impl-review.test.sh && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.34.1] - 2026-05-26
+## [0.34.1] — 2026-05-26
 
 ### Added
 - **`tests/ci-wiring.test.sh` — drift-guard for `.github/workflows/test.yml` (#210; prevents #196 recurrence).** Converts the existing SYNC convention between the `shape-checks` (ubuntu) and `shape-checks-windows` jobs into an enforced invariant. Asserts five locks: W1 every `tests/*.test.sh` on disk is wired into the ubuntu job; W1b ubuntu has no references to nonexistent test files; W2 windows is a (non-strict) subset of ubuntu; W3 windows has no phantom references; W4 (ubuntu − windows) equals the canonical `# === BEGIN ci-wiring windows-skip-list ===` marker block now embedded in the windows job's comment header. A new `tests/*.test.sh` committed without being wired into the ubuntu job — or a Unix-only fixture added without an entry in the marker block — now reds CI immediately. Portable: bash + awk + grep + sed + sort + comm, runs in both shape-checks jobs (ubuntu-latest native bash + windows-latest Git Bash). Wired as the FIRST entry in each job's `run:` block so a wiring drift fails fast.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.1] - 2026-05-26
+
+### Added
+- **`tests/ci-wiring.test.sh` — drift-guard for `.github/workflows/test.yml` (#210; prevents #196 recurrence).** Converts the existing SYNC convention between the `shape-checks` (ubuntu) and `shape-checks-windows` jobs into an enforced invariant. Asserts five locks: W1 every `tests/*.test.sh` on disk is wired into the ubuntu job; W1b ubuntu has no references to nonexistent test files; W2 windows is a (non-strict) subset of ubuntu; W3 windows has no phantom references; W4 (ubuntu − windows) equals the canonical `# === BEGIN ci-wiring windows-skip-list ===` marker block now embedded in the windows job's comment header. A new `tests/*.test.sh` committed without being wired into the ubuntu job — or a Unix-only fixture added without an entry in the marker block — now reds CI immediately. Portable: bash + awk + grep + sed + sort + comm, runs in both shape-checks jobs (ubuntu-latest native bash + windows-latest Git Bash). Wired as the FIRST entry in each job's `run:` block so a wiring drift fails fast.
+
+### Changed
+- Version bumped to 0.34.1 across `plugin.json`, `marketplace.json`, the README badge, and the test version ratchets (`goal.test.sh` G20, `solve-claim.test.sh`).
+
 ## [0.34.0] — 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.34.0-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.34.1-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/tests/ci-wiring.test.sh
+++ b/tests/ci-wiring.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# tests/ci-wiring.test.sh — drift-guard for .github/workflows/test.yml.
+# Issue #210: locks the SYNC convention between the shape-checks ubuntu and
+# shape-checks-windows jobs into an enforced invariant so a new
+# tests/*.test.sh that is committed on disk but NOT wired into both jobs
+# reds CI immediately (closes the silent-orphan failure mode of #196).
+#
+# Invariants:
+#   W1  — every tests/*.test.sh on disk is wired into the ubuntu
+#         shape-checks job's run: block. Ubuntu is the completeness oracle.
+#   W1b — the ubuntu job has no references to nonexistent test files.
+#   W2  — the windows shape-checks-windows job is a subset of the ubuntu
+#         job (no windows-only entries or stray refs).
+#   W3  — the windows job has no references to nonexistent test files.
+#   W4  — (ubuntu − windows) equals the canonical windows-skip-list marker
+#         block delimited by `# === BEGIN ci-wiring windows-skip-list ===`
+#         / `# === END ci-wiring windows-skip-list ===` in test.yml. A new
+#         Unix-only fixture cannot be added to ubuntu without also being
+#         declared in the marker block, and the marker block cannot drift
+#         from the actual skip set.
+#
+# Portable: bash + awk + grep + sed + sort + comm. Runs on ubuntu-latest
+# (native bash) and windows-latest (Git Bash) without any extra deps.
+
+set -u
+set -o pipefail
+
+THIS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$THIS_DIR/.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/test.yml"
+
+PASS=0; FAIL=0
+echo "## ci-wiring drift guard (#210)"
+
+if [ ! -r "$WORKFLOW" ]; then
+  echo "  ABORT — workflow file missing or unreadable: $WORKFLOW"; exit 99
+fi
+if [ ! -d "$REPO_ROOT/tests" ]; then
+  echo "  ABORT — tests/ directory missing: $REPO_ROOT/tests"; exit 99
+fi
+
+on_disk=$(cd "$REPO_ROOT" && ls tests/*.test.sh 2>/dev/null | sed 's#tests/##' | sort -u)
+if [ -z "$on_disk" ]; then
+  echo "  ABORT — no tests/*.test.sh on disk"; exit 99
+fi
+
+# Comment-strip BEFORE grep so references inside free-text comments
+# (e.g. "mirroring secret-scan.test.sh") never pollute the wiring set.
+ubuntu_wired=$(awk '/^  shape-checks:/,/^  shape-checks-windows:/' "$WORKFLOW" \
+  | grep -v '^[[:space:]]*#' \
+  | grep -oE 'tests/[a-zA-Z0-9._-]+\.test\.sh' | sed 's#tests/##' | sort -u)
+windows_wired=$(awk '/^  shape-checks-windows:/,0' "$WORKFLOW" \
+  | grep -v '^[[:space:]]*#' \
+  | grep -oE 'tests/[a-zA-Z0-9._-]+\.test\.sh' | sed 's#tests/##' | sort -u)
+
+# Canonical windows-skip-list marker block. Lines of the form `#   - foo.test.sh`
+# between the BEGIN/END delimiters; everything else inside the block is ignored
+# so an in-block comment line ("# Update both this block AND the run: block.")
+# does not pollute the set.
+marker_block=$(awk '
+  /^[[:space:]]*#[[:space:]]+===[[:space:]]+BEGIN ci-wiring windows-skip-list[[:space:]]+===/ { inb=1; next }
+  /^[[:space:]]*#[[:space:]]+===[[:space:]]+END ci-wiring windows-skip-list[[:space:]]+===/   { inb=0 }
+  inb { print }
+' "$WORKFLOW" \
+  | grep -oE '#[[:space:]]+-[[:space:]]+[a-zA-Z0-9._-]+\.test\.sh' \
+  | grep -oE '[a-zA-Z0-9._-]+\.test\.sh' | sort -u)
+
+# W1 — every on-disk test must be wired into ubuntu.
+missing_from_ubuntu=$(comm -23 <(echo "$on_disk") <(echo "$ubuntu_wired"))
+if [ -z "$missing_from_ubuntu" ]; then
+  echo "  PASS  W1 every tests/*.test.sh is wired into the ubuntu shape-checks job"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  W1 these on-disk tests are NOT wired into the ubuntu shape-checks job:"
+  printf '          %s\n' $missing_from_ubuntu
+  echo "         Add them to .github/workflows/test.yml under the shape-checks job's run: block."
+  FAIL=$((FAIL+1))
+fi
+
+# W1b — ubuntu must not reference nonexistent tests.
+phantom_in_ubuntu=$(comm -13 <(echo "$on_disk") <(echo "$ubuntu_wired"))
+if [ -z "$phantom_in_ubuntu" ]; then
+  echo "  PASS  W1b the ubuntu job has no references to nonexistent test files"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  W1b the ubuntu job references tests that do NOT exist on disk:"
+  printf '          %s\n' $phantom_in_ubuntu
+  FAIL=$((FAIL+1))
+fi
+
+# W2 — windows must be a subset of ubuntu.
+windows_only=$(comm -13 <(echo "$ubuntu_wired") <(echo "$windows_wired"))
+if [ -z "$windows_only" ]; then
+  echo "  PASS  W2 the windows job is a subset of the ubuntu job"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  W2 the windows job references tests NOT in the ubuntu job (windows-only or phantom):"
+  printf '          %s\n' $windows_only
+  FAIL=$((FAIL+1))
+fi
+
+# W3 — windows must not reference nonexistent tests.
+phantom_in_windows=$(comm -13 <(echo "$on_disk") <(echo "$windows_wired"))
+if [ -z "$phantom_in_windows" ]; then
+  echo "  PASS  W3 the windows job has no references to nonexistent test files"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  W3 the windows job references tests that do NOT exist on disk:"
+  printf '          %s\n' $phantom_in_windows
+  FAIL=$((FAIL+1))
+fi
+
+# W4 — (ubuntu - windows) must equal the marker block exactly.
+actual_skipped=$(comm -23 <(echo "$ubuntu_wired") <(echo "$windows_wired"))
+if [ -z "$marker_block" ]; then
+  echo "  FAIL  W4 the windows-skip-list marker block is missing or empty in test.yml"
+  echo "         Expected a block delimited by:"
+  echo "           # === BEGIN ci-wiring windows-skip-list ==="
+  echo "           # === END ci-wiring windows-skip-list ==="
+  echo "         with one entry per line in the form '#   - <filename>.test.sh'."
+  FAIL=$((FAIL+1))
+elif [ "$actual_skipped" = "$marker_block" ]; then
+  echo "  PASS  W4 (ubuntu − windows) matches the windows-skip-list marker block"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  W4 (ubuntu − windows) drifted from the windows-skip-list marker block."
+  echo "         marker block declares:"
+  printf '           %s\n' $marker_block
+  echo "         actual (ubuntu − windows):"
+  printf '           %s\n' $actual_skipped
+  echo "         Either wire the missing tests into windows OR update the marker block to match."
+  FAIL=$((FAIL+1))
+fi
+
+echo "  Result: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/ci-wiring.test.sh
+++ b/tests/ci-wiring.test.sh
@@ -2,8 +2,10 @@
 # tests/ci-wiring.test.sh — drift-guard for .github/workflows/test.yml.
 # Issue #210: locks the SYNC convention between the shape-checks ubuntu and
 # shape-checks-windows jobs into an enforced invariant so a new
-# tests/*.test.sh that is committed on disk but NOT wired into both jobs
-# reds CI immediately (closes the silent-orphan failure mode of #196).
+# tests/*.test.sh that is committed on disk but NOT wired into the ubuntu
+# shape-checks job reds CI immediately (closes the silent-orphan failure
+# mode of #196). Ubuntu is the completeness oracle; windows is the subset
+# (Unix-only fixtures are declared in the marker block — see W4).
 #
 # Invariants:
 #   W1  — every tests/*.test.sh on disk is wired into the ubuntu
@@ -129,6 +131,9 @@ else
   echo "         actual (ubuntu − windows):"
   printf '           %s\n' $actual_skipped
   echo "         Either wire the missing tests into windows OR update the marker block to match."
+  echo "         Marker block lives in .github/workflows/test.yml between"
+  echo "           # === BEGIN ci-wiring windows-skip-list ==="
+  echo "           # === END ci-wiring windows-skip-list ==="
   FAIL=$((FAIL+1))
 fi
 

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -277,11 +277,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.34.0) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.0"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.0"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.0-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.0\]'        "G20.changelog"
+echo "== G20: version bump locked (0.34.1) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.1"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.1"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.1-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.1\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.33.20 -> 0.34.0 propagated =="
+echo "== Version bump 0.34.0 -> 0.34.1 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.34.0"' \
-  "plugin.json bumped to 0.34.0"
+  '"version": "0.34.1"' \
+  "plugin.json bumped to 0.34.1"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.34.0"' \
-  "marketplace.json bumped to 0.34.0"
+  '"version": "0.34.1"' \
+  "marketplace.json bumped to 0.34.1"
 assert_grep "$README" \
-  "version-0\\.34\\.0-blue" \
-  "README version badge bumped to 0.34.0"
+  "version-0\\.34\\.1-blue" \
+  "README version badge bumped to 0.34.1"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.34\.0\]' \
-  "CHANGELOG has [0.34.0] section header"
+  '^## \[0\.34\.1\]' \
+  "CHANGELOG has [0.34.1] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary
- Adds `tests/ci-wiring.test.sh` as a drift-guard for `.github/workflows/test.yml`, converting the SYNC convention between the `shape-checks` (ubuntu) and `shape-checks-windows` jobs into a runtime-enforced invariant. Closes the silent-orphan failure mode of #196 — a new `tests/*.test.sh` committed without wiring into either job now reds CI immediately.
- Embeds a canonical `# === BEGIN ci-wiring windows-skip-list ===` marker block in the windows job's comment header listing the eleven Unix-only fixtures (zsh / python3 + PyYAML / executable fake-gh fixture); the W4 invariant asserts `(ubuntu − windows) == marker_block`, so a Unix-only fixture added to ubuntu without a marker entry — or a marker drift in either direction — fails fast.
- Wires the new test as the FIRST entry in both jobs' `run:` blocks so a wiring drift surfaces before the rest of the suite runs.

## Invariants enforced

| ID  | Lock |
|-----|------|
| W1  | every `tests/*.test.sh` on disk is wired into the ubuntu job |
| W1b | the ubuntu job has no references to nonexistent test files |
| W2  | the windows job is a (non-strict) subset of ubuntu — no windows-only entries |
| W3  | the windows job has no references to nonexistent test files |
| W4  | `(ubuntu − windows)` equals the canonical windows-skip-list marker block in test.yml |

Together they convert the existing `# When a test file is added or removed, update BOTH jobs by hand — there is no automated drift guard between the two lists.` convention into a hard CI gate.

## Portability

Pure bash + awk + grep + sed + sort + comm — no extra deps. Verified locally against both extractions; runs on ubuntu-latest (native bash) and windows-latest (Git Bash) via Git for Windows. The free-text comments above the marker block preserve the per-fixture `why` (the zsh/python3/executable reasons) for humans editing the workflow.

## Version bump

Per the project version-bump-everywhere mandate, this is a `0.34.0 → 0.34.1` patch (ci/test hygiene; no runtime behavior change):

- `plugins/uberdev/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `README.md` badge
- `CHANGELOG.md` — new `## [0.34.1]` section
- `tests/goal.test.sh` G20 (release ratchet)
- `tests/solve-claim.test.sh` version-bump block (release ratchet)

## Test Plan
- [x] `bash tests/ci-wiring.test.sh` — 5/5 PASS locally on this branch (W1, W1b, W2, W3, W4)
- [x] Smoke-tested the failure mode: created an unwired `tests/_fake-orphan.test.sh`, guard returned non-zero (W1 FAIL surfacing the orphan by name); removed the fixture, guard returned 0
- [x] `bash tests/goal.test.sh` (G20 ratchet) — PASS at 0.34.1
- [x] `bash tests/solve-claim.test.sh` (version-bump block) — PASS at 0.34.1
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — YAML parses; both jobs have 48 / 37 run lines respectively, `ci-wiring.test.sh` is the first test in each
- [ ] CI: both `shape-checks` jobs green on this PR (the new guard runs first; if anything is unwired this PR will catch itself before the rest of the suite executes)

Closes #210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version to 0.34.1 across all manifests and documentation
  * Enhanced CI configuration and test infrastructure to ensure consistent validation across platforms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->