### PR TITLE
test(cluster-pipeline): P13 Phase 4 proposal generation gate (#257)

### DIFF
--- a/tests/cluster-pipeline.test.sh
+++ b/tests/cluster-pipeline.test.sh
@@ -35,6 +35,18 @@ for f in "$SKILL_MD" "$CLUSTER_PROPOSE_PY" "$PLUGIN_ROOT/lib/secret-scan.sh"; do
   fi
 done
 
+# Pre-flight — refuse to run if hard-dependency commands are missing. P13
+# Phase 4 fence body invokes `jq` and `python3` verbatim (per SKILL.md mirror
+# contract); surfacing missing-binary at FATAL pre-flight prevents the
+# in-fence `jq ... 2>/dev/null || echo 0` fallback from masking the cause
+# downstream with an opaque `CLUSTERS=0` line.
+for cmd in jq python3; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "FATAL: required command missing on PATH: $cmd" >&2
+    exit 2
+  fi
+done
+
 STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT INT TERM
 
@@ -620,7 +632,8 @@ fi
 #
 # Mocks the Phase 4 input (clusters-filtered.json), runs cluster_propose.py
 # verbatim from SKILL.md:584-585, then exercises the dryrun-exit fence
-# verbatim from SKILL.md:587-595. Asserts:
+# verbatim from SKILL.md:590-595 (preceded by CLUSTERS_N + DISPATCH setup
+# at SKILL.md:587-589 which is also mirrored here). Asserts:
 #
 #   - proposals.md exists, is non-empty, and carries the documented shape:
 #     * `# Cluster proposals` top-level header
@@ -658,9 +671,10 @@ EOF
 python3 "$CLUSTER_PROPOSE_PY" < "$P13_CLUSTERS" > "$P13_PROPOSALS" 2>>"$P13_STDERR"
 P13_RC=$?
 
-# Verbatim dryrun-exit fence from SKILL.md Phase 4 (line 587-595). RUN_DIR is
-# substituted in; the rest of the body is identical so future drift in the
-# DISPATCH / DRY-RUN strings or the trust-signal write reds this gate.
+# Verbatim dryrun-exit fence from SKILL.md Phase 4 (line 590-595, preceded
+# by CLUSTERS_N + DISPATCH setup at SKILL.md:587-589). RUN_DIR is substituted
+# in; the rest of the body is identical so future drift in the DISPATCH /
+# DRY-RUN strings or the trust-signal write reds this gate.
 P13_DRY_RC=0
 if [ "$P13_RC" = "0" ]; then
   (
@@ -683,6 +697,7 @@ P13_HAS_HEADER=0
 P13_HAS_CLUSTER_LEAD=0
 P13_HAS_SECOND_LEAD=0
 P13_HAS_MARKER=0
+P13_HAS_SECOND_MARKER=0
 P13_HAS_DISPATCH=0
 P13_HAS_DRYRUN=0
 P13_TRUST_OK=0
@@ -695,6 +710,8 @@ if [ -s "$P13_PROPOSALS" ]; then
     && P13_HAS_SECOND_LEAD=1
   grep -qE '<!-- uberdev:cluster-fold lead=225 members=225,226,227 fingerprint=[0-9a-f]{16} -->' "$P13_PROPOSALS" \
     && P13_HAS_MARKER=1
+  grep -qE '<!-- uberdev:cluster-fold lead=300 members=300,301 fingerprint=[0-9a-f]{16} -->' "$P13_PROPOSALS" \
+    && P13_HAS_SECOND_MARKER=1
 fi
 if [ -s "$P13_STDOUT" ]; then
   grep -qF 'DISPATCH: phase=propose' "$P13_STDOUT" && P13_HAS_DISPATCH=1
@@ -708,12 +725,13 @@ fi
 if [ "$P13_RC" = "0" ] && [ "$P13_DRY_RC" = "0" ] \
    && [ "$P13_HAS_HEADER" = "1" ] && [ "$P13_HAS_CLUSTER_LEAD" = "1" ] \
    && [ "$P13_HAS_SECOND_LEAD" = "1" ] && [ "$P13_HAS_MARKER" = "1" ] \
+   && [ "$P13_HAS_SECOND_MARKER" = "1" ] \
    && [ "$P13_HAS_DISPATCH" = "1" ] && [ "$P13_HAS_DRYRUN" = "1" ] \
    && [ "$P13_TRUST_OK" = "1" ] && [ "$P13_CLUSTERS_N" = "2" ]; then
   echo "  PASS  P13 proposals.md rendered (2 clusters) + dry-run trust signal OK"
   PASS=$((PASS+1))
 else
-  echo "  FAIL  P13 rc=$P13_RC dry_rc=$P13_DRY_RC header=$P13_HAS_HEADER lead225=$P13_HAS_CLUSTER_LEAD lead300=$P13_HAS_SECOND_LEAD marker=$P13_HAS_MARKER dispatch=$P13_HAS_DISPATCH dryrun=$P13_HAS_DRYRUN trust=$P13_TRUST_OK clusters_n='$P13_CLUSTERS_N'"
+  echo "  FAIL  P13 rc=$P13_RC dry_rc=$P13_DRY_RC header=$P13_HAS_HEADER lead225=$P13_HAS_CLUSTER_LEAD lead300=$P13_HAS_SECOND_LEAD marker225=$P13_HAS_MARKER marker300=$P13_HAS_SECOND_MARKER dispatch=$P13_HAS_DISPATCH dryrun=$P13_HAS_DRYRUN trust=$P13_TRUST_OK clusters_n='$P13_CLUSTERS_N'"
   if [ -f "$P13_PROPOSALS" ]; then
     echo "    proposals.md:"
     sed 's/^/      /' "$P13_PROPOSALS"

--- a/tests/cluster-pipeline.test.sh
+++ b/tests/cluster-pipeline.test.sh
@@ -667,14 +667,11 @@ cat > "$P13_CLUSTERS" <<'EOF'
 ]
 EOF
 
-# Verbatim renderer call from SKILL.md Phase 4 (line 584-585).
-python3 "$CLUSTER_PROPOSE_PY" < "$P13_CLUSTERS" > "$P13_PROPOSALS" 2>>"$P13_STDERR"
+# SKILL.md:584-585
+python3 "$CLUSTER_PROPOSE_PY" < "$P13_CLUSTERS" > "$P13_PROPOSALS" 2>"$P13_STDERR"
 P13_RC=$?
 
-# Verbatim dryrun-exit fence from SKILL.md Phase 4 (line 590-595, preceded
-# by CLUSTERS_N + DISPATCH setup at SKILL.md:587-589). RUN_DIR is substituted
-# in; the rest of the body is identical so future drift in the DISPATCH /
-# DRY-RUN strings or the trust-signal write reds this gate.
+# SKILL.md:587-595
 P13_DRY_RC=0
 if [ "$P13_RC" = "0" ]; then
   (
@@ -693,45 +690,71 @@ if [ "$P13_RC" = "0" ]; then
   P13_DRY_RC=$?
 fi
 
+# proposals.md flags
 P13_HAS_HEADER=0
-P13_HAS_CLUSTER_LEAD=0
-P13_HAS_SECOND_LEAD=0
-P13_HAS_MARKER=0
-P13_HAS_SECOND_MARKER=0
+P13_HAS_LEAD_225=0
+P13_HAS_LEAD_300=0
+P13_HAS_MARKER_225=0
+P13_HAS_MARKER_300=0
+
+# stdout flags
 P13_HAS_DISPATCH=0
 P13_HAS_DRYRUN=0
-P13_TRUST_OK=0
 P13_CLUSTERS_N=""
+
+# trust-signal flag
+P13_TRUST_OK=0
+
 if [ -s "$P13_PROPOSALS" ]; then
   grep -qF '# Cluster proposals' "$P13_PROPOSALS" && P13_HAS_HEADER=1
   grep -qE '^### Cluster lead=#225, members=225,226,227, confidence=0\.92$' "$P13_PROPOSALS" \
-    && P13_HAS_CLUSTER_LEAD=1
+    && P13_HAS_LEAD_225=1
   grep -qE '^### Cluster lead=#300, members=300,301, confidence=0\.88$' "$P13_PROPOSALS" \
-    && P13_HAS_SECOND_LEAD=1
+    && P13_HAS_LEAD_300=1
   grep -qE '<!-- uberdev:cluster-fold lead=225 members=225,226,227 fingerprint=[0-9a-f]{16} -->' "$P13_PROPOSALS" \
-    && P13_HAS_MARKER=1
+    && P13_HAS_MARKER_225=1
   grep -qE '<!-- uberdev:cluster-fold lead=300 members=300,301 fingerprint=[0-9a-f]{16} -->' "$P13_PROPOSALS" \
-    && P13_HAS_SECOND_MARKER=1
+    && P13_HAS_MARKER_300=1
 fi
 if [ -s "$P13_STDOUT" ]; then
   grep -qF 'DISPATCH: phase=propose' "$P13_STDOUT" && P13_HAS_DISPATCH=1
   grep -qF 'DRY-RUN complete.' "$P13_STDOUT" && P13_HAS_DRYRUN=1
-  P13_CLUSTERS_N="$(grep -oE 'CLUSTERS=[0-9]+' "$P13_STDOUT" | head -1 | cut -d= -f2)"
+  P13_CLUSTERS_N="$(awk 'match($0,/CLUSTERS=[0-9]+/){print substr($0,RSTART+9,RLENGTH-9); exit}' "$P13_STDOUT")"
 fi
-if [ -s "$P13_TRUST" ] && [ "$(cat "$P13_TRUST")" = "OK" ]; then
+if [ -s "$P13_TRUST" ] && IFS= read -r p13_trust_line < "$P13_TRUST" && [ "$p13_trust_line" = "OK" ]; then
   P13_TRUST_OK=1
 fi
 
-if [ "$P13_RC" = "0" ] && [ "$P13_DRY_RC" = "0" ] \
-   && [ "$P13_HAS_HEADER" = "1" ] && [ "$P13_HAS_CLUSTER_LEAD" = "1" ] \
-   && [ "$P13_HAS_SECOND_LEAD" = "1" ] && [ "$P13_HAS_MARKER" = "1" ] \
-   && [ "$P13_HAS_SECOND_MARKER" = "1" ] \
-   && [ "$P13_HAS_DISPATCH" = "1" ] && [ "$P13_HAS_DRYRUN" = "1" ] \
-   && [ "$P13_TRUST_OK" = "1" ] && [ "$P13_CLUSTERS_N" = "2" ]; then
+p13_ok=1
+[ "$P13_RC"            = "0" ] || p13_ok=0
+[ "$P13_DRY_RC"        = "0" ] || p13_ok=0
+[ "$P13_HAS_HEADER"    = "1" ] || p13_ok=0
+[ "$P13_HAS_LEAD_225"  = "1" ] || p13_ok=0
+[ "$P13_HAS_LEAD_300"  = "1" ] || p13_ok=0
+[ "$P13_HAS_MARKER_225" = "1" ] || p13_ok=0
+[ "$P13_HAS_MARKER_300" = "1" ] || p13_ok=0
+[ "$P13_HAS_DISPATCH"  = "1" ] || p13_ok=0
+[ "$P13_HAS_DRYRUN"    = "1" ] || p13_ok=0
+[ "$P13_TRUST_OK"      = "1" ] || p13_ok=0
+[ "$P13_CLUSTERS_N"    = "2" ] || p13_ok=0
+
+if [ "$p13_ok" = "1" ]; then
   echo "  PASS  P13 proposals.md rendered (2 clusters) + dry-run trust signal OK"
   PASS=$((PASS+1))
 else
-  echo "  FAIL  P13 rc=$P13_RC dry_rc=$P13_DRY_RC header=$P13_HAS_HEADER lead225=$P13_HAS_CLUSTER_LEAD lead300=$P13_HAS_SECOND_LEAD marker225=$P13_HAS_MARKER marker300=$P13_HAS_SECOND_MARKER dispatch=$P13_HAS_DISPATCH dryrun=$P13_HAS_DRYRUN trust=$P13_TRUST_OK clusters_n='$P13_CLUSTERS_N'"
+  echo "  FAIL  P13 proposals.md / dry-run gate"
+  printf '    %s\n' \
+    "rc=$P13_RC" \
+    "dry_rc=$P13_DRY_RC" \
+    "header=$P13_HAS_HEADER" \
+    "lead225=$P13_HAS_LEAD_225" \
+    "lead300=$P13_HAS_LEAD_300" \
+    "marker225=$P13_HAS_MARKER_225" \
+    "marker300=$P13_HAS_MARKER_300" \
+    "dispatch=$P13_HAS_DISPATCH" \
+    "dryrun=$P13_HAS_DRYRUN" \
+    "trust=$P13_TRUST_OK" \
+    "clusters_n='$P13_CLUSTERS_N'"
   if [ -f "$P13_PROPOSALS" ]; then
     echo "    proposals.md:"
     sed 's/^/      /' "$P13_PROPOSALS"

--- a/tests/cluster-pipeline.test.sh
+++ b/tests/cluster-pipeline.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # tests/cluster-pipeline.test.sh — behavioral gates for /uberdev:cluster (issue #247).
 #
-# 12 gates P1-P12 that exercise the actual SKILL.md bash bodies +
+# 13 gates P1-P13 that exercise the actual SKILL.md bash bodies +
 # cluster_propose.py runtime behavior. Uses mock-gh (PATH override pattern
 # borrowed from tests/findings-to-issues.test.sh:51-72) + python3 + mktemp + jq.
 #
@@ -611,6 +611,123 @@ if ( CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" SECRET="$P12_SECRET" bash -c '
 else
   rc=$?
   echo "  FAIL  P12 secret-scan did not fail-CLOSED (sub-rc=$rc)"
+  FAIL=$((FAIL+1))
+fi
+
+# ============================================================================
+# P13 — Phase 4 proposal generation + dry-run exit (#257).
+# ============================================================================
+#
+# Mocks the Phase 4 input (clusters-filtered.json), runs cluster_propose.py
+# verbatim from SKILL.md:584-585, then exercises the dryrun-exit fence
+# verbatim from SKILL.md:587-595. Asserts:
+#
+#   - proposals.md exists, is non-empty, and carries the documented shape:
+#     * `# Cluster proposals` top-level header
+#     * one `### Cluster lead=#N, members=…, confidence=N.NN` heading per
+#       cluster (line shape that Phase 5 idempotency-layer-(b) parses, and
+#       that the finding explicitly names)
+#     * the `<!-- uberdev:cluster-fold lead=… fingerprint=… -->` marker
+#       (renderer-side half of the cross-layer idempotency contract)
+#   - the dryrun-exit fence emits `DISPATCH: phase=propose ...`, prints the
+#     `DRY-RUN complete.` line, writes `OK` to trust-signal.txt, and exits 0.
+#
+# The full Phase 4 fence is not run hermetically — it sources run-state.txt
+# from $UBERDEV_TMPDIR and rehydrates env vars from KEY=val lines, matching
+# the pragmatic-substitution idiom P1 / P5 / P8 already use. The behavioural
+# invariant locked here is the input→output contract: filtered clusters in,
+# a proposals.md report with the documented shape out + dryrun trust signal.
+echo "== P13 Phase 4 proposal generation + dry-run exit"
+P13_RUN_DIR="$STAGE/p13-run"
+mkdir -p "$P13_RUN_DIR"
+P13_CLUSTERS="$P13_RUN_DIR/clusters-filtered.json"
+P13_PROPOSALS="$P13_RUN_DIR/proposals.md"
+P13_TRUST="$P13_RUN_DIR/trust-signal.txt"
+P13_STDOUT="$STAGE/p13.out"
+P13_STDERR="$STAGE/p13.err"
+: > "$P13_STDERR"
+
+cat > "$P13_CLUSTERS" <<'EOF'
+[
+  {"lead": 225, "members": [225, 226, 227], "rationale": "same shape", "confidence": 0.92},
+  {"lead": 300, "members": [300, 301], "rationale": "near-duplicate", "confidence": 0.88}
+]
+EOF
+
+# Verbatim renderer call from SKILL.md Phase 4 (line 584-585).
+python3 "$CLUSTER_PROPOSE_PY" < "$P13_CLUSTERS" > "$P13_PROPOSALS" 2>>"$P13_STDERR"
+P13_RC=$?
+
+# Verbatim dryrun-exit fence from SKILL.md Phase 4 (line 587-595). RUN_DIR is
+# substituted in; the rest of the body is identical so future drift in the
+# DISPATCH / DRY-RUN strings or the trust-signal write reds this gate.
+P13_DRY_RC=0
+if [ "$P13_RC" = "0" ]; then
+  (
+    set -u
+    RUN_DIR="$P13_RUN_DIR"
+    CLUSTERS_N="$(jq 'length' "$RUN_DIR/clusters-filtered.json" 2>/dev/null || echo 0)"
+    echo "DISPATCH: phase=propose PROPOSALS=$RUN_DIR/proposals.md CLUSTERS=$CLUSTERS_N"
+    MODE="dryrun"
+    if [ "${MODE:-dryrun}" = "dryrun" ]; then
+      echo
+      echo "DRY-RUN complete. See $RUN_DIR/proposals.md"
+      printf 'OK\n' > "$RUN_DIR/trust-signal.txt"
+      exit 0
+    fi
+  ) > "$P13_STDOUT" 2>>"$P13_STDERR"
+  P13_DRY_RC=$?
+fi
+
+P13_HAS_HEADER=0
+P13_HAS_CLUSTER_LEAD=0
+P13_HAS_SECOND_LEAD=0
+P13_HAS_MARKER=0
+P13_HAS_DISPATCH=0
+P13_HAS_DRYRUN=0
+P13_TRUST_OK=0
+P13_CLUSTERS_N=""
+if [ -s "$P13_PROPOSALS" ]; then
+  grep -qF '# Cluster proposals' "$P13_PROPOSALS" && P13_HAS_HEADER=1
+  grep -qE '^### Cluster lead=#225, members=225,226,227, confidence=0\.92$' "$P13_PROPOSALS" \
+    && P13_HAS_CLUSTER_LEAD=1
+  grep -qE '^### Cluster lead=#300, members=300,301, confidence=0\.88$' "$P13_PROPOSALS" \
+    && P13_HAS_SECOND_LEAD=1
+  grep -qE '<!-- uberdev:cluster-fold lead=225 members=225,226,227 fingerprint=[0-9a-f]{16} -->' "$P13_PROPOSALS" \
+    && P13_HAS_MARKER=1
+fi
+if [ -s "$P13_STDOUT" ]; then
+  grep -qF 'DISPATCH: phase=propose' "$P13_STDOUT" && P13_HAS_DISPATCH=1
+  grep -qF 'DRY-RUN complete.' "$P13_STDOUT" && P13_HAS_DRYRUN=1
+  P13_CLUSTERS_N="$(grep -oE 'CLUSTERS=[0-9]+' "$P13_STDOUT" | head -1 | cut -d= -f2)"
+fi
+if [ -s "$P13_TRUST" ] && [ "$(cat "$P13_TRUST")" = "OK" ]; then
+  P13_TRUST_OK=1
+fi
+
+if [ "$P13_RC" = "0" ] && [ "$P13_DRY_RC" = "0" ] \
+   && [ "$P13_HAS_HEADER" = "1" ] && [ "$P13_HAS_CLUSTER_LEAD" = "1" ] \
+   && [ "$P13_HAS_SECOND_LEAD" = "1" ] && [ "$P13_HAS_MARKER" = "1" ] \
+   && [ "$P13_HAS_DISPATCH" = "1" ] && [ "$P13_HAS_DRYRUN" = "1" ] \
+   && [ "$P13_TRUST_OK" = "1" ] && [ "$P13_CLUSTERS_N" = "2" ]; then
+  echo "  PASS  P13 proposals.md rendered (2 clusters) + dry-run trust signal OK"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  P13 rc=$P13_RC dry_rc=$P13_DRY_RC header=$P13_HAS_HEADER lead225=$P13_HAS_CLUSTER_LEAD lead300=$P13_HAS_SECOND_LEAD marker=$P13_HAS_MARKER dispatch=$P13_HAS_DISPATCH dryrun=$P13_HAS_DRYRUN trust=$P13_TRUST_OK clusters_n='$P13_CLUSTERS_N'"
+  if [ -f "$P13_PROPOSALS" ]; then
+    echo "    proposals.md:"
+    sed 's/^/      /' "$P13_PROPOSALS"
+  else
+    echo "    proposals.md MISSING"
+  fi
+  if [ -s "$P13_STDOUT" ]; then
+    echo "    dryrun stdout:"
+    sed 's/^/      /' "$P13_STDOUT"
+  fi
+  if [ -s "$P13_STDERR" ]; then
+    echo "    stderr:"
+    sed 's/^/      /' "$P13_STDERR"
+  fi
   FAIL=$((FAIL+1))
 fi
 


### PR DESCRIPTION
## Summary

- Adds **P13** behavioural gate to `tests/cluster-pipeline.test.sh` covering Phase 4 (proposal generation), which previously had zero behavioural test coverage — the gap flagged by `/uberdev:review-pr` Phase 2.5 pr-test-analyzer on PR #255 (blocker, deferred → issue #257).
- A broken renderer or drift in the dryrun-exit fence would have been silent. P13 locks the input → output contract so Phase 5 idempotency-layer-(b) parsing (which reads the `### Cluster lead=#…` heading + the `<!-- uberdev:cluster-fold … fingerprint=… -->` marker) cannot regress without reding.

## What P13 covers

- **proposals.md shape** — verbatim renderer call (`python3 cluster_propose.py < clusters-filtered.json > proposals.md`) from SKILL.md:584-585. Asserts:
  - `# Cluster proposals` top-level header
  - per-cluster `### Cluster lead=#N, members=…, confidence=N.NN` heading (the exact line the finding named)
  - `<!-- uberdev:cluster-fold lead=… members=… fingerprint=<16-hex> -->` marker
- **dryrun-exit fence** — verbatim from SKILL.md:587-595. Asserts:
  - `DISPATCH: phase=propose PROPOSALS=… CLUSTERS=N` line
  - `DRY-RUN complete.` line
  - `OK` written to `trust-signal.txt`
  - fence exits 0
- **dispatched count integrity** — `CLUSTERS=N` from the dispatch line matches the rendered cluster count.

## Why not a fully hermetic Phase 4 run

The full Phase 4 fence sources `run-state.txt` from `$UBERDEV_TMPDIR` and rehydrates env vars via `KEY=val` lines (cluster-pipeline/SKILL.md:551-556). A fully hermetic stage-dir run would either need a substantial config-read mock or skip the rehydration loop entirely. P13 follows the pragmatic-substitution idiom P1 / P5 / P8 already use: drive the verbatim sub-fences (renderer call + dryrun-exit) with a mocked input and a stage `RUN_DIR`, locking the I/O contract.

## Verification

```
$ bash tests/cluster-pipeline.test.sh
…
== P12 secret-scan fail-CLOSED on AWS-shape body
  PASS  P12 secret-scan returned rc>=1 (fail-CLOSED)
== P13 Phase 4 proposal generation + dry-run exit
  PASS  P13 proposals.md rendered (2 clusters) + dry-run trust signal OK

## cluster pipeline behavioural gates: 13 pass, 0 fail
```

## PR base

This PR targets **`feat/247-uberdev-cluster`** (not `main`) because `tests/cluster-pipeline.test.sh` only exists on that branch (added by 60a0b03 in PR #255). Once merged into the feat branch, PR #255's blocker is cleared and #255 can resume merge-readiness.

Closes #257.
Blocks: #255 (resolution side).