### PR TITLE
feat(models): run /turbo, /solve, /goal + all subagents on Opus 4.8 1M via inherit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.34.13",
+      "version": "0.35.0",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.0] — 2026-05-28
+
+### Changed
+- **Models:** `/turbo`, `/solve`, and `/goal` now dispatch every agent on `claude-opus-4-8[1m]` (was `claude-opus-4-7[1m]`).
+- **Agents:** the 22 former-`sonnet` subagents plus the 9 `opus` subagents and 4 pipeline skills now use `model: inherit`, so the whole subagent tree runs on the session's Opus 4.8 1M model. The 6 `haiku` agents and 4 pre-existing `inherit` agents are unchanged. Former-`sonnet` agents carry a `# WAIT 4.8 sonnet` comment to revisit when Sonnet 4.8 ships.
+- Swept stale Sonnet / Opus-4.7 model references from agent descriptions, the `/issue` command docs, the `orchestrator` and `post-impl-review` skills, and the README; `plan-writer` no longer pins its internal research subagents to Sonnet.
+
 ## [0.34.13] — 2026-05-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.34.13-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.0-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)
@@ -25,7 +25,7 @@
 
 ## Heads up — this plugin burns tokens fast
 
-UberDev's whole personality is **parallel agent fanout**: `/issue` runs a 2-Sonnet-scout fanout, `/uberdev:review-pr` and `/uberdev:simplify` fan out 3–5 reviewers concurrently, `/solve` waves dispatch every task in parallel, `/merge` spawns one conflict-resolver per conflicted file. That's where the speed and quality come from — and that's where the cost comes from.
+UberDev's whole personality is **parallel agent fanout**: `/issue` runs a 2-scout fanout, `/uberdev:review-pr` and `/uberdev:simplify` fan out 3–5 reviewers concurrently, `/solve` waves dispatch every task in parallel, `/merge` spawns one conflict-resolver per conflicted file. That's where the speed and quality come from — and that's where the cost comes from.
 
 **Recommended setup: 2× Claude Max ×20 subscriptions.** A single Pro or single Max usage window genuinely is not enough headroom for a normal day of `/turbo` + `/review-pr` + `/merge` cycles. Expect to hit the limit mid-task on a single seat.
 
@@ -39,7 +39,7 @@ UberDev's whole personality is **parallel agent fanout**: `/issue` runs a 2-Sonn
 |---|---|
 | **`/solve <issue#>`** | Spawns an autonomous Claude agent as a `claude --bg` background session (visible in `claude agents`). Tier-aware: trivial issues skip brainstorm; large ones get the full orchestrator → spec → plan → wave-dispatch → review pipeline. |
 | **`/turbo <issue#>`** | Unattended `/solve`. Same pipeline, but the brainstorm phase auto-accepts the lead agent's recommendation and Q&A is resolved against the research bundle. Use when you trust the recommendation and want issue → PR with no babysitting. |
-| **`/issue <description>`** | Creates a well-investigated, deduped, label-validated GitHub issue from a one-line ask. 2-Sonnet-scout fanout (codebase + triage) runs in <30 s, with conventional-commit titling and template-by-type. |
+| **`/issue <description>`** | Creates a well-investigated, deduped, label-validated GitHub issue from a one-line ask. 2-scout fanout (codebase + triage) runs in <30 s, with conventional-commit titling and template-by-type. |
 | **`/review-pr [<PR#>]`** | Comprehensive PR review using specialized agents fanned out in parallel — code review, simplifier, silent-failure hunter, type-design analyzer, comment analyzer, test analyzer. |
 | **`/merge [<PR#> \| --all]`** | Lands an approved PR into the integration branch — autopilot. Bare invocation auto-discovers scope: single PR for the current branch, or all eligible open PRs against `integration_branch`. Ordering, per-PR strategy, conflict resolution (one parallel agent per conflicted file), and local sync, all unattended. |
 | **`/dev <idea>`** | Prototype fast lane. Decomposes a free-text idea, builds it via parallel `Task()` subagents in-session, runs one light review, opens a PR labelled `prototype`, and auto-files a harden issue. Deliberately skips spec/plan and full `/review-pr`. Honors `--no-pr` / `--no-issue`. |
@@ -147,7 +147,7 @@ claude agents                          # monitor active /solve and /turbo backgr
 claude --bg \
   --prompt-file /tmp/solve-prompt-123.txt \
   --worktree solve-issue-123 \
-  --model 'claude-opus-4-7[1m]'
+  --model 'claude-opus-4-8[1m]'
 ```
 
 Monitor with `claude agents` (the Agent View peek panel handles `AskUserQuestion` prompts inline — type the response and press Enter). Session names display natively from the `--worktree solve-issue-N` flag; no OSC tab-rename or `cmux workspace-action` is needed.
@@ -207,7 +207,7 @@ Or per-invocation: `--integration-branch=develop`.
 
 ## `/issue` — investigation-first issue creation
 
-Pipeline: classify → 2-Sonnet-scout fanout (`codebase-scout` + `triage-scout`, parallel in one turn — dedup against closed issues, label/scope validation against `gh label list` and commitlint) → draft → user-confirm → create → print `Next step: /solve N`. Median wall-clock under 30 seconds.
+Pipeline: classify → 2-scout fanout (`codebase-scout` + `triage-scout`, parallel in one turn — dedup against closed issues, label/scope validation against `gh label list` and commitlint) → draft → user-confirm → create → print `Next step: /solve N`. Median wall-clock under 30 seconds.
 
 Templates by type — bug (`fix`), feature (`feat`), or chore/refactor — each producing conventional-commit-style titles and a body footed with `**Triage hint:** <trivial|small|medium>` that `/solve` reads later to pick the workflow without reclassifying.
 
@@ -325,7 +325,7 @@ Bundled upstream license texts in `plugins/uberdev/licenses/`.
 |---|---|
 | **Repo-agnostic by default** | Commands derive `$REPO` from `gh repo view` at runtime. No hardcoded org/project IDs. |
 | **No GitHub Project board auto-add** | Portability over board affordance. May return via opt-in `.claude/board.json`. |
-| **Model pin baked in** *(in `solve.md`)* | Spawned agents run on `claude-opus-4-7[1m]` for reproducibility. Forks should adjust. |
+| **Model pin baked in** *(in `lib/dispatch.sh`)* | Spawned agents run on `claude-opus-4-8[1m]` for reproducibility. Forks should adjust. |
 | **Background sessions via `claude --bg`** | `/solve` and `/turbo` dispatch into Agent View — supervised by Claude Code's daemon, isolated per-worktree, platform-agnostic. No terminal emulator required. |
 | **Triage hint in every issue body** | `/solve` skips re-classification and picks the right workflow without re-reading the body. |
 | **Conventional commits enforced** | `feat(scope):` / `fix(scope):` / `chore(scope):` / `refactor(scope):`. `enhancement` is a label, never a type. |

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.34.13",
+  "version": "0.35.0",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/agents/ci-rebase-handler.md
+++ b/plugins/uberdev/agents/ci-rebase-handler.md
@@ -1,7 +1,8 @@
 ---
 name: ci-rebase-handler
 description: Rebases the PR branch onto its base when CI failure class is stale_base. Uses --force-with-lease=<branch>:<expected-old-sha> --force-if-includes; never bare --force. Delegates per-file conflicts to existing conflict-resolver agent. Halts on unresolvable conflict. Dispatched from /uberdev:review-pr Phase 3 ROUTE (Step 6c.4).
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: red
 ---
 

--- a/plugins/uberdev/agents/ci-rebase-handler.md
+++ b/plugins/uberdev/agents/ci-rebase-handler.md
@@ -1,7 +1,7 @@
 ---
 name: ci-rebase-handler
 description: Rebases the PR branch onto its base when CI failure class is stale_base. Uses --force-with-lease=<branch>:<expected-old-sha> --force-if-includes; never bare --force. Delegates per-file conflicts to existing conflict-resolver agent. Halts on unresolvable conflict. Dispatched from /uberdev:review-pr Phase 3 ROUTE (Step 6c.4).
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: red
 ---

--- a/plugins/uberdev/agents/code-simplifier.md
+++ b/plugins/uberdev/agents/code-simplifier.md
@@ -39,7 +39,7 @@ description: |
   </commentary>
   assistant: "Now I'll use the uberdev:code-simplifier agent to audit the optimized code for clarity and surface advisory findings on our coding standards"
   </example>
-model: opus
+model: inherit
 ---
 
 You are an expert code simplification auditor focused on identifying opportunities to enhance code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in spotting deviations from project-specific best practices and surfacing concrete simplification opportunities — `file:line` + description — for the controller or a downstream writer command to act on. You prioritize readable, explicit code over overly compact solutions. This is a balance that you have mastered as a result of your years as an expert software engineer.

--- a/plugins/uberdev/agents/codebase-scout.md
+++ b/plugins/uberdev/agents/codebase-scout.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-scout
 description: "Lightweight codebase scout for /uberdev:issue (runs on inherit — the session model). Greps and reads on description keywords, returns 1-3 real file paths under ## Likely area and an optional one-line root-cause hypothesis when issue_type=fix. Never invents paths."
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 tools: ["Read", "Grep", "Glob", "Bash"]
 ---

--- a/plugins/uberdev/agents/codebase-scout.md
+++ b/plugins/uberdev/agents/codebase-scout.md
@@ -1,7 +1,8 @@
 ---
 name: codebase-scout
-description: "Lightweight codebase scout for /uberdev:issue (runs on Sonnet). Greps and reads on description keywords, returns 1-3 real file paths under ## Likely area and an optional one-line root-cause hypothesis when issue_type=fix. Never invents paths."
-model: sonnet
+description: "Lightweight codebase scout for /uberdev:issue (runs on inherit — the session model). Greps and reads on description keywords, returns 1-3 real file paths under ## Likely area and an optional one-line root-cause hypothesis when issue_type=fix. Never invents paths."
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 tools: ["Read", "Grep", "Glob", "Bash"]
 ---
 
@@ -17,7 +18,7 @@ Inputs arrive as a YAML payload in your dispatch prompt:
 description: "<verbatim user description>"
 issue_type: fix | feat | refactor | test | docs | chore
 working_dir: "<absolute path>"
-model_hint: sonnet   # audit-trail aid; this agent is already pinned to sonnet via frontmatter
+model_hint: inherit   # audit-trail aid; this agent inherits the session model (Opus 4.8 1M) via frontmatter
 ```
 
 ## Process
