### PR TITLE
fix(goal-state): guard uberdev_dispatch_one dep in dispatch helpers (#207)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,22 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.34.1",
+      "version": "0.34.2",
       "category": "workflow",
-      "tags": ["github", "issue-tracking", "autonomous-agents", "agent-view", "background-sessions", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
+      "tags": [
+        "github",
+        "issue-tracking",
+        "autonomous-agents",
+        "agent-view",
+        "background-sessions",
+        "skills",
+        "code-review",
+        "tdd",
+        "brainstorm",
+        "visual-companion",
+        "debugging",
+        "worktrees"
+      ]
     }
   ]
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,7 @@ jobs:
           bash tests/uberthink.test.sh && \
           bash tests/uberthink-report.test.sh && \
           bash tests/goal-state-sidecar.test.sh && \
+          bash tests/goal-dispatch-helpers.test.sh && \
           bash tests/using-git-worktrees.test.sh && \
           bash tests/goal.test.sh && \
           bash tests/goal-batch-barrier.test.sh
@@ -208,6 +209,7 @@ jobs:
           bash tests/ubersimplify-aggregate.test.sh && \
           bash tests/simplify.test.sh && \
           bash tests/goal-state-sidecar.test.sh && \
+          bash tests/goal-dispatch-helpers.test.sh && \
           bash tests/using-git-worktrees.test.sh && \
           bash tests/goal.test.sh && \
           bash tests/goal-batch-barrier.test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.2] — 2026-05-26
+
+### Fixed
+- **`lib/goal-state.sh` `_uberdev_goal_dispatch_review_pr` + `_uberdev_goal_dispatch_merge`: guard the `uberdev_dispatch_one` lib/dispatch.sh dependency (#207, same latent-crash class as #195).** Both helpers now run a `command -v uberdev_dispatch_one` preflight after argument validation and BEFORE any counter-write or `mktemp`; on a missing dep they fail loud with the distinct dep-missing rc=4 and a `goal-state:` diagnostic naming the symbol, instead of crashing mid-dispatch on a bare `command not found` after the per-PR attempt counter had already been incremented (phantom attempt with no actual dispatch). The "External imports" header at the top of `goal-state.sh` consolidates both dispatch-lib symbols (`_uberdev_dispatch_prepare_tmp_target`, `uberdev_dispatch_one`) under one paragraph; `_uberdev_goal_dispatch_merge` also reorders `_uberdev_goal_validate_id` above the `mktemp` so the id-validate failure path no longer leaks a stray prompt file. New `tests/goal-dispatch-helpers.test.sh` covers the rc=4 + diagnostic + no-CNF-leak + no-stray-file negative cases (fresh `bash -c` without dispatch.sh) plus a stub-based positive case proving both helpers reach `uberdev_dispatch_one` with the `(pr, "small", prompt_file)` shape when the dep is present. Wired into both ubuntu + windows CI matrices.
+
+### Changed
+- Version bumped to 0.34.2 across `plugin.json`, `marketplace.json`, the README badge, and the test version ratchets (`goal.test.sh` G20, `solve-claim.test.sh`). Re-numbered from #217's original 0.34.1 to avoid collision with #216 (PR landing order: #216 → 0.34.1, #217 → 0.34.2, #218 → 0.34.3).
+
 ## [0.34.1] — 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.34.1-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.34.2-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",
@@ -9,5 +9,20 @@
   "homepage": "https://github.com/TheFJK/UberDev",
   "repository": "https://github.com/TheFJK/UberDev",
   "license": "MIT",
-  "keywords": ["github", "gh-cli", "autonomous-agents", "agent-view", "background-sessions", "issue-tracking", "workflow", "skills", "code-review", "tdd", "brainstorm", "visual-companion", "debugging", "worktrees"]
+  "keywords": [
+    "github",
+    "gh-cli",
+    "autonomous-agents",
+    "agent-view",
+    "background-sessions",
+    "issue-tracking",
+    "workflow",
+    "skills",
+    "code-review",
+    "tdd",
+    "brainstorm",
+    "visual-companion",
+    "debugging",
+    "worktrees"
+  ]
 }

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -1026,13 +1026,8 @@ _uberdev_goal_dispatch_review_pr() {
     printf 'goal-state: unsafe UBERDEV_GOAL_ID %s; refusing review-pr dispatch for PR #%s\n' "$goal_id" "$pr" >&2
     return 1
   }
