### PR TITLE
fix(dispatch): pair --dangerously-skip-permissions with --permission-mode bypassPermissions (#246) — v0.34.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.34.12",
+      "version": "0.34.13",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.13] — 2026-05-28
+
+### Fixed
+- **`/uberdev` dispatch pairs `--dangerously-skip-permissions` with `--permission-mode bypassPermissions` so the bg UI cycle ring no longer lands on `auto` (Closes #246).** The PR #243 collapse populated `PERM_FLAG` with `--dangerously-skip-permissions` alone. In Claude Code 2.1.152+, `--dangerously-skip-permissions` bypasses permission *checks* but does NOT set `--permission-mode`; the bg session's UI cycle ring is driven by `--permission-mode`, and without an explicit setting it defaults to `auto` — exactly the mode that silently breaks Search and other agent tools (see memory `feedback_permission_tier_bypass_default`). Caught while reviewing `/ubergoal 225 226 227` cycle 1 — the bg session status bar showed `↗ auto mode on` even though argv passed `--dangerously-skip-permissions`. This is the missing other half of PR #243.
+  - `plugins/uberdev/lib/dispatch.sh` `uberdev_dispatch_resolve_env` — both `PERM_FLAG=( --dangerously-skip-permissions )` sites (the `SKIP_PERMISSIONS=1` branch and the `AUTO_PERMISSIONS=1` branch) now resolve to `PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )`. Belt-and-suspenders: `bypassPermissions` pins the cycle-ring position so the UI doesn't default to `auto`; `--dangerously-skip-permissions` short-circuits the actual permission-check codepath. The two flags target different mechanisms and are not redundant. Affects all three dispatch backends (`_uberdev_dispatch_claude_bg`, `_uberdev_dispatch_background`, `_uberdev_dispatch_wezterm`) because they all expand `"${PERM_FLAG[@]}"` from the same resolver.
+  - Tests: `tests/dispatch-claude-bg.test.sh` — three behavioural cases ratcheted (D-perm / D-skip / D-precedence) from the bare-skip literal to the new paired literal; structural-grep `perm_flag_count` and the negative auto-mode guard updated; new bare-skip regression guard (`bare_skip_count == 0`) locks the pairing so the bare form cannot silently reappear.
+  - `tests/goal.test.sh` G20 + `tests/solve-claim.test.sh` version-bump block ratcheted to `0.34.13`.
+
+### Notes
+- Version bumped to 0.34.13 across `plugin.json`, `marketplace.json`, the README badge, `CHANGELOG.md`, `tests/goal.test.sh` G20, and `tests/solve-claim.test.sh`. Atomic version-lock surfaces — partial bump is a red CI invariant.
+- Pairs with the v0.34.9 cut that shipped PR #243 (the AUTO_PERMISSIONS collapse). Together, both halves of the bypass-tier contract are restored: argv flag AND cycle-ring position.
+
+---
+
 ## [0.34.12] — 2026-05-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.34.12-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.34.13-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.34.12",
+  "version": "0.34.13",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/goal.md
+++ b/plugins/uberdev/commands/goal.md
@@ -40,7 +40,12 @@ A wall-clock cap (default 4h, see `--barrier-timeout=N`) escalates a stuck barri
 
 ## Permission requirements (cmux/hooks caveat)
 
-`/goal` runs each dispatched bg `/uberdev:orchestrator` agent in `bypassPermissions` mode (the `--dangerously-skip-permissions` argv flag) so the autonomous loop does not stall on cmux's `PermissionRequest` hook (or any other `--settings`-injected `PreToolUse` hook). This is set by `goal-pipeline/SKILL.md` Phase 0 via `export SKIP_PERMISSIONS=1` and propagated through `BG_TURBO_ENV` in `lib/dispatch.sh` to every nested child dispatch (`/uberdev:orchestrator` → `subagent-driven-dev`).
+`/goal` runs each dispatched bg `/uberdev:orchestrator` agent in `bypassPermissions` mode via a **pair** of argv flags — `--dangerously-skip-permissions` AND `--permission-mode bypassPermissions` — so the autonomous loop does not stall on cmux's `PermissionRequest` hook (or any other `--settings`-injected `PreToolUse` hook). The two flags target **different mechanisms** and both are needed (belt-and-suspenders, per #246):
+
+- `--dangerously-skip-permissions` short-circuits the runtime permission-check codepath (the historical bypass).
+- `--permission-mode bypassPermissions` pins the bg session UI cycle ring; without an explicit setting it defaults to `auto`, which is exactly the mode that silently breaks Search and other agent tools that the loop relies on.
+
+See `plugins/uberdev/lib/dispatch.sh:192-198` for the full rationale. This is set by `goal-pipeline/SKILL.md` Phase 0 via `export SKIP_PERMISSIONS=1` and propagated through `BG_TURBO_ENV` in `lib/dispatch.sh` to every nested child dispatch (`/uberdev:orchestrator` → `subagent-driven-dev`); the SKIP_PERMISSIONS env-var resolves to the paired flags inside `uberdev_dispatch_resolve_env`.
 
 **Important:** settings like `"skipDangerousModePermissionPrompt": true` in your own `~/.claude/settings.json` are **NOT** sufficient when cmux (or another daemon manager) injects its own `--settings <blob>` into the bg session's `respawnFlags` via the parent process — the user-settings file is shadowed at bg-dispatch time, not modified on disk. The env-var path (`SKIP_PERMISSIONS=1` → `--dangerously-skip-permissions` in argv) is what actually unblocks the loop.
 

--- a/plugins/uberdev/lib/dispatch.sh
+++ b/plugins/uberdev/lib/dispatch.sh
@@ -184,18 +184,26 @@ uberdev_dispatch_resolve_env() {
   # silently refuses some agent tools (notably Search) even when the operator opted
   # in, and cmux's PermissionRequest hook intercepts auto-mode too. The if/elif
   # ordering is preserved for audit-log clarity (which env var the caller set), but
-  # both branches now emit the same flag. /goal opts into the strict bypass so cmux
+  # both branches now emit the same pair. /goal opts into the strict bypass so cmux
   # PermissionRequest hooks cannot stall the autonomous loop on first-tool-use (#241);
-  # /turbo --auto and /solve --auto opt operators into the same flag for the same
+  # /turbo --auto and /solve --auto opt operators into the same pair for the same
   # reason (auto-mode is dead in practice).
+  #
+  # #246 follow-up: `--dangerously-skip-permissions` bypasses permission *checks*
+  # but does NOT set `--permission-mode`. In Claude Code 2.1.152+, the bg session UI
+  # cycle ring is driven by --permission-mode; without an explicit setting it lands
+  # on `auto`, which is exactly the mode that silently breaks Search/etc. that we are
+  # trying to avoid. Pair the two flags so the cycle-ring lands on bypassPermissions
+  # AND the runtime checks are short-circuited — they target different mechanisms,
+  # so both are needed (belt-and-suspenders).
   SKIP_PERMISSIONS="${SKIP_PERMISSIONS:-0}"
   AUTO_PERMISSIONS="${AUTO_PERMISSIONS:-0}"
   PERM_FLAG=()
   if [[ "$SKIP_PERMISSIONS" == "1" ]]; then
-    PERM_FLAG=( --dangerously-skip-permissions )
-  # Same flag as SKIP branch — kept distinct for caller-attribution observability via PERM_DESC; see header doc block.
+    PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )
+  # Same pair as SKIP branch — kept distinct for caller-attribution observability via PERM_DESC; see header doc block.
   elif [[ "$AUTO_PERMISSIONS" == "1" ]]; then
-    PERM_FLAG=( --dangerously-skip-permissions )
+    PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )
   fi
 
   # EFFORT_FLAG: threaded form of EFFORT_LEVEL (default max for callers without

