### PR TITLE
fix(goal-pipeline): parameterise awk field refs to avoid Skill renderer collision (#222)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.34.4",
+      "version": "0.34.5",
       "category": "workflow",
       "tags": [
         "github",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,7 @@ jobs:
           bash tests/using-git-worktrees.test.sh && \
           bash tests/goal.test.sh && \
           bash tests/goal-batch-barrier.test.sh && \
+          bash tests/skill-renderer-awk-collision.test.sh && \
           bash tests/test-harness-source-guards.test.sh
 
   shape-checks-windows:
@@ -214,4 +215,5 @@ jobs:
           bash tests/using-git-worktrees.test.sh && \
           bash tests/goal.test.sh && \
           bash tests/goal-batch-barrier.test.sh && \
+          bash tests/skill-renderer-awk-collision.test.sh && \
           bash tests/test-harness-source-guards.test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 ## [0.34.5] — 2026-05-27
 
 ### Fixed
-- **Skill renderer corrupted awk `$1`/`$2`/`$3` field refs inside `goal-pipeline/SKILL.md` (Closes #222).** The Claude Code Skill loader substitutes positional non-flag args of `$ARGUMENTS` into the entire SKILL.md body, including inside single-quoted awk one-liners. `/ubergoal all gh issues` rendered `awk '$1==p && $2=="x"{t=$3}'` as `awk 'gh==p && issues=="x"{t=}'` (or `'219==p && 198=="x"{t=}'` for numeric args), producing false convergence (`all_pr_count=1` regardless of real PR set), bogus `FAILED` transitions (every `dispatch_ts` returned 0), and broken state-skip gates. 8 awk one-liners in `goal-pipeline/SKILL.md` (lines 221, 353, 367, 387, 459, 678, 956, 1059) plus 1 in `orchestrator/SKILL.md` (line 197) and 1 in `requesting-code-review/SKILL.md` (line 56) were all rewritten to use parameterised field refs (`-v c1=1 -v c2=2 -v c3=3` + `$c1`/`$c2`/`$c3`) so the renderer cannot touch them. The `$cN` form is not a positional shell reference and the renderer leaves it untouched.
+- **Skill renderer corrupted awk `$0`-`$9` field refs across 6 SKILL.md files (Closes #222).** The Claude Code Skill loader substitutes positional non-flag args of `$ARGUMENTS` into the entire SKILL.md body, **including inside single-quoted awk one-liners AND multi-line awk script bodies**. `/ubergoal all gh issues` rendered `awk '$1==p && $2=="x"{t=$3}'` as `awk 'gh==p && issues=="x"{t=}'` (or `'219==p && 198=="x"{t=}'` for numeric args), producing false convergence (`all_pr_count=1` regardless of real PR set), bogus `FAILED` transitions (every `dispatch_ts` returned 0), and broken state-skip gates. The same class also bit `$0` (the renderer substitutes the first positional non-flag into `$0`), which silently broke `/turbo 5 6 7` multi-issue dedupe (`awk '!seen[$0]++'` rendered as `!seen[5]++`, dropping every issue past the first). 14 awk sites total across 6 SKILL.md files were rewritten to use parameterised field refs (`-v cN=N` + `$cN`) so the renderer cannot touch them — the `$cN` form is not a positional shell reference and the renderer leaves it untouched:
+  - `plugins/uberdev/skills/goal-pipeline/SKILL.md` — 8 sites (lines 221, 353, 367, 387, 461, 680, 958, 1061) on `$1`/`$2`/`$3`.
+  - `plugins/uberdev/skills/orchestrator/SKILL.md` — 2 sites (line 199 single-line `$2`, line 225 multi-line `$1`) plus matching doc at line 279.
+  - `plugins/uberdev/skills/requesting-code-review/SKILL.md` — 1 site (line 56) on `$1`.
+  - `plugins/uberdev/skills/solve-pipeline/SKILL.md` — 1 site (line 93) on `$0`.
+  - `plugins/uberdev/skills/merge-pipeline/SKILL.md` — 1 site (line 809) on `$0`.
+  - `plugins/uberdev/skills/finish-branch/SKILL.md` — 1 site (line 162) on `$0` (3 references in one awk).
 
 ### Added
-- `tests/skill-renderer-awk-collision.test.sh` — drift-guard scanning every `plugins/uberdev/skills/*/SKILL.md` for awk script bodies containing bare `$N` field refs (with inverse fixture proof that the regex still flags the bad shape and does not false-positive on the safe parameterised form). Wired into both ubuntu and windows CI matrices.
+- `tests/skill-renderer-awk-collision.test.sh` — drift-guard scanning every `plugins/uberdev/skills/*/SKILL.md` for awk script bodies containing bare `$N` field refs (0-9). Uses a flattened-file scan (`tr '\n' ' '`) to catch multi-line awks (orchestrator/SKILL.md:225-class regressions that line-anchored greps silently pass), with regex constrained to `awk[^']*'[^']*\$[0-9][^c]` so it matches only inside the FIRST single-quoted body after `awk` (prevents greedy `.*` from spanning across the whole flattened file). R2 fixture proofs cover both single-line AND multi-line vulnerable shapes; R3 inverse fixture covers the full `$c0`/`$c1`/`$c2`/`$c3` safe set. Wired into both ubuntu and windows CI matrices.
 
 ### Notes
 - Version bumped to 0.34.5 across `plugin.json`, `marketplace.json`, the README badge, `CHANGELOG.md`, `tests/goal.test.sh` G20, and `tests/solve-claim.test.sh`. Atomic version-lock surfaces — partial bump is a red CI invariant.
+- Scope expanded mid-review (from `$1`-`$3` to `$0`-`$9`) after the `/review-pr` Phase 1 general-lens reviewer surfaced the orchestrator multi-line awk site missed by the original line-anchored regex; same root cause, so the three additional `$0` sites are folded into this PR rather than deferred.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.5] — 2026-05-27
+
+### Fixed
+- **Skill renderer corrupted awk `$1`/`$2`/`$3` field refs inside `goal-pipeline/SKILL.md` (Closes #222).** The Claude Code Skill loader substitutes positional non-flag args of `$ARGUMENTS` into the entire SKILL.md body, including inside single-quoted awk one-liners. `/ubergoal all gh issues` rendered `awk '$1==p && $2=="x"{t=$3}'` as `awk 'gh==p && issues=="x"{t=}'` (or `'219==p && 198=="x"{t=}'` for numeric args), producing false convergence (`all_pr_count=1` regardless of real PR set), bogus `FAILED` transitions (every `dispatch_ts` returned 0), and broken state-skip gates. 8 awk one-liners in `goal-pipeline/SKILL.md` (lines 221, 353, 367, 387, 459, 678, 956, 1059) plus 1 in `orchestrator/SKILL.md` (line 197) and 1 in `requesting-code-review/SKILL.md` (line 56) were all rewritten to use parameterised field refs (`-v c1=1 -v c2=2 -v c3=3` + `$c1`/`$c2`/`$c3`) so the renderer cannot touch them. The `$cN` form is not a positional shell reference and the renderer leaves it untouched.
+
+### Added
+- `tests/skill-renderer-awk-collision.test.sh` — drift-guard scanning every `plugins/uberdev/skills/*/SKILL.md` for awk script bodies containing bare `$N` field refs (with inverse fixture proof that the regex still flags the bad shape and does not false-positive on the safe parameterised form). Wired into both ubuntu and windows CI matrices.
+
+### Notes
+- Version bumped to 0.34.5 across `plugin.json`, `marketplace.json`, the README badge, `CHANGELOG.md`, `tests/goal.test.sh` G20, and `tests/solve-claim.test.sh`. Atomic version-lock surfaces — partial bump is a red CI invariant.
+
+---
+
 ## [0.34.4] — 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.34.4-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.34.5-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.34.4",
+  "version": "0.34.5",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -159,7 +159,7 @@ if [ -n "$QUESTIONS_FILE" ] && [ -f "$QUESTIONS_FILE" ]; then
     echo "The following questions were answered automatically — please review:"
     echo
     # Extract questions and auto-picks; render as a markdown table.
-    awk '/^## Q[0-9]+:/{q=$0; sub(/^## Q[0-9]+: */, "", q)} /^\*\*Auto-pick:\*\*/{a=$0; sub(/^\*\*Auto-pick:\*\* */, "", a)} /^\*\*Confidence:\*\*/{c=$0; sub(/^\*\*Confidence:\*\* */, "", c); print "| " q " | " a " | " c " |"}' "$QUESTIONS_FILE" | (echo "| Question | Choice | Confidence |"; echo "|----------|--------|------------|"; cat)
+    awk -v c0=0 '/^## Q[0-9]+:/{q=$c0; sub(/^## Q[0-9]+: */, "", q)} /^\*\*Auto-pick:\*\*/{a=$c0; sub(/^\*\*Auto-pick:\*\* */, "", a)} /^\*\*Confidence:\*\*/{c=$c0; sub(/^\*\*Confidence:\*\* */, "", c); print "| " q " | " a " | " c " |"}' "$QUESTIONS_FILE" | (echo "| Question | Choice | Confidence |"; echo "|----------|--------|------------|"; cat)
   } >> "$PR_BODY_FILE"
 fi
 

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -218,7 +218,7 @@ declare -a active_issues=()
 dispatched_this_cycle=0
 remaining_queue=()
 for ISSUE_NUM in "${queue[@]}"; do
-  current_state="$(awk -v i="$ISSUE_NUM" '{state[$1]=$2} END {print state[i]}' \
+  current_state="$(awk -v i="$ISSUE_NUM" -v c1=1 -v c2=2 '{state[$c1]=$c2} END {print state[i]}' \
     "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
   case "$current_state" in
     solving|pr-pushed) continue ;;
@@ -350,7 +350,7 @@ while true; do
   # no PR exists yet, `uberdev_goal_agent_busy_for_issue` disambiguates "solver
   # still working" from "solver died", bounded by _UBERDEV_GOAL_SOLVE_TIMEOUT.
   for issue in "${active_issues[@]}"; do
-    istate="$(awk -v i="$issue" '{s[$1]=$2} END{print s[i]}' \
+    istate="$(awk -v i="$issue" -v c1=1 -v c2=2 '{s[$c1]=$c2} END{print s[i]}' \
       "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
     case "$istate" in pr-pushed|resolved|failed) continue ;; esac
     pr_num="$(uberdev_goal_find_pr_for_issue "$issue")"
@@ -364,7 +364,7 @@ while true; do
       # warn-and-continue on rc != 0 — a transient registry write must not
       # fail the watch loop.
       batch_tsv="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}/goal-${GOAL_ID}-batch-prs.tsv"
-      if [ ! -f "$batch_tsv" ] || ! awk -F'\t' -v p="$pr_num" '$1==p{found=1; exit} END{exit !found}' "$batch_tsv"; then
+      if [ ! -f "$batch_tsv" ] || ! awk -F'\t' -v p="$pr_num" -v c1=1 '$c1==p{found=1; exit} END{exit !found}' "$batch_tsv"; then
         uberdev_goal_register_batch_pr "$GOAL_ID" "$pr_num" "$issue" \
           || printf 'goal: register_batch_pr deferred-call failed for PR=%s issue=%s (rc=%s)\n' "$pr_num" "$issue" "$?" >&2
       fi
@@ -384,7 +384,7 @@ while true; do
     if uberdev_goal_agent_busy_for_issue "$issue"; then
       any_active=1
     else
-      dispatch_ts="$(awk -v i="$issue" '$1==i && $2=="solving"{t=$3} END{print t+0}' \
+      dispatch_ts="$(awk -v i="$issue" -v c1=1 -v c2=2 -v c3=3 '$c1==i && $c2=="solving"{t=$c3} END{print t+0}' \
         "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
       if [ "$(( now - dispatch_ts ))" -lt "$_UBERDEV_GOAL_SOLVE_TIMEOUT" ]; then
         any_active=1
@@ -453,10 +453,12 @@ while true; do
         # against a much-newer transition timestamp, never crossing the
         # threshold. The original awk printed every row's ts for the PR and
         # the shell captured only the LAST line, masking the bug except
-        # under specific transition orderings. `!t{t=$3}` guards FIRST-seen;
+        # under specific transition orderings. `!t{t=$c3}` guards FIRST-seen;
         # `t+0` coerces empty → 0 so the downstream `$((now - seen_ts))` is
-        # arithmetic-safe even when no row exists.
-        seen_ts=$(awk -F'\t' -v p="$pr_num" '$1==p && $2=="pushed-reviewing" && !t{t=$3} END{print t+0}' \
+        # arithmetic-safe even when no row exists. The `-v c1=1 -v c2=2 -v c3=3`
+        # parameterisation (issue #222) prevents the Skill renderer from
+        # substituting positional args of `$ARGUMENTS` into the awk field refs.
+        seen_ts=$(awk -F'\t' -v p="$pr_num" -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="pushed-reviewing" && !t{t=$c3} END{print t+0}' \
           "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" 2>/dev/null)
         # Marker probe (Component 3.2)
         if _uberdev_goal_locked_marker_for_pr_fresh "$pr_num" "$REVIEW_GRACE_SECS"; then
@@ -675,7 +677,7 @@ while true; do
         # is `solve-issue-<pr>` and `agent_busy_for_issue "$pr"` matches it
         # correctly. (The function name says "for_issue" because the SHARED
         # naming convention is solve-issue-<key>; the key here is a PR.)
-        merge_ts="$(awk -v p="$pr" '$1==p && $2=="merging"{t=$3} END{print t+0}' \
+        merge_ts="$(awk -v p="$pr" -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="merging"{t=$c3} END{print t+0}' \
           "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" 2>/dev/null)"
         if [ "$(( now - merge_ts ))" -ge "$_UBERDEV_GOAL_MERGE_TIMEOUT" ] \
            && ! uberdev_goal_agent_busy_for_issue "$pr"; then
@@ -953,7 +955,7 @@ terminal_prs="$(uberdev_goal_list_prs_in_state "$GOAL_ID" merged \
   ; uberdev_goal_list_prs_in_state "$GOAL_ID" merge-failed \
   ; uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held \
   ; uberdev_goal_list_prs_in_state "$GOAL_ID" red-held)"
-all_pr_count="$(awk '{print $1}' "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" \
+all_pr_count="$(awk -v c1=1 '{print $c1}' "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" \
   | sort -u | wc -l)"
 terminal_count="$(printf '%s\n' "$terminal_prs" | grep -c . || true)"
 if [ "${#new_candidates[@]}" = "0" ] && [ "$terminal_count" = "$all_pr_count" ]; then
@@ -1056,7 +1058,7 @@ print_summary() {
     uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held | sed 's/^/yellow-held\t/'; \
     uberdev_goal_list_prs_in_state "$GOAL_ID" red-held    | sed 's/^/red-held\t/' )"
   prs_held_count="$(printf '%s\n' "$prs_held_lines" | grep -c . || true)"
-  issues_resolved="$(awk '$2=="resolved" {print $1}' \
+  issues_resolved="$(awk -v c1=1 -v c2=2 '$c2=="resolved" {print $c1}' \
     "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" | grep -c . || true)"
   wall_secs="$(( $(date +%s) - watch_start ))"
   printf 'goal %s: cycles=%s/%s prs_merged=%s prs_held=%s issues_resolved=%s wall_secs=%s\n' \

--- a/plugins/uberdev/skills/merge-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/merge-pipeline/SKILL.md
@@ -806,7 +806,7 @@ CLOSED_ISSUES=($(printf '%s' "$PR_BODY_FOR_CLEANUP" \
   | grep -oiE '(^|[^[:alnum:]_-])(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
   | grep -oE '#[0-9]+' \
   | tr -d '#' \
-  | awk '!seen[$0]++'))
+  | awk -v c0=0 '!seen[$c0]++'))
 for CLEAR_ISSUE_NUM in "${CLOSED_ISSUES[@]}"; do
   # Combined cleanup: label + assignee in one gh round-trip. gh fails atomically
   # on partial error so the previous split-call form (with assignee removal as

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -193,8 +193,10 @@ else
           continue
         fi
 
-        # head_sha presence + reachability check.
-        STORED_SHA="$(awk '/^head_sha:/{print $2; exit}' "$F" 2>/dev/null)"
+        # head_sha presence + reachability check. The `-v c2=2` parameterisation
+        # prevents the Skill renderer from substituting positional args of
+        # $ARGUMENTS into the awk field ref (issue #222).
+        STORED_SHA="$(awk -v c2=2 '/^head_sha:/{print $c2; exit}' "$F" 2>/dev/null)"
         if [ -z "$STORED_SHA" ] || ! [[ "$STORED_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
           emit_topic_log "$TOPIC" dispatched "fresh-run,reason=missing-head-sha"
           continue
@@ -270,7 +272,7 @@ fresh(F) :=
 
 Helper definitions (each replaceable by a single shell command):
 
-- **`head_sha_reachable(F)`** — `git cat-file -e $(awk '/^head_sha:/{print $2; exit}' F)^{commit} 2>/dev/null`. Exit-0 means reachable. The reachability probe runs FIRST, before any `git diff` invocation — an unreachable SHA never leaks into a `git diff` command line. Per security research: never let raw `git diff` exit code drive control flow.
+- **`head_sha_reachable(F)`** — `git cat-file -e $(awk -v c2=2 '/^head_sha:/{print $c2; exit}' F)^{commit} 2>/dev/null`. Exit-0 means reachable. The reachability probe runs FIRST, before any `git diff` invocation — an unreachable SHA never leaks into a `git diff` command line. Per security research: never let raw `git diff` exit code drive control flow. The `-v c2=2` parameterisation defends against the Skill renderer substituting positional args of `$ARGUMENTS` into the field ref (issue #222).
 - **`divergence(F)`** — `git rev-list --count <stored>..HEAD`. Returns an integer. Compare against `$UBERDEV_CACHE_DIVERGENCE_THRESHOLD` (default 50; env > config > default; see "Cache divergence threshold" below) using `[ "$DIVERGENCE" -gt "$UBERDEV_CACHE_DIVERGENCE_THRESHOLD" ]`.
 - **`files_touched_since(F)`** — `git diff --name-only <stored>..HEAD`. Returns a set of paths.
 - **`files_investigated(F)`** — parse the lines after the `## Files investigated` heading until the next `^## ` heading, extract the first whitespace-separated token per line, strip any `:LINE-RANGE` suffix. Validator: `^[A-Za-z0-9_./-]+$` — reject any line containing `$`, `` ` ``, `;`, `\`, or embedded newlines. Lines that fail validation are silently dropped from the set (artifact stays valid); the artifact is rejected only on `head_sha` validation failure (`missing-head-sha`).

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -217,11 +217,10 @@ else
           continue
         fi
 
-        # file-intersection check (fail-open per policy above). The `-v c1=1`
-        # parameterisation prevents the Skill renderer from substituting positional
-        # args of $ARGUMENTS into the awk field ref — same defence as the single-
-        # line awks above; multi-line awk bodies are equally vulnerable because
-        # the renderer scans the SKILL.md body text-blind (issue #222).
+        # file-intersection check (fail-open per policy above). Same #222
+        # defence as the line-199 awk above; multi-line awk bodies are
+        # equally vulnerable because the renderer scans the SKILL.md body
+        # text-blind, not single-quote-aware.
         FILES_INVESTIGATED="$(awk -v c1=1 '
           /^## Files investigated/ { capture=1; next }
           /^## / { capture=0 }

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -217,13 +217,17 @@ else
           continue
         fi
 
-        # file-intersection check (fail-open per policy above).
-        FILES_INVESTIGATED="$(awk '
+        # file-intersection check (fail-open per policy above). The `-v c1=1`
+        # parameterisation prevents the Skill renderer from substituting positional
+        # args of $ARGUMENTS into the awk field ref — same defence as the single-
+        # line awks above; multi-line awk bodies are equally vulnerable because
+        # the renderer scans the SKILL.md body text-blind (issue #222).
+        FILES_INVESTIGATED="$(awk -v c1=1 '
           /^## Files investigated/ { capture=1; next }
           /^## / { capture=0 }
           capture && NF {
             sub(/^- /, "")
-            split($1, p, ":")
+            split($c1, p, ":")
             if (p[1] ~ /^[A-Za-z0-9_.\/-]+$/) print p[1]
           }
         ' "$F")"

--- a/plugins/uberdev/skills/requesting-code-review/SKILL.md
+++ b/plugins/uberdev/skills/requesting-code-review/SKILL.md
@@ -53,7 +53,7 @@ Use Task tool with uberdev:code-reviewer type, fill template at `code-reviewer.m
 
 You: Let me request code review before proceeding.
 
-BASE_SHA=$(git log --oneline | grep "Task 1" | head -1 | awk '{print $1}')
+BASE_SHA=$(git log --oneline | grep "Task 1" | head -1 | awk -v c1=1 '{print $c1}')
 HEAD_SHA=$(git rev-parse HEAD)
 
 [Dispatch uberdev:code-reviewer subagent]

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -90,7 +90,7 @@ _uberdev_audit_emit() {
 # worktree path `.claude/worktrees/solve-issue-N/` — the second spawn's
 # `git worktree remove --force` would nuke the first's checkout mid-run).
 # Array assignment `arr=($(...))` word-splits on $IFS in BOTH bash and zsh.
-ISSUE_NUMS=($(echo "$ARGUMENTS" | tr ' ' '\n' | grep -E '^[0-9]+$' | awk '!seen[$0]++'))
+ISSUE_NUMS=($(echo "$ARGUMENTS" | tr ' ' '\n' | grep -E '^[0-9]+$' | awk -v c0=0 '!seen[$c0]++'))
 
 OVERRIDE=$(echo "$ARGUMENTS" | grep -oE '\-\-(trivial|small|full)' | head -1 | sed 's/--//')
 # --- Phase A: --terminal= deprecation shim (NEW v0.22.0) ---

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -288,11 +288,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.34.4) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.4"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.4"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.4-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.4\]'        "G20.changelog"
+echo "== G20: version bump locked (0.34.5) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.5"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.5"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.5-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.5\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/skill-renderer-awk-collision.test.sh
+++ b/tests/skill-renderer-awk-collision.test.sh
@@ -32,20 +32,47 @@ if [ ! -d "$SKILLS_DIR" ]; then
 fi
 
 # R1 — no plugins/uberdev/skills/*/SKILL.md may contain an awk command with
-# a bare `$N` field ref (1-9) in its script body. The regex matches a line
-# containing `awk` followed by `$<digit>` not followed by `c` — `$c1` /
-# `$c2` / `$c3` (the parameterised form) is the safe shape and the digit
-# in `$c1` is not preceded by `$`, so the regex correctly skips it.
+# a bare `$N` field ref (0-9) inside its single-quoted script body. The regex
+# `awk[^']*'[^']*\$[0-9][^c]` matches:
+#   awk          — the keyword
+#   [^']*        — any non-quote chars (flags, -F, -v assignments)
+#   '            — opening single-quote of the awk script body
+#   [^']*        — any non-quote chars within the body (everything up to
+#                  the first `$N` if present)
+#   \$[0-9][^c]  — bare `$<digit>` not followed by `c` (i.e. NOT `$c0`/`$c1`)
 #
-# Why the `[^c]` lookahead: the parameterised form `$cN` puts `c` AFTER the
-# `$`, not before the digit. So `awk -v c1=1 '{print $c1}'` has `$c1` where
-# the regex `\$[1-9]` does NOT match (because the char after `$` is `c`, not
-# a digit). Conversely `awk '{print $1}'` has `$1<eol>` where the regex `\$[1-9][^c]`
-# DOES match. The trailing `[^c]` is just defensive — it rejects the (currently
-# impossible) form `$1c` that would shadow `$c1`.
+# Why `$0` is included: the Skill renderer also substitutes the first
+# positional non-flag arg into bare `$0` references. solve-pipeline's
+# `awk '!seen[$0]++'` (the dedupe-by-whole-line idiom) rendered as
+# `awk '!seen[222]++'` on `/turbo 222` — works by luck on single-issue
+# input but drops every issue past the first on `/turbo 5 6 7`. Same
+# class of bug as `$1`-`$9`, same parameterised fix shape: `-v c0=0`
+# and `$c0`. See merge-pipeline:809 + finish-branch:162 + solve-pipeline:93.
+#
+# The `[^']*` anchors are load-bearing: without them, a greedy `.*` after
+# `awk` would span across the entire flattened file and flag a `$N` in a
+# completely unrelated context (e.g. a shell variable `$1` in a separate
+# bash block far away from any awk invocation). The `[^']*` bounds the
+# match to the FIRST single-quoted string immediately after `awk`, which is
+# the actual awk script body that the Skill renderer would corrupt.
+#
+# Multi-line awk scripts (issue #222 review blocker — orchestrator/SKILL.md:
+# 226-class regression): the awk keyword may appear on one line while the
+# bare `$N` lives on a later line of the same single-quoted body. A naive
+# per-line `grep` misses this entirely. We flatten the file via `tr '\n' ' '`
+# before scanning, so a single-quoted awk body spread across many lines
+# becomes one logical line and the [^']*-bounded match still applies cleanly.
+# Line-number reporting is sacrificed (file path identifies the vulnerable
+# file; the operator greps for the site); an acceptable trade for catching
+# the bug class the original line-anchored shape silently passed.
 
-hits="$(find "$SKILLS_DIR" -name "SKILL.md" -print0 \
-  | xargs -0 grep -nHE "awk.*\\\$[1-9][^c]" 2>/dev/null || true)"
+hits=""
+while IFS= read -r -d '' skill_file; do
+  flattened="$(tr '\n' ' ' < "$skill_file")"
+  if printf '%s' "$flattened" | grep -qE "awk[^']*'[^']*\\\$[0-9][^c]"; then
+    hits="$hits$skill_file"$'\n'
+  fi
+done < <(find "$SKILLS_DIR" -name "SKILL.md" -print0)
 
 if [ -z "$hits" ]; then
   echo "  PASS  R1 no plugins/uberdev/skills/*/SKILL.md awk script body contains a bare \$N field ref"
@@ -64,32 +91,61 @@ fi
 # guard itself is wired correctly — if a future refactor accidentally breaks
 # the regex (e.g. someone changes `\$[1-9]` to `\$[1-3]` and a new $4 site
 # slips through), R2 catches it before the live R1 above silently passes.
+# Three sub-fixtures: simple awk, -F'\t' prefix awk, and a multi-line awk
+# (the third anchors the multi-line scan path strengthened post-#224 review).
 fixture="$(mktemp)"
-trap 'rm -f "$fixture"' EXIT
+fixture_multi="$(mktemp)"
+trap 'rm -f "$fixture" "$fixture_multi"' EXIT
 cat > "$fixture" <<'EOF_FIXTURE'
 # fake awk site — the regex must flag this
 foo="$(awk '$1==p{print $2}' file.tsv)"
 EOF_FIXTURE
-if grep -nE "awk.*\\\$[1-9][^c]" "$fixture" >/dev/null 2>&1; then
-  echo "  PASS  R2 the guard regex correctly flags a synthetic vulnerable awk shape"
+cat > "$fixture_multi" <<'EOF_MULTI'
+# multi-line awk site — line-anchored grep MUST miss it but the flattened
+# scan (tr '\n' ' ' + grep) MUST catch it. Anchors orchestrator/SKILL.md:226
+# class of regression (issue #222 review blocker).
+foo="$(awk '
+  /^header/ { capture=1; next }
+  capture && NF {
+    split($1, p, ":")
+  }
+' input.tsv)"
+EOF_MULTI
+# Simple-shape (single-line) — sanity check that the basic case is caught.
+if grep -nE "awk[^']*'[^']*\\\$[0-9][^c]" "$fixture" >/dev/null 2>&1; then
+  echo "  PASS  R2.simple the guard regex flags a single-line vulnerable awk shape"
   PASS=$((PASS+1))
 else
-  echo "  FAIL  R2 the guard regex no longer flags a synthetic vulnerable awk shape"
-  echo "         The R1 scan above is silently passing on every file because the regex is broken."
-  echo "         Check this file's grep pattern (currently: awk.*\\\$[1-9][^c])."
+  echo "  FAIL  R2.simple the guard regex no longer flags a single-line vulnerable awk shape"
+  echo "         Check this file's grep pattern (currently: awk[^']*'[^']*\\\$[0-9][^c])."
+  FAIL=$((FAIL+1))
+fi
+# Multi-line-shape — the inside-out check for the flattened scan path. A
+# line-anchored grep on this fixture would NOT match; the flattened scan
+# MUST. If this regresses, R1 silently passes on multi-line vulnerable awks
+# (exactly the bug class found at orchestrator/SKILL.md:226).
+multi_flat="$(tr '\n' ' ' < "$fixture_multi")"
+if printf '%s' "$multi_flat" | grep -qE "awk[^']*'[^']*\\\$[0-9][^c]"; then
+  echo "  PASS  R2.multiline the flattened scan flags a multi-line vulnerable awk shape"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  R2.multiline the flattened scan no longer flags multi-line vulnerable awks"
+  echo "         orchestrator/SKILL.md:226-class regressions will silently pass R1."
   FAIL=$((FAIL+1))
 fi
 
 # R3 — fixture proof of the inverse: a synthetic SKILL.md fragment using the
 # safe parameterised shape MUST NOT be flagged by the regex. Guards against
 # the regex becoming over-broad and false-positiving on the recommended fix.
+# Includes $c1, $c2, AND $c3 (covers every column index used in the source
+# fixes — goal-pipeline uses up to $c3 at lines 387/461/680).
 safe_fixture="$(mktemp)"
-trap 'rm -f "$fixture" "$safe_fixture"' EXIT
+trap 'rm -f "$fixture" "$fixture_multi" "$safe_fixture"' EXIT
 cat > "$safe_fixture" <<'EOF_SAFE'
 # parameterised awk — must NOT be flagged
-foo="$(awk -v c1=1 -v c2=2 '$c1==p{print $c2}' file.tsv)"
+foo="$(awk -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="x"{t=$c3}' file.tsv)"
 EOF_SAFE
-if grep -nE "awk.*\\\$[1-9][^c]" "$safe_fixture" >/dev/null 2>&1; then
+if grep -nE "awk[^']*'[^']*\\\$[0-9][^c]" "$safe_fixture" >/dev/null 2>&1; then
   echo "  FAIL  R3 the guard regex false-positives on the parameterised \`-v cN=N\` + \`\$cN\` shape"
   echo "         R1 will now red CI on every site that has been correctly fixed."
   FAIL=$((FAIL+1))

--- a/tests/skill-renderer-awk-collision.test.sh
+++ b/tests/skill-renderer-awk-collision.test.sh
@@ -7,15 +7,16 @@
 # `--max-parallel=1 219 198` becomes `awk '219==p && 198=="x"{t=}'` —
 # corrupting every column ref. The fix is to parameterise the field refs:
 #   awk -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="x"{t=$c3}'
-# The renderer doesn't recognise `$c1` / `$c2` / `$c3` as positional, so
-# the awk script body is preserved verbatim.
+# The renderer doesn't recognise `$c1` / `$c2` / `$c3` as positional (the
+# char immediately after `$` is `c`, not a digit), so the awk script body
+# is preserved verbatim.
 #
 # This guard scans every plugins/uberdev/skills/*/SKILL.md and fails CI when
 # it finds an awk command whose script body contains a bare `$N` field ref
-# (1-9). Adopt the `-v cN=N` + `$cN` form instead.
+# (0-9). Adopt the `-v cN=N` + `$cN` form instead.
 #
-# Portable: bash + grep + find + sort. Runs on ubuntu-latest (native bash)
-# and windows-latest (Git Bash) without any extra deps.
+# Portable: bash + grep + find + sort + tr. Runs on ubuntu-latest (native
+# bash) and windows-latest (Git Bash) without any extra deps.
 
 set -u
 set -o pipefail
@@ -23,6 +24,46 @@ set -o pipefail
 THIS_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$THIS_DIR/.." && pwd)"
 SKILLS_DIR="$REPO_ROOT/plugins/uberdev/skills"
+
+# Single source of truth for the vulnerable-awk regex (Phase 2 simplify-lens
+# Reuse / Quality / Efficiency convergence — was duplicated 4× before).
+#
+# Pattern: `awk[^']*'[^']*\$[0-9]` — anchors:
+#   awk      — the keyword.
+#   [^']*    — any non-quote chars (flags, -F, -v assignments).
+#   '        — opening single-quote of the awk script body.
+#   [^']*    — any non-quote chars within the body, up to the first `$N`.
+#   \$[0-9]  — bare `$<digit>` (0-9). The safe parameterised form `$c1` /
+#              `$c2` etc. has `c` immediately after `$` (alphabetic, not a
+#              digit), so the regex does not match it — no `[^c]` exclusion
+#              needed, and adding one was a false-negative source: `[^c]`
+#              required SOME char after the digit, missing `$N` at end-of-
+#              file (degenerate after flatten) AND erroneously skipping the
+#              `$1cents` shape (vulnerable but with `c` immediately after).
+#
+# Why `$0` is included: the Skill renderer also substitutes the first
+# positional non-flag arg into bare `$0` references. solve-pipeline's
+# `awk '!seen[$0]++'` (dedupe-by-whole-line) rendered as `awk '!seen[222]++'`
+# on `/turbo 222` — works by luck on single-issue input but drops every
+# issue past the first on `/turbo 5 6 7`. Same bug class, same fix shape:
+# `-v c0=0` + `$c0`. See merge-pipeline:809 + finish-branch:162 + solve-
+# pipeline:93.
+#
+# Why `[^']*` anchors are load-bearing: without them, a greedy `.*` after
+# `awk` would span across the entire flattened file and false-flag a `$N`
+# in an unrelated bash block far from any awk. The `[^']*` bounds the match
+# to the FIRST single-quoted string after `awk`, which is the actual awk
+# script body the Skill renderer would corrupt.
+#
+# Why we flatten files first (issue #222 review blocker — orchestrator/
+# SKILL.md:225-class regression): multi-line awk scripts have the awk
+# keyword on one line and the bare `$N` on a later line of the same single-
+# quoted body. A naive per-line `grep` misses this entirely. We flatten via
+# `tr '\n' ' '` before scanning, so a multi-line awk body becomes one
+# logical line and the `[^']*`-bounded match still applies cleanly.
+# Line-number reporting is sacrificed (file path identifies the vulnerable
+# file; the operator greps for the site).
+GUARD_REGEX="awk[^']*'[^']*\\\$[0-9]"
 
 PASS=0; FAIL=0
 echo "## skill-renderer awk-collision drift guard (#222)"
@@ -32,44 +73,11 @@ if [ ! -d "$SKILLS_DIR" ]; then
 fi
 
 # R1 — no plugins/uberdev/skills/*/SKILL.md may contain an awk command with
-# a bare `$N` field ref (0-9) inside its single-quoted script body. The regex
-# `awk[^']*'[^']*\$[0-9][^c]` matches:
-#   awk          — the keyword
-#   [^']*        — any non-quote chars (flags, -F, -v assignments)
-#   '            — opening single-quote of the awk script body
-#   [^']*        — any non-quote chars within the body (everything up to
-#                  the first `$N` if present)
-#   \$[0-9][^c]  — bare `$<digit>` not followed by `c` (i.e. NOT `$c0`/`$c1`)
-#
-# Why `$0` is included: the Skill renderer also substitutes the first
-# positional non-flag arg into bare `$0` references. solve-pipeline's
-# `awk '!seen[$0]++'` (the dedupe-by-whole-line idiom) rendered as
-# `awk '!seen[222]++'` on `/turbo 222` — works by luck on single-issue
-# input but drops every issue past the first on `/turbo 5 6 7`. Same
-# class of bug as `$1`-`$9`, same parameterised fix shape: `-v c0=0`
-# and `$c0`. See merge-pipeline:809 + finish-branch:162 + solve-pipeline:93.
-#
-# The `[^']*` anchors are load-bearing: without them, a greedy `.*` after
-# `awk` would span across the entire flattened file and flag a `$N` in a
-# completely unrelated context (e.g. a shell variable `$1` in a separate
-# bash block far away from any awk invocation). The `[^']*` bounds the
-# match to the FIRST single-quoted string immediately after `awk`, which is
-# the actual awk script body that the Skill renderer would corrupt.
-#
-# Multi-line awk scripts (issue #222 review blocker — orchestrator/SKILL.md:
-# 226-class regression): the awk keyword may appear on one line while the
-# bare `$N` lives on a later line of the same single-quoted body. A naive
-# per-line `grep` misses this entirely. We flatten the file via `tr '\n' ' '`
-# before scanning, so a single-quoted awk body spread across many lines
-# becomes one logical line and the [^']*-bounded match still applies cleanly.
-# Line-number reporting is sacrificed (file path identifies the vulnerable
-# file; the operator greps for the site); an acceptable trade for catching
-# the bug class the original line-anchored shape silently passed.
-
+# a bare `$N` field ref (0-9) inside its single-quoted script body.
 hits=""
 while IFS= read -r -d '' skill_file; do
   flattened="$(tr '\n' ' ' < "$skill_file")"
-  if printf '%s' "$flattened" | grep -qE "awk[^']*'[^']*\\\$[0-9][^c]"; then
+  if printf '%s' "$flattened" | grep -qE "$GUARD_REGEX"; then
     hits="$hits$skill_file"$'\n'
   fi
 done < <(find "$SKILLS_DIR" -name "SKILL.md" -print0)
@@ -82,27 +90,33 @@ else
   printf '          %s\n' "$hits" | sed 's/^/  /'
   echo "         Fix: add \`-v c1=1 -v c2=2 -v c3=3\` to the awk invocation and use \`\$c1\` / \`\$c2\` / \`\$c3\`"
   echo "         in place of \`\$1\` / \`\$2\` / \`\$3\`. See goal-pipeline/SKILL.md for examples and"
-  echo "         tests/skill-renderer-awk-collision.test.sh's header comment for the why."
+  echo "         this file's header comment for the why."
   FAIL=$((FAIL+1))
 fi
+
+# R2 + R3 fixture setup — single trap install up front covers every mktemp.
+# Bash supports ONE EXIT trap per shell; declaring all three fixtures + one
+# trap before any cat-into-fixture avoids the prior two-trap shape where the
+# second silently superseded the first (Phase 2 simplify Quality + Efficiency).
+fixture_simple="$(mktemp)"
+fixture_multi="$(mktemp)"
+fixture_safe="$(mktemp)"
+trap 'rm -f "$fixture_simple" "$fixture_multi" "$fixture_safe"' EXIT
 
 # R2 — fixture proof: a synthetic SKILL.md fragment containing the bad shape
 # MUST be detected by the same regex. This is an inside-out check that the
 # guard itself is wired correctly — if a future refactor accidentally breaks
-# the regex (e.g. someone changes `\$[1-9]` to `\$[1-3]` and a new $4 site
+# the regex (e.g. someone narrows `\$[0-9]` to `\$[1-3]` and a new $4 site
 # slips through), R2 catches it before the live R1 above silently passes.
-# Three sub-fixtures: simple awk, -F'\t' prefix awk, and a multi-line awk
-# (the third anchors the multi-line scan path strengthened post-#224 review).
-fixture="$(mktemp)"
-fixture_multi="$(mktemp)"
-trap 'rm -f "$fixture" "$fixture_multi"' EXIT
-cat > "$fixture" <<'EOF_FIXTURE'
+# Two sub-fixtures: simple single-line awk + a multi-line awk (the latter
+# anchors the multi-line scan path strengthened post-#224 review).
+cat > "$fixture_simple" <<'EOF_FIXTURE'
 # fake awk site — the regex must flag this
 foo="$(awk '$1==p{print $2}' file.tsv)"
 EOF_FIXTURE
 cat > "$fixture_multi" <<'EOF_MULTI'
 # multi-line awk site — line-anchored grep MUST miss it but the flattened
-# scan (tr '\n' ' ' + grep) MUST catch it. Anchors orchestrator/SKILL.md:226
+# scan (tr '\n' ' ' + grep) MUST catch it. Anchors orchestrator/SKILL.md:225
 # class of regression (issue #222 review blocker).
 foo="$(awk '
   /^header/ { capture=1; next }
@@ -111,41 +125,41 @@ foo="$(awk '
   }
 ' input.tsv)"
 EOF_MULTI
+
 # Simple-shape (single-line) — sanity check that the basic case is caught.
-if grep -nE "awk[^']*'[^']*\\\$[0-9][^c]" "$fixture" >/dev/null 2>&1; then
+if grep -qE "$GUARD_REGEX" "$fixture_simple"; then
   echo "  PASS  R2.simple the guard regex flags a single-line vulnerable awk shape"
   PASS=$((PASS+1))
 else
   echo "  FAIL  R2.simple the guard regex no longer flags a single-line vulnerable awk shape"
-  echo "         Check this file's grep pattern (currently: awk[^']*'[^']*\\\$[0-9][^c])."
+  echo "         Check GUARD_REGEX in this file (currently: $GUARD_REGEX)."
   FAIL=$((FAIL+1))
 fi
+
 # Multi-line-shape — the inside-out check for the flattened scan path. A
 # line-anchored grep on this fixture would NOT match; the flattened scan
 # MUST. If this regresses, R1 silently passes on multi-line vulnerable awks
-# (exactly the bug class found at orchestrator/SKILL.md:226).
+# (exactly the bug class found at orchestrator/SKILL.md:225).
 multi_flat="$(tr '\n' ' ' < "$fixture_multi")"
-if printf '%s' "$multi_flat" | grep -qE "awk[^']*'[^']*\\\$[0-9][^c]"; then
+if printf '%s' "$multi_flat" | grep -qE "$GUARD_REGEX"; then
   echo "  PASS  R2.multiline the flattened scan flags a multi-line vulnerable awk shape"
   PASS=$((PASS+1))
 else
   echo "  FAIL  R2.multiline the flattened scan no longer flags multi-line vulnerable awks"
-  echo "         orchestrator/SKILL.md:226-class regressions will silently pass R1."
+  echo "         orchestrator/SKILL.md:225-class regressions will silently pass R1."
   FAIL=$((FAIL+1))
 fi
 
 # R3 — fixture proof of the inverse: a synthetic SKILL.md fragment using the
 # safe parameterised shape MUST NOT be flagged by the regex. Guards against
 # the regex becoming over-broad and false-positiving on the recommended fix.
-# Includes $c1, $c2, AND $c3 (covers every column index used in the source
-# fixes — goal-pipeline uses up to $c3 at lines 387/461/680).
-safe_fixture="$(mktemp)"
-trap 'rm -f "$fixture" "$fixture_multi" "$safe_fixture"' EXIT
-cat > "$safe_fixture" <<'EOF_SAFE'
+# Includes $c0, $c1, $c2, AND $c3 (covers every column index in the source
+# fixes — solve/merge/finish use $c0; goal-pipeline uses up to $c3).
+cat > "$fixture_safe" <<'EOF_SAFE'
 # parameterised awk — must NOT be flagged
-foo="$(awk -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="x"{t=$c3}' file.tsv)"
+foo="$(awk -v c0=0 -v c1=1 -v c2=2 -v c3=3 '!seen[$c0]++ && $c1==p && $c2=="x"{t=$c3}' file.tsv)"
 EOF_SAFE
-if grep -nE "awk[^']*'[^']*\\\$[0-9][^c]" "$safe_fixture" >/dev/null 2>&1; then
+if grep -qE "$GUARD_REGEX" "$fixture_safe"; then
   echo "  FAIL  R3 the guard regex false-positives on the parameterised \`-v cN=N\` + \`\$cN\` shape"
   echo "         R1 will now red CI on every site that has been correctly fixed."
   FAIL=$((FAIL+1))

--- a/tests/skill-renderer-awk-collision.test.sh
+++ b/tests/skill-renderer-awk-collision.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# tests/skill-renderer-awk-collision.test.sh — drift-guard for issue #222.
+#
+# The Claude Code Skill loader substitutes positional non-flag args of
+# $ARGUMENTS into the entire SKILL.md body, INCLUDING inside single-quoted
+# awk one-liners. So `awk '$1==p && $2=="x"{t=$3}'` rendered against args
+# `--max-parallel=1 219 198` becomes `awk '219==p && 198=="x"{t=}'` —
+# corrupting every column ref. The fix is to parameterise the field refs:
+#   awk -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="x"{t=$c3}'
+# The renderer doesn't recognise `$c1` / `$c2` / `$c3` as positional, so
+# the awk script body is preserved verbatim.
+#
+# This guard scans every plugins/uberdev/skills/*/SKILL.md and fails CI when
+# it finds an awk command whose script body contains a bare `$N` field ref
+# (1-9). Adopt the `-v cN=N` + `$cN` form instead.
+#
+# Portable: bash + grep + find + sort. Runs on ubuntu-latest (native bash)
+# and windows-latest (Git Bash) without any extra deps.
+
+set -u
+set -o pipefail
+
+THIS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$THIS_DIR/.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/plugins/uberdev/skills"
+
+PASS=0; FAIL=0
+echo "## skill-renderer awk-collision drift guard (#222)"
+
+if [ ! -d "$SKILLS_DIR" ]; then
+  echo "  ABORT — skills directory missing: $SKILLS_DIR"; exit 99
+fi
+
+# R1 — no plugins/uberdev/skills/*/SKILL.md may contain an awk command with
+# a bare `$N` field ref (1-9) in its script body. The regex matches a line
+# containing `awk` followed by `$<digit>` not followed by `c` — `$c1` /
+# `$c2` / `$c3` (the parameterised form) is the safe shape and the digit
+# in `$c1` is not preceded by `$`, so the regex correctly skips it.
+#
+# Why the `[^c]` lookahead: the parameterised form `$cN` puts `c` AFTER the
+# `$`, not before the digit. So `awk -v c1=1 '{print $c1}'` has `$c1` where
+# the regex `\$[1-9]` does NOT match (because the char after `$` is `c`, not
+# a digit). Conversely `awk '{print $1}'` has `$1<eol>` where the regex `\$[1-9][^c]`
+# DOES match. The trailing `[^c]` is just defensive — it rejects the (currently
+# impossible) form `$1c` that would shadow `$c1`.
+
+hits="$(find "$SKILLS_DIR" -name "SKILL.md" -print0 \
+  | xargs -0 grep -nHE "awk.*\\\$[1-9][^c]" 2>/dev/null || true)"
+
+if [ -z "$hits" ]; then
+  echo "  PASS  R1 no plugins/uberdev/skills/*/SKILL.md awk script body contains a bare \$N field ref"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  R1 these SKILL.md awk one-liners use bare \$N field refs vulnerable to the renderer:"
+  printf '          %s\n' "$hits" | sed 's/^/  /'
+  echo "         Fix: add \`-v c1=1 -v c2=2 -v c3=3\` to the awk invocation and use \`\$c1\` / \`\$c2\` / \`\$c3\`"
+  echo "         in place of \`\$1\` / \`\$2\` / \`\$3\`. See goal-pipeline/SKILL.md for examples and"
+  echo "         tests/skill-renderer-awk-collision.test.sh's header comment for the why."
+  FAIL=$((FAIL+1))
+fi
+
+# R2 — fixture proof: a synthetic SKILL.md fragment containing the bad shape
+# MUST be detected by the same regex. This is an inside-out check that the
+# guard itself is wired correctly — if a future refactor accidentally breaks
+# the regex (e.g. someone changes `\$[1-9]` to `\$[1-3]` and a new $4 site
+# slips through), R2 catches it before the live R1 above silently passes.
+fixture="$(mktemp)"
+trap 'rm -f "$fixture"' EXIT
+cat > "$fixture" <<'EOF_FIXTURE'
+# fake awk site — the regex must flag this
+foo="$(awk '$1==p{print $2}' file.tsv)"
+EOF_FIXTURE
+if grep -nE "awk.*\\\$[1-9][^c]" "$fixture" >/dev/null 2>&1; then
+  echo "  PASS  R2 the guard regex correctly flags a synthetic vulnerable awk shape"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  R2 the guard regex no longer flags a synthetic vulnerable awk shape"
+  echo "         The R1 scan above is silently passing on every file because the regex is broken."
+  echo "         Check this file's grep pattern (currently: awk.*\\\$[1-9][^c])."
+  FAIL=$((FAIL+1))
+fi
+
+# R3 — fixture proof of the inverse: a synthetic SKILL.md fragment using the
+# safe parameterised shape MUST NOT be flagged by the regex. Guards against
+# the regex becoming over-broad and false-positiving on the recommended fix.
+safe_fixture="$(mktemp)"
+trap 'rm -f "$fixture" "$safe_fixture"' EXIT
+cat > "$safe_fixture" <<'EOF_SAFE'
+# parameterised awk — must NOT be flagged
+foo="$(awk -v c1=1 -v c2=2 '$c1==p{print $c2}' file.tsv)"
+EOF_SAFE
+if grep -nE "awk.*\\\$[1-9][^c]" "$safe_fixture" >/dev/null 2>&1; then
+  echo "  FAIL  R3 the guard regex false-positives on the parameterised \`-v cN=N\` + \`\$cN\` shape"
+  echo "         R1 will now red CI on every site that has been correctly fixed."
+  FAIL=$((FAIL+1))
+else
+  echo "  PASS  R3 the guard regex does NOT false-positive on the safe parameterised shape"
+  PASS=$((PASS+1))
+fi
+
+echo "  Result: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.34.3 -> 0.34.4 propagated =="
+echo "== Version bump 0.34.4 -> 0.34.5 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.34.4"' \
-  "plugin.json bumped to 0.34.4"
+  '"version": "0.34.5"' \
+  "plugin.json bumped to 0.34.5"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.34.4"' \
-  "marketplace.json bumped to 0.34.4"
+  '"version": "0.34.5"' \
+  "marketplace.json bumped to 0.34.5"
 assert_grep "$README" \
-  "version-0\\.34\\.4-blue" \
-  "README version badge bumped to 0.34.4"
+  "version-0\\.34\\.5-blue" \
+  "README version badge bumped to 0.34.5"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.34\.4\]' \
-  "CHANGELOG has [0.34.4] section header"
+  '^## \[0\.34\.5\]' \
+  "CHANGELOG has [0.34.5] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/turbo-flow.test.sh
+++ b/tests/turbo-flow.test.sh
@@ -191,7 +191,7 @@ echo
 echo "== solve-pipeline accepts multiple issue numbers (multi-issue dispatch) =="
 # /turbo 5 6 7 must spawn one agent per issue in parallel. The skill tokenizes
 # $ARGUMENTS via a portable bash-and-zsh-safe pipeline (`tr ' ' '\n' | grep -E
-# '^[0-9]+$' | awk '!seen[$0]++'`), validates every issue up front (Phase A),
+# '^[0-9]+$' | awk -v c0=0 '!seen[$c0]++'`), validates every issue up front (Phase A),
 # and only then spawns (Phase B). If any issue fails validation, the entire
 # batch aborts with no agents dispatched.
 #
@@ -215,8 +215,8 @@ assert_grep "$SOLVE_PIPELINE" \
   'echo "\$TERMINAL_FLAG_DEPRECATED_NOTE" >&2' \
   "Phase A emits TERMINAL_FLAG_DEPRECATED_NOTE to stderr on --terminal= encounter"
 assert_grep "$SOLVE_PIPELINE" \
-  "awk '!seen\[\\\$0\]\+\+'" \
-  "solve-pipeline dedupes via awk !seen[\$0]++ (preserves first-seen order, prevents same-issue worktree race)"
+  "awk -v c0=0 '!seen\[\\\$c0\]\+\+'" \
+  "solve-pipeline dedupes via awk -v c0=0 !seen[\$c0]++ (preserves first-seen order, prevents same-issue worktree race; #222 parameterised against renderer collision)"
 assert_grep "$SOLVE_PIPELINE" \
   'SH_WORD_SPLIT|word-split|word split' \
   "solve-pipeline comment explains the zsh word-split footgun (regression-prevention)"


### PR DESCRIPTION
## Summary

The Claude Code Skill loader substitutes positional non-flag args of `$ARGUMENTS` into the entire SKILL.md body, **including inside single-quoted awk one-liners**. So `/ubergoal all gh issues` rendered

```bash
awk '$1==p && $2=="pushed-reviewing" && !t{t=$3} END{print t+0}'
```

as

```bash
awk 'gh==p && issues=="pushed-reviewing" && !t{t=} END{print t+0}'
```

— corrupting every column ref. With numeric args (`--max-parallel=1 219 198`) the same line rendered as `'219==p && 198=="..."{t=}'`. The downstream effects across `goal-pipeline/SKILL.md`:

- Phase 3 `awk '{print $1}'` printed the same literal per row → `sort -u | wc -l = 1` → `all_pr_count=1` regardless of real PR set → false `goal_converged` on every run.
- Phase 2 `dispatch_ts` reads always returned 0 → every active solver instantly classified `FAILED (no PR, agent idle, …)`.
- Phase 1/2 state-skip gates (`case "$istate" in pr-pushed|resolved|failed) continue ;;`) always fell through because the awk returned a numeric literal, not the actual state string.

This made `/uberdev:goal` unusable on this repo.

## Fix

Add `-v c1=1 -v c2=2 -v c3=3` to every vulnerable awk and reference `$c1` / `$c2` / `$c3` instead of `$1` / `$2` / `$3`. The renderer does not treat `$cN` as a positional shell var, so the awk script body is preserved verbatim. Smallest-diff defence; no helper-hoist into `lib/goal-state.sh` needed.

### Sites fixed

| File | Lines | Awk shape (before) |
| --- | --- | --- |
| `plugins/uberdev/skills/goal-pipeline/SKILL.md` | 221, 353, 367, 387, 459, 678, 956, 1059 | 8 one-liners covering state-read, dispatch-ts, seen-ts, merge-ts, all-pr-count, issues-resolved |
| `plugins/uberdev/skills/orchestrator/SKILL.md` | 197 + matching docstring 273 | `'/^head_sha:/{print $2; exit}'` |
| `plugins/uberdev/skills/requesting-code-review/SKILL.md` | 56 | `awk '{print $1}'` |

## Regression guard

`tests/skill-renderer-awk-collision.test.sh` — scans every `plugins/uberdev/skills/*/SKILL.md` for awk script bodies containing bare `$N` field refs (1–9), with **R2 inverse-fixture proof** that the regex still flags the bad shape and **R3 inverse-fixture proof** that it does not false-positive on the safe parameterised form. Wired into both ubuntu and windows CI matrices (`.github/workflows/test.yml`).

## Verification

```
$ bash tests/skill-renderer-awk-collision.test.sh
  PASS  R1 no plugins/uberdev/skills/*/SKILL.md awk script body contains a bare $N field ref
  PASS  R2 the guard regex correctly flags a synthetic vulnerable awk shape
  PASS  R3 the guard regex does NOT false-positive on the safe parameterised shape
  Result: 3 passed, 0 failed

$ bash tests/goal.test.sh
  ... 421 passed, 0 failed (G20 version-lock block at 0.34.5)

$ bash tests/solve-claim.test.sh
  ... Summary: 104 pass, 0 fail (version-bump propagated block at 0.34.5)

$ bash tests/ci-wiring.test.sh
  ... 5 passed, 0 failed (new test wired into both ubuntu + windows jobs)
```

## Version bump

`0.34.4 → 0.34.5` across the 6 required surfaces:

- `plugins/uberdev/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `README.md` badge
- `CHANGELOG.md` (new `[0.34.5]` section)
- `tests/goal.test.sh` G20 block
- `tests/solve-claim.test.sh` propagated block

Git tag + GitHub release will follow the merge per `CLAUDE.md` workflow.

## Test plan

- [x] `bash tests/skill-renderer-awk-collision.test.sh` — 3/3 PASS
- [x] `bash tests/goal.test.sh` — 421/421 PASS (G20 version-lock block at 0.34.5)
- [x] `bash tests/solve-claim.test.sh` — 104/104 PASS (version-bump propagated block at 0.34.5)
- [x] `bash tests/ci-wiring.test.sh` — 5/5 PASS (new test wired into both jobs)
- [ ] CI shape-checks (ubuntu + windows) on the PR

Closes #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed awk field-reference corruption in the skill renderer that was impacting data extraction and processing across multiple skill pipelines and automation workflows.

* **Tests**
  * Added regression test integrated into the continuous integration pipeline to automatically detect and prevent similar field-reference corruption issues from recurring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->