-  # #207 — preflight the lib/dispatch.sh dependency. The dispatch entry-point
-  # uberdev_dispatch_one is sourced from lib/dispatch.sh; a caller that skipped
-  # that source would otherwise hit a bare `command not found` AFTER the counter
-  # TSV had already been appended (leaking a phantom attempt with no actual
-  # dispatch). Fail loud with the distinct dep-missing rc (matches the writer +
-  # register_batch_pr precedent at #195), BEFORE any counter read/write or
-  # mktemp, so no side effects or temp siblings leak on the missing-dep path.
+  # #207 — preflight lib/dispatch.sh; without it, a CNF leaks a phantom attempt
+  # to the counter TSV. rc=4 mirrors the writer + register_batch_pr precedent.
   if ! command -v uberdev_dispatch_one >/dev/null 2>&1; then
     printf 'goal-state: _uberdev_goal_dispatch_review_pr requires lib/dispatch.sh sourced first (missing uberdev_dispatch_one)\n' >&2
     return 4
@@ -1077,18 +1072,12 @@ _uberdev_goal_dispatch_merge() {
   local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
   local goal_id="${UBERDEV_GOAL_ID:-unknown}"
   # #156 — refuse a forged provenance id rather than pathing a counter TSV with it.
-  # Moved above the mktemp + prompt_file write (formerly below) so the id-validate
-  # rc=1 path no longer leaks a stray prompt file; #207's dispatch-dep preflight
-  # then slots in here too — uniform layout with _uberdev_goal_dispatch_review_pr.
   _uberdev_goal_validate_id "$goal_id" || {
     printf 'goal-state: unsafe UBERDEV_GOAL_ID %s; refusing merge dispatch for PR #%s\n' "$goal_id" "$pr" >&2
     return 1
   }
-  # #207 — preflight the lib/dispatch.sh dependency. Same rationale as the
-  # sibling helper _uberdev_goal_dispatch_review_pr: a missing uberdev_dispatch_one
-  # would otherwise CNF AFTER the per-PR counter TSV had already been appended
-  # (phantom attempt with no actual dispatch). Fail loud with rc=4 BEFORE any
-  # mktemp or counter write, so no side effects leak on the missing-dep path.
+  # #207 — same dispatch.sh preflight as _uberdev_goal_dispatch_review_pr: a
+  # missing uberdev_dispatch_one would otherwise CNF after a phantom counter row.
   if ! command -v uberdev_dispatch_one >/dev/null 2>&1; then
     printf 'goal-state: _uberdev_goal_dispatch_merge requires lib/dispatch.sh sourced first (missing uberdev_dispatch_one)\n' >&2
     return 4

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -48,16 +48,22 @@
 #   _uberdev_goal_batch_green_prs_ordered  GOAL_ID                (issue #211)
 #   _uberdev_goal_rebase_collision_chain   GOAL_ID JUST_MERGED_PR (issue #211)
 # External imports:
-#   - lib/dispatch.sh :: _uberdev_dispatch_prepare_tmp_target — REQUIRED by
-#     uberdev_goal_write_run_state, which reuses this #155 TOCTOU-safe target-prep
-#     helper for every run-state sidecar it writes (issue #195). goal-state.sh
-#     does NOT source dispatch.sh itself (no stable relative path from a sourced
-#     lib + avoids a load-order cycle); the CALLER must source lib/dispatch.sh
-#     BEFORE invoking the writer. A `command -v` preflight at the top of
-#     uberdev_goal_write_run_state enforces the contract — it fails loud (rc=4,
-#     `goal-state:` diagnostic) rather than crashing mid-write on a `command not
-#     found`. The goal-pipeline fences already source dispatch.sh first; any
-#     standalone caller (and the tests) must do the same.
+#   - lib/dispatch.sh :: _uberdev_dispatch_prepare_tmp_target, uberdev_dispatch_one
+#     — both REQUIRED, both live in lib/dispatch.sh (NOT in this file).
+#       _uberdev_dispatch_prepare_tmp_target backs uberdev_goal_write_run_state +
+#         uberdev_goal_register_batch_pr (#155 TOCTOU-safe target-prep helper —
+#         #195 added the writer guard).
+#       uberdev_dispatch_one is the dispatch entry-point reached by the two
+#         internal dispatch helpers (_uberdev_goal_dispatch_review_pr +
+#         _uberdev_goal_dispatch_merge — #207 added the matching guards;
+#         same latent-crash class as #195).
+#     goal-state.sh does NOT source dispatch.sh itself (no stable relative path
+#     from a sourced lib + avoids a load-order cycle); the CALLER must source
+#     lib/dispatch.sh BEFORE invoking any of these functions. A `command -v`
+#     preflight at the top of each consumer enforces the contract — they fail
+#     loud (rc=4, `goal-state:` diagnostic) rather than crashing mid-call on a
+#     `command not found`. The goal-pipeline fences already source dispatch.sh
+#     first; any standalone caller (and the tests) must do the same.
 #   - discover.sh is sourced opportunistically (below) for stderr-isolation
 #     helpers, but no function names are required from it. The `gh_jq_or_jq` shim
 #     below is a local-file jq wrapper; the spec/plan named it after a discover.sh
@@ -1020,6 +1026,17 @@ _uberdev_goal_dispatch_review_pr() {
     printf 'goal-state: unsafe UBERDEV_GOAL_ID %s; refusing review-pr dispatch for PR #%s\n' "$goal_id" "$pr" >&2
     return 1
   }
+  # #207 — preflight the lib/dispatch.sh dependency. The dispatch entry-point
+  # uberdev_dispatch_one is sourced from lib/dispatch.sh; a caller that skipped
+  # that source would otherwise hit a bare `command not found` AFTER the counter
+  # TSV had already been appended (leaking a phantom attempt with no actual
+  # dispatch). Fail loud with the distinct dep-missing rc (matches the writer +
+  # register_batch_pr precedent at #195), BEFORE any counter read/write or
+  # mktemp, so no side effects or temp siblings leak on the missing-dep path.
+  if ! command -v uberdev_dispatch_one >/dev/null 2>&1; then
+    printf 'goal-state: _uberdev_goal_dispatch_review_pr requires lib/dispatch.sh sourced first (missing uberdev_dispatch_one)\n' >&2
+    return 4
+  fi
   local current; current="$(_uberdev_goal_count_review_pr_attempts "$goal_id" "$pr")"
   local cap="${_UBERDEV_GOAL_MAX_REVIEW_PR_ATTEMPTS:-3}"
   if [ "$current" -ge "$cap" ]; then
@@ -1057,6 +1074,25 @@ _uberdev_goal_dispatch_review_pr() {
 _uberdev_goal_dispatch_merge() {
   local pr="$1"
   _uberdev_goal_validate_int "$pr" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  local goal_id="${UBERDEV_GOAL_ID:-unknown}"
+  # #156 — refuse a forged provenance id rather than pathing a counter TSV with it.
+  # Moved above the mktemp + prompt_file write (formerly below) so the id-validate
+  # rc=1 path no longer leaks a stray prompt file; #207's dispatch-dep preflight
+  # then slots in here too — uniform layout with _uberdev_goal_dispatch_review_pr.
+  _uberdev_goal_validate_id "$goal_id" || {
+    printf 'goal-state: unsafe UBERDEV_GOAL_ID %s; refusing merge dispatch for PR #%s\n' "$goal_id" "$pr" >&2
+    return 1
+  }
+  # #207 — preflight the lib/dispatch.sh dependency. Same rationale as the
+  # sibling helper _uberdev_goal_dispatch_review_pr: a missing uberdev_dispatch_one
+  # would otherwise CNF AFTER the per-PR counter TSV had already been appended
+  # (phantom attempt with no actual dispatch). Fail loud with rc=4 BEFORE any
+  # mktemp or counter write, so no side effects leak on the missing-dep path.
+  if ! command -v uberdev_dispatch_one >/dev/null 2>&1; then
+    printf 'goal-state: _uberdev_goal_dispatch_merge requires lib/dispatch.sh sourced first (missing uberdev_dispatch_one)\n' >&2
+    return 4
+  fi
   local prompt_file
   # B5 — same rc-check pattern as _uberdev_goal_dispatch_review_pr above.
   # Without this, a silent mktemp failure (read-only /tmp, exhausted inode
@@ -1070,14 +1106,6 @@ _uberdev_goal_dispatch_merge() {
     return 1
   fi
   printf '/uberdev:merge %s\n' "$pr" > "$prompt_file"
-  # Increment per-PR attempt counter.
-  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
-  local goal_id="${UBERDEV_GOAL_ID:-unknown}"
-  # #156 — refuse a forged provenance id rather than pathing a counter TSV with it.
-  _uberdev_goal_validate_id "$goal_id" || {
-    printf 'goal-state: unsafe UBERDEV_GOAL_ID %s; refusing merge dispatch for PR #%s\n' "$goal_id" "$pr" >&2
-    return 1
-  }
   local current; current="$(_uberdev_goal_count_merge_attempts "$goal_id" "$pr")"
   local next=$(( current + 1 ))
   # #157 — fail closed: an unrecorded merge attempt would defeat the per-PR

--- a/tests/goal-dispatch-helpers.test.sh
+++ b/tests/goal-dispatch-helpers.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# tests/goal-dispatch-helpers.test.sh
+#
+# Behavioral coverage for the lib/dispatch.sh dependency guards in
+# lib/goal-state.sh's two dispatch helpers (issue #207):
+#   _uberdev_goal_dispatch_review_pr
+#   _uberdev_goal_dispatch_merge
+#
+# Both helpers call uberdev_dispatch_one — which lives in lib/dispatch.sh,
+# NOT in goal-state.sh — without any preflight. A caller that sources
+# goal-state.sh without dispatch.sh would otherwise hit a bare `command
+# not found` mid-dispatch. The guards must:
+#   - fail loud with rc=4 (matching the writer + register_batch_pr convention)
+#   - emit a diagnostic naming lib/dispatch.sh + the missing symbol
+#   - never let `command not found` leak through
+#   - run AFTER cheap arg validation (so bad-arg rcs stay at 1) but BEFORE
+#     mktemp (so no temp sibling leaks on the missing-dep path)
+#
+# Mirrors the #195 fresh-`bash -c` pattern in tests/goal-state-sidecar.test.sh.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"
+export CLAUDE_PLUGIN_ROOT
+GOAL_LIB="$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+DISPATCH_LIB="$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+
+for f in "$GOAL_LIB" "$DISPATCH_LIB"; do
+  if [ ! -r "$f" ]; then
+    printf 'FATAL: required file missing or unreadable: %s\n' "$f" >&2
+    exit 2
+  fi
+done
+
+PASS=0
+FAIL=0
+assert_eq() {
+  local got="$1" want="$2" label="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS + 1)); printf '  PASS  %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1)); printf '  FAIL  %s (got=[%s] want=[%s])\n' "$label" "$got" "$want" >&2
+  fi
+}
+
+_t_tmpdir="$(mktemp -d 2>/dev/null || printf '/tmp/goal-disp-%s' "$$")"
+mkdir -p "$_t_tmpdir"
+UBERDEV_TMPDIR="$_t_tmpdir"
+export UBERDEV_TMPDIR
+trap 'rm -rf "$_t_tmpdir"' EXIT
+
+# ---------------------------------------------------------------------------
+# NEGATIVE: dispatch.sh withheld → both helpers must trip the preflight.
+# Valid pr + valid UBERDEV_GOAL_ID so the int + id validates pass and the
+# guard, not validation, is what trips. Counter-attempts TSV pre-seeded
+# empty so `_uberdev_goal_count_review_pr_attempts` returns 0 < cap.
+# ---------------------------------------------------------------------------
+
+echo "== #207: _uberdev_goal_dispatch_review_pr preflights its lib/dispatch.sh dependency =="
+g_dir_rpr="$(mktemp -d 2>/dev/null || printf '/tmp/goal-207-rpr-%s' "$$")"
+g_rpr_rc="$(UBERDEV_TMPDIR="$g_dir_rpr" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  UBERDEV_GOAL_ID="goal-test-rpr00207" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"   # dispatch.sh deliberately NOT sourced
+    _uberdev_goal_dispatch_review_pr 123 2>"$UBERDEV_TMPDIR/rpr-err.txt"
+    printf "%s" "$?"
+  ')"
+assert_eq "$g_rpr_rc" "4" "#207 rpr missing-dispatch: returns the distinct dependency rc (4), not 1 or 127"
+if grep -q 'requires lib/dispatch.sh' "$g_dir_rpr/rpr-err.txt" 2>/dev/null; then
+  assert_eq "diag" "diag"    "#207 rpr missing-dispatch: emits diagnostic naming lib/dispatch.sh"
+else
+  assert_eq "diag" "MISSING" "#207 rpr missing-dispatch: emits diagnostic naming lib/dispatch.sh"
+fi
+if grep -q 'uberdev_dispatch_one' "$g_dir_rpr/rpr-err.txt" 2>/dev/null; then
+  assert_eq "names-sym" "names-sym"    "#207 rpr missing-dispatch: diagnostic names the missing symbol"
+else
+  assert_eq "names-sym" "MISSING-SYM"  "#207 rpr missing-dispatch: diagnostic names the missing symbol"
+fi
+if grep -qi 'command not found' "$g_dir_rpr/rpr-err.txt" 2>/dev/null; then
+  assert_eq "no-cnf" "command-not-found-leaked" "#207 rpr missing-dispatch: NO raw 'command not found' crash noise"
+else
+  assert_eq "no-cnf" "no-cnf"                   "#207 rpr missing-dispatch: NO raw 'command not found' crash noise"
+fi
+# Guard must trip BEFORE mktemp; no stray prompt-file sibling left behind.
+# _uberdev_goal_dispatch_review_pr's mktemp is bare (no template), so the
+# leak target is any newly-created file under $UBERDEV_TMPDIR. Empty
+# isolated tmpdir means a hit here = leak.
+rpr_stray="$(find "$g_dir_rpr" -maxdepth 1 -type f ! -name 'rpr-err.txt' 2>/dev/null | head -1)"
+assert_eq "${rpr_stray:-none}" "none" "#207 rpr missing-dispatch: no stray prompt-file/temp sibling leaked"
+rm -rf "$g_dir_rpr"
+
+echo "== #207: _uberdev_goal_dispatch_merge preflights its lib/dispatch.sh dependency =="
+g_dir_mrg="$(mktemp -d 2>/dev/null || printf '/tmp/goal-207-mrg-%s' "$$")"
+g_mrg_rc="$(UBERDEV_TMPDIR="$g_dir_mrg" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  UBERDEV_GOAL_ID="goal-test-mrg00207" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"   # dispatch.sh deliberately NOT sourced
+    _uberdev_goal_dispatch_merge 456 2>"$UBERDEV_TMPDIR/mrg-err.txt"
+    printf "%s" "$?"
+  ')"
+assert_eq "$g_mrg_rc" "4" "#207 mrg missing-dispatch: returns the distinct dependency rc (4), not 1 or 127"
+if grep -q 'requires lib/dispatch.sh' "$g_dir_mrg/mrg-err.txt" 2>/dev/null; then
+  assert_eq "diag" "diag"    "#207 mrg missing-dispatch: emits diagnostic naming lib/dispatch.sh"
+else
+  assert_eq "diag" "MISSING" "#207 mrg missing-dispatch: emits diagnostic naming lib/dispatch.sh"
+fi
+if grep -q 'uberdev_dispatch_one' "$g_dir_mrg/mrg-err.txt" 2>/dev/null; then
+  assert_eq "names-sym" "names-sym"    "#207 mrg missing-dispatch: diagnostic names the missing symbol"
+else
+  assert_eq "names-sym" "MISSING-SYM"  "#207 mrg missing-dispatch: diagnostic names the missing symbol"
+fi
+if grep -qi 'command not found' "$g_dir_mrg/mrg-err.txt" 2>/dev/null; then
+  assert_eq "no-cnf" "command-not-found-leaked" "#207 mrg missing-dispatch: NO raw 'command not found' crash noise"
+else
+  assert_eq "no-cnf" "no-cnf"                   "#207 mrg missing-dispatch: NO raw 'command not found' crash noise"
+fi
+mrg_stray="$(find "$g_dir_mrg" -maxdepth 1 -type f ! -name 'mrg-err.txt' 2>/dev/null | head -1)"
+assert_eq "${mrg_stray:-none}" "none" "#207 mrg missing-dispatch: no stray prompt-file/temp sibling leaked"
+rm -rf "$g_dir_mrg"
+
+# ---------------------------------------------------------------------------
+# POSITIVE: with dispatch.sh sourced (so the symbol exists) AND a same-
+# session stub of uberdev_dispatch_one, both helpers must proceed past the
+# guard, run their counter-write + mktemp, and reach the dispatch call.
+# The stub records the call and returns 0 — we then assert the helper
+# itself returns 0 and the stub got the expected (pr, "small", file) shape.
+# ---------------------------------------------------------------------------
+
+echo "== #207: dispatch.sh sourced + uberdev_dispatch_one stub → both helpers reach the dispatch =="
+g_dir_pos="$(mktemp -d 2>/dev/null || printf '/tmp/goal-207-pos-%s' "$$")"
+pos_out="$(UBERDEV_TMPDIR="$g_dir_pos" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  UBERDEV_GOAL_ID="goal-test-pos00207" bash -c '
+    . "$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+    . "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+    # Override the real dispatch entry-point AFTER sourcing — bash will use
+    # this redefinition. The stub records its argv shape so the test can
+    # assert the helper threaded the right tier+args.
+    uberdev_dispatch_one() {
+      printf "%s|%s|%s\n" "$1" "$2" "$3" > "$UBERDEV_TMPDIR/dispatch-call.txt"
+      return 0
+    }
+    _uberdev_goal_dispatch_review_pr 789; rpr_rc=$?
+    _uberdev_goal_dispatch_merge      890; mrg_rc=$?
+    printf "rpr=%s mrg=%s\n" "$rpr_rc" "$mrg_rc"
+    # Surface the recorded dispatch shape (last call wins).
+    cat "$UBERDEV_TMPDIR/dispatch-call.txt" 2>/dev/null
+  ')"
+# rc=0 from both helpers (passed the guard, reached the stub, stub returned 0)
+case "$pos_out" in
+  *"rpr=0 mrg=0"*)
+    assert_eq "happy" "happy" "#207 pos: both helpers return 0 when dispatch.sh is sourced + stub installed" ;;
+  *)
+    assert_eq "happy" "MISSING (got: $pos_out)" "#207 pos: both helpers return 0 when dispatch.sh is sourced + stub installed" ;;
+esac
+case "$pos_out" in
+  *"890|small|"*)
+    assert_eq "stub-shape" "stub-shape" "#207 pos: stub receives (pr, \"small\", prompt_file) — helper threaded tier correctly" ;;
+  *)
+    assert_eq "stub-shape" "MISSING (got: $pos_out)" "#207 pos: stub receives (pr, \"small\", prompt_file) — helper threaded tier correctly" ;;
+esac
+rm -rf "$g_dir_pos"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "== Summary =="
+printf 'PASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/goal-dispatch-helpers.test.sh
+++ b/tests/goal-dispatch-helpers.test.sh
@@ -2,19 +2,7 @@
 # tests/goal-dispatch-helpers.test.sh
 #
 # Behavioral coverage for the lib/dispatch.sh dependency guards in