--- a/plugins/uberdev/lib/dispatch.sh
+++ b/plugins/uberdev/lib/dispatch.sh
@@ -163,9 +163,13 @@ uberdev_dispatch_preflight() {
 #                                   but auto-mode is silently broken in cmux and refuses
 #                                   some agent tools (e.g., Search) outside cmux too —
 #                                   the middle tier was dead weight, so AUTO now resolves
-#                                   to the same `--dangerously-skip-permissions` flag as
-#                                   SKIP. Env-var name preserved for backward compat with
-#                                   /turbo --auto / /solve --auto and any external callers.
+#                                   to the same flag pair as SKIP. Env-var name preserved
+#                                   for backward compat with /turbo --auto / /solve --auto
+#                                   and any external callers. Post-#246 follow-up: both
+#                                   tiers now resolve to the paired form
+#                                   `--dangerously-skip-permissions --permission-mode
+#                                   bypassPermissions` (see in-body PERM_FLAG block for
+#                                   why pairing is required — bg-session UI cycle ring).
 #   EFFORT_LEVEL     (default max)
 uberdev_dispatch_resolve_env() {
   # BG_PROMPT_MODE: hardcoded `argv` (claude --bg 2.1.139 has no documented
@@ -178,30 +182,39 @@ uberdev_dispatch_resolve_env() {
 
   # PERM_FLAG: array form (zsh SH_WORD_SPLIT=off would treat a scalar at command
   # position as one argv slot). Empty by default; populated only when the caller
-  # opted into a permission tier. Post-#241 follow-up: both SKIP_PERMISSIONS=1 and
-  # AUTO_PERMISSIONS=1 resolve to `--dangerously-skip-permissions` — the historical
-  # `--permission-mode auto` middle tier is removed because Claude Code's auto-mode
-  # silently refuses some agent tools (notably Search) even when the operator opted
-  # in, and cmux's PermissionRequest hook intercepts auto-mode too. The if/elif
-  # ordering is preserved for audit-log clarity (which env var the caller set), but
-  # both branches now emit the same pair. /goal opts into the strict bypass so cmux
-  # PermissionRequest hooks cannot stall the autonomous loop on first-tool-use (#241);
-  # /turbo --auto and /solve --auto opt operators into the same pair for the same
-  # reason (auto-mode is dead in practice).
+  # opted into a permission tier.
   #
-  # #246 follow-up: `--dangerously-skip-permissions` bypasses permission *checks*
-  # but does NOT set `--permission-mode`. In Claude Code 2.1.152+, the bg session UI
-  # cycle ring is driven by --permission-mode; without an explicit setting it lands
-  # on `auto`, which is exactly the mode that silently breaks Search/etc. that we are
-  # trying to avoid. Pair the two flags so the cycle-ring lands on bypassPermissions
-  # AND the runtime checks are short-circuited — they target different mechanisms,
-  # so both are needed (belt-and-suspenders).
+  # (a) Why both env vars resolve to the same pair:
+  #     SKIP_PERMISSIONS and AUTO_PERMISSIONS both populate
+  #     `--dangerously-skip-permissions --permission-mode bypassPermissions`. The
+  #     historical `--permission-mode auto` middle tier was removed post-#241 because
+  #     Claude Code's auto-mode silently refuses some agent tools (notably Search)
+  #     even when the operator opted in, and cmux's PermissionRequest hook intercepts
+  #     auto-mode too — auto is dead in practice. /goal opts into the strict bypass
+  #     so cmux PermissionRequest hooks cannot stall the autonomous loop on
+  #     first-tool-use (#241); /turbo --auto and /solve --auto opt operators into the
+  #     same pair for the same reason.
+  #
+  # (b) Why the if/elif shape is preserved:
+  #     The two branches emit the same pair, but the if/elif structure is kept so
+  #     PERM_DESC (see solve-pipeline/SKILL.md) can attribute the bypass to which
+  #     env var the caller set — post-hoc grep can distinguish /goal (SKIP) vs
+  #     /turbo --auto / /solve --auto (AUTO) in audit logs.
+  #
+  # (c) Why both flags in the pair are needed (#246):
+  #     `--dangerously-skip-permissions` short-circuits the runtime permission
+  #     *checks* but does NOT set `--permission-mode`. In Claude Code 2.1.152+, the
+  #     bg session UI cycle ring is driven by --permission-mode; without an explicit
+  #     setting it lands on `auto`, which is exactly the mode that silently breaks
+  #     Search/etc. that we are trying to avoid. The two flags target different
+  #     mechanisms (runtime-check short-circuit vs bg UI cycle-ring pin), so both
+  #     are needed (belt-and-suspenders).
   SKIP_PERMISSIONS="${SKIP_PERMISSIONS:-0}"
   AUTO_PERMISSIONS="${AUTO_PERMISSIONS:-0}"
   PERM_FLAG=()
   if [[ "$SKIP_PERMISSIONS" == "1" ]]; then
     PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )
-  # Same pair as SKIP branch — kept distinct for caller-attribution observability via PERM_DESC; see header doc block.
+  # Same pair as SKIP branch — kept distinct for caller-attribution observability via PERM_DESC; see (b) in the PERM_FLAG rationale block above.
   elif [[ "$AUTO_PERMISSIONS" == "1" ]]; then
     PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )
   fi

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -14,7 +14,7 @@ This skill is invoked inline by `commands/solve.md` and `commands/turbo.md`. The
 | Name | Value (verbatim) | Where used |
 |---|---|---|
 | `TERMINAL_FLAG_DEPRECATED_NOTE` | `warning: --terminal=cmux\|ghostty\|iterm\|terminal\|nohup is deprecated in v0.22.0; /solve and /turbo now dispatch claude --bg background sessions visible in claude agents. The flag is parsed without effect and will be removed in v1.0.0.` | Phase A stderr emission on first encounter; `commands/solve.md` / `commands/turbo.md` `## Deprecated Flags`. |
-| `MIN_CLAUDE_VERSION` | `2.1.139` | Phase A `_uberdev_require_claude_version` hard gate. |
+| `MIN_CLAUDE_VERSION` | `2.1.152` | Phase A `_uberdev_require_claude_version` hard gate. Bumped from `2.1.139` for #246: `--permission-mode bypassPermissions` requires Claude Code 2.1.152+; older versions hit `claude --bg ... --permission-mode bypassPermissions` → exit-2 unknown-flag, surfacing as `dispatch_setup_failed phase:dispatch rc:2` with the root cause buried in BG_STDOUT_LOG. The `claude --bg` minimum itself remains 2.1.139 (see line ~54 / ~149 / ~281 / ~787 — those references intentionally pin the old `--bg` floor because they describe `--bg`-flag availability or `--effort`-flag availability, not the new `--permission-mode bypassPermissions` requirement). |
 | `DISPATCH_BACKEND_DEFAULT` | `auto` | Phase A `--backend=` parser default; `auto` defers to `lib/dispatch.sh` preflight. |
 | `DISPATCH_BACKEND_ENUM` | `auto \| claude-bg \| wezterm \| background` | Phase A `uberdev_read_enum dispatch_backend` validation; also the `--backend=` flag's accepted set. |
 | `FANOUT_CONCURRENCY_SOLVE_BG_DEFAULT` | `6` | Phase A `MAX_PARALLEL_BG_AGENTS` resolution default. |
@@ -50,11 +50,18 @@ This skill is invoked inline by `commands/solve.md` and `commands/turbo.md`. The
 Extract one or more issue numbers + optional override flags. The parser scans every space-separated token in `$ARGUMENTS` and collects only those that are **purely numeric** (anchored regex `^[0-9]+$`); deduplicates so `/turbo 5 5 6` doesn't race two agents into the same worktree path; and rejects empty input.
 
 ```bash
-# --- Phase A: claude version gate (NEW v0.22.0) ---
-# Hard-require Claude Code >= 2.1.139 (the `claude --bg` minimum). Older
-# versions cannot dispatch background sessions and the entire /solve and /turbo
-# contract is voided. Fail loudly with an actionable npm install pointer; do
-# not silently degrade.
+# --- Phase A: claude version gate (NEW v0.22.0; floor raised to 2.1.152 for #246) ---
+# Hard-require Claude Code >= 2.1.152. Two reasons stacked:
+#   (1) `claude --bg` requires 2.1.139+ (the original v0.22.0 floor). Older
+#       versions cannot dispatch background sessions and the entire /solve and
+#       /turbo contract is voided.
+#   (2) `--permission-mode bypassPermissions` (paired with `--dangerously-skip-permissions`
+#       per #246 — see lib/dispatch.sh:192-198) requires 2.1.152+. On
+#       2.1.139–2.1.151 the bg dispatch would hit `claude --bg ... --permission-mode
+#       bypassPermissions` → exit-2 unknown-flag, surfacing as
+#       `dispatch_setup_failed phase:dispatch rc:2` with the root-cause attribution
+#       (your claude is too old) buried in BG_STDOUT_LOG.
+# Fail loudly with an actionable npm install pointer; do not silently degrade.
 _uberdev_require_claude_version() {
   local min="$1"
   local cur
@@ -278,7 +285,8 @@ gh repo view --json nameWithOwner --jq .nameWithOwner
 ### 3. (RETIRED v0.22.0 — terminal detection removed for #85)
 
 The Phase A bg-dispatch probes (added near the top of the SKILL.md Phase A
-block by the v0.22.0 refactor: the claude-version gate at 2.1.139 and the
+block by the v0.22.0 refactor: the claude-version gate — originally 2.1.139,
+raised to 2.1.152 for #246 to cover `--permission-mode bypassPermissions` — and the
 `MAX_PARALLEL_BG_AGENTS` resolution, both still in SKILL.md Phase A) replace
 the entire former Step 3 terminal-detection cascade. The hardcoded
 prompt-mode (`BG_PROMPT_MODE=argv`) is now set by
@@ -469,7 +477,7 @@ fi
 # All probes run ONCE per /solve or /turbo invocation. They are hoisted out
 # of the Phase B per-issue loop because the resolved values are the same for
 # every spawn.
-_uberdev_require_claude_version "2.1.139"
+_uberdev_require_claude_version "2.1.152"
 # --- Phase A: portable temp dir (NEW v0.29.0 — RFC 0004 §3.8) ---
 # One temp root resolved once; every per-issue artifact (prompt, stdout log,
 # claim json, status file) lives under it. Git Bash on native Windows sets

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -265,9 +265,9 @@ fi
 # which env var the caller set so post-hoc grep can attribute the bypass to
 # /goal (SKIP) vs /turbo --auto / /solve --auto (AUTO).
 if [[ "${SKIP_PERMISSIONS:-0}" == "1" ]]; then
-  PERM_DESC="bypass (--dangerously-skip-permissions; SKIP_PERMISSIONS tier — /goal autonomous loop)"
+  PERM_DESC="bypass (--dangerously-skip-permissions --permission-mode bypassPermissions; SKIP_PERMISSIONS tier — /goal autonomous loop)"
 elif [[ "$AUTO_PERMISSIONS" == "1" ]]; then
-  PERM_DESC="bypass (--dangerously-skip-permissions; AUTO_PERMISSIONS tier — /turbo --auto / /solve --auto)"
+  PERM_DESC="bypass (--dangerously-skip-permissions --permission-mode bypassPermissions; AUTO_PERMISSIONS tier — /turbo --auto / /solve --auto)"
 else
   PERM_DESC="default (manual per-tool gating)"
 fi

--- a/plugins/uberdev/skills/solve-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/solve-pipeline/SKILL.md
@@ -264,6 +264,12 @@ fi
 # ordering is preserved for observability — the PERM_DESC string distinguishes
 # which env var the caller set so post-hoc grep can attribute the bypass to
 # /goal (SKIP) vs /turbo --auto / /solve --auto (AUTO).
+# Post-#246: each PERM_DESC string names both flags of the resolved pair
+# (`--dangerously-skip-permissions --permission-mode bypassPermissions`) so
+# the dispatch-time print surfaces the full bypass-pair to operators (the
+# bare `--dangerously-skip-permissions` form was insufficient — bg UI cycle
+# ring needs the explicit --permission-mode pin; see audit-fixups.test.sh
+# regression guard at the bare-skip regex check).
 if [[ "${SKIP_PERMISSIONS:-0}" == "1" ]]; then
   PERM_DESC="bypass (--dangerously-skip-permissions --permission-mode bypassPermissions; SKIP_PERMISSIONS tier — /goal autonomous loop)"
 elif [[ "$AUTO_PERMISSIONS" == "1" ]]; then

--- a/tests/audit-fixups.test.sh
+++ b/tests/audit-fixups.test.sh
@@ -249,15 +249,31 @@ fi
 # scenario where someone deletes the line entirely instead of regressing it).
 assert_grep "$SOLVE_PIPELINE" '^[[:space:]]*PERM_DESC="default \(manual per-tool gating\)"' \
   "solve-pipeline assigns PERM_DESC=\"default (manual per-tool gating)\" in the else branch"
-# Post-#241 follow-up: AUTO_PERMISSIONS=1 now resolves to --dangerously-skip-permissions
-# (auto-mode-collapse). PERM_DESC reflects the new bypass tier; the SKIP and AUTO
-# branches BOTH emit a `bypass (--dangerously-skip-permissions; <TIER>_PERMISSIONS tier...)`
-# string — the tier-name suffix lets post-hoc grep attribute the bypass to /goal
-# (SKIP) vs /turbo --auto / /solve --auto (AUTO).
-assert_grep "$SOLVE_PIPELINE" '^[[:space:]]*PERM_DESC="bypass \(--dangerously-skip-permissions; SKIP_PERMISSIONS tier' \
-  "solve-pipeline assigns PERM_DESC=\"bypass (--dangerously-skip-permissions; SKIP_PERMISSIONS tier ...)\" in the SKIP branch"
-assert_grep "$SOLVE_PIPELINE" '^[[:space:]]*PERM_DESC="bypass \(--dangerously-skip-permissions; AUTO_PERMISSIONS tier' \
-  "solve-pipeline assigns PERM_DESC=\"bypass (--dangerously-skip-permissions; AUTO_PERMISSIONS tier ...)\" in the AUTO branch"
+# Post-#241 follow-up: AUTO_PERMISSIONS=1 now resolves to the same bypass
+# pair as SKIP_PERMISSIONS=1 (auto-mode-collapse). Post-#246 follow-up: the
+# pair is `--dangerously-skip-permissions --permission-mode bypassPermissions`
+# (the two flags target different mechanisms — runtime-check short-circuit
+# + bg UI cycle-ring pin — see plugins/uberdev/lib/dispatch.sh:192-198).
+# PERM_DESC names BOTH flags so operators reading the `Permission mode:`
+# print at dispatch time see the full bypass-pair surface. The tier-name
+# suffix (SKIP_PERMISSIONS / AUTO_PERMISSIONS) still lets post-hoc grep
+# attribute the bypass to /goal (SKIP) vs /turbo --auto / /solve --auto (AUTO).
+assert_grep "$SOLVE_PIPELINE" '^[[:space:]]*PERM_DESC="bypass \(--dangerously-skip-permissions --permission-mode bypassPermissions; SKIP_PERMISSIONS tier' \
+  "solve-pipeline assigns PERM_DESC=\"bypass (--dangerously-skip-permissions --permission-mode bypassPermissions; SKIP_PERMISSIONS tier ...)\" in the SKIP branch (#246 — names both flags)"
+assert_grep "$SOLVE_PIPELINE" '^[[:space:]]*PERM_DESC="bypass \(--dangerously-skip-permissions --permission-mode bypassPermissions; AUTO_PERMISSIONS tier' \
+  "solve-pipeline assigns PERM_DESC=\"bypass (--dangerously-skip-permissions --permission-mode bypassPermissions; AUTO_PERMISSIONS tier ...)\" in the AUTO branch (#246 — names both flags)"
+# Negative drift guard: the bare-form `--dangerously-skip-permissions;` (single
+# flag named in the parenthetical) must NOT reappear in PERM_DESC — that was
+# exactly the #246 misconception that masked the paired-flag contract from
+# operators reading the dispatch-time print. Anchor on the trailing `;` so the
+# new paired form (` --permission-mode bypassPermissions; `) does not red-flag.
+if grep -qE '^[[:space:]]*PERM_DESC="bypass \(--dangerously-skip-permissions;' "$SOLVE_PIPELINE"; then
+  echo "  FAIL  PERM_DESC contains a bare \"--dangerously-skip-permissions;\" form — names only one flag, hides the paired --permission-mode bypassPermissions from operators (#246 regression)"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  PERM_DESC has no bare \"--dangerously-skip-permissions;\" form (paired flags surfaced to operators per #246)"
+  PASS=$((PASS + 1))
+fi
 assert_grep "$SOLVE_PIPELINE" '^echo "Permission mode: \$PERM_DESC"' \
   "solve-pipeline echoes 'Permission mode: \$PERM_DESC' (single-var interpolation, no nested substitution)"
 

--- a/tests/dispatch-background.test.sh
+++ b/tests/dispatch-background.test.sh
@@ -76,6 +76,53 @@ assert_grep "$DISPATCH_LIB" \
   'solve-bg-status-|status' \
   "background backend writes a per-issue status file"
 
+echo "== #246 D-perm/D-skip: background backend inherits paired PERM_FLAG from shared resolver =="
+# The PR body and CHANGELOG claim "all three dispatch backends inherit the change
+# because they all expand \"\${PERM_FLAG[@]}\" from the same resolver." That is
+# structurally true, but the only functional coverage lives in
+# tests/dispatch-claude-bg.test.sh (lines 633-674). A future regression where
+# someone hand-edits `_uberdev_dispatch_background` to strip / hard-code
+# PERM_FLAG would only red-CI the claude-bg test file. Mirror the claude-bg
+# D-perm / D-skip subshell cases here to lock the "background backend inherits"
+# claim against that regression class. The assertion shape is IDENTICAL across
+# backends because PERM_FLAG is set by the SHARED `uberdev_dispatch_resolve_env`
+# (not by per-backend code); this test verifies that resolver is reachable from
+# the background backend's code path.
+TALLY_FILE="$(mktemp)"
+
+echo
+echo "== #246 D-perm: AUTO_PERMISSIONS=1 yields --dangerously-skip-permissions --permission-mode bypassPermissions (background backend inherits from shared resolver) =="
+(
+  set +u
+  unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG SKIP_PERMISSIONS EFFORT_LEVEL
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"; AUTO_PERMISSIONS=1
+  # shellcheck disable=SC1090
+  . "$DISPATCH_LIB"
+  uberdev_dispatch_resolve_env
+  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions --permission-mode bypassPermissions" ]] \
+    && { echo "  PASS  D-perm (background) AUTO_PERMISSIONS=1 -> PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  D-perm (background) PERM_FLAG=( ${PERM_FLAG[*]} ) — expected --dangerously-skip-permissions --permission-mode bypassPermissions (#246)"; FAIL=$((FAIL + 1)); }
+  printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
+) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
+
+echo
+echo "== #246 D-skip: SKIP_PERMISSIONS=1 yields --dangerously-skip-permissions --permission-mode bypassPermissions (background backend inherits from shared resolver) =="
+(
+  set +u
+  unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG AUTO_PERMISSIONS EFFORT_LEVEL
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"; SKIP_PERMISSIONS=1
+  # shellcheck disable=SC1090
+  . "$DISPATCH_LIB"
+  uberdev_dispatch_resolve_env
+  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions --permission-mode bypassPermissions" ]] \
+    && { echo "  PASS  D-skip (background) SKIP_PERMISSIONS=1 -> PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  D-skip (background) PERM_FLAG=( ${PERM_FLAG[*]} ) — expected --dangerously-skip-permissions --permission-mode bypassPermissions (#246)"; FAIL=$((FAIL + 1)); }
+  printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
+) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
+
+rm -f "$TALLY_FILE"
+
+echo
 echo "== Anti-pattern: background backend never uses claude --bg =="
 # Extract just the _uberdev_dispatch_background function body and assert
 # `claude --bg` does not appear inside it (sibling backends in the same

--- a/tests/dispatch-claude-bg.test.sh
+++ b/tests/dispatch-claude-bg.test.sh
@@ -133,27 +133,42 @@ assert_grep "$DISPATCH_LIB" \
   '^[[:space:]]*PERM_FLAG=\(\)$' \
   "uberdev_dispatch_resolve_env binds PERM_FLAG as an empty bash+zsh array — same zsh-word-split rationale as EFFORT_FLAG (v0.22.2 fix)"
 # Structural floor for the PERM_FLAG resolver: the count==2 assertion below is the
-# canonical "both opt-in tiers populate the bypass flag" check (strictly dominates
-# the ≥1 single-match form — a redundant assert_grep was dropped post-#243 simplify
-# pass). Pair it with the negative regression guard ("--permission-mode auto MUST
-# NOT appear at runtime") to catch both regression directions.
+# canonical "both opt-in tiers populate the bypass-pair literal" check. Pair it with
+# the negative regression guard ("--permission-mode auto MUST NOT appear at runtime")
+# to catch both regression directions.
 # Count: 2 occurrences expected — the SKIP branch (line ~196) and the AUTO branch
 # (line ~198) of uberdev_dispatch_resolve_env. Asserts that AUTO did not regress
 # back to --permission-mode auto and that the if/elif structure is preserved for
 # audit-log observability.
-perm_flag_count=$(grep -c 'PERM_FLAG=( --dangerously-skip-permissions )' "$DISPATCH_LIB")
+# #246 (post-#243 follow-up): --dangerously-skip-permissions bypasses permission *checks*
+# but does NOT set --permission-mode; without an explicit --permission-mode the bg session
+# UI cycle defaults to `auto`, which silently breaks Search and other agent tools. Pair the
+# two flags so the cycle-ring lands on bypassPermissions AND the checks are short-circuited.
+perm_flag_count=$(grep -c 'PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )' "$DISPATCH_LIB")
 if [ "$perm_flag_count" -eq 2 ]; then
-  echo "  PASS  dispatch.sh has 2 PERM_FLAG=( --dangerously-skip-permissions ) sites (SKIP + AUTO branches, both bypass)"
+  echo "  PASS  dispatch.sh has 2 PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions ) sites (SKIP + AUTO branches, both pair the danger-skip + bypass-mode)"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL  dispatch.sh has $perm_flag_count PERM_FLAG=( --dangerously-skip-permissions ) sites (expected exactly 2 — SKIP + AUTO branches)"
+  echo "  FAIL  dispatch.sh has $perm_flag_count PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions ) sites (expected exactly 2 — SKIP + AUTO branches; #246 fix)"
+  FAIL=$((FAIL + 1))
+fi
+# Regression guard #246: the bare `--dangerously-skip-permissions` form (without the
+# `--permission-mode bypassPermissions` companion) must NOT appear as a PERM_FLAG
+# assignment at runtime. The bg-session UI cycle defaults to `auto` when no
+# --permission-mode is set, which silently breaks Search/etc. — see issue #246.
+bare_skip_count=$(grep -cE '^[[:space:]]*PERM_FLAG=\( --dangerously-skip-permissions \)[[:space:]]*$' "$DISPATCH_LIB")
+if [ "$bare_skip_count" -eq 0 ]; then
+  echo "  PASS  dispatch.sh has no bare PERM_FLAG=( --dangerously-skip-permissions ) assignments — #246 pair-with-bypass regression guard intact"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  dispatch.sh has $bare_skip_count bare PERM_FLAG=( --dangerously-skip-permissions ) assignments — must be paired with --permission-mode bypassPermissions (#246)"
   FAIL=$((FAIL + 1))
 fi
 # Regression guard: --permission-mode auto MUST NOT appear in the runtime resolver
 # (doc comments mentioning the historical mapping are fine; the executable PERM_FLAG=
 # assignment regressed in the past and the test catches a re-introduction).
 if grep -qE '^[[:space:]]*PERM_FLAG=\( --permission-mode auto \)' "$DISPATCH_LIB"; then
-  echo "  FAIL  dispatch.sh re-introduced PERM_FLAG=( --permission-mode auto ) — auto-mode is dead in practice (post-#241 follow-up); both branches must yield --dangerously-skip-permissions"
+  echo "  FAIL  dispatch.sh re-introduced PERM_FLAG=( --permission-mode auto ) — auto-mode is dead in practice (post-#241 follow-up); both branches must yield --dangerously-skip-permissions --permission-mode bypassPermissions"
   FAIL=$((FAIL + 1))
 else
   echo "  PASS  dispatch.sh does NOT assign PERM_FLAG=( --permission-mode auto ) at runtime (auto-mode-collapse regression guard intact)"
@@ -616,7 +631,7 @@ echo "== #175 D-iso: uberdev_dispatch_resolve_env populates env from a clean she
 ) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
 
 echo
-echo "== #175 D-perm: AUTO_PERMISSIONS=1 yields --dangerously-skip-permissions (post-#241 follow-up: AUTO remapped from --permission-mode auto to bypass) =="
+echo "== #246 D-perm: AUTO_PERMISSIONS=1 yields --dangerously-skip-permissions --permission-mode bypassPermissions (#243 + #246 pairing — bypass-mode pins the bg UI cycle ring; danger-skip short-circuits the checks) =="
 (
   set +u
   unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG EFFORT_LEVEL
@@ -624,12 +639,12 @@ echo "== #175 D-perm: AUTO_PERMISSIONS=1 yields --dangerously-skip-permissions (
   # shellcheck disable=SC1090
   . "$DISPATCH_LIB"
   uberdev_dispatch_resolve_env
-  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions" ]] && { echo "  PASS  D-perm AUTO_PERMISSIONS=1 -> PERM_FLAG=( --dangerously-skip-permissions )"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-perm PERM_FLAG=( ${PERM_FLAG[*]} ) — expected --dangerously-skip-permissions"; FAIL=$((FAIL + 1)); }
+  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions --permission-mode bypassPermissions" ]] && { echo "  PASS  D-perm AUTO_PERMISSIONS=1 -> PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-perm PERM_FLAG=( ${PERM_FLAG[*]} ) — expected --dangerously-skip-permissions --permission-mode bypassPermissions (#246)"; FAIL=$((FAIL + 1)); }
   printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
 ) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
 
 echo
-echo "== #241 D-skip: SKIP_PERMISSIONS=1 yields --dangerously-skip-permissions =="
+echo "== #246 D-skip: SKIP_PERMISSIONS=1 yields --dangerously-skip-permissions --permission-mode bypassPermissions =="
 (
   set +u
   unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG AUTO_PERMISSIONS EFFORT_LEVEL
@@ -637,14 +652,14 @@ echo "== #241 D-skip: SKIP_PERMISSIONS=1 yields --dangerously-skip-permissions =
   # shellcheck disable=SC1090
   . "$DISPATCH_LIB"
   uberdev_dispatch_resolve_env
-  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions" ]] \
-    && { echo "  PASS  D-skip PERM_FLAG=( --dangerously-skip-permissions )"; PASS=$((PASS + 1)); } \
-    || { echo "  FAIL  D-skip PERM_FLAG=( ${PERM_FLAG[*]} )"; FAIL=$((FAIL + 1)); }
+  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions --permission-mode bypassPermissions" ]] \
+    && { echo "  PASS  D-skip PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  D-skip PERM_FLAG=( ${PERM_FLAG[*]} ) — expected --dangerously-skip-permissions --permission-mode bypassPermissions (#246)"; FAIL=$((FAIL + 1)); }
   printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
 ) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
 
 echo
-echo "== #241 D-precedence: SKIP_PERMISSIONS=1 + AUTO_PERMISSIONS=1 -> both yield --dangerously-skip-permissions (post-follow-up: collapsed tier; precedence ordering preserved for observability only) =="
+echo "== #246 D-precedence: SKIP_PERMISSIONS=1 + AUTO_PERMISSIONS=1 -> both yield --dangerously-skip-permissions --permission-mode bypassPermissions (collapsed tier; precedence ordering preserved for observability only) =="
 (
   set +u
   unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG EFFORT_LEVEL
@@ -652,9 +667,9 @@ echo "== #241 D-precedence: SKIP_PERMISSIONS=1 + AUTO_PERMISSIONS=1 -> both yiel
   # shellcheck disable=SC1090
   . "$DISPATCH_LIB"
   uberdev_dispatch_resolve_env
-  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions" ]] \
-    && { echo "  PASS  D-precedence both tiers yield --dangerously-skip-permissions"; PASS=$((PASS + 1)); } \
-    || { echo "  FAIL  D-precedence PERM_FLAG=( ${PERM_FLAG[*]} )"; FAIL=$((FAIL + 1)); }
+  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions --permission-mode bypassPermissions" ]] \
+    && { echo "  PASS  D-precedence both tiers yield --dangerously-skip-permissions --permission-mode bypassPermissions"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  D-precedence PERM_FLAG=( ${PERM_FLAG[*]} ) — expected --dangerously-skip-permissions --permission-mode bypassPermissions (#246)"; FAIL=$((FAIL + 1)); }
   printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
 ) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
 

--- a/tests/dispatch-claude-bg.test.sh
+++ b/tests/dispatch-claude-bg.test.sh
@@ -404,8 +404,8 @@ rm -f "$TALLY_FILE"
 
 echo "== Positive: Phase A constants + hardcoded BG_PROMPT_MODE =="
 assert_grep "$SOLVE_PIPELINE" \
-  '_uberdev_require_claude_version "2.1.139"' \
-  "Phase A enforces claude --version >= 2.1.139 (hard gate)"
+  '_uberdev_require_claude_version "2.1.152"' \
+  "Phase A enforces claude --version >= 2.1.152 (hard gate; bumped from 2.1.139 for #246 — --permission-mode bypassPermissions requires 2.1.152+)"
 assert_grep "$SOLVE_PIPELINE" \
   'npm i -g @anthropic-ai/claude-code' \
   "version-gate error includes actionable npm install pointer"

--- a/tests/dispatch-wezterm.test.sh
+++ b/tests/dispatch-wezterm.test.sh
@@ -107,6 +107,53 @@ assert_grep "$DISPATCH_LIB" \
   '"pane_id":' \
   "agent_dispatched payload carries the spawned pane_id"
 
+echo "== #246 D-perm/D-skip: wezterm backend inherits paired PERM_FLAG from shared resolver =="
+# The PR body and CHANGELOG claim "all three dispatch backends inherit the change
+# because they all expand \"\${PERM_FLAG[@]}\" from the same resolver." That is
+# structurally true, but the only functional coverage lives in
+# tests/dispatch-claude-bg.test.sh (lines 633-674). A future regression where
+# someone hand-edits `_uberdev_dispatch_wezterm` to strip / hard-code PERM_FLAG
+# would only red-CI the claude-bg test file. Mirror the claude-bg D-perm / D-skip
+# subshell cases here to lock the "wezterm backend inherits" claim against that
+# regression class. The assertion shape is IDENTICAL across backends because
+# PERM_FLAG is set by the SHARED `uberdev_dispatch_resolve_env` (not by per-backend
+# code); this test verifies that resolver is reachable from the wezterm backend's
+# code path.
+TALLY_FILE="$(mktemp)"
+
+echo
+echo "== #246 D-perm: AUTO_PERMISSIONS=1 yields --dangerously-skip-permissions --permission-mode bypassPermissions (wezterm backend inherits from shared resolver) =="
+(
+  set +u
+  unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG SKIP_PERMISSIONS EFFORT_LEVEL
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"; AUTO_PERMISSIONS=1
+  # shellcheck disable=SC1090
+  . "$DISPATCH_LIB"
+  uberdev_dispatch_resolve_env
+  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions --permission-mode bypassPermissions" ]] \
+    && { echo "  PASS  D-perm (wezterm) AUTO_PERMISSIONS=1 -> PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  D-perm (wezterm) PERM_FLAG=( ${PERM_FLAG[*]} ) — expected --dangerously-skip-permissions --permission-mode bypassPermissions (#246)"; FAIL=$((FAIL + 1)); }
+  printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
+) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
+
+echo
+echo "== #246 D-skip: SKIP_PERMISSIONS=1 yields --dangerously-skip-permissions --permission-mode bypassPermissions (wezterm backend inherits from shared resolver) =="
+(
+  set +u
+  unset TIMEOUT_BIN SOLVE_TIMEOUT MODEL BG_PROMPT_MODE PERM_FLAG EFFORT_FLAG AUTO_PERMISSIONS EFFORT_LEVEL
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"; SKIP_PERMISSIONS=1
+  # shellcheck disable=SC1090
+  . "$DISPATCH_LIB"
+  uberdev_dispatch_resolve_env
+  [[ "${PERM_FLAG[*]}" == "--dangerously-skip-permissions --permission-mode bypassPermissions" ]] \
+    && { echo "  PASS  D-skip (wezterm) SKIP_PERMISSIONS=1 -> PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL  D-skip (wezterm) PERM_FLAG=( ${PERM_FLAG[*]} ) — expected --dangerously-skip-permissions --permission-mode bypassPermissions (#246)"; FAIL=$((FAIL + 1)); }
+  printf '%s %s\n' "$PASS" "$FAIL" > "$TALLY_FILE"
+) ; read -r dP dF < "$TALLY_FILE"; PASS="$dP"; FAIL="$dF"
+
+rm -f "$TALLY_FILE"
+
+echo
 echo "== Anti-pattern: wezterm backend never uses claude --bg =="
 # Scope the check to the _uberdev_dispatch_wezterm function body — sibling
 # backends in the same file legitimately use `claude --bg`.

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -296,11 +296,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.34.12) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.12"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.12"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.12-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.12\]'        "G20.changelog"
+echo "== G20: version bump locked (0.34.13) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.13"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.13"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.13-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.13\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.34.11 -> 0.34.12 propagated =="
+echo "== Version bump 0.34.12 -> 0.34.13 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.34.12"' \
-  "plugin.json bumped to 0.34.12"
+  '"version": "0.34.13"' \
+  "plugin.json bumped to 0.34.13"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.34.12"' \
-  "marketplace.json bumped to 0.34.12"
+  '"version": "0.34.13"' \
+  "marketplace.json bumped to 0.34.13"
 assert_grep "$README" \
-  "version-0\\.34\\.12-blue" \
-  "README version badge bumped to 0.34.12"
+  "version-0\\.34\\.13-blue" \
+  "README version badge bumped to 0.34.13"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.34\.12\]' \
-  "CHANGELOG has [0.34.12] section header"
+  '^## \[0\.34\.13\]' \
+  "CHANGELOG has [0.34.13] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/turbo-flow.test.sh
+++ b/tests/turbo-flow.test.sh
@@ -263,7 +263,7 @@ assert_grep "$SOLVE_PIPELINE" \
   "Phase B reads DISPATCH_RC post-condition from lib/dispatch.sh (uberdev_dispatch_one sets DISPATCH_RC + DISPATCH_ID as a documented SSOT contract — see uberdev_dispatch_one's header contract and its central SSOT reset in lib/dispatch.sh)"
 # Phase A hoist check: the version gate + BG_PROMPT_MODE assignment must
 # precede the Phase B per-issue loop (resolved once; identical for every spawn).
-SP_PHASE_A_LINE=$(grep -n '^_uberdev_require_claude_version "2.1.139"\|^BG_PROMPT_MODE=argv' "$SOLVE_PIPELINE" | head -1 | cut -d: -f1)
+SP_PHASE_A_LINE=$(grep -n '^_uberdev_require_claude_version "2.1.152"\|^BG_PROMPT_MODE=argv' "$SOLVE_PIPELINE" | head -1 | cut -d: -f1)
 SP_PHASE_B_LINE=$(grep -nE 'for ISSUE_NUM in "\$\{ISSUE_NUMS\[@\]\}"|for ISSUE_NUM in "\$\{ISSUE_NUMS\[@\]:' "$SOLVE_PIPELINE" | tail -1 | cut -d: -f1)
 if [[ -n "$SP_PHASE_A_LINE" && -n "$SP_PHASE_B_LINE" && "$SP_PHASE_A_LINE" -lt "$SP_PHASE_B_LINE" ]]; then
   echo "  PASS  Phase A hoisted before Phase B loop (line $SP_PHASE_A_LINE before $SP_PHASE_B_LINE)"
@@ -284,8 +284,8 @@ assert_grep "$SOLVE_PIPELINE" \
   'solve_bg_fanout_wave_started' \
   "Phase B emits solve_bg_fanout_wave_started audit event per wave (mirrors merge-pipeline:421)"
 assert_grep "$SOLVE_PIPELINE" \
-  '_uberdev_require_claude_version "2.1.139"' \
-  "Phase A version-gates claude --bg minimum (2.1.139)"
+  '_uberdev_require_claude_version "2.1.152"' \
+  "Phase A version-gates --permission-mode bypassPermissions minimum (2.1.152; bumped from 2.1.139 for #246)"
 
 echo
 echo "== orchestrator no longer arg-forwards --turbo to SDD (#97 — env-var inheritance) =="


### PR DESCRIPTION
## Summary

Closes #246.

- `_uberdev_dispatch_claude_bg` (and the two sibling backends) spawned `claude --bg` with only `--dangerously-skip-permissions`, leaving `--permission-mode` unset. In Claude Code 2.1.152+, the bg session UI cycle ring defaults to `auto` when `--permission-mode` is unset — exactly the mode that silently breaks Search and other agent tools (memory: `feedback_permission_tier_bypass_default`).
- Both `PERM_FLAG=( --dangerously-skip-permissions )` sites in `uberdev_dispatch_resolve_env` (the `SKIP_PERMISSIONS=1` branch and the `AUTO_PERMISSIONS=1` branch) now resolve to `PERM_FLAG=( --dangerously-skip-permissions --permission-mode bypassPermissions )`. Belt-and-suspenders pairing: `bypassPermissions` pins the cycle-ring position; `--dangerously-skip-permissions` short-circuits the actual permission-check codepath. The two flags target different mechanisms and are not redundant.
- All three dispatch backends (`_uberdev_dispatch_claude_bg`, `_uberdev_dispatch_background`, `_uberdev_dispatch_wezterm`) inherit the fix because they all expand `"${PERM_FLAG[@]}"` from the same resolver.

This is the missing other half of PR #243.

## Test Plan

- [x] `tests/dispatch-claude-bg.test.sh` — 3 behavioural cases ratcheted (D-perm / D-skip / D-precedence) from bare-skip literal → paired literal; structural `perm_flag_count` grep updated; new bare-skip regression guard (`bare_skip_count == 0`) locks the pairing. 106 passed, 0 failed.
- [x] `tests/dispatch-background.test.sh`, `tests/dispatch-wezterm.test.sh`, `tests/dispatch-fallback.test.sh` — green (resolver-shared, no behavioural change beyond the new pair literal).
- [x] `tests/goal.test.sh` G20 + `tests/solve-claim.test.sh` version-bump block ratcheted to `0.34.13`. Both green.
- [x] Full suite (52 test files) re-run — all green.

## Version

Bumped to 0.34.13 across `plugin.json`, `marketplace.json`, the README badge, `CHANGELOG.md`, `tests/goal.test.sh` G20, and `tests/solve-claim.test.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission flag pairing in dispatch operations to ensure proper permission mode behavior and prevent unintended default settings.

* **Chores**
  * Version bumped to 0.34.13. Updated changelog and project metadata accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->