@@ -53,4 +54,4 @@ summary: |
 
 ## Cost note
 
-This agent runs on Sonnet by frontmatter pin. If the runtime ignores the pin (see `affaan-m/everything-claude-code#173`), the dispatcher's escape hatch is `CLAUDE_CODE_SUBAGENT_MODEL=sonnet`.
+This agent runs on `inherit` — it uses the dispatching session's model (Opus 4.8 1M). To force a specific subagent model regardless of session, set `CLAUDE_CODE_SUBAGENT_MODEL=<model>` (see `affaan-m/everything-claude-code#173`).

--- a/plugins/uberdev/agents/conflict-resolver.md
+++ b/plugins/uberdev/agents/conflict-resolver.md
@@ -1,7 +1,8 @@
 ---
 name: conflict-resolver
 description: Resolves a single conflicted file from a PR merge in a scratch worktree. Reads <ours> and <theirs> hunks; returns a textually-justified resolution or a clean refusal. One agent per conflicted file; dispatched in a SINGLE assistant turn from skills/merge-pipeline/SKILL.md Phase 3.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: orange
 ---
 

--- a/plugins/uberdev/agents/conflict-resolver.md
+++ b/plugins/uberdev/agents/conflict-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: conflict-resolver
 description: Resolves a single conflicted file from a PR merge in a scratch worktree. Reads <ours> and <theirs> hunks; returns a textually-justified resolution or a clean refusal. One agent per conflicted file; dispatched in a SINGLE assistant turn from skills/merge-pipeline/SKILL.md Phase 3.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: orange
 ---

--- a/plugins/uberdev/agents/findings-to-issues.md
+++ b/plugins/uberdev/agents/findings-to-issues.md
@@ -1,7 +1,8 @@
 ---
 name: findings-to-issues
 description: Persists deferred findings (severity ∈ {blocker, critical, major, important} AND disposition != APPLIED) from /uberdev:review-pr Phase 1 + Phase 2 aggregates as durable GitHub issues with HTML-comment fingerprint dedupe, fail-CLOSED safety, and a hard MAX_NEW=10 per-run write cap. Blocker/critical findings receive @author mentions and Blocks: PR-N backrefs; major/important findings are filed silently. Dispatched via Task(subagent_type=uberdev:findings-to-issues) from /uberdev:review-pr Phase 2.5 and /uberdev:simplify Phase 3.5. Halts the parent run iff blocker findings are deferred OR critical/blocker overflow exceeds MAX_NEW (RFC 0002).
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: orange
 ---
 

--- a/plugins/uberdev/agents/findings-to-issues.md
+++ b/plugins/uberdev/agents/findings-to-issues.md
@@ -1,7 +1,7 @@
 ---
 name: findings-to-issues
 description: Persists deferred findings (severity ∈ {blocker, critical, major, important} AND disposition != APPLIED) from /uberdev:review-pr Phase 1 + Phase 2 aggregates as durable GitHub issues with HTML-comment fingerprint dedupe, fail-CLOSED safety, and a hard MAX_NEW=10 per-run write cap. Blocker/critical findings receive @author mentions and Blocks: PR-N backrefs; major/important findings are filed silently. Dispatched via Task(subagent_type=uberdev:findings-to-issues) from /uberdev:review-pr Phase 2.5 and /uberdev:simplify Phase 3.5. Halts the parent run iff blocker findings are deferred OR critical/blocker overflow exceeds MAX_NEW (RFC 0002).
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: orange
 ---

--- a/plugins/uberdev/agents/merge-strategy-decider.md
+++ b/plugins/uberdev/agents/merge-strategy-decider.md
@@ -1,7 +1,7 @@
 ---
 name: merge-strategy-decider
 description: Picks per-PR merge strategy in {squash, rebase, merge} from PR shape (commit count, conventional-commit ratio, divergence, WIP markers, repo convention) plus an advisory merge-strategy:<name> PR label hint. Emits a strategy plus rationale. One agent per PR; dispatched in a SINGLE assistant turn from skills/merge-pipeline/SKILL.md Phase 2.2.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: yellow
 ---

--- a/plugins/uberdev/agents/merge-strategy-decider.md
+++ b/plugins/uberdev/agents/merge-strategy-decider.md
@@ -1,7 +1,8 @@
 ---
 name: merge-strategy-decider
 description: Picks per-PR merge strategy in {squash, rebase, merge} from PR shape (commit count, conventional-commit ratio, divergence, WIP markers, repo convention) plus an advisory merge-strategy:<name> PR label hint. Emits a strategy plus rationale. One agent per PR; dispatched in a SINGLE assistant turn from skills/merge-pipeline/SKILL.md Phase 2.2.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: yellow
 ---
 

--- a/plugins/uberdev/agents/plan-writer.md
+++ b/plugins/uberdev/agents/plan-writer.md
@@ -1,7 +1,7 @@
 ---
 name: plan-writer
-description: Writer subagent that turns a spec into a wave-decomposed implementation plan. Internally dispatches up to 3 Sonnet research subagents (file-deps map, test-coverage map, wave-decomposer self-check). Returns structured handle with wave/task counts.
-model: opus
+description: Writer subagent that turns a spec into a wave-decomposed implementation plan. Internally dispatches up to 3 research subagents (file-deps map, test-coverage map, wave-decomposer self-check) on the session model (inherit → Opus 4.8 1M). Returns structured handle with wave/task counts.
+model: inherit
 color: green
 ---
 
@@ -44,7 +44,7 @@ If the spec lacks an acceptance-criteria section, set `status: BLOCKED` immediat
 
 ### Step 2: Internal research fanout
 
-Dispatch internal research subagents **in a single message** (parallel). Use the **Task** tool. All subagent models should be Sonnet.
+Dispatch internal research subagents **in a single message** (parallel). Use the **Task** tool. All subagents inherit the session model (Opus 4.8 1M); do not pin a smaller model.
 
 **Always dispatch (all tiers):**
 - **File-deps agent** — prompt: `"Map file dependencies for the components described in <spec_path>. For each file the plan will create or modify, list the other files it imports or depends on. Output a markdown table: File | Depends On. Be exhaustive — include test files."`