-# lib/goal-state.sh's two dispatch helpers (issue #207):
-#   _uberdev_goal_dispatch_review_pr
-#   _uberdev_goal_dispatch_merge
-#
-# Both helpers call uberdev_dispatch_one — which lives in lib/dispatch.sh,
-# NOT in goal-state.sh — without any preflight. A caller that sources
-# goal-state.sh without dispatch.sh would otherwise hit a bare `command
-# not found` mid-dispatch. The guards must:
-#   - fail loud with rc=4 (matching the writer + register_batch_pr convention)
-#   - emit a diagnostic naming lib/dispatch.sh + the missing symbol
-#   - never let `command not found` leak through
-#   - run AFTER cheap arg validation (so bad-arg rcs stay at 1) but BEFORE
-#     mktemp (so no temp sibling leaks on the missing-dep path)
+# lib/goal-state.sh's two dispatch helpers (issue #207).
 #
 # Mirrors the #195 fresh-`bash -c` pattern in tests/goal-state-sidecar.test.sh.
 set -u
@@ -43,18 +31,10 @@ assert_eq() {
   fi
 }
 
-_t_tmpdir="$(mktemp -d 2>/dev/null || printf '/tmp/goal-disp-%s' "$$")"
-mkdir -p "$_t_tmpdir"
-UBERDEV_TMPDIR="$_t_tmpdir"
-export UBERDEV_TMPDIR
-trap 'rm -rf "$_t_tmpdir"' EXIT
-
-# ---------------------------------------------------------------------------
 # NEGATIVE: dispatch.sh withheld → both helpers must trip the preflight.
 # Valid pr + valid UBERDEV_GOAL_ID so the int + id validates pass and the
 # guard, not validation, is what trips. Counter-attempts TSV pre-seeded
 # empty so `_uberdev_goal_count_review_pr_attempts` returns 0 < cap.
