### PR TITLE
fix(goal-pipeline): parameterise awk $1/$2/$3 to neutralise Skill-loader substitution (#222) — v0.34.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.34.4",
+      "version": "0.34.5",
       "category": "workflow",
       "tags": [
         "github",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,7 @@ jobs:
           bash tests/using-git-worktrees.test.sh && \
           bash tests/goal.test.sh && \
           bash tests/goal-batch-barrier.test.sh && \
+          bash tests/goal-pipeline-awk-positional.test.sh && \
           bash tests/test-harness-source-guards.test.sh
 
   shape-checks-windows:
@@ -214,4 +215,5 @@ jobs:
           bash tests/using-git-worktrees.test.sh && \
           bash tests/goal.test.sh && \
           bash tests/goal-batch-barrier.test.sh && \
+          bash tests/goal-pipeline-awk-positional.test.sh && \
           bash tests/test-harness-source-guards.test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.5] — 2026-05-27
+
+### Fixed
+- **`plugins/uberdev/skills/goal-pipeline/SKILL.md`: Skill loader text-substitutes positional non-flag args of `$ARGUMENTS` into the rendered SKILL.md body, ignoring single-quote boundaries — every awk one-liner using `$1`/`$2`/`$3` as field references was corrupted at runtime (#222).** Effects: Phase 1/2 state-skip gates always fell through, Phase 2 `dispatch_ts`/`seen_ts`/`merge_ts` reads always returned 0 (driving false `FAILED` transitions + premature `/review-pr` re-dispatch + premature `merging→green` retry), and Phase 3 `all_pr_count` always equalled 1 (driving false `goal_converged`). Option-1 fix: parameterise each awk field ref via `-v c1=1 -v c2=2 -v c3=3` and reference `$c1`/`$c2`/`$c3` — the renderer leaves `$cN` untouched. All 8 affected sites (lines 222, 358, 371, 391, 463, 682, 960, 1063) fixed in goal-pipeline; the other 5 pipeline SKILL.md files (uberscan, ubersimplify, merge, solve, testers) audited and confirmed clean. New static drift-guard `tests/goal-pipeline-awk-positional.test.sh` walks every `awk ` line in all 6 pipeline SKILL.md files via a single-quote-aware state machine and asserts no `$[1-9]` literal appears inside a single-quoted region — defense-in-depth lock against regression in any pipeline. Wired into both ubuntu + windows CI matrices.
+
+### Notes
+- Version bumped to 0.34.5 across `plugin.json`, `marketplace.json`, the README badge, `CHANGELOG.md`, `tests/goal.test.sh` G20, and `tests/solve-claim.test.sh`. Atomic version-lock surfaces — partial bump is a red CI invariant.
+
+---
+
 ## [0.34.4] — 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.34.4-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.34.5-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.34.4",
+  "version": "0.34.5",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -218,7 +218,11 @@ declare -a active_issues=()
 dispatched_this_cycle=0
 remaining_queue=()
 for ISSUE_NUM in "${queue[@]}"; do
-  current_state="$(awk -v i="$ISSUE_NUM" '{state[$1]=$2} END {print state[i]}' \
+  # #222 — `$1`/`$2`/`$3` literals would be text-substituted by the Skill
+  # loader at $ARGUMENTS-render time (it does NOT respect single-quote
+  # boundaries). Parameterise via `-v c1=1 -v c2=2 -v c3=3` so the renderer
+  # leaves the field refs untouched.
+  current_state="$(awk -v i="$ISSUE_NUM" -v c1=1 -v c2=2 '{state[$c1]=$c2} END {print state[i]}' \
     "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
   case "$current_state" in
     solving|pr-pushed) continue ;;
@@ -350,7 +354,7 @@ while true; do
   # no PR exists yet, `uberdev_goal_agent_busy_for_issue` disambiguates "solver
   # still working" from "solver died", bounded by _UBERDEV_GOAL_SOLVE_TIMEOUT.
   for issue in "${active_issues[@]}"; do
-    istate="$(awk -v i="$issue" '{s[$1]=$2} END{print s[i]}' \
+    istate="$(awk -v i="$issue" -v c1=1 -v c2=2 '{s[$c1]=$c2} END{print s[i]}' \
       "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
     case "$istate" in pr-pushed|resolved|failed) continue ;; esac
     pr_num="$(uberdev_goal_find_pr_for_issue "$issue")"
@@ -364,7 +368,7 @@ while true; do
       # warn-and-continue on rc != 0 — a transient registry write must not
       # fail the watch loop.
       batch_tsv="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}/goal-${GOAL_ID}-batch-prs.tsv"
-      if [ ! -f "$batch_tsv" ] || ! awk -F'\t' -v p="$pr_num" '$1==p{found=1; exit} END{exit !found}' "$batch_tsv"; then
+      if [ ! -f "$batch_tsv" ] || ! awk -F'\t' -v p="$pr_num" -v c1=1 '$c1==p{found=1; exit} END{exit !found}' "$batch_tsv"; then
         uberdev_goal_register_batch_pr "$GOAL_ID" "$pr_num" "$issue" \
           || printf 'goal: register_batch_pr deferred-call failed for PR=%s issue=%s (rc=%s)\n' "$pr_num" "$issue" "$?" >&2
       fi
@@ -384,7 +388,7 @@ while true; do
     if uberdev_goal_agent_busy_for_issue "$issue"; then
       any_active=1
     else
-      dispatch_ts="$(awk -v i="$issue" '$1==i && $2=="solving"{t=$3} END{print t+0}' \
+      dispatch_ts="$(awk -v i="$issue" -v c1=1 -v c2=2 -v c3=3 '$c1==i && $c2=="solving"{t=$c3} END{print t+0}' \
         "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
       if [ "$(( now - dispatch_ts ))" -lt "$_UBERDEV_GOAL_SOLVE_TIMEOUT" ]; then
         any_active=1
@@ -456,7 +460,7 @@ while true; do
         # under specific transition orderings. `!t{t=$3}` guards FIRST-seen;
         # `t+0` coerces empty → 0 so the downstream `$((now - seen_ts))` is
         # arithmetic-safe even when no row exists.
-        seen_ts=$(awk -F'\t' -v p="$pr_num" '$1==p && $2=="pushed-reviewing" && !t{t=$3} END{print t+0}' \
+        seen_ts=$(awk -F'\t' -v p="$pr_num" -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="pushed-reviewing" && !t{t=$c3} END{print t+0}' \
           "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" 2>/dev/null)
         # Marker probe (Component 3.2)
         if _uberdev_goal_locked_marker_for_pr_fresh "$pr_num" "$REVIEW_GRACE_SECS"; then
@@ -675,7 +679,7 @@ while true; do
         # is `solve-issue-<pr>` and `agent_busy_for_issue "$pr"` matches it
         # correctly. (The function name says "for_issue" because the SHARED
         # naming convention is solve-issue-<key>; the key here is a PR.)
-        merge_ts="$(awk -v p="$pr" '$1==p && $2=="merging"{t=$3} END{print t+0}' \
+        merge_ts="$(awk -v p="$pr" -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="merging"{t=$c3} END{print t+0}' \
           "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" 2>/dev/null)"
         if [ "$(( now - merge_ts ))" -ge "$_UBERDEV_GOAL_MERGE_TIMEOUT" ] \
            && ! uberdev_goal_agent_busy_for_issue "$pr"; then
@@ -953,7 +957,7 @@ terminal_prs="$(uberdev_goal_list_prs_in_state "$GOAL_ID" merged \
   ; uberdev_goal_list_prs_in_state "$GOAL_ID" merge-failed \
   ; uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held \
   ; uberdev_goal_list_prs_in_state "$GOAL_ID" red-held)"
-all_pr_count="$(awk '{print $1}' "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" \
+all_pr_count="$(awk -v c1=1 '{print $c1}' "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" \
   | sort -u | wc -l)"
 terminal_count="$(printf '%s\n' "$terminal_prs" | grep -c . || true)"
 if [ "${#new_candidates[@]}" = "0" ] && [ "$terminal_count" = "$all_pr_count" ]; then
@@ -1056,7 +1060,7 @@ print_summary() {
     uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held | sed 's/^/yellow-held\t/'; \
     uberdev_goal_list_prs_in_state "$GOAL_ID" red-held    | sed 's/^/red-held\t/' )"
   prs_held_count="$(printf '%s\n' "$prs_held_lines" | grep -c . || true)"
-  issues_resolved="$(awk '$2=="resolved" {print $1}' \
+  issues_resolved="$(awk -v c1=1 -v c2=2 '$c2=="resolved" {print $c1}' \
     "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" | grep -c . || true)"
   wall_secs="$(( $(date +%s) - watch_start ))"
   printf 'goal %s: cycles=%s/%s prs_merged=%s prs_held=%s issues_resolved=%s wall_secs=%s\n' \

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -457,7 +457,7 @@ while true; do
         # against a much-newer transition timestamp, never crossing the
         # threshold. The original awk printed every row's ts for the PR and
         # the shell captured only the LAST line, masking the bug except
-        # under specific transition orderings. `!t{t=$3}` guards FIRST-seen;
+        # under specific transition orderings. `!t{t=$c3}` guards FIRST-seen;
         # `t+0` coerces empty → 0 so the downstream `$((now - seen_ts))` is
         # arithmetic-safe even when no row exists.
         seen_ts=$(awk -F'\t' -v p="$pr_num" -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="pushed-reviewing" && !t{t=$c3} END{print t+0}' \

--- a/tests/goal-pipeline-awk-positional.test.sh
+++ b/tests/goal-pipeline-awk-positional.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# tests/goal-pipeline-awk-positional.test.sh — regression-lock for #222.
+#
+# The Claude Code Skill loader text-blind-substitutes positional non-flag args
+# of $ARGUMENTS into the entire rendered SKILL.md body. The substitution does
+# NOT respect single-quote boundaries, so awk field references like $1 / $2 /
+# $3 inside `awk '...'` one-liners are rewritten as if they were shell
+# positional parameters. That silently corrupts every state-read in
+# goal-pipeline (Phase 1 skip-check, Phase 2 dispatch_ts / seen_ts / merge_ts,
+# Phase 3 all_pr_count / issues_resolved), causing false convergence and
+# false FAILED transitions.
+#
+# The fix (issue #222 Option 1) is to parameterise the field refs via
+#   awk -v c1=1 -v c2=2 -v c3=3 '... $c1 ... $c2 ... $c3 ...'
+# The renderer does NOT substitute $cN (it's not a positional shell var).
+#
+# This static test walks every awk one-liner in the pipeline SKILL.md bodies
+# and asserts no `$1`..`$9` literal field-ref appears inside a single-quoted
+# region. Defense-in-depth: covers all 5 *-pipeline files so a future
+# regression in any of them is caught.
+#
+# Detection algorithm: state-machine walk over each line containing `awk `.
+# Track an in_quote toggle as we encounter `'`; accumulate the bytes seen
+# while in_quote is true. Match `$[1-9]` against the accumulated buffer.
+# The toggle is sufficient because shell single quotes do not nest and do
+# not support backslash-escape inside the quoted region.
+
+set -u
+THIS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$THIS_DIR/.." && pwd)"
+PIPELINE_DIR="$REPO_ROOT/plugins/uberdev/skills"
+
+PASS=0; FAIL=0
+echo "## goal-pipeline awk positional-arg-substitution guard (#222)"
+
+# Subjects: every *-pipeline SKILL.md that runs through the args-substituting
+# Skill loader. goal-pipeline was the trigger; the others get the same
+# defense-in-depth lock so a future regression is caught immediately.
+SUBJECTS=(
+  "$PIPELINE_DIR/goal-pipeline/SKILL.md"
+  "$PIPELINE_DIR/uberscan-pipeline/SKILL.md"
+  "$PIPELINE_DIR/ubersimplify-pipeline/SKILL.md"
+  "$PIPELINE_DIR/merge-pipeline/SKILL.md"
+  "$PIPELINE_DIR/solve-pipeline/SKILL.md"
+  "$PIPELINE_DIR/testers-pipeline/SKILL.md"
+)
+
+for SUBJECT in "${SUBJECTS[@]}"; do
+  rel="${SUBJECT#"$REPO_ROOT/"}"
+  if [ ! -r "$SUBJECT" ]; then
+    echo "  FAIL  G_$(basename "$(dirname "$SUBJECT")") subject not readable: $rel"
+    FAIL=$((FAIL+1))
+    continue
+  fi
+  violations=$(awk '
+    /awk[ \t]/ {
+      line = $0
+      in_quote = 0
+      quoted = ""
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        if (c == "\047") {
+          in_quote = !in_quote
+        } else if (in_quote) {
+          quoted = quoted c
+        }
+      }
+      if (match(quoted, /\$[1-9]/) > 0) {
+        printf "    %s:%d  %s\n", FILENAME, NR, $0
+        v++
+      }
+    }
+    END { exit (v > 0 ? 1 : 0) }
+  ' "$SUBJECT")
+  rc=$?
+  tag="G_$(basename "$(dirname "$SUBJECT")")"
+  if [ "$rc" -eq 0 ]; then
+    echo "  PASS  $tag $rel: no \$N field refs inside single-quoted awk scripts"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL  $tag $rel: \$N field refs inside single-quoted awk scripts (Skill renderer will substitute):"
+    printf '%s\n' "$violations"
+    echo "         Fix: parameterise via 'awk -v c1=1 -v c2=2 -v c3=3 ... \$c1 ... \$c2 ... \$c3 ...'"
+    FAIL=$((FAIL+1))
+  fi
+done
+
+echo "  Result: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/goal-pipeline-awk-positional.test.sh
+++ b/tests/goal-pipeline-awk-positional.test.sh
@@ -16,8 +16,9 @@
 #
 # This static test walks every awk one-liner in the pipeline SKILL.md bodies
 # and asserts no `$1`..`$9` literal field-ref appears inside a single-quoted
-# region. Defense-in-depth: covers all 5 *-pipeline files so a future
-# regression in any of them is caught.
+# region. Defense-in-depth: dynamically discovers every *-pipeline SKILL.md
+# under plugins/uberdev/skills so the guard self-extends as new pipelines
+# are added — a future regression in any of them is caught immediately.
 #
 # Detection algorithm: state-machine walk over each line containing `awk `.
 # Track an in_quote toggle as we encounter `'`; accumulate the bytes seen
@@ -34,16 +35,17 @@ PASS=0; FAIL=0
 echo "## goal-pipeline awk positional-arg-substitution guard (#222)"
 
 # Subjects: every *-pipeline SKILL.md that runs through the args-substituting
-# Skill loader. goal-pipeline was the trigger; the others get the same
+# Skill loader. Dynamic glob so the guard self-extends as new pipelines are
+# added. goal-pipeline was the trigger; every other *-pipeline gets the same
 # defense-in-depth lock so a future regression is caught immediately.
-SUBJECTS=(
-  "$PIPELINE_DIR/goal-pipeline/SKILL.md"
-  "$PIPELINE_DIR/uberscan-pipeline/SKILL.md"
-  "$PIPELINE_DIR/ubersimplify-pipeline/SKILL.md"
-  "$PIPELINE_DIR/merge-pipeline/SKILL.md"
-  "$PIPELINE_DIR/solve-pipeline/SKILL.md"
-  "$PIPELINE_DIR/testers-pipeline/SKILL.md"
-)
+SUBJECTS=()
+for f in "$PIPELINE_DIR"/*-pipeline/SKILL.md; do
+  [ -e "$f" ] && SUBJECTS+=("$f")
+done
+if [ "${#SUBJECTS[@]}" -eq 0 ]; then
+  echo "  FAIL  no *-pipeline/SKILL.md subjects discovered under $PIPELINE_DIR"
+  exit 1
+fi
 
 for SUBJECT in "${SUBJECTS[@]}"; do
   rel="${SUBJECT#"$REPO_ROOT/"}"

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -288,11 +288,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.34.4) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.4"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.4"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.4-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.4\]'        "G20.changelog"
+echo "== G20: version bump locked (0.34.5) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.5"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.5"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.5-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.5\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.34.3 -> 0.34.4 propagated =="
+echo "== Version bump 0.34.4 -> 0.34.5 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.34.4"' \
-  "plugin.json bumped to 0.34.4"
+  '"version": "0.34.5"' \
+  "plugin.json bumped to 0.34.5"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.34.4"' \
-  "marketplace.json bumped to 0.34.4"
+  '"version": "0.34.5"' \
+  "marketplace.json bumped to 0.34.5"
 assert_grep "$README" \
-  "version-0\\.34\\.4-blue" \
-  "README version badge bumped to 0.34.4"
+  "version-0\\.34\\.5-blue" \
+  "README version badge bumped to 0.34.5"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.34\.4\]' \
-  "CHANGELOG has [0.34.4] section header"
+  '^## \[0\.34\.5\]' \
+  "CHANGELOG has [0.34.5] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary
- Parameterise every `awk '... $1 ... $2 ... $3 ...'` one-liner in `plugins/uberdev/skills/goal-pipeline/SKILL.md` via `-v c1=1 -v c2=2 -v c3=3` and reference `$c1`/`$c2`/`$c3`. The Skill loader text-substitutes positional non-flag args of `$ARGUMENTS` into the rendered SKILL.md body, ignoring single-quote boundaries — every awk field ref was being rewritten as a shell positional, silently corrupting 8 state-read sites and driving false `goal_converged` / false `FAILED` transitions / premature `/review-pr` re-dispatch / premature `merging→green` retry.
- Add `tests/goal-pipeline-awk-positional.test.sh` — a single-quote-aware state-machine walker over every `awk ` line in all 6 pipeline SKILL.md files; asserts no `$[1-9]` literal appears inside a single-quoted region. Defense-in-depth lock against regression across goal/uberscan/ubersimplify/merge/solve/testers pipelines. Wired into both ubuntu and windows CI matrices.
- Bump version 0.34.4 → 0.34.5 across the 6 atomic lock surfaces (plugin.json, marketplace.json, README badge, CHANGELOG.md, `tests/goal.test.sh` G20, `tests/solve-claim.test.sh`). Partial bump is a red CI invariant.

## Test Plan
- [x] `bash tests/goal-pipeline-awk-positional.test.sh` — new guard passes on all 6 pipeline files (6 passed, 0 failed).
- [x] `bash tests/ci-wiring.test.sh` — drift guard PASS (new test wired into both ubuntu + windows matrices).
- [x] `bash tests/goal.test.sh` — G20 version assertions updated to 0.34.5.
- [x] `bash tests/solve-claim.test.sh` — version bump block updated 0.34.4 → 0.34.5.
- [x] Full CI ubuntu shape-check list (44 tests) runs green locally.
- [ ] CI workflow `Tests / shape-checks (ubuntu-latest)` green.
- [ ] CI workflow `Tests / shape-checks-windows (windows-latest)` green.

Closes #222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter substitution bug in goal-pipeline affecting timestamp reads and goal convergence logic

* **Tests**
  * Added regression test to CI to prevent similar issues

* **Chores**
  * Version bumped to 0.34.5

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->