### PR TITLE
fix(goal): SKIP_PERMISSIONS env tier — autonomous /goal stops stalling on cmux PermissionRequest (#241)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.34.7",
+      "version": "0.34.8",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.8] — 2026-05-27
+
+### Fixed
+- **`/uberdev:goal` stalls on cmux-mediated environments — bg agents flap busy/idle without producing PRs (Closes #241).** On macOS + cmux, dispatched bg `/turbo` agents stall on the first `Bash` tool call ("The user doesn't want to proceed with this tool use") because cmux's `PermissionRequest` hook (injected via `--settings <blob>` into the bg session's `respawnFlags`) shadows the user's own `~/.claude/settings.json` and refuses the prompt after a 125 s timeout. The contrast run with a manual `claude --bg --dangerously-skip-permissions` ran cleanly with zero rejections — confirming the strict bypass is the unblocking flag.
+  - Added a third `SKIP_PERMISSIONS` env-var tier to `uberdev_dispatch_resolve_env` (`lib/dispatch.sh`) with strict precedence over `AUTO_PERMISSIONS`. Maps to `PERM_FLAG=( --dangerously-skip-permissions )` when `${SKIP_PERMISSIONS:-0} == 1`. Literal `PERM_FLAG=()` and `PERM_FLAG=( --permission-mode auto )` lines preserved verbatim for structural-shape tests.
+  - `goal-pipeline/SKILL.md` Phase 0 step 4 exports `SKIP_PERMISSIONS=1` unconditionally — the operator's `/uberdev:goal` invocation IS the opt-in to autonomous-convergence; no per-run flag.
+  - Both `BG_TURBO_ENV` blocks (`_uberdev_dispatch_claude_bg` and `_uberdev_dispatch_background`) append `SKIP_PERMISSIONS=1` when set, propagating the env-var across the `env(1)` boundary so nested child dispatches also resolve to the bypass flag. Gates on `${SKIP_PERMISSIONS:-0}` directly (NOT on `AUTO_MODE`) — the semantics are independent of turbo-mode and the defensive `unset` in `/turbo`/`/solve` is the pollution gate.
+  - Defensive `unset SKIP_PERMISSIONS` in `commands/turbo.md` and `commands/solve.md` mirrors the #97 `UBERDEV_TURBO` hardening pattern — prevents shell-rc / stale-session pollution from silently elevating bare invocations.
+  - New "## Permission requirements (cmux/hooks caveat)" section in `commands/goal.md` documents the `--settings`-shadowing failure mode and the env-var path that actually unblocks the loop.
+  - Tests: D-skip + D-precedence behavioural tests (mirror D-perm template); structural greps for `PERM_FLAG=( --dangerously-skip-permissions )` and `BG_TURBO_ENV+=( SKIP_PERMISSIONS=1 )` in both dispatch arms; G20c assertion for `export SKIP_PERMISSIONS=1`; T-no-skip-turbo / T-no-skip-solve negative-test assertions; D-iso unset list updated to include `SKIP_PERMISSIONS`.
+  - Trust-boundary unchanged. The orchestrator's `<external-untrusted-input>` trust-wrap (emitted at prompt-construction time, unaffected by the `--permission-mode` argv flag) remains the defence against prompt-injection. Residual security risk is explicitly accepted as the cost of autonomous-convergence; the alternative (perpetually stalled `/goal`) is worse.
+
+### Notes
+- Version bumped to 0.34.8 across `plugin.json`, `marketplace.json`, the README badge, `CHANGELOG.md`, `tests/goal.test.sh` G20, and `tests/solve-claim.test.sh`. Atomic version-lock surfaces — partial bump is a red CI invariant.
+
+---
+
 ## [0.34.7] — 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.34.7-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.34.8-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.34.7",
+  "version": "0.34.8",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/goal.md
+++ b/plugins/uberdev/commands/goal.md
@@ -42,7 +42,7 @@ A wall-clock cap (default 4h, see `--barrier-timeout=N`) escalates a stuck barri
 
 `/goal` runs each dispatched bg `/turbo` agent in `bypassPermissions` mode (the `--dangerously-skip-permissions` argv flag) so the autonomous loop does not stall on cmux's `PermissionRequest` hook (or any other `--settings`-injected `PreToolUse` hook). This is set by `goal-pipeline/SKILL.md` Phase 0 via `export SKIP_PERMISSIONS=1` and propagated through `BG_TURBO_ENV` in `lib/dispatch.sh` to every nested child dispatch (`/turbo` → `/orchestrator` → `subagent-driven-dev`).
 
-**Important:** settings like `"skipDangerousModePermissionPrompt": true` in your own `~/.claude/settings.json` are **NOT** sufficient when cmux (or another daemon manager) injects its own `--settings <blob>` into the bg session's `respawnFlags`. The user-settings path is shadowed at bg-dispatch time. The env-var path (`SKIP_PERMISSIONS=1` → `--dangerously-skip-permissions` in argv) is what actually unblocks the loop.
+**Important:** settings like `"skipDangerousModePermissionPrompt": true` in your own `~/.claude/settings.json` are **NOT** sufficient when cmux (or another daemon manager) injects its own `--settings <blob>` into the bg session's `respawnFlags` via the parent process — the user-settings file is shadowed at bg-dispatch time, not modified on disk. The env-var path (`SKIP_PERMISSIONS=1` → `--dangerously-skip-permissions` in argv) is what actually unblocks the loop.
 
 Standalone `/uberdev:turbo` and `/uberdev:solve` defensively `unset SKIP_PERMISSIONS` so a stale shell export from an earlier `/goal` run cannot silently elevate them. Outside `/goal`, operator-gated permissions are preserved by design (RFC 0005 §2.3 scoped-relaxation contract).
 

--- a/plugins/uberdev/commands/goal.md
+++ b/plugins/uberdev/commands/goal.md
@@ -38,4 +38,12 @@ A wall-clock cap (default 4h, see `--barrier-timeout=N`) escalates a stuck barri
 - `feedback_brainstorm_no_gates.md`: `/turbo` runs non-interactive (no human gates) because `/goal` dispatches `/turbo --turbo`; parallel research + always-on agent reviewers still run.
 - **RED-override NEVER inherited:** `--i-know-what-im-doing` is NOT threaded through any `/goal` logic — RED PRs (BLOCKER findings or `halted_due_to_overflow`) cannot be merged inside `/goal` even if the operator passes the override to a downstream `/merge` (D14). The flag is mentioned here exactly once, in this negative call-out, by design.
 
+## Permission requirements (cmux/hooks caveat)
+
+`/goal` runs each dispatched bg `/turbo` agent in `bypassPermissions` mode (the `--dangerously-skip-permissions` argv flag) so the autonomous loop does not stall on cmux's `PermissionRequest` hook (or any other `--settings`-injected `PreToolUse` hook). This is set by `goal-pipeline/SKILL.md` Phase 0 via `export SKIP_PERMISSIONS=1` and propagated through `BG_TURBO_ENV` in `lib/dispatch.sh` to every nested child dispatch (`/turbo` → `/orchestrator` → `subagent-driven-dev`).
+
+**Important:** settings like `"skipDangerousModePermissionPrompt": true` in your own `~/.claude/settings.json` are **NOT** sufficient when cmux (or another daemon manager) injects its own `--settings <blob>` into the bg session's `respawnFlags`. The user-settings path is shadowed at bg-dispatch time. The env-var path (`SKIP_PERMISSIONS=1` → `--dangerously-skip-permissions` in argv) is what actually unblocks the loop.
+
+Standalone `/uberdev:turbo` and `/uberdev:solve` defensively `unset SKIP_PERMISSIONS` so a stale shell export from an earlier `/goal` run cannot silently elevate them. Outside `/goal`, operator-gated permissions are preserved by design (RFC 0005 §2.3 scoped-relaxation contract).
+
 Now invoke the `uberdev:goal-pipeline` skill — it owns the 5-phase pipeline (preflight, dispatch, watch, collect-next, converge/halt). The skill renders inline, so `$ARGUMENTS` remains in scope for its logic.

--- a/plugins/uberdev/commands/solve.md
+++ b/plugins/uberdev/commands/solve.md
@@ -42,6 +42,7 @@ An audit event `deprecated_flag_used` is recorded for each first-encounter emiss
 ```bash
 export AUTO_MODE=0       # /solve = interactive mode (post-impl-review wired in trivial/small; orchestrator + review-pr hybrid OR detector returns TURBO=0 when neither UBERDEV_TURBO=1 nor --turbo is present, #97)
 unset UBERDEV_TURBO      # NEW (#97): defend against shell-rc pollution from prior /turbo or .zshrc export of UBERDEV_TURBO=1 — MUST run BEFORE Skill('uberdev:solve-pipeline') below so the launcher inherits a clean env
+unset SKIP_PERMISSIONS   # (#241): mirror #97 hardening; /solve is interactive — never auto-elevates regardless of a stale SKIP_PERMISSIONS=1 left over from a prior /goal in the same shell
 ```
 
 Now invoke the `uberdev:solve-pipeline` skill — it owns the bash launcher (arg parsing, repo detection, tier classification, prompt heredoc, terminal spawn, notify, retitle). The skill renders inline, so `$AUTO_MODE` and `$ARGUMENTS` remain in scope for its bash blocks.

--- a/plugins/uberdev/commands/solve.md
+++ b/plugins/uberdev/commands/solve.md
@@ -42,7 +42,7 @@ An audit event `deprecated_flag_used` is recorded for each first-encounter emiss
 ```bash
 export AUTO_MODE=0       # /solve = interactive mode (post-impl-review wired in trivial/small; orchestrator + review-pr hybrid OR detector returns TURBO=0 when neither UBERDEV_TURBO=1 nor --turbo is present, #97)
 unset UBERDEV_TURBO      # NEW (#97): defend against shell-rc pollution from prior /turbo or .zshrc export of UBERDEV_TURBO=1 — MUST run BEFORE Skill('uberdev:solve-pipeline') below so the launcher inherits a clean env
-unset SKIP_PERMISSIONS   # (#241): mirror #97 hardening; /solve is interactive — never auto-elevates regardless of a stale SKIP_PERMISSIONS=1 left over from a prior /goal in the same shell
+unset SKIP_PERMISSIONS   # (#241): mirror #97 hardening; /solve is interactive — never auto-elevates regardless of a stale SKIP_PERMISSIONS=1 left over from a prior /goal in the same shell. MUST run BEFORE Skill('uberdev:solve-pipeline') below so the launcher inherits a clean env (same ordering rule as the UBERDEV_TURBO unset above).
 ```
 
 Now invoke the `uberdev:solve-pipeline` skill — it owns the bash launcher (arg parsing, repo detection, tier classification, prompt heredoc, terminal spawn, notify, retitle). The skill renders inline, so `$AUTO_MODE` and `$ARGUMENTS` remain in scope for its bash blocks.

--- a/plugins/uberdev/commands/turbo.md
+++ b/plugins/uberdev/commands/turbo.md
@@ -45,6 +45,7 @@ An audit event `deprecated_flag_used` is recorded for each first-encounter emiss
 ```bash
 export AUTO_MODE=1       # /turbo = unattended mode (post-impl-review omitted in trivial/small; orchestrator + review-pr detect turbo via UBERDEV_TURBO env-var OR --turbo arg — hybrid OR detector, #97)
 export UBERDEV_TURBO=1   # NEW (#97): chain-wide unattended-mode signal — inherits via Skill() into solve-pipeline + via fork+exec into claude --bg child (env(1)-mediated, since timeout(1) sits in front of the inline-prefix slot)
+unset SKIP_PERMISSIONS   # (#241) defend against shell-rc / stale-session pollution from a prior /goal export — /turbo retains operator-gated perms by design
 ```
 
 Now invoke the `uberdev:solve-pipeline` skill.

--- a/plugins/uberdev/commands/turbo.md
+++ b/plugins/uberdev/commands/turbo.md
@@ -45,7 +45,7 @@ An audit event `deprecated_flag_used` is recorded for each first-encounter emiss
 ```bash
 export AUTO_MODE=1       # /turbo = unattended mode (post-impl-review omitted in trivial/small; orchestrator + review-pr detect turbo via UBERDEV_TURBO env-var OR --turbo arg — hybrid OR detector, #97)
 export UBERDEV_TURBO=1   # NEW (#97): chain-wide unattended-mode signal — inherits via Skill() into solve-pipeline + via fork+exec into claude --bg child (env(1)-mediated, since timeout(1) sits in front of the inline-prefix slot)
-unset SKIP_PERMISSIONS   # (#241) defend against shell-rc / stale-session pollution from a prior /goal export — /turbo retains operator-gated perms by design
+unset SKIP_PERMISSIONS   # (#241) defend against shell-rc / stale-session pollution from a prior /goal export — /turbo retains operator-gated perms by design. MUST run BEFORE Skill('uberdev:solve-pipeline') below so the launcher inherits a clean env (mirrors the #97 UBERDEV_TURBO unset ordering rule for /solve).
 ```
 
 Now invoke the `uberdev:solve-pipeline` skill.

--- a/plugins/uberdev/lib/dispatch.sh
+++ b/plugins/uberdev/lib/dispatch.sh
@@ -153,8 +153,12 @@ uberdev_dispatch_preflight() {
 # PATH. Does NOT read or write UBERDEV_RESOLVED_BACKEND (that is preflight's;
 # RFC 0005 D15 constrains backend resolution only — env resolution is exempt).
 # Inputs (read with safe defaults so goal-pipeline, which has no arg-parser,
-# can call it): SKIP_PERMISSIONS (default 0), AUTO_PERMISSIONS (default 0),
-# EFFORT_LEVEL (default max).
+# can call it). Exhaustive list — this is the SSOT for both solve-pipeline
+# Phase A and goal-pipeline Phase 0 callers; any new opt-in env var must be
+# added here AND threaded through both call sites:
+#   SKIP_PERMISSIONS (default 0)  — bypass tier; /goal opts in (#241)
+#   AUTO_PERMISSIONS (default 0)  — auto tier; /turbo/--auto opts in
+#   EFFORT_LEVEL     (default max)
 uberdev_dispatch_resolve_env() {
   # BG_PROMPT_MODE: hardcoded `argv` (claude --bg 2.1.139 has no documented
   # --prompt-file / stdin form; the file/stdin arms in _uberdev_dispatch_claude_bg
@@ -166,12 +170,14 @@ uberdev_dispatch_resolve_env() {
 
   # PERM_FLAG: array form (zsh SH_WORD_SPLIT=off would treat a scalar at command
   # position as one argv slot). Empty by default; populated only when the caller
-  # opted into a permission tier. SKIP_PERMISSIONS=1 (--dangerously-skip-permissions)
-  # wins over AUTO_PERMISSIONS=1 (--permission-mode auto) when both are set —
-  # /goal opts into the strict bypass so cmux PermissionRequest hooks cannot
-  # stall the autonomous loop on first-tool-use (#241). Both literal lines
-  # PERM_FLAG=() and PERM_FLAG=( --permission-mode auto ) preserved verbatim
-  # for the structural-shape tests in tests/dispatch-claude-bg.test.sh.
+  # opted into a permission tier. When both SKIP_PERMISSIONS=1 and
+  # AUTO_PERMISSIONS=1 are set, the skip tier takes precedence (enforced by the
+  # if/elif ordering below — not a deliberate priority engine, just lexical
+  # control flow). /goal opts into the strict bypass so cmux PermissionRequest
+  # hooks cannot stall the autonomous loop on first-tool-use (#241). Both
+  # literal lines PERM_FLAG=() and PERM_FLAG=( --permission-mode auto )
+  # preserved verbatim for the structural-shape tests in
+  # tests/dispatch-claude-bg.test.sh.
   SKIP_PERMISSIONS="${SKIP_PERMISSIONS:-0}"
   AUTO_PERMISSIONS="${AUTO_PERMISSIONS:-0}"
   PERM_FLAG=()
@@ -352,12 +358,15 @@ _uberdev_dispatch_claude_bg() {
   fi
   # UBERDEV_TURBO=1 chain-wide signal for /turbo (AUTO_MODE=1) only; env(1)
   # mediates the inline-prefix because timeout(1) is argv[0]. Empty array
-  # under AUTO_MODE=0 -> no-op passthrough.
+  # under AUTO_MODE=0 -> no-op passthrough. See commands/turbo.md + commands/
+  # solve.md + RFC 0005 §2.3 (scoped-relaxation contract — propagation
+  # rules for unattended-mode signals).
   # SKIP_PERMISSIONS=1 is /goal's autonomous-loop opt-in (#241); propagated
   # to the bg child so its own uberdev_dispatch_resolve_env call sees the
   # bypass tier. Gates on SKIP_PERMISSIONS directly, NOT on AUTO_MODE — the
-  # defensive `unset` in commands/turbo.md + commands/solve.md is the
-  # pollution gate. `+=` (append) preserves any UBERDEV_TURBO=1 set above.
+  # defensive `unset` in commands/turbo.md + commands/solve.md (RFC 0005 §2.3
+  # scoped-relaxation contract) is the pollution gate. `+=` (append)
+  # preserves any UBERDEV_TURBO=1 set above.
   local BG_TURBO_ENV=()
   [[ "${AUTO_MODE:-0}" == "1" ]] && BG_TURBO_ENV=( UBERDEV_TURBO=1 )
   [[ "${SKIP_PERMISSIONS:-0}" == "1" ]] && BG_TURBO_ENV+=( SKIP_PERMISSIONS=1 )
@@ -607,6 +616,17 @@ LUA
 # _uberdev_dispatch_wezterm ISSUE_NUM TIER PROMPT_FILE
 # Spawns each agent as a foreground headless `claude -p` in a visible WezTerm
 # pane. Sets DISPATCH_RC and DISPATCH_ID (the spawned pane id).
+#
+# Intentional asymmetry vs. claude-bg / background backends: this backend does
+# NOT env(1)-wrap the spawn with BG_TURBO_ENV (no UBERDEV_TURBO / SKIP_PERMISSIONS
+# propagation). Per design Q4 (docs/uberdev/specs/2026-05-27-goal-skip-permissions-
+# propagation-design.md), wezterm is the attended-mode backend — visible panes,
+# operator can approve permission prompts manually — so the cmux PermissionRequest
+# stall does not apply. PERM_FLAG argv-threading to the directly-dispatched
+# claude -p (line 673) carries `--dangerously-skip-permissions` to the
+# first-level child for callers that opt in via SKIP_PERMISSIONS; that is the
+# scope wezterm supports today. Nested /turbo→/orchestrator→SDD bypass under
+# wezterm is filed as an open question (design doc §Open questions item 2).
 _uberdev_dispatch_wezterm() {
   local ISSUE_NUM="$1" TIER="$2" PROMPT_FILE="$3"
   DISPATCH_RC=0

--- a/plugins/uberdev/lib/dispatch.sh
+++ b/plugins/uberdev/lib/dispatch.sh
@@ -174,10 +174,7 @@ uberdev_dispatch_resolve_env() {
   # AUTO_PERMISSIONS=1 are set, the skip tier takes precedence (enforced by the
   # if/elif ordering below — not a deliberate priority engine, just lexical
   # control flow). /goal opts into the strict bypass so cmux PermissionRequest
-  # hooks cannot stall the autonomous loop on first-tool-use (#241). Both
-  # literal lines PERM_FLAG=() and PERM_FLAG=( --permission-mode auto )
-  # preserved verbatim for the structural-shape tests in
-  # tests/dispatch-claude-bg.test.sh.
+  # hooks cannot stall the autonomous loop on first-tool-use (#241).
   SKIP_PERMISSIONS="${SKIP_PERMISSIONS:-0}"
   AUTO_PERMISSIONS="${AUTO_PERMISSIONS:-0}"
   PERM_FLAG=()
@@ -508,6 +505,7 @@ _uberdev_dispatch_background() {
       "{\"issue\":$ISSUE_NUM,\"phase\":\"prompt_read\",\"backend\":\"background\",\"rc\":1}"
     return 1
   fi
+  # BG_TURBO_ENV: same propagation contract as the claude-bg arm — see lines ~359-369 for the rationale (UBERDEV_TURBO + SKIP_PERMISSIONS, RFC 0005 §2.3 scoped-relaxation contract).
   local BG_TURBO_ENV=()
   [[ "${AUTO_MODE:-0}" == "1" ]] && BG_TURBO_ENV=( UBERDEV_TURBO=1 )
   [[ "${SKIP_PERMISSIONS:-0}" == "1" ]] && BG_TURBO_ENV+=( SKIP_PERMISSIONS=1 )
@@ -619,8 +617,7 @@ LUA
 #
 # Intentional asymmetry vs. claude-bg / background backends: this backend does
 # NOT env(1)-wrap the spawn with BG_TURBO_ENV (no UBERDEV_TURBO / SKIP_PERMISSIONS
-# propagation). Per design Q4 (docs/uberdev/specs/2026-05-27-goal-skip-permissions-
-# propagation-design.md), wezterm is the attended-mode backend — visible panes,
+# propagation). Per design Q4 (see `docs/uberdev/specs/...-goal-skip-permissions-propagation-design.md` §Q4 / Non-goals), wezterm is the attended-mode backend — visible panes,
 # operator can approve permission prompts manually — so the cmux PermissionRequest
 # stall does not apply. PERM_FLAG argv-threading to the directly-dispatched
 # claude -p (line 673) carries `--dangerously-skip-permissions` to the

--- a/plugins/uberdev/lib/dispatch.sh
+++ b/plugins/uberdev/lib/dispatch.sh
@@ -153,7 +153,8 @@ uberdev_dispatch_preflight() {
 # PATH. Does NOT read or write UBERDEV_RESOLVED_BACKEND (that is preflight's;
 # RFC 0005 D15 constrains backend resolution only — env resolution is exempt).
 # Inputs (read with safe defaults so goal-pipeline, which has no arg-parser,
-# can call it): AUTO_PERMISSIONS (default 0), EFFORT_LEVEL (default max).
+# can call it): SKIP_PERMISSIONS (default 0), AUTO_PERMISSIONS (default 0),
+# EFFORT_LEVEL (default max).
 uberdev_dispatch_resolve_env() {
   # BG_PROMPT_MODE: hardcoded `argv` (claude --bg 2.1.139 has no documented
   # --prompt-file / stdin form; the file/stdin arms in _uberdev_dispatch_claude_bg
@@ -165,10 +166,20 @@ uberdev_dispatch_resolve_env() {
 
   # PERM_FLAG: array form (zsh SH_WORD_SPLIT=off would treat a scalar at command
   # position as one argv slot). Empty by default; populated only when the caller
-  # opted into --permission-mode auto via AUTO_PERMISSIONS=1.
+  # opted into a permission tier. SKIP_PERMISSIONS=1 (--dangerously-skip-permissions)
+  # wins over AUTO_PERMISSIONS=1 (--permission-mode auto) when both are set —
+  # /goal opts into the strict bypass so cmux PermissionRequest hooks cannot
+  # stall the autonomous loop on first-tool-use (#241). Both literal lines
+  # PERM_FLAG=() and PERM_FLAG=( --permission-mode auto ) preserved verbatim
+  # for the structural-shape tests in tests/dispatch-claude-bg.test.sh.
+  SKIP_PERMISSIONS="${SKIP_PERMISSIONS:-0}"
   AUTO_PERMISSIONS="${AUTO_PERMISSIONS:-0}"
   PERM_FLAG=()
-  [[ "$AUTO_PERMISSIONS" == "1" ]] && PERM_FLAG=( --permission-mode auto )
+  if [[ "$SKIP_PERMISSIONS" == "1" ]]; then
+    PERM_FLAG=( --dangerously-skip-permissions )
+  elif [[ "$AUTO_PERMISSIONS" == "1" ]]; then
+    PERM_FLAG=( --permission-mode auto )
+  fi
 
   # EFFORT_FLAG: threaded form of EFFORT_LEVEL (default max for callers without
   # an --effort parser, e.g. goal-pipeline). Bash+zsh array.
@@ -342,8 +353,14 @@ _uberdev_dispatch_claude_bg() {
   # UBERDEV_TURBO=1 chain-wide signal for /turbo (AUTO_MODE=1) only; env(1)
   # mediates the inline-prefix because timeout(1) is argv[0]. Empty array
   # under AUTO_MODE=0 -> no-op passthrough.
+  # SKIP_PERMISSIONS=1 is /goal's autonomous-loop opt-in (#241); propagated
+  # to the bg child so its own uberdev_dispatch_resolve_env call sees the
+  # bypass tier. Gates on SKIP_PERMISSIONS directly, NOT on AUTO_MODE — the
+  # defensive `unset` in commands/turbo.md + commands/solve.md is the
+  # pollution gate. `+=` (append) preserves any UBERDEV_TURBO=1 set above.
   local BG_TURBO_ENV=()
   [[ "${AUTO_MODE:-0}" == "1" ]] && BG_TURBO_ENV=( UBERDEV_TURBO=1 )
+  [[ "${SKIP_PERMISSIONS:-0}" == "1" ]] && BG_TURBO_ENV+=( SKIP_PERMISSIONS=1 )
   local BG_PROMPT_MODE="${BG_PROMPT_MODE:-argv}"
   case "$BG_PROMPT_MODE" in
     file)
@@ -484,6 +501,7 @@ _uberdev_dispatch_background() {
   fi
   local BG_TURBO_ENV=()
   [[ "${AUTO_MODE:-0}" == "1" ]] && BG_TURBO_ENV=( UBERDEV_TURBO=1 )
+  [[ "${SKIP_PERMISSIONS:-0}" == "1" ]] && BG_TURBO_ENV+=( SKIP_PERMISSIONS=1 )
   # Detached headless claude -p. cwd = the worktree. `claude -p` print mode
   # is non-interactive and verified on native Windows -> logs cleanly.
   # nohup + `&` + disown fully detach so the agent outlives this shell.

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -132,7 +132,7 @@ Notes on the enums:
    # stall first-tool-use. The autonomous-loop contract requires it; standalone
    # /turbo + /solve defensively unset this var (see commands/turbo.md and
    # commands/solve.md). EFFORT_LEVEL stays unset -> helper applies :-max.
-   export SKIP_PERMISSIONS=1     # autonomous-convergence loop contract (#241); BG_TURBO_ENV propagates this var across the env(1) boundary into the claude --bg child, after which /turbo+/orchestrator+SDD inherit it via ordinary process-env from that child (not via repeated env(1) wraps).
+   export SKIP_PERMISSIONS=1     # (#241) /goal autonomous-loop opt-in; propagation via BG_TURBO_ENV — see lib/dispatch.sh BG_TURBO_ENV blocks
    uberdev_dispatch_resolve_env || exit 1   # establishes TIMEOUT_BIN/SOLVE_TIMEOUT/MODEL/PERM_FLAG/EFFORT_FLAG/BG_PROMPT_MODE once
    ```
 

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -127,8 +127,12 @@ Notes on the enums:
    # UBERDEV_RESOLVED_BACKEND is now exported (D15: resolved once, frozen for the run).
    # /goal dispatches /turbo per issue, so mirror /turbo's unattended dispatch env.
    export AUTO_MODE=1            # matches commands/turbo.md (enables UBERDEV_TURBO=1 in the bg env)
-   # AUTO_PERMISSIONS and EFFORT_LEVEL are intentionally left unset -> helper applies
-   # :-0 / :-max defaults (turbo-parity: empty PERM_FLAG, EFFORT_FLAG=( --effort max )).
+   # /goal opts every dispatched bg agent into bypassPermissions so the cmux
+   # PermissionRequest hook (or any --settings-shadowing daemon hook) does not
+   # stall first-tool-use. The autonomous-loop contract requires it; standalone
+   # /turbo + /solve defensively unset this var (see commands/turbo.md and
+   # commands/solve.md). EFFORT_LEVEL stays unset -> helper applies :-max.
+   export SKIP_PERMISSIONS=1     # autonomous-convergence loop contract (#241); inherited by /turbo+/orchestrator+SDD via BG_TURBO_ENV
    uberdev_dispatch_resolve_env || exit 1   # establishes TIMEOUT_BIN/SOLVE_TIMEOUT/MODEL/PERM_FLAG/EFFORT_FLAG/BG_PROMPT_MODE once
    ```
 

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -132,7 +132,7 @@ Notes on the enums:
    # stall first-tool-use. The autonomous-loop contract requires it; standalone
    # /turbo + /solve defensively unset this var (see commands/turbo.md and
    # commands/solve.md). EFFORT_LEVEL stays unset -> helper applies :-max.
-   export SKIP_PERMISSIONS=1     # autonomous-convergence loop contract (#241); inherited by /turbo+/orchestrator+SDD via BG_TURBO_ENV
+   export SKIP_PERMISSIONS=1     # autonomous-convergence loop contract (#241); BG_TURBO_ENV propagates this var across the env(1) boundary into the claude --bg child, after which /turbo+/orchestrator+SDD inherit it via ordinary process-env from that child (not via repeated env(1) wraps).
    uberdev_dispatch_resolve_env || exit 1   # establishes TIMEOUT_BIN/SOLVE_TIMEOUT/MODEL/PERM_FLAG/EFFORT_FLAG/BG_PROMPT_MODE once
    ```
 

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -255,7 +255,7 @@ fi
 # lib/dispatch.sh:uberdev_dispatch_resolve_env (skip wins over auto when
 # both are set; same lexical if/elif ordering).
 if [[ "${SKIP_PERMISSIONS:-0}" == "1" ]]; then
-  PERM_DESC="bypass (--dangerously-skip-permissions; /goal autonomous loop)"
+  PERM_DESC="bypass (--dangerously-skip-permissions)"
 elif [[ "$AUTO_PERMISSIONS" == "1" ]]; then
   PERM_DESC="auto (Claude Code AI classifier)"
 else

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -248,7 +248,15 @@ fi
 # form (NOT the v0.21.0 one-liner `echo "Permission mode: $([[…]] && echo
 # … || echo …)"` which trips zsh NOMATCH when re-emitted into a generated
 # .sh — regression guard tests/audit-fixups.test.sh C8).
-if [[ "$AUTO_PERMISSIONS" == "1" ]]; then
+# SKIP_PERMISSIONS branch first: observability only — bg-child stdout
+# previously printed "default (manual per-tool gating)" under SKIP_PERMISSIONS=1
+# (#241), which contradicted the actual --dangerously-skip-permissions tier
+# (general-lens finding 3). Matches the PERM_FLAG precedence in
+# lib/dispatch.sh:uberdev_dispatch_resolve_env (skip wins over auto when
+# both are set; same lexical if/elif ordering).
+if [[ "${SKIP_PERMISSIONS:-0}" == "1" ]]; then
+  PERM_DESC="bypass (--dangerously-skip-permissions; /goal autonomous loop)"
+elif [[ "$AUTO_PERMISSIONS" == "1" ]]; then
   PERM_DESC="auto (Claude Code AI classifier)"
 else
   PERM_DESC="default (manual per-tool gating)"

--- a/tests/dispatch-background.test.sh
+++ b/tests/dispatch-background.test.sh
@@ -58,6 +58,9 @@ assert_grep "$DISPATCH_LIB" \
 assert_grep "$DISPATCH_LIB" \
   '"\$\{PERM_FLAG\[@\]\}"' \
   "background backend threads \"\${PERM_FLAG[@]}\" into claude -p"
+assert_grep "$DISPATCH_LIB" \
+  'BG_TURBO_ENV\+=\( SKIP_PERMISSIONS=1 \)' \
+  "BG_TURBO_ENV propagates SKIP_PERMISSIONS to background dispatch arm (#241)"
 
 echo "== Positive: status-file writes + audit payload =="
 assert_grep "$DISPATCH_LIB" \

--- a/tests/dispatch-claude-bg.test.sh
+++ b/tests/dispatch-claude-bg.test.sh
@@ -135,6 +135,16 @@ assert_grep "$DISPATCH_LIB" \
 assert_grep "$DISPATCH_LIB" \
   'PERM_FLAG=\( --permission-mode auto \)' \
   "uberdev_dispatch_resolve_env AUTO_PERMISSIONS branch populates PERM_FLAG as an array, not a scalar"
+assert_grep "$DISPATCH_LIB" \
+  'PERM_FLAG=\( --dangerously-skip-permissions \)' \
+  "uberdev_dispatch_resolve_env SKIP_PERMISSIONS branch populates PERM_FLAG with the bypass flag (#241)"
+assert_grep "$DISPATCH_LIB" \
+  'BG_TURBO_ENV\+=\( SKIP_PERMISSIONS=1 \)' \
+  "BG_TURBO_ENV propagates SKIP_PERMISSIONS to nested child dispatches (#241)"
+assert_grep "$REPO_ROOT/plugins/uberdev/commands/turbo.md" 'unset SKIP_PERMISSIONS' \
+  "T-no-skip-turbo (#241 pollution defence — turbo defends against stale /goal export)"
+assert_grep "$REPO_ROOT/plugins/uberdev/commands/solve.md" 'unset SKIP_PERMISSIONS' \
+  "T-no-skip-solve (#241 pollution defence — solve is interactive, never auto-elevates)"
 assert_grep "$SOLVE_PIPELINE" \
   '_uberdev_audit_emit effort_resolved' \
   "Phase A emits effort_resolved audit event with {source, level}"
@@ -568,7 +578,7 @@ echo
 echo "== #175 D-iso: uberdev_dispatch_resolve_env populates env from a clean shell =="
 (
   set +u
-  unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG AUTO_PERMISSIONS EFFORT_LEVEL
+  unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG AUTO_PERMISSIONS SKIP_PERMISSIONS EFFORT_LEVEL
   CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"
   # shellcheck disable=SC1090
   . "$DISPATCH_LIB"
@@ -594,6 +604,36 @@ echo "== #175 D-perm: AUTO_PERMISSIONS=1 yields --permission-mode auto =="
   . "$DISPATCH_LIB"
   uberdev_dispatch_resolve_env
   [[ "${PERM_FLAG[*]}" == "--permission-mode auto" ]] && { echo "  PASS  D-perm PERM_FLAG=( --permission-mode auto )"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-perm PERM_FLAG=( ${PERM_FLAG[*]} )"; FAIL=$((FAIL + 1)); }
+  printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
+) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
+
+echo
+echo "== #241 D-skip: SKIP_PERMISSIONS=1 yields --dangerously-skip-permissions =="
+(
+  set +u
+  unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG AUTO_PERMISSIONS EFFORT_LEVEL
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"; SKIP_PERMISSIONS=1
+  # shellcheck disable=SC1090
+  . "$DISPATCH_LIB"
+  uberdev_dispatch_resolve_env
+  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions" ]] \
+    && { echo "  PASS  D-skip PERM_FLAG=( --dangerously-skip-permissions )"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  D-skip PERM_FLAG=( ${PERM_FLAG[*]} )"; FAIL=$((FAIL + 1)); }
+  printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
+) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
+
+echo
+echo "== #241 D-precedence: SKIP_PERMISSIONS=1 + AUTO_PERMISSIONS=1 -> skip wins =="
+(
+  set +u
+  unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG EFFORT_LEVEL
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"; SKIP_PERMISSIONS=1; AUTO_PERMISSIONS=1
+  # shellcheck disable=SC1090
+  . "$DISPATCH_LIB"
+  uberdev_dispatch_resolve_env
+  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions" ]] \
+    && { echo "  PASS  D-precedence skip wins over auto"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  D-precedence PERM_FLAG=( ${PERM_FLAG[*]} )"; FAIL=$((FAIL + 1)); }
   printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
 ) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
 

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -291,15 +291,16 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.34.7) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.7"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.7"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.7-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.7\]'        "G20.changelog"
+echo "== G20: version bump locked (0.34.8) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.8"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.8"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.8-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.8\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"
 assert_grep "$GOAL_SKILL" 'export AUTO_MODE=1'            "G20b.phase0-sets-AUTO_MODE (#175 turbo-parity)"
+assert_grep "$GOAL_SKILL" 'export SKIP_PERMISSIONS=1'     "G20c.phase0-sets-SKIP_PERMISSIONS (#241 cmux/hook bypass)"
 
 echo
 echo "== G23: CLI-version-independent gh+file detection (issue #180) =="

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.34.6 -> 0.34.7 propagated =="
+echo "== Version bump 0.34.7 -> 0.34.8 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.34.7"' \
-  "plugin.json bumped to 0.34.7"
+  '"version": "0.34.8"' \
+  "plugin.json bumped to 0.34.8"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.34.7"' \
-  "marketplace.json bumped to 0.34.7"
+  '"version": "0.34.8"' \
+  "marketplace.json bumped to 0.34.8"
 assert_grep "$README" \
-  "version-0\\.34\\.7-blue" \
-  "README version badge bumped to 0.34.7"
+  "version-0\\.34\\.8-blue" \
+  "README version badge bumped to 0.34.8"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.34\.7\]' \
-  "CHANGELOG has [0.34.7] section header"
+  '^## \[0\.34\.8\]' \
+  "CHANGELOG has [0.34.8] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/turbo-flow.test.sh
+++ b/tests/turbo-flow.test.sh
@@ -180,6 +180,10 @@ assert_grep "$TURBO_CMD" 'export UBERDEV_TURBO=1' \
   "/turbo thin wrapper exports UBERDEV_TURBO=1 (#97 — chain-wide unattended-mode signal)"
 assert_grep "$SOLVE_CMD" 'unset UBERDEV_TURBO' \
   "/solve thin wrapper unsets UBERDEV_TURBO (#97 — defends against shell-rc pollution)"
+assert_grep "$TURBO_CMD" 'unset SKIP_PERMISSIONS' \
+  "T-no-skip-turbo (#241 — /turbo defends against shell-rc pollution from prior /goal SKIP_PERMISSIONS=1 export)"
+assert_grep "$SOLVE_CMD" 'unset SKIP_PERMISSIONS' \
+  "T-no-skip-solve (#241 — /solve is interactive, never auto-elevates regardless of stale /goal export)"
 assert_grep "$TURBO_CMD" \
   'argument-hint:.*<issue-number>.*\[<issue-number>' \
   "/turbo argument-hint documents multi-issue syntax"


### PR DESCRIPTION
## Summary
- Adds a third `SKIP_PERMISSIONS` env-var tier in `uberdev_dispatch_resolve_env` that emits `PERM_FLAG=( --dangerously-skip-permissions )` with strict precedence over `AUTO_PERMISSIONS`. The bypass tier is what `/uberdev:goal` needs to escape cmux's `PermissionRequest` hook — which intercepts even `--permission-mode auto` and stalls bg agents on first-tool-use.
- Propagates `SKIP_PERMISSIONS=1` via `BG_TURBO_ENV` in both `_uberdev_dispatch_claude_bg` and `_uberdev_dispatch_background` so nested child dispatches re-resolve the bypass tier in their own `uberdev_dispatch_resolve_env` call. Defensive `unset SKIP_PERMISSIONS` in `commands/turbo.md` and `commands/solve.md` mirrors the #97 `unset UBERDEV_TURBO` hardening — standalone `/turbo` / `/solve` are NOT silently elevated by a stale `/goal` export.
- New "Permission requirements (cmux/hooks caveat)" section in `commands/goal.md` documents that `~/.claude/settings.json` is shadowed at bg-dispatch time when cmux injects `--settings <blob>` into the bg session's `respawnFlags`; the env-var path is what actually unblocks the loop.

Closes #241

## Test Plan

- [x] `tests/dispatch-claude-bg.test.sh` — 105 PASS / 0 FAIL (new: D-skip behavioural, D-precedence behavioural, structural greps for `PERM_FLAG=( --dangerously-skip-permissions )` and `BG_TURBO_ENV+=( SKIP_PERMISSIONS=1 )`, T-no-skip-turbo + T-no-skip-solve negative tests, D-iso defensive `unset SKIP_PERMISSIONS`)
- [x] `tests/dispatch-background.test.sh` — 13 PASS / 0 FAIL (new: BG_TURBO_ENV+= grep on the background arm)
- [x] `tests/goal.test.sh` — 441 PASS / 0 FAIL (new: G20c assertion for `export SKIP_PERMISSIONS=1`; G20 version-lock bumped 0.34.7 → 0.34.8)
- [x] `tests/solve-claim.test.sh` — 104 PASS / 0 FAIL (version-bump propagation block bumped 0.34.7 → 0.34.8)
- [x] `tests/turbo-flow.test.sh` — 86 PASS / 0 FAIL (T-no-skip negative tests for `unset SKIP_PERMISSIONS` in commands/turbo.md + commands/solve.md)
- [x] Full shell-test suite — 1954 PASS / 0 FAIL across all `tests/*.test.sh`
- [x] Structural shape — `PERM_FLAG=()` literal preserved (count==1), `PERM_FLAG=( --permission-mode auto )` literal preserved (count>=1), new `PERM_FLAG=( --dangerously-skip-permissions )` present (count==1), `BG_TURBO_ENV+=( SKIP_PERMISSIONS=1 )` count==2 (both dispatch arms)
- [x] Version-bump atomicity — 0.34.8 in plugin.json, marketplace.json, README badge, CHANGELOG, plus the two test version-locks (`tests/goal.test.sh` G20 and `tests/solve-claim.test.sh`)
- [ ] **Manual verification at release time (NOT executed in CI — requires cmux daemon):** from a clean shell on macOS + cmux, run `/uberdev:goal 7 9` on a repo with two open issues. Expected before fix: bg agents flap busy/idle, `~/.claude/jobs/<short>/state.json` reads `tempo: blocked`, transcripts dead at ~32 lines after `Bash: gh issue view N` rejection. Expected after fix: agents reach `pushed-reviewing` without flap, no rejections in transcripts, `permissionMode:bypassPermissions` recorded.

## Scope of the relaxation

- Inside `/uberdev:goal` only — Phase 0 sets `export SKIP_PERMISSIONS=1`; the autonomous-loop contract requires unattended dispatch and the operator's `/uberdev:goal` invocation IS the consent gate.
- Outside `/uberdev:goal` — standalone `/turbo` and `/solve` defensively `unset SKIP_PERMISSIONS` so a stale shell export cannot silently elevate them. RFC 0005 §2.3 scoped-relaxation contract preserved.
- Wezterm dispatch backend left unchanged — attended-mode (visible panes), cmux PermissionRequest stall does not apply. Documented in the spec as a non-goal.
- Trust-boundary handling unchanged — `<external-untrusted-input>` wrap convention lives in subagent prompt templates (prompt-construction time), unaffected by the `--permission-mode` argv flag.

## Files changed

- `plugins/uberdev/lib/dispatch.sh` — new 3-tier PERM_FLAG `if/elif/fi` block; `BG_TURBO_ENV+=` SKIP_PERMISSIONS append in both dispatch arms.
- `plugins/uberdev/skills/goal-pipeline/SKILL.md` — Phase 0 step 4: `export SKIP_PERMISSIONS=1` + justification comment.
- `plugins/uberdev/commands/turbo.md` + `plugins/uberdev/commands/solve.md` — defensive `unset SKIP_PERMISSIONS` (mirrors #97).
- `plugins/uberdev/commands/goal.md` — new "Permission requirements (cmux/hooks caveat)" section.
- Tests: `tests/dispatch-claude-bg.test.sh`, `tests/dispatch-background.test.sh`, `tests/goal.test.sh`, `tests/solve-claim.test.sh`, `tests/turbo-flow.test.sh`.
- Version bump: `plugins/uberdev/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `README.md`, `CHANGELOG.md`, `tests/goal.test.sh` G20, `tests/solve-claim.test.sh`.


## Open questions answered by /turbo

These questions were synthesized from the Phase 1 research bundle and auto-picked under `--turbo`. Review the medium-confidence row before merging.

| Question | Choice | Confidence |
|----------|--------|------------|
| Variable name for the new permission tier | `SKIP_PERMISSIONS` | high |
| Defensive `unset SKIP_PERMISSIONS` in `/solve` AND `/turbo` command files | Defensive `unset SKIP_PERMISSIONS` in BOTH `commands/turbo.md` and `commands/solve.md`, mirroring #97. | high |
| SKIP_PERMISSIONS propagation through `BG_TURBO_ENV` for nested dispatches | (a) — propagate `SKIP_PERMISSIONS=1` whenever it is set in the parent shell, independent of `AUTO_MODE`. | medium — option (c) (UBERDEV_GOAL_ID gate) is the cleanest RFC-aligned choice but adds coupling; (a) + defensive unset achieves the same end-state with fewer moving parts. If the spec-reviewer flags this, fall back to (c). |
| Wezterm dispatch backend — SKIP_PERMISSIONS propagation | (a) — leave wezterm unchanged; the PERM_FLAG argv threading already carries `--dangerously-skip-permissions` to the directly-dispatched child agent. If the cmux PermissionRequest hook lives inside the claude-bg dispatch path (not wezterm), wezterm is not affected by this issue's repro. The wezterm backend is currently selected only when the user passes `--backend=wezterm`, which is a deliberate operator action (operator is present at a real TTY) so the issue's autonomous-loop scenario doesn't apply. | high |
| Version bump — patch vs minor | patch — 0.34.7 → 0.34.8 | high |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved /uberdev:goal stalling in cmux-mediated environments.

* **New Features**
  * Introduced SKIP_PERMISSIONS env var to allow permission-bypass behavior, propagated through background/turbo flows; wrappers now defensively unset it to avoid escalation.

* **Documentation**
  * Added a “Permission requirements (cmux/hooks caveat)” section and updated docs to explain SKIP_PERMISSIONS behavior.

* **Release**
  * Bumped release to 0.34.8; CHANGELOG and README updated.

* **Tests**
  * Added/updated tests to cover SKIP_PERMISSIONS propagation and isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->