-# ---------------------------------------------------------------------------
 
 echo "== #207: _uberdev_goal_dispatch_review_pr preflights its lib/dispatch.sh dependency =="
 g_dir_rpr="$(mktemp -d 2>/dev/null || printf '/tmp/goal-207-rpr-%s' "$$")"
@@ -116,13 +96,11 @@ mrg_stray="$(find "$g_dir_mrg" -maxdepth 1 -type f ! -name 'mrg-err.txt' 2>/dev/
 assert_eq "${mrg_stray:-none}" "none" "#207 mrg missing-dispatch: no stray prompt-file/temp sibling leaked"
 rm -rf "$g_dir_mrg"
 
-# ---------------------------------------------------------------------------
 # POSITIVE: with dispatch.sh sourced (so the symbol exists) AND a same-
 # session stub of uberdev_dispatch_one, both helpers must proceed past the
 # guard, run their counter-write + mktemp, and reach the dispatch call.
 # The stub records the call and returns 0 — we then assert the helper
 # itself returns 0 and the stub got the expected (pr, "small", file) shape.
-# ---------------------------------------------------------------------------
 
 echo "== #207: dispatch.sh sourced + uberdev_dispatch_one stub → both helpers reach the dispatch =="
 g_dir_pos="$(mktemp -d 2>/dev/null || printf '/tmp/goal-207-pos-%s' "$$")"