--- a/plugins/uberdev/agents/research-codebase.md
+++ b/plugins/uberdev/agents/research-codebase.md
@@ -1,7 +1,7 @@
 ---
 name: research-codebase
 description: Codebase research subagent for the orchestrator. Maps existing patterns, conventions, and relevant files for an issue. Returns a summary file path; orchestrator never reads the raw research into its context.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: cyan
 ---

--- a/plugins/uberdev/agents/research-codebase.md
+++ b/plugins/uberdev/agents/research-codebase.md
@@ -1,7 +1,8 @@
 ---
 name: research-codebase
 description: Codebase research subagent for the orchestrator. Maps existing patterns, conventions, and relevant files for an issue. Returns a summary file path; orchestrator never reads the raw research into its context.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: cyan
 ---
 

--- a/plugins/uberdev/agents/research-constraints.md
+++ b/plugins/uberdev/agents/research-constraints.md
@@ -1,7 +1,8 @@
 ---
 name: research-constraints
 description: Hard-constraints research subagent. Reads CLAUDE.md (global + project), docs/rfc/*, docs/adr/* to surface architectural mandates and existing decisions that constrain the design space.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: red
 ---
 

--- a/plugins/uberdev/agents/research-constraints.md
+++ b/plugins/uberdev/agents/research-constraints.md
@@ -1,7 +1,7 @@
 ---
 name: research-constraints
 description: Hard-constraints research subagent. Reads CLAUDE.md (global + project), docs/rfc/*, docs/adr/* to surface architectural mandates and existing decisions that constrain the design space.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: red
 ---

--- a/plugins/uberdev/agents/research-patterns.md
+++ b/plugins/uberdev/agents/research-patterns.md
@@ -1,7 +1,8 @@
 ---
 name: research-patterns
 description: In-repo pattern research subagent. Finds related closed PRs, similar features, commit-history precedents. Distinct from research-codebase (which maps files for the current issue) — this looks for prior precedents to mirror.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: magenta
 ---
 

--- a/plugins/uberdev/agents/research-patterns.md
+++ b/plugins/uberdev/agents/research-patterns.md
@@ -1,7 +1,7 @@
 ---
 name: research-patterns
 description: In-repo pattern research subagent. Finds related closed PRs, similar features, commit-history precedents. Distinct from research-codebase (which maps files for the current issue) — this looks for prior precedents to mirror.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: magenta
 ---

--- a/plugins/uberdev/agents/research-prior-art.md
+++ b/plugins/uberdev/agents/research-prior-art.md
@@ -1,7 +1,8 @@
 ---
 name: research-prior-art
 description: External prior-art research subagent. Web search + Context7 docs lookup for libraries, frameworks, or design patterns relevant to the issue. Distinct from research-patterns (in-repo) — this is the outside view.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: yellow
 ---
 

--- a/plugins/uberdev/agents/research-prior-art.md
+++ b/plugins/uberdev/agents/research-prior-art.md
@@ -1,7 +1,7 @@
 ---
 name: research-prior-art
 description: External prior-art research subagent. Web search + Context7 docs lookup for libraries, frameworks, or design patterns relevant to the issue. Distinct from research-patterns (in-repo) — this is the outside view.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: yellow
 ---

--- a/plugins/uberdev/agents/research-security.md
+++ b/plugins/uberdev/agents/research-security.md
@@ -1,7 +1,7 @@
 ---
 name: research-security
 description: Security research subagent for the orchestrator and /issue. Runs Semgrep SAST, cross-references awesome-secure-defaults by detected stack, summarises severity findings. Returns the universal research YAML contract; orchestrator never reads raw findings into its context.
-model: opus
+model: inherit
 color: red
 ---
 

--- a/plugins/uberdev/agents/spec-reviewer.md
+++ b/plugins/uberdev/agents/spec-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: spec-reviewer
 description: Reviewer subagent for design specs. Reads spec from disk, verifies against issue requirements, research bundle, and constraints. Returns APPROVE | REVISIONS_REQUIRED | REJECT. Gated phase — only runs for tier ≥ medium with --paranoid, or large always.
-model: opus
+model: inherit
 color: purple
 ---
 

--- a/plugins/uberdev/agents/spec-reviser.md
+++ b/plugins/uberdev/agents/spec-reviser.md
@@ -1,7 +1,7 @@
 ---
 name: spec-reviser
 description: Spec revision subagent. Takes an existing spec path + a change request (from spec-reviewer findings or user feedback in /solve mode) and produces a revised spec in clean context. Used by uberdev:orchestrator when REVISIONS_REQUIRED.
-model: opus
+model: inherit
 color: navy
 ---
 

--- a/plugins/uberdev/agents/spec-writer.md
+++ b/plugins/uberdev/agents/spec-writer.md
@@ -1,7 +1,7 @@
 ---
 name: spec-writer
 description: Writer subagent that synthesises a research bundle + answers into a design spec. Returns structured handle; orchestrator never reads the spec body. Used by uberdev:orchestrator phase 3.
-model: opus
+model: inherit
 color: blue
 ---
 

--- a/plugins/uberdev/agents/testers-a11y-critic.md
+++ b/plugins/uberdev/agents/testers-a11y-critic.md
@@ -1,7 +1,8 @@
 ---
 name: testers-a11y-critic
 description: Accessibility-critic persona for /uberdev:testers. Audits keyboard-only nav, screen-reader semantics, focus traps, color contrast, prefers-reduced-motion. Cross-references web.dev a11y guidelines. Read-only.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: cyan
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_press_key", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_evaluate", "Write(.uberdev/research/*)"]
 ---

--- a/plugins/uberdev/agents/testers-a11y-critic.md
+++ b/plugins/uberdev/agents/testers-a11y-critic.md
@@ -1,7 +1,7 @@
 ---
 name: testers-a11y-critic
 description: Accessibility-critic persona for /uberdev:testers. Audits keyboard-only nav, screen-reader semantics, focus traps, color contrast, prefers-reduced-motion. Cross-references web.dev a11y guidelines. Read-only.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: cyan
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_press_key", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_evaluate", "Write(.uberdev/research/*)"]

--- a/plugins/uberdev/agents/testers-adversarial-security.md
+++ b/plugins/uberdev/agents/testers-adversarial-security.md
@@ -1,7 +1,8 @@
 ---
 name: testers-adversarial-security
 description: Adversarial-security persona for /uberdev:testers. Probes XSS/SQLi/SSTI, unicode normalization tricks, auth race conditions, IDOR/URL tampering, request replay. Read-only — files findings only against the 10-invariant oracle library.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: red
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(node*)", "Bash(date*)", "Bash(jq*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_fill_form", "mcp__plugin_playwright_playwright__browser_evaluate", "mcp__plugin_playwright_playwright__browser_run_code_unsafe", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_network_requests", "mcp__plugin_playwright_playwright__browser_network_request", "mcp__plugin_playwright_playwright__browser_console_messages", "Write(.uberdev/research/*)"]
 ---

--- a/plugins/uberdev/agents/testers-adversarial-security.md
+++ b/plugins/uberdev/agents/testers-adversarial-security.md
@@ -1,7 +1,7 @@
 ---
 name: testers-adversarial-security
 description: Adversarial-security persona for /uberdev:testers. Probes XSS/SQLi/SSTI, unicode normalization tricks, auth race conditions, IDOR/URL tampering, request replay. Read-only — files findings only against the 10-invariant oracle library.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: red
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(node*)", "Bash(date*)", "Bash(jq*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_fill_form", "mcp__plugin_playwright_playwright__browser_evaluate", "mcp__plugin_playwright_playwright__browser_run_code_unsafe", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_network_requests", "mcp__plugin_playwright_playwright__browser_network_request", "mcp__plugin_playwright_playwright__browser_console_messages", "Write(.uberdev/research/*)"]

--- a/plugins/uberdev/agents/testers-chaos-engineer.md
+++ b/plugins/uberdev/agents/testers-chaos-engineer.md
@@ -1,7 +1,8 @@
 ---
 name: testers-chaos-engineer
 description: Chaos-engineering persona for /uberdev:testers. Runs flows under Slow 3G, Offline, CPU 4x throttle, simulated 5xx, connection drops. Uses Chrome DevTools MCP throttling primitives. Read-only.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: purple
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_network_requests", "mcp__plugin_playwright_playwright__browser_console_messages", "Write(.uberdev/research/*)"]
 ---

--- a/plugins/uberdev/agents/testers-chaos-engineer.md
+++ b/plugins/uberdev/agents/testers-chaos-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: testers-chaos-engineer
 description: Chaos-engineering persona for /uberdev:testers. Runs flows under Slow 3G, Offline, CPU 4x throttle, simulated 5xx, connection drops. Uses Chrome DevTools MCP throttling primitives. Read-only.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: purple
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_network_requests", "mcp__plugin_playwright_playwright__browser_console_messages", "Write(.uberdev/research/*)"]

--- a/plugins/uberdev/agents/testers-mobile-thumb.md
+++ b/plugins/uberdev/agents/testers-mobile-thumb.md
@@ -1,7 +1,7 @@
 ---
 name: testers-mobile-thumb
 description: Mobile-thumb persona for /uberdev:testers. 375px viewport, touch-only, slow tap (200ms), portrait/landscape switch mid-flow, iOS safe-area. Read-only.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: green
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_resize", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "Write(.uberdev/research/*)"]

--- a/plugins/uberdev/agents/testers-mobile-thumb.md
+++ b/plugins/uberdev/agents/testers-mobile-thumb.md
@@ -1,7 +1,8 @@
 ---
 name: testers-mobile-thumb
 description: Mobile-thumb persona for /uberdev:testers. 375px viewport, touch-only, slow tap (200ms), portrait/landscape switch mid-flow, iOS safe-area. Read-only.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: green
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_resize", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "Write(.uberdev/research/*)"]
 ---

--- a/plugins/uberdev/agents/testers-monitor-devils-advocate.md
+++ b/plugins/uberdev/agents/testers-monitor-devils-advocate.md
@@ -1,7 +1,7 @@
 ---
 name: testers-monitor-devils-advocate
 description: Devil's-advocate monitor for /uberdev:testers. Challenges every claimed finding, demands evidence anchors, flags findings without an invariant_violated mapping, rejects sycophantic confirmations. Separate-prompt critic (Snorkel self-critique-paradox countermeasure). Read-only.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: magenta
 allowed-tools: ["Bash(date*)", "Bash(jq*)", "Read", "Write(.uberdev/research/*)"]

--- a/plugins/uberdev/agents/testers-monitor-devils-advocate.md
+++ b/plugins/uberdev/agents/testers-monitor-devils-advocate.md
@@ -1,7 +1,8 @@
 ---
 name: testers-monitor-devils-advocate
 description: Devil's-advocate monitor for /uberdev:testers. Challenges every claimed finding, demands evidence anchors, flags findings without an invariant_violated mapping, rejects sycophantic confirmations. Separate-prompt critic (Snorkel self-critique-paradox countermeasure). Read-only.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: magenta
 allowed-tools: ["Bash(date*)", "Bash(jq*)", "Read", "Write(.uberdev/research/*)"]
 ---

--- a/plugins/uberdev/agents/testers-monitor-primary.md
+++ b/plugins/uberdev/agents/testers-monitor-primary.md
@@ -1,7 +1,7 @@
 ---
 name: testers-monitor-primary
 description: Primary monitor for /uberdev:testers. Reads all 6 personas' findings from the previous wave, generates per-persona follow-up prompts for the next wave, promotes findings to verified:true when reproduced by ≥2 independent personas against the same invariant. Read-only.
-model: opus
+model: inherit
 color: blue
 allowed-tools: ["Bash(date*)", "Bash(jq*)", "Bash(sha256sum*)", "Read", "Write(.uberdev/research/*)"]
 ---

--- a/plugins/uberdev/agents/testers-panicked-grandma.md
+++ b/plugins/uberdev/agents/testers-panicked-grandma.md
@@ -1,7 +1,7 @@
 ---
 name: testers-panicked-grandma
 description: Slow-reader, easily-confused persona for /uberdev:testers. Mis-clicks ~10% of actions, abandons after 3 errors, always tries Back button, gets stuck in modals. Read-only — files findings only against the 10-invariant oracle library.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: yellow
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_console_messages", "mcp__plugin_playwright_playwright__browser_navigate_back", "Write(.uberdev/research/*)"]

--- a/plugins/uberdev/agents/testers-panicked-grandma.md
+++ b/plugins/uberdev/agents/testers-panicked-grandma.md
@@ -1,7 +1,8 @@
 ---
 name: testers-panicked-grandma
 description: Slow-reader, easily-confused persona for /uberdev:testers. Mis-clicks ~10% of actions, abandons after 3 errors, always tries Back button, gets stuck in modals. Read-only — files findings only against the 10-invariant oracle library.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: yellow
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_console_messages", "mcp__plugin_playwright_playwright__browser_navigate_back", "Write(.uberdev/research/*)"]
 ---

--- a/plugins/uberdev/agents/testers-power-user.md
+++ b/plugins/uberdev/agents/testers-power-user.md
@@ -1,7 +1,8 @@
 ---
 name: testers-power-user
 description: Power-user persona for /uberdev:testers. Pastes 10k-char inputs, opens 20 tabs, double-clicks everything, hammers Enter, uses keyboard shortcuts. Read-only — files findings only against the 10-invariant oracle library.
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: orange
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(node*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_fill_form", "mcp__plugin_playwright_playwright__browser_press_key", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_console_messages", "mcp__plugin_playwright_playwright__browser_tabs", "mcp__plugin_playwright_playwright__browser_network_requests", "Write(.uberdev/research/*)"]
 ---

--- a/plugins/uberdev/agents/testers-power-user.md
+++ b/plugins/uberdev/agents/testers-power-user.md
@@ -1,7 +1,7 @@
 ---
 name: testers-power-user
 description: Power-user persona for /uberdev:testers. Pastes 10k-char inputs, opens 20 tabs, double-clicks everything, hammers Enter, uses keyboard shortcuts. Read-only — files findings only against the 10-invariant oracle library.
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: orange
 allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(node*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_fill_form", "mcp__plugin_playwright_playwright__browser_press_key", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_console_messages", "mcp__plugin_playwright_playwright__browser_tabs", "mcp__plugin_playwright_playwright__browser_network_requests", "Write(.uberdev/research/*)"]

--- a/plugins/uberdev/agents/triage-scout.md
+++ b/plugins/uberdev/agents/triage-scout.md
@@ -1,7 +1,8 @@
 ---
 name: triage-scout
-description: "Lightweight triage scout for /uberdev:issue (runs on Sonnet). Runs gh search issues (open + closed), gh label list, and reads commitlint config if present. Returns duplicate matches, validated label set, and validated commit scope. Never invents labels."
-model: sonnet
+description: "Lightweight triage scout for /uberdev:issue (runs on inherit — the session model). Runs gh search issues (open + closed), gh label list, and reads commitlint config if present. Returns duplicate matches, validated label set, and validated commit scope. Never invents labels."
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 tools: ["Bash", "Read"]
 ---
 
@@ -16,7 +17,7 @@ description: "<verbatim user description>"
 issue_type: fix | feat | refactor | test | docs | chore
 working_dir: "<absolute path>"
 repo_slug: "<owner>/<repo>"
-model_hint: sonnet   # audit-trail aid
+model_hint: inherit   # audit-trail aid
 ```
 
 ## Process
@@ -50,4 +51,4 @@ summary: |
 
 ## Cost note
 
-Pinned to Sonnet by frontmatter. Escape hatch: `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` (see `affaan-m/everything-claude-code#173`).
+Runs on `inherit` — the session model (Opus 4.8 1M). To force a specific subagent model, set `CLAUDE_CODE_SUBAGENT_MODEL=<model>` (see `affaan-m/everything-claude-code#173`).

--- a/plugins/uberdev/agents/triage-scout.md
+++ b/plugins/uberdev/agents/triage-scout.md
@@ -1,7 +1,7 @@
 ---
 name: triage-scout
 description: "Lightweight triage scout for /uberdev:issue (runs on inherit — the session model). Runs gh search issues (open + closed), gh label list, and reads commitlint config if present. Returns duplicate matches, validated label set, and validated commit scope. Never invents labels."
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 tools: ["Bash", "Read"]
 ---

--- a/plugins/uberdev/agents/trust-trail-evaluator.md
+++ b/plugins/uberdev/agents/trust-trail-evaluator.md
@@ -1,7 +1,8 @@
 ---
 name: trust-trail-evaluator
 description: Evaluates whether the /review-pr trust trail (label + trailer + audit JSON) on a PR remains valid against the live HEAD SHA. Inspects ancestor, diff-empty, and log-empty structural primitives plus PR-state corroborators; emits a verdict in {PASS, STALE, INVALID, FORCE_PUSHED} with rationale. One agent per PR; dispatched in a SINGLE assistant turn from skills/merge-pipeline/SKILL.md Phase 1.4 PATH_2 sub-condition (c).
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: cyan
 ---
 

--- a/plugins/uberdev/agents/trust-trail-evaluator.md
+++ b/plugins/uberdev/agents/trust-trail-evaluator.md
@@ -1,7 +1,7 @@
 ---
 name: trust-trail-evaluator
 description: Evaluates whether the /review-pr trust trail (label + trailer + audit JSON) on a PR remains valid against the live HEAD SHA. Inspects ancestor, diff-empty, and log-empty structural primitives plus PR-state corroborators; emits a verdict in {PASS, STALE, INVALID, FORCE_PUSHED} with rationale. One agent per PR; dispatched in a SINGLE assistant turn from skills/merge-pipeline/SKILL.md Phase 1.4 PATH_2 sub-condition (c).
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: cyan
 ---

--- a/plugins/uberdev/agents/uberthink-arbiter.md
+++ b/plugins/uberdev/agents/uberthink-arbiter.md
@@ -1,7 +1,7 @@
 ---
 name: uberthink-arbiter
 description: dispatched by /uberthink — Wave-7 rank & deliver (pairwise Elo over floor-survivors + 4-axis sub-criteria scoring + novelty recheck + moonshot flagging); emits ranked.yaml
-model: opus
+model: inherit
 color: orange
 ---
 

--- a/plugins/uberdev/agents/uberthink-falsifier.md
+++ b/plugins/uberdev/agents/uberthink-falsifier.md
@@ -1,7 +1,8 @@
 ---
 name: uberthink-falsifier
 description: dispatched by /uberthink — Wave-5 falsify (lens ∈ steelman | premortem | redteam | physics); marks each kill-cause fatal|fixable for the genetic loop
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: red
 ---
 

--- a/plugins/uberdev/agents/uberthink-falsifier.md
+++ b/plugins/uberdev/agents/uberthink-falsifier.md
@@ -1,7 +1,7 @@
 ---
 name: uberthink-falsifier
 description: dispatched by /uberthink — Wave-5 falsify (lens ∈ steelman | premortem | redteam | physics); marks each kill-cause fatal|fixable for the genetic loop
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: red
 ---

--- a/plugins/uberdev/agents/uberthink-frame.md
+++ b/plugins/uberdev/agents/uberthink-frame.md
@@ -1,7 +1,8 @@
 ---
 name: uberthink-frame
 description: dispatched by /uberthink — Wave-0 framing (lens ∈ schema/teardown/prior-art/constraints); schema lens also does donor selection + scope gate
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: cyan
 ---
 

--- a/plugins/uberdev/agents/uberthink-frame.md
+++ b/plugins/uberdev/agents/uberthink-frame.md
@@ -1,7 +1,7 @@
 ---
 name: uberthink-frame
 description: dispatched by /uberthink — Wave-0 framing (lens ∈ schema/teardown/prior-art/constraints); schema lens also does donor selection + scope gate
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: cyan
 ---

--- a/plugins/uberdev/agents/uberthink-generator.md
+++ b/plugins/uberdev/agents/uberthink-generator.md
@@ -1,7 +1,8 @@
 ---
 name: uberthink-generator
 description: dispatched by /uberthink — persona-parameterized divergence (field-scout for a donor domain | triz | morphological | provocateur | bridge)
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: green
 ---
 

--- a/plugins/uberdev/agents/uberthink-generator.md
+++ b/plugins/uberdev/agents/uberthink-generator.md
@@ -1,7 +1,7 @@
 ---
 name: uberthink-generator
 description: dispatched by /uberthink — persona-parameterized divergence (field-scout for a donor domain | triz | morphological | provocateur | bridge)
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: green
 ---

--- a/plugins/uberdev/agents/uberthink-moderator.md
+++ b/plugins/uberdev/agents/uberthink-moderator.md
@@ -1,7 +1,7 @@
 ---
 name: uberthink-moderator
 description: dispatched by /uberthink — Wave-2 Co-STORM gap-gate (identifies what the per-island divergence missed)
-# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+# WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: cyan
 ---

--- a/plugins/uberdev/agents/uberthink-moderator.md
+++ b/plugins/uberdev/agents/uberthink-moderator.md
@@ -1,7 +1,8 @@
 ---
 name: uberthink-moderator
 description: dispatched by /uberthink — Wave-2 Co-STORM gap-gate (identifies what the per-island divergence missed)
-model: sonnet
+# WAIT 4.8 sonnet: was sonnet (4.6); using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
+model: inherit
 color: cyan
 ---
 

--- a/plugins/uberdev/agents/uberthink-synthesizer.md
+++ b/plugins/uberdev/agents/uberthink-synthesizer.md
@@ -1,7 +1,7 @@
 ---
 name: uberthink-synthesizer
 description: dispatched by /uberthink — Wave-3 per-island + Wave-6 global combine (lens ∈ weave | crossover | mutate)
-model: opus
+model: inherit
 color: magenta
 ---
 

--- a/plugins/uberdev/commands/issue.md
+++ b/plugins/uberdev/commands/issue.md
@@ -10,7 +10,7 @@ User's description: $ARGUMENTS
 
 **Usage:** `/issue <description> [--no-explore]`
 
-Auto-classifies → dispatches **two Task agents** in a single assistant turn (`uberdev:codebase-scout` + `uberdev:triage-scout`, both running on Sonnet) → drafts the body inline from their YAML returns → confirms with the user → creates → offers `/solve` as follow-up. Median wall-clock under 30s.
+Auto-classifies → dispatches **two Task agents** in a single assistant turn (`uberdev:codebase-scout` + `uberdev:triage-scout`, both running on inherit — the session model) → drafts the body inline from their YAML returns → confirms with the user → creates → offers `/solve` as follow-up. Median wall-clock under 30s.
 
 ## Phase 0: Detect repo + parse flags
 
@@ -25,7 +25,7 @@ REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 NO_EXPLORE=$(echo "$ARGUMENTS" | grep -qE '\-\-no-explore' && echo 1 || echo 0)
 DESC=$(echo "$ARGUMENTS" | sed -E 's/ *--no-explore//g')
 if [ "$NO_EXPLORE" = "1" ]; then
-  echo "notice: --no-explore is deprecated; the default fanout is now 2 Sonnet scouts. Removal target: v1.0.0" >&2
+  echo "notice: --no-explore is deprecated; the default fanout is now 2 scouts. Removal target: v1.0.0" >&2
 fi
 ```
 
@@ -42,16 +42,16 @@ Parse `$DESC`. Determine:
 
 > `enhancement` is a **label**, never a commit type. Titles always use `feat(scope):` / `fix(scope):` / `chore(scope):` / `refactor(scope):`.
 
-## Phase 2: Dispatch the two Sonnet scouts (single assistant turn)
+## Phase 2: Dispatch the two scouts (single assistant turn)
 
-Phase 2 dispatches **two Task agents** in a single assistant turn (one message, two `Task` tool_use blocks): `uberdev:codebase-scout` and `uberdev:triage-scout`. Both pin `model: sonnet` in their frontmatter and re-name Sonnet in their description string for audit-trail visibility. Their returns are inline YAML; nothing is persisted to disk.
+Phase 2 dispatches **two Task agents** in a single assistant turn (one message, two `Task` tool_use blocks): `uberdev:codebase-scout` and `uberdev:triage-scout`. Both pin `model: inherit` in their frontmatter, so they run on the session model (Opus 4.8 1M). Their returns are inline YAML; nothing is persisted to disk.
 
-> **Model-pinning escape hatch.** If you observe the scouts running on Opus despite their frontmatter, set `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` as a global override (tracked at `affaan-m/everything-claude-code#173`).
+> **Model override.** To force a specific subagent model regardless of the session, set `CLAUDE_CODE_SUBAGENT_MODEL=<model>` as a global override (tracked at `affaan-m/everything-claude-code#173`).
 
 Each brief carries the literal resolved values for `description` (the user's `$DESC` from Phase 0), `issue_type` (from Phase 1 classification), `working_dir` (the absolute repo root), and `repo_slug` (the resolved `$REPO`).
 
-- **`uberdev:codebase-scout`** — receives `{description, issue_type, working_dir, model_hint: sonnet}` and returns YAML with `likely_area: [paths]` and (if `issue_type=fix`) `likely_root_cause: "one-line hypothesis"`. Drives the bug template's `## Likely area` and `## Likely root cause` sections.
-- **`uberdev:triage-scout`** — receives `{description, issue_type, working_dir, repo_slug, model_hint: sonnet}` and returns YAML with `duplicates: [{number, title, state}]`, `valid_labels: [...]`, `valid_scope: "..."`, `commitlint_present: true|false`. Drives the duplicate section, the `--label` flags, and the title scope. (`issue_type` is required so the scout picks the base label — `bug` for `fix`, `enhancement` for `feat` — without re-classifying.)
+- **`uberdev:codebase-scout`** — receives `{description, issue_type, working_dir, model_hint: inherit}` and returns YAML with `likely_area: [paths]` and (if `issue_type=fix`) `likely_root_cause: "one-line hypothesis"`. Drives the bug template's `## Likely area` and `## Likely root cause` sections.
+- **`uberdev:triage-scout`** — receives `{description, issue_type, working_dir, repo_slug, model_hint: inherit}` and returns YAML with `duplicates: [{number, title, state}]`, `valid_labels: [...]`, `valid_scope: "..."`, `commitlint_present: true|false`. Drives the duplicate section, the `--label` flags, and the title scope. (`issue_type` is required so the scout picks the base label — `bug` for `fix`, `enhancement` for `feat` — without re-classifying.)
 
 If the codebase scout returns `status: BLOCKED` (no real paths grounded), the main thread substitutes `"No clear area identified — defer to /brainstorm"` in the `## Likely area` section. **Never invent paths.**
 
@@ -220,4 +220,4 @@ Next step: /solve $ISSUE_NUM
 - **Always confirm** — show the full draft, wait for explicit approval before `gh issue create`.
 - **No screenshots section** — user adds those manually after creation if needed.
 - **WHAT/HOW boundary enforced** — issue body never contains an implementation checklist or fix design; that work belongs in `/uberdev:brainstorm`. Bug template's `## Likely root cause` is a causal triple (symptom/mechanism/owning code), not a file list. Feat template's `## What changes` describes externally visible result, not implementation strategy.
-- **Model-pinning escape hatch** — if you observe the scouts running on Opus despite frontmatter `model: sonnet`, set `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` as a global override. Tracked at `affaan-m/everything-claude-code#173`.
+- **Model override** — to force a specific subagent model regardless of the session, set `CLAUDE_CODE_SUBAGENT_MODEL=<model>` as a global override. Tracked at `affaan-m/everything-claude-code#173`.

--- a/plugins/uberdev/lib/dispatch.sh
+++ b/plugins/uberdev/lib/dispatch.sh
@@ -178,7 +178,7 @@ uberdev_dispatch_resolve_env() {
   BG_PROMPT_MODE=argv
 
   # MODEL: single-quoted to keep zsh from glob-evaluating [1m] under NOMATCH.
-  MODEL='claude-opus-4-7[1m]'
+  MODEL='claude-opus-4-8[1m]'
 
   # PERM_FLAG: array form (zsh SH_WORD_SPLIT=off would treat a scalar at command
   # position as one argv slot). Empty by default; populated only when the caller

--- a/plugins/uberdev/skills/orchestrator/SKILL.md
+++ b/plugins/uberdev/skills/orchestrator/SKILL.md
@@ -522,7 +522,7 @@ If `verdict: REJECT` → abort with diagnostic.
 
 ### Phase 4: plan-writer
 
-Dispatch `plan-writer` with `spec_path`, `tier`, `topic_slug`. The plan-writer internally dispatches its own Sonnet research subagents — orchestrator just waits for the final return.
+Dispatch `plan-writer` with `spec_path`, `tier`, `topic_slug`. The plan-writer internally dispatches its own research subagents (session model — Opus 4.8 1M) — orchestrator just waits for the final return.
 
 Verification: `[ -f $artifact_path ]`, `[ $(wc -c < $artifact_path) -gt 500 ]`, `grep -E "^## Execution Waves" $artifact_path` succeeds, content sha matches.
 

--- a/plugins/uberdev/skills/post-impl-review/SKILL.md
+++ b/plugins/uberdev/skills/post-impl-review/SKILL.md
@@ -38,7 +38,7 @@ If a reviewer agent surfaces a finding that "we should re-plan", record it as a 
 
 - `changed_paths` — list of files modified by the implementation (e.g. `gh pr diff <N> --name-only` output from `/uberdev:review-pr` Phase 1).
 - `commit_range` — git rev range for diff context, e.g. `<base>..HEAD` where `<base>` is the PR base ref.
-- `tier` — one of `trivial` / `small` / `medium` / `large`. Used only for reviewer model selection (Haiku for trivial/small, Sonnet for medium/large) per each agent's frontmatter.
+- `tier` — one of `trivial` / `small` / `medium` / `large`. Used only for reviewer model selection per each agent's frontmatter (the lightweight lenses pin Haiku; the code-reviewer lens inherits the session model — Opus 4.8 1M).
 - `aspect_emphasis` — optional list of aspect-token strings (e.g. `["tests", "errors"]`) forwarded from `/uberdev:review-pr` Step 1's `ASPECT_LIST`. Default: empty list. When non-empty, Step 1 below appends a `## Emphasis` subsection to the shared brief listing each token. The emphasis section is identical across all 6 reviewers — emphasis is uniform, never per-reviewer.
 
 ## Process
@@ -92,12 +92,12 @@ In ONE assistant turn, fire 6 Task() calls in parallel. Each receives the same b
 
 | Reviewer | Agent file | Lens |
 |---|---|---|
-| `code-reviewer` (correctness lens) | `agents/code-reviewer.md` (sonnet) | Correctness, design, CLAUDE.md compliance |
+| `code-reviewer` (correctness lens) | `agents/code-reviewer.md` (inherit) | Correctness, design, CLAUDE.md compliance |
 | `silent-failure-hunter` | `agents/silent-failure-hunter.md` | Swallowed errors, ignored returns, silent fallbacks |
 | `type-design-analyzer` | `agents/type-design-analyzer.md` | `any`/`unknown` misuse, type safety holes |
 | `comment-analyzer` | `agents/comment-analyzer.md` | Stale, redundant, or load-bearing comments |
 | `pr-test-analyzer` | `agents/pr-test-analyzer.md` (haiku) | Behavioral test coverage, critical gaps, test quality |
-| `code-reviewer` (general lens) | `agents/code-reviewer.md` (sonnet) | Catch-all for issues that fall outside the other 5 lenses (the brief flags this lens via the dispatcher's prompt) |
+| `code-reviewer` (general lens) | `agents/code-reviewer.md` (inherit) | Catch-all for issues that fall outside the other 5 lenses (the brief flags this lens via the dispatcher's prompt) |
 
 **Net change vs. pre-#73 fanout:** −`code-simplifier` (moved to Phase 2 of `/uberdev:review-pr` as the named lens dispatcher), +`pr-test-analyzer` (was documented in `/review-pr` `## Agent Descriptions` but never actually fanned out from this skill). 5 → 6 reviewers; composition changed.
 

--- a/plugins/uberdev/skills/testers-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/testers-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: testers-pipeline
 description: Use when /uberdev:testers is invoked. Orchestrates a read-only 8-agent adversarial QA audit squad (6 personas + 2 monitors) across 3 coordinated waves against a web/api/native target; routes findings into findings-to-issues.
-model: opus
+model: inherit
 ---
 
 # Testers Pipeline

--- a/plugins/uberdev/skills/uberscan-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/uberscan-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uberscan-pipeline
 description: Use when /uberdev:uberscan is invoked. Orchestrates a read-only whole-codebase audit by chunking the repo, running the review-pr Phase-1 reviewer fleet (6 agents) per chunk in concurrent waves, executing a repo-global Semgrep SAST + test-coverage pass, aggregating findings into a markdown report, and filing deduped GitHub issues. Never writes code.
-model: opus
+model: inherit
 ---
 
 # Uberscan Pipeline

--- a/plugins/uberdev/skills/ubersimplify-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/ubersimplify-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ubersimplify-pipeline
 description: Use when /uberdev:ubersimplify is invoked. Orchestrates whole-codebase 3-lens simplification — chunks the repo (shared lib/chunk.py), audits each chunk with the three code-simplifier lenses in concurrent waves, applies preserve-behavior fixes via code-fixer as one refactor: commit per chunk on a new branch, opens ONE PR, and files leftover blocker findings as GitHub issues. --audit-only is read-only.
-model: opus
+model: inherit
 ---
 
 # Ubersimplify Pipeline

--- a/plugins/uberdev/skills/uberthink-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/uberthink-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uberthink-pipeline
 description: 7-wave island-aware directive-emitter for /uberthink — frames the goal, runs N parallel evolutionary islands (diverge → gap-gate → combine → converge → falsify → genetic-loop-back ≤3) → cross-pollinate → rank → deliver dossier + file top ideas
-model: opus
+model: inherit
 ---
 
 # Uberthink Pipeline

--- a/tests/dispatch-claude-bg.test.sh
+++ b/tests/dispatch-claude-bg.test.sh
@@ -253,7 +253,7 @@ assert_grep "$DISPATCH_LIB" \
   '^uberdev_dispatch_resolve_env\(\)' \
   "#175 — uberdev_dispatch_resolve_env function is defined in lib/dispatch.sh"
 assert_grep "$DISPATCH_LIB" \
-  "MODEL='claude-opus-4-7\[1m\]'" \
+  "MODEL='claude-opus-4-8\[1m\]'" \
   "#175 — helper sets MODEL single-quoted (blocks zsh [1m] glob)"
 assert_grep "$DISPATCH_LIB" \
   'if \[\[ -n "\$TIMEOUT_BIN" \]\]; then' \
@@ -622,7 +622,7 @@ echo "== #175 D-iso: uberdev_dispatch_resolve_env populates env from a clean she
   [[ "$rc" -eq 0 ]] && { echo "  PASS  D-iso resolve_env returns 0"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso resolve_env rc=$rc"; FAIL=$((FAIL + 1)); }
   [[ -n "$TIMEOUT_BIN" ]] && { echo "  PASS  D-iso TIMEOUT_BIN non-empty"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso TIMEOUT_BIN empty"; FAIL=$((FAIL + 1)); }
   if [ -x "$TIMEOUT_BIN" ] || command -v "$TIMEOUT_BIN" >/dev/null 2>&1; then echo "  PASS  D-iso TIMEOUT_BIN executable/resolvable"; PASS=$((PASS + 1)); else echo "  FAIL  D-iso TIMEOUT_BIN not executable ($TIMEOUT_BIN)"; FAIL=$((FAIL + 1)); fi
-  [[ "$MODEL" == 'claude-opus-4-7[1m]' ]] && { echo "  PASS  D-iso MODEL correct"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso MODEL='$MODEL'"; FAIL=$((FAIL + 1)); }
+  [[ "$MODEL" == 'claude-opus-4-8[1m]' ]] && { echo "  PASS  D-iso MODEL correct"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso MODEL='$MODEL'"; FAIL=$((FAIL + 1)); }
   case "$SOLVE_TIMEOUT" in (''|*[!0-9]*) echo "  FAIL  D-iso SOLVE_TIMEOUT not numeric ('$SOLVE_TIMEOUT')"; FAIL=$((FAIL + 1));; (*) echo "  PASS  D-iso SOLVE_TIMEOUT numeric"; PASS=$((PASS + 1));; esac
   [[ "$BG_PROMPT_MODE" == "argv" ]] && { echo "  PASS  D-iso BG_PROMPT_MODE=argv"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso BG_PROMPT_MODE='$BG_PROMPT_MODE'"; FAIL=$((FAIL + 1)); }
   [[ "${EFFORT_FLAG[*]}" == "--effort max" ]] && { echo "  PASS  D-iso EFFORT_FLAG=( --effort max )"; PASS=$((PASS + 1)); } || { echo "  FAIL  D-iso EFFORT_FLAG=( ${EFFORT_FLAG[*]} )"; FAIL=$((FAIL + 1)); }

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -296,11 +296,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.34.13) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.34\.13"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.34\.13"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.34\.13-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.34\.13\]'        "G20.changelog"
+echo "== G20: version bump locked (0.35.0) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.35\.0"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.35\.0"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.35\.0-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.35\.0\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/install.test.sh
+++ b/tests/install.test.sh
@@ -153,11 +153,11 @@ echo
 echo "== I3: existing unrelated settings keys are preserved =="
 SANDBOX="$(make_sandbox)"
 seed_settings "$SANDBOX" \
-  '{"theme":"dark","model":"claude-opus-4-7","permissions":{"allow":["Bash"]}}'
+  '{"theme":"dark","model":"claude-opus-4-8","permissions":{"allow":["Bash"]}}'
 if run_install "$SANDBOX"; then
   if jq -e '
       .theme == "dark"
-      and .model == "claude-opus-4-7"
+      and .model == "claude-opus-4-8"
       and .permissions.allow == ["Bash"]
       and .enabledPlugins["uberdev@uberdev"] == true
     ' "$SANDBOX/.claude/settings.json" >/dev/null 2>&1; then

--- a/tests/issue-causal-fanout.test.sh
+++ b/tests/issue-causal-fanout.test.sh
@@ -66,7 +66,7 @@ assert_no_grep "$ISSUE_CMD" \
   "Phase 1.5 mkdir removed"
 
 echo
-echo "== Phase 2 dispatches the two Sonnet scouts =="
+echo "== Phase 2 dispatches the two scouts =="
 assert_grep "$ISSUE_CMD" \
   'two Task agents|2 Task agents' \
   "/issue prose mentions 2-agent count"
@@ -183,19 +183,19 @@ assert_no_grep "$BRAINSTORM" \
   "brainstorm no longer documents per-topic skip"
 
 echo
-echo "== Scout agents pinned to Sonnet (defence-in-depth) =="
+echo "== Scout agents run on inherit — the session model =="
 assert_grep "$CODEBASE_SCOUT" \
-  '^model: sonnet$' \
-  "codebase-scout YAML frontmatter pins model: sonnet"
+  '^model: inherit$' \
+  "codebase-scout YAML frontmatter pins model: inherit"
 assert_grep "$CODEBASE_SCOUT" \
-  'runs on Sonnet|Sonnet)' \
-  "codebase-scout description names Sonnet (audit trail)"
+  'runs on inherit' \
+  "codebase-scout description names inherit (audit trail)"
 assert_grep "$TRIAGE_SCOUT" \
-  '^model: sonnet$' \
-  "triage-scout YAML frontmatter pins model: sonnet"
+  '^model: inherit$' \
+  "triage-scout YAML frontmatter pins model: inherit"
 assert_grep "$TRIAGE_SCOUT" \
-  'runs on Sonnet|Sonnet)' \
-  "triage-scout description names Sonnet (audit trail)"
+  'runs on inherit' \
+  "triage-scout description names inherit (audit trail)"
 assert_grep "$ISSUE_CMD" \
   'CLAUDE_CODE_SUBAGENT_MODEL' \
   "/issue documents CLAUDE_CODE_SUBAGENT_MODEL escape hatch"

--- a/tests/merge.test.sh
+++ b/tests/merge.test.sh
@@ -802,7 +802,7 @@ if [ ! -r "$TTE_FILE" ]; then
   FAIL=$((FAIL + 1))
 else
   assert_grep "$TTE_FILE" '^name: trust-trail-evaluator'           "M47.1 — agent name frontmatter"
-  assert_grep "$TTE_FILE" '^model: sonnet'                          "M47.2 — agent model frontmatter"
+  assert_grep "$TTE_FILE" '^model: inherit'                          "M47.2 — agent model frontmatter"
   assert_grep "$TTE_FILE" '^description: '                           "M47.3 — agent description frontmatter non-empty"
   assert_grep "$TTE_FILE" '^## Inputs'                              "M47.4 — Inputs section present"
   assert_grep "$TTE_FILE" '^## Tools authorised'                    "M47.5 — Tools authorised section present"
@@ -820,7 +820,7 @@ if [ ! -r "$MSD_FILE" ]; then
   FAIL=$((FAIL + 1))
 else
   assert_grep "$MSD_FILE" '^name: merge-strategy-decider'           "M48.1 — agent name frontmatter"
-  assert_grep "$MSD_FILE" '^model: sonnet'                          "M48.2 — agent model frontmatter"
+  assert_grep "$MSD_FILE" '^model: inherit'                          "M48.2 — agent model frontmatter"
   assert_grep "$MSD_FILE" '^description: '                          "M48.3 — agent description frontmatter non-empty"
   assert_grep "$MSD_FILE" '^## Inputs'                              "M48.4 — Inputs section present"
   assert_grep "$MSD_FILE" '^## Tools authorised'                    "M48.5 — Tools authorised section present"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.34.12 -> 0.34.13 propagated =="
+echo "== Version bump 0.34.13 -> 0.35.0 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.34.13"' \
-  "plugin.json bumped to 0.34.13"
+  '"version": "0.35.0"' \
+  "plugin.json bumped to 0.35.0"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.34.13"' \
-  "marketplace.json bumped to 0.34.13"
+  '"version": "0.35.0"' \
+  "marketplace.json bumped to 0.35.0"
 assert_grep "$README" \
-  "version-0\\.34\\.13-blue" \
-  "README version badge bumped to 0.34.13"
+  "version-0\\.35\\.0-blue" \
+  "README version badge bumped to 0.35.0"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.34\.13\]' \
-  "CHANGELOG has [0.34.13] section header"
+  '^## \[0\.35\.0\]' \
+  "CHANGELOG has [0.35.0] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/solve-effort-flag.test.sh
+++ b/tests/solve-effort-flag.test.sh
@@ -280,7 +280,7 @@ echo "fake prompt body" > "$SANDBOX/prompt.txt"
   # Stand-ins for the other Phase A variables consumed by the argv arm.
   TIMEOUT_BIN=""
   SOLVE_TIMEOUT=10
-  MODEL='claude-opus-4-7[1m]'
+  MODEL='claude-opus-4-8[1m]'
   PERM_FLAG=()
   ISSUE_NUM=128
   PROMPT_BODY="$(cat "$SANDBOX/prompt.txt")"

--- a/tests/solve-pipeline-zsh.test.sh
+++ b/tests/solve-pipeline-zsh.test.sh
@@ -99,7 +99,7 @@ chmod +x "$STUB_DIR/claude"
   EFFORT_FLAG=( --effort "$EFFORT_LEVEL" )
   TIMEOUT_BIN=""
   SOLVE_TIMEOUT=10
-  MODEL='claude-opus-4-7[1m]'
+  MODEL='claude-opus-4-8[1m]'
   ISSUE_NUM=128
   PROMPT_BODY="fake prompt body"
   cmd=( "$STUB_DIR/claude" --bg
@@ -158,7 +158,7 @@ CAPTURE_FILE_2="$(mktemp)"
   EFFORT_FLAG=( --effort "$EFFORT_LEVEL" )
   TIMEOUT_BIN=""
   SOLVE_TIMEOUT=10
-  MODEL='claude-opus-4-7[1m]'
+  MODEL='claude-opus-4-8[1m]'
   ISSUE_NUM=128
   PROMPT_BODY="fake prompt body"
   cmd=( "$STUB_DIR/claude" --bg

--- a/tests/uberthink.test.sh
+++ b/tests/uberthink.test.sh
@@ -65,22 +65,22 @@ ck_msg "personas.yaml donor_catalog tiers: tier1..tier5 ALL present" \
 
 echo "== U4: all 6 agent files exist with uberthink-* names + valid models =="
 # Spec §2.5 model assignments:
-#   frame=sonnet, generator=sonnet, moderator=sonnet, falsifier=sonnet,
-#   synthesizer=opus, arbiter=opus
+#   all 6 agents now pin model: inherit (session model — Opus 4.8 1M),
+#   overriding the original spec §2.5 per the all-inherit policy.
 declare -a AGENTS=(frame generator moderator falsifier synthesizer arbiter)
 declare -A WANT_MODEL=(
-  [frame]=sonnet [generator]=sonnet [moderator]=sonnet [falsifier]=sonnet
-  [synthesizer]=opus [arbiter]=opus
+  [frame]=inherit [generator]=inherit [moderator]=inherit [falsifier]=inherit
+  [synthesizer]=inherit [arbiter]=inherit
 )
 for a in "${AGENTS[@]}"; do
   f="$AGENTS_DIR/uberthink-$a.md"
   ck "agent file exists: uberthink-$a.md" "[ -r '$f' ]"
   ck "agent frontmatter name is uberthink-$a" "grep -qE '^name: uberthink-$a\$' '$f'"
-  # model is one of opus|sonnet|haiku
-  ck "agent model in {opus,sonnet,haiku}: uberthink-$a" "grep -qE '^model: (opus|sonnet|haiku)\$' '$f'"
+  # model is one of opus|sonnet|haiku|inherit
+  ck "agent model in {opus,sonnet,haiku,inherit}: uberthink-$a" "grep -qE '^model: (opus|sonnet|haiku|inherit)\$' '$f'"
   # spec §2.5 specific assignment
   want="${WANT_MODEL[$a]}"
-  ck "agent model matches spec §2.5: uberthink-$a == $want" "grep -qE '^model: $want\$' '$f'"
+  ck "agent model matches all-inherit policy: uberthink-$a == $want" "grep -qE '^model: $want\$' '$f'"
 done
 
 echo "== U5: SKILL.md single-message invariant =="


### PR DESCRIPTION
## What

Moves the whole UberDev dispatch/agent fleet onto **Opus 4.8 1M** and removes Sonnet/Opus-4.7 pins.

- **Dispatch model** (`lib/dispatch.sh`): `claude-opus-4-7[1m]` → `claude-opus-4-8[1m]`. `/turbo`, `/solve`, `/goal` now launch every top-level agent on Opus 4.8 1M (verified: the `--model` flag accepts the `[1m]` variant).
- **Subagents → `model: inherit`** so the entire tree follows the session model:
  - **22** former `sonnet` agents → `inherit`, each carrying a `# WAIT 4.8 sonnet` frontmatter comment to revisit when Sonnet 4.8 ships.
  - **9** `opus` agents + **4** pipeline skills → `inherit` (gain the 1M window).
  - **6** `haiku` agents and **4** pre-existing `inherit` agents are **unchanged** (kept `haiku` intentionally).
- **Prose swept**: stale "Sonnet" / "Opus 4.7" claims removed from agent descriptions, the `/issue` command doc, the `orchestrator` + `post-impl-review` skills, and the README. `plan-writer` no longer instructs its internal research subagents to use Sonnet (behavioral fix).

## Why

`inherit` is the only documented way to bind a subagent to the dispatching session's exact model; pinning `claude-opus-4-8[1m]` in frontmatter is undocumented and can silently fall back to base 4.8. With dispatch pinned to `4-8[1m]`, `inherit` propagates the 1M context down the whole tree and is future-proof.

## Heads-up

The `/issue` scouts (`codebase-scout`, `triage-scout`) were deliberately Sonnet for a fast/cheap <30s flow; they're now `inherit` (Opus 4.8 1M — heavier). Consistent with the sonnet→inherit rule, but `haiku` may fit better there if cost matters — easy follow-up.

## Verification

- Synced 7 model/version test-locks (dispatch-claude-bg, solve-effort-flag, solve-pipeline-zsh, merge, issue-causal-fanout, uberthink, install).
- Version bumped to **v0.35.0** across all 6 in-repo locations (plugin.json, marketplace.json, README badge, CHANGELOG, goal `G20`, solve-claim). Tag + GitHub Release to follow on merge.
- **17/17** affected + version-lock tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes: v0.35.0

* **Chores**
  * Bumped plugin version to 0.35.0.
  * Updated default dispatch model for `/turbo`, `/solve`, and `/goal` commands.
  * Consolidated agent configurations to inherit the session model across the subagent tree.

* **Documentation**
  * Updated CHANGELOG, README, and command documentation to reflect model configuration changes.
  * Updated all test assertions to verify correct version and model settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->