@@ -158,9 +136,7 @@ case "$pos_out" in
 esac
 rm -rf "$g_dir_pos"
 
-# ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
 echo
 echo "== Summary =="
 printf 'PASS=%d FAIL=%d\n' "$PASS" "$FAIL"

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -277,11 +277,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.34.1) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.1"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.1"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.1-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.1\]'        "G20.changelog"
+echo "== G20: version bump locked (0.34.2) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.2"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.2"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.2-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.2\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.34.0 -> 0.34.1 propagated =="
+echo "== Version bump 0.34.1 -> 0.34.2 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.34.1"' \
-  "plugin.json bumped to 0.34.1"
+  '"version": "0.34.2"' \
+  "plugin.json bumped to 0.34.2"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.34.1"' \
-  "marketplace.json bumped to 0.34.1"
+  '"version": "0.34.2"' \
+  "marketplace.json bumped to 0.34.2"
 assert_grep "$README" \
-  "version-0\\.34\\.1-blue" \
-  "README version badge bumped to 0.34.1"
+  "version-0\\.34\\.2-blue" \
+  "README version badge bumped to 0.34.2"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.34\.1\]' \
-  "CHANGELOG has [0.34.1] section header"
+  '^## \[0\.34\.2\]' \
+  "CHANGELOG has [0.34.2] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary

- `_uberdev_goal_dispatch_review_pr` and `_uberdev_goal_dispatch_merge` both call `uberdev_dispatch_one` from `lib/dispatch.sh` without a preflight. A caller that sources `goal-state.sh` without sourcing `lib/dispatch.sh` first would hit a bare `command not found` mid-dispatch, AFTER the per-PR attempt counter TSV had already been appended (phantom attempt with no actual dispatch and a misleading rc).
- Adds the `command -v uberdev_dispatch_one` preflight to both helpers (rc=4 + `goal-state:` diagnostic, matching the precedent set by #195/PR #206 for `_uberdev_dispatch_prepare_tmp_target`). Placed after arg validation, BEFORE any counter-read/write or `mktemp`, so no side effects leak on the missing-dep path.
- Consolidates the "External imports" header at the top of `goal-state.sh` so both dispatch-lib symbols (`_uberdev_dispatch_prepare_tmp_target` for the writer/register, `uberdev_dispatch_one` for the two dispatch helpers) sit under one paragraph — fixes the doc inconsistency #207 called out.
- Reorders `_uberdev_goal_validate_id` above `mktemp` in `_uberdev_goal_dispatch_merge` so the id-validate failure path no longer leaks a stray prompt file (uniform shape with the sibling helper).
- Adds 12 behavioral assertions in `tests/goal-dispatch-helpers.test.sh` (fresh `bash -c` pattern mirrored from `tests/goal-state-sidecar.test.sh`'s #195 test): negative cases (rc=4 + diagnostic + no-CNF-leak + no-stray-file per helper) and a positive stub-based case proving both helpers reach `uberdev_dispatch_one` with the `(pr, "small", prompt_file)` shape when the dep is present.
- Wires the new test file into both ubuntu + windows CI matrices in `.github/workflows/test.yml`.
- Version bumped 0.34.0 → 0.34.1 across the six locked sites (plugin.json, marketplace.json, README badge, CHANGELOG, `goal.test.sh` G20, `solve-claim.test.sh`).

## Test plan

- [x] `bash tests/goal-dispatch-helpers.test.sh` — 12/12 PASS (new)
- [x] `bash tests/goal.test.sh` — 365/365 PASS (G20 ratchet matches 0.34.1)
- [x] `bash tests/goal-state-sidecar.test.sh` — 26/26 PASS (parallel #195 coverage unaffected)
- [x] `bash tests/goal-batch-barrier.test.sh` — 8/8 PASS
- [x] `bash tests/solve-claim.test.sh` — 104/104 PASS (version-bump assertions match 0.34.1)
- [x] `bash tests/dispatch-claude-bg.test.sh` — 99/99 PASS (dispatch lib unchanged)
- [x] `bash tests/dispatch-fallback.test.sh` — 12/12 PASS
- [x] `bash tests/dispatch-background.test.sh` — 12/12 PASS
- [x] `bash tests/config-override.test.sh` — 90/90 PASS
- [x] `bash -n plugins/uberdev/lib/goal-state.sh` — syntax OK; sources cleanly with both helpers defined

Related: #195, PR #206.

Closes #207.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dispatch helper robustness to gracefully handle missing dependencies with proper error codes and diagnostics, preventing stray temporary file leakage.

* **Tests**
  * Added comprehensive test coverage for dispatch helper behavior under both failure and success scenarios.

* **Chores**
  * Version bumped to 0.34.2 across plugin manifests, marketplace, and documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->