### PR TITLE
refactor(goal-pipeline): hoist inline awk into sourced lib helpers + renderer-collision sweep (v0.35.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.3",
+      "version": "0.35.4",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.4] — 2026-05-29
+
+### Changed
+- **goal-pipeline — hoisted all 8 inline `awk` state-reads into `lib/goal-state.sh` helpers** (#229, #237, #230, #234). The awk one-liners in `skills/goal-pipeline/SKILL.md` previously relied on the `-v c1=1 -v c2=2 -v c3=3` renderer-collision workaround (#222); they are now seven sourced helpers — `uberdev_goal_get_issue_state`, `uberdev_goal_issue_ts_in_state`, `uberdev_goal_pr_ts_in_state`, `uberdev_goal_pr_first_ts_in_state`, `uberdev_goal_batch_has_pr`, `uberdev_goal_count_distinct_prs`, `uberdev_goal_count_resolved_issues` — backed by an internal `_uberdev_goal_ts_in_state`. Because `lib/goal-state.sh` is **sourced, never Skill-rendered**, the helpers use clean, semantic `$1`/`$2`/`$3` field refs the renderer cannot corrupt, and the SKILL.md call sites now carry zero awk. The per-site `$ARGUMENTS`-collision rationale collapses to a single anchor on the first-wins helper.
+
+### Fixed
+- **goal-pipeline convergence no longer false-fails on macOS** (#229). `uberdev_goal_count_distinct_prs` returns a clean integer; the prior `… | sort -u | wc -l` form padded with leading spaces under macOS/BSD `wc -l`, and the convergence check compares it with `=` (string equality) against a grep-based terminal count — so the padding could falsely block convergence.
+- **goal-pipeline surfaces a failed `/review-pr` re-dispatch** (#219). The `_uberdev_goal_dispatch_review_pr` call site in the held-PR poll loop now emits an rc breadcrumb on a genuine dispatch failure (the intentional cap-reached skip stays silent) instead of swallowing the return code.
+- **`/review-pr` conflict-file extraction is renderer-safe** (#237). The executed `awk '/^UU / {print $2}'` in `commands/review-pr.md`'s multi-stage-rebase recovery used a bare `$2` the slash-arg renderer would overwrite with the PR-number argv; parameterised to `-v c2=2 … $c2`. A new `R1b` drift-guard in `tests/skill-renderer-awk-collision.test.sh` scans `commands/*.md` so the shape cannot regress (agent system prompts are excluded — they are not positionally substituted).
+- **`requesting-code-review` doc example is renderer-safe** (#232). The illustrative SHA-extraction `awk '{print $1}'` in an Example block is now `cut -d' ' -f1` — no `$N`, reads cleanly, immune to the renderer.
+
 ## [0.35.3] — 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.3-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.4-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.3",
+  "version": "0.35.4",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/review-pr.md
+++ b/plugins/uberdev/commands/review-pr.md
@@ -571,7 +571,7 @@ Pass `--turbo` (anywhere in the arguments) to acknowledge invocation from `finis
            # `git rebase --continue` exited non-zero. Two sub-cases:
            #   (a) Multi-stage rebase: continuation surfaced a NEW conflict set.
            #       Re-bind `conflicted_files` from the live rebase state via
-           #       `git status --porcelain | awk '/^UU / {print $2}'` and re-enter
+           #       `git status --porcelain | awk -v c2=2 '/^UU / {print $c2}'` and re-enter
            #       step 3 against the NEW list (NOT the agent's original list —
            #       conflict-resolver REFUSES paths outside its pre-computed set per
            #       `agents/conflict-resolver.md` Refusal triggers + Inputs). Bounded
@@ -581,7 +581,7 @@ Pass `--turbo` (anywhere in the arguments) to acknowledge invocation from `finis
            #   (b) Non-conflict failure (pre-commit hook rejection, GPG signing
            #       failure, etc): no UU entries → halt.
            # Use mapfile -t (NOT unquoted expansion) so paths with spaces survive.
-           mapfile -t conflicted_files < <(git status --porcelain | awk '/^UU / {print $2}')
+           mapfile -t conflicted_files < <(git status --porcelain | awk -v c2=2 '/^UU / {print $c2}')
            if [ "${#conflicted_files[@]}" -gt 0 ]; then
              # Re-enter step 3 with the new list (single-shot per CI_FIX_LOOP_CAP).
              :

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -688,6 +688,9 @@ uberdev_goal_get_pr_state() {
 #   $2 = state — state-machine label (e.g. pushed-reviewing / merging / solving)
 #   $3 = ts    — epoch seconds of the transition
 # Tab-separated; `-F'\t'` is the correct parse (a state label never holds a tab).
+# NOTE: goal-<id>-batch-prs.tsv is a DIFFERENT 4-col layout (pr<TAB>issue<TAB>ts<TAB>state —
+# written by uberdev_goal_register_batch_pr); uberdev_goal_batch_has_pr keys on $1
+# (pr is genuinely col 1 there) so the $1==key contract still holds for it.
 
 # _uberdev_goal_ts_in_state FILE KEY STATE [FIRST_WINS]
 # Internal: echo the transition ts (epoch int) for rows matching KEY+STATE,
@@ -695,6 +698,9 @@ uberdev_goal_get_pr_state() {
 # (the review-grace contract — issue #222 B8: the grace clock must run from the
 # FIRST pushed-reviewing transition, never a later re-entry, or `now - seen_ts`
 # never crosses the threshold); the default (last-wins) takes the most recent.
+# Path contract: callers pass a fully-constructed FILE path
+# ($tmpdir/goal-<id>-{pr,issue}-states.tsv) — mirrored by the three public
+# wrappers uberdev_goal_{issue,pr,pr_first}_ts_in_state below.
 _uberdev_goal_ts_in_state() {
   local file="$1" key="$2" state="$3" first="${4:-0}"
   [ -f "$file" ] || { printf '0\n'; return 0; }

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -14,6 +14,13 @@
 #   uberdev_goal_locate_review_pr_audit        ISSUE_NUM
 #   uberdev_goal_locate_review_pr_audit_by_pr  PR_NUM
 #   uberdev_goal_get_pr_state                  GOAL_ID PR
+#   uberdev_goal_get_issue_state               GOAL_ID ISSUE
+#   uberdev_goal_issue_ts_in_state             GOAL_ID ISSUE STATE
+#   uberdev_goal_pr_ts_in_state                GOAL_ID PR STATE
+#   uberdev_goal_pr_first_ts_in_state          GOAL_ID PR STATE
+#   uberdev_goal_batch_has_pr                  GOAL_ID PR
+#   uberdev_goal_count_distinct_prs            GOAL_ID
+#   uberdev_goal_count_resolved_issues         GOAL_ID
 #   uberdev_goal_record_held_audit             GOAL_ID PR AUDIT_PATH
 #   uberdev_goal_get_last_held_audit           GOAL_ID PR
 #   uberdev_goal_find_pr_for_issue             ISSUE_NUM   (gh; issue #180)
@@ -30,6 +37,7 @@
 #   uberdev_goal_batch_all_terminal            GOAL_ID            (issue #211)
 #   uberdev_goal_batch_unblock_wait_clear      GOAL_ID            (issue #211)
 # Internal:
+#   _uberdev_goal_ts_in_state              FILE KEY STATE [FIRST_WINS]
 #   _uberdev_goal_validate_int             N
 #   _uberdev_goal_validate_id              GOAL_ID
 #   _uberdev_goal_append                   FILE LINE
@@ -660,6 +668,127 @@ uberdev_goal_get_pr_state() {
   local f="$tmpdir/goal-$goal_id-pr-states.tsv"
   [ -f "$f" ] || return 0
   awk -v p="$pr" '$1==p {state=$2} END {print state}' "$f"
+}
+
+# ---------------------------------------------------------------------------
+# TSV state-read helpers (issues #229/#230/#234/#237 — renderer-collision hoist)
+#
+# These wrap the inline awk state-reads that previously lived in
+# skills/goal-pipeline/SKILL.md. SKILL.md is Skill-RENDERED: the loader
+# substitutes positional args of $ARGUMENTS into bare `$1`/`$2`/`$3` inside awk
+# single-quoted script bodies (issue #222), which corrupts every field ref.
+# This file is SOURCED, never rendered, so the awk bodies below use clean,
+# SEMANTIC field refs documented by the column contract. Hoisting every awk
+# state-read here is the permanent fix: the SKILL.md call sites become helper
+# calls with ZERO awk, so the renderer has nothing to corrupt and the
+# `-v c1=1 -v c2=2 -v c3=3` workaround is retired.
+#
+# TSV column contract (goal-<id>-pr-states.tsv AND goal-<id>-issue-states.tsv):
+#   $1 = key   — PR number (pr-states) or issue number (issue-states)
+#   $2 = state — state-machine label (e.g. pushed-reviewing / merging / solving)
+#   $3 = ts    — epoch seconds of the transition
+# Tab-separated; `-F'\t'` is the correct parse (a state label never holds a tab).
+
+# _uberdev_goal_ts_in_state FILE KEY STATE [FIRST_WINS]
+# Internal: echo the transition ts (epoch int) for rows matching KEY+STATE,
+# coerced to 0 when absent/empty. FIRST_WINS=1 takes the EARLIEST matching ts
+# (the review-grace contract — issue #222 B8: the grace clock must run from the
+# FIRST pushed-reviewing transition, never a later re-entry, or `now - seen_ts`
+# never crosses the threshold); the default (last-wins) takes the most recent.
+_uberdev_goal_ts_in_state() {
+  local file="$1" key="$2" state="$3" first="${4:-0}"
+  [ -f "$file" ] || { printf '0\n'; return 0; }
+  awk -F'\t' -v k="$key" -v s="$state" -v first="$first" \
+    '$1==k && $2==s { if (first!="1" || t=="") t=$3 } END { print t+0 }' "$file"
+}
+
+# uberdev_goal_get_issue_state GOAL_ID ISSUE
+# Latest issue-machine state for ISSUE (empty when never transitioned). The
+# issue-states mirror of uberdev_goal_get_pr_state.
+uberdev_goal_get_issue_state() {
+  local goal_id="$1" issue="$2"
+  _uberdev_goal_validate_id "$goal_id" || return 1   # #156
+  _uberdev_goal_validate_int "$issue" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  local f="$tmpdir/goal-$goal_id-issue-states.tsv"
+  [ -f "$f" ] || return 0
+  awk -F'\t' -v i="$issue" '$1==i {state=$2} END {print state}' "$f"
+}
+
+# uberdev_goal_issue_ts_in_state GOAL_ID ISSUE STATE
+# Latest ts (epoch int, 0 when absent) for ISSUE in STATE on issue-states.tsv.
+uberdev_goal_issue_ts_in_state() {
+  local goal_id="$1" issue="$2" state="$3"
+  _uberdev_goal_validate_id "$goal_id" || return 1   # #156
+  _uberdev_goal_validate_int "$issue" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  _uberdev_goal_ts_in_state "$tmpdir/goal-$goal_id-issue-states.tsv" "$issue" "$state" 0
+}
+
+# uberdev_goal_pr_ts_in_state GOAL_ID PR STATE
+# Latest ts (epoch int, 0 when absent) for PR in STATE on pr-states.tsv.
+uberdev_goal_pr_ts_in_state() {
+  local goal_id="$1" pr="$2" state="$3"
+  _uberdev_goal_validate_id "$goal_id" || return 1   # #156
+  _uberdev_goal_validate_int "$pr" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  _uberdev_goal_ts_in_state "$tmpdir/goal-$goal_id-pr-states.tsv" "$pr" "$state" 0
+}
+
+# uberdev_goal_pr_first_ts_in_state GOAL_ID PR STATE
+# EARLIEST ts (epoch int, 0 when absent) for PR in STATE on pr-states.tsv.
+# First-wins is load-bearing for the review-grace window (issue #222 B8).
+uberdev_goal_pr_first_ts_in_state() {
+  local goal_id="$1" pr="$2" state="$3"
+  _uberdev_goal_validate_id "$goal_id" || return 1   # #156
+  _uberdev_goal_validate_int "$pr" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  _uberdev_goal_ts_in_state "$tmpdir/goal-$goal_id-pr-states.tsv" "$pr" "$state" 1
+}
+
+# uberdev_goal_batch_has_pr GOAL_ID PR
+# rc 0 iff a row keyed on PR exists in goal-<id>-batch-prs.tsv; rc 1 when PR is
+# absent OR the registry file does not exist yet. Replaces the inline
+# `[ ! -f tsv ] || awk ... exit !found` idempotent-registration guard.
+uberdev_goal_batch_has_pr() {
+  local goal_id="$1" pr="$2"
+  _uberdev_goal_validate_id "$goal_id" || return 1   # #156
+  _uberdev_goal_validate_int "$pr" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  local f="$tmpdir/goal-$goal_id-batch-prs.tsv"
+  [ -f "$f" ] || return 1
+  awk -F'\t' -v p="$pr" '$1==p {found=1; exit} END {exit !found}' "$f"
+}
+
+# uberdev_goal_count_distinct_prs GOAL_ID
+# Count of DISTINCT PR numbers recorded in goal-<id>-pr-states.tsv (0 when the
+# file is absent/empty). Returns a CLEAN integer — the prior
+# `awk '{print $1}' | sort -u | wc -l` form padded with leading spaces on
+# macOS/BSD `wc -l`, and the convergence check at SKILL.md compares this with
+# `=` (string equality) against a grep-based terminal count, so the padding
+# could falsely fail convergence on macOS. The dedup-and-count awk avoids both
+# the padding and the extra sort+wc subprocesses.
+uberdev_goal_count_distinct_prs() {
+  local goal_id="$1"
+  _uberdev_goal_validate_id "$goal_id" || return 1   # #156
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  local f="$tmpdir/goal-$goal_id-pr-states.tsv"
+  [ -f "$f" ] || { printf '0\n'; return 0; }
+  awk -F'\t' '$1 != "" && !seen[$1]++ {n++} END {print n+0}' "$f"
+}
+
+# uberdev_goal_count_resolved_issues GOAL_ID
+# Count of issue-states.tsv rows in a resolved terminal state (resolved or
+# resolved-by-no-action) — a print_summary stat. Row-count semantics preserved
+# from the prior `awk ... {print $1} | grep -c .` form (each issue resolves
+# once). 0 when the file is absent.
+uberdev_goal_count_resolved_issues() {
+  local goal_id="$1"
+  _uberdev_goal_validate_id "$goal_id" || return 1   # #156
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  local f="$tmpdir/goal-$goal_id-issue-states.tsv"
+  [ -f "$f" ] || { printf '0\n'; return 0; }
+  awk -F'\t' '$2=="resolved" || $2=="resolved-by-no-action" {n++} END {print n+0}' "$f"
 }
 
 # uberdev_goal_record_held_audit GOAL_ID PR AUDIT_PATH

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -224,8 +224,7 @@ declare -a active_issues=()
 dispatched_this_cycle=0
 remaining_queue=()
 for ISSUE_NUM in "${queue[@]}"; do
-  current_state="$(awk -v i="$ISSUE_NUM" -v c1=1 -v c2=2 '{state[$c1]=$c2} END {print state[i]}' \
-    "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
+  current_state="$(uberdev_goal_get_issue_state "$GOAL_ID" "$ISSUE_NUM" 2>/dev/null)"
   # Issue #236 — `dispatched` is the pre-spawn guard state written below before
   # uberdev_dispatch_one. Adding it to the skip-check closes the leaf-crash-
   # pre-state-write double-spawn surface: a leaf that crashes between spawn
@@ -427,8 +426,7 @@ while true; do
   # no PR exists yet, `uberdev_goal_agent_busy_for_issue` disambiguates "solver
   # still working" from "solver died", bounded by _UBERDEV_GOAL_SOLVE_TIMEOUT.
   for issue in "${active_issues[@]}"; do
-    istate="$(awk -v i="$issue" -v c1=1 -v c2=2 '{s[$c1]=$c2} END{print s[i]}' \
-      "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
+    istate="$(uberdev_goal_get_issue_state "$GOAL_ID" "$issue" 2>/dev/null)"
     case "$istate" in pr-pushed|resolved|resolved-by-no-action|failed) continue ;; esac
     pr_num="$(uberdev_goal_find_pr_for_issue "$issue")"
     if [ -n "$pr_num" ]; then
@@ -440,8 +438,7 @@ while true; do
       # resolutions in the same cycle) don't double-write. Best-effort:
       # warn-and-continue on rc != 0 — a transient registry write must not
       # fail the watch loop.
-      batch_tsv="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}/goal-${GOAL_ID}-batch-prs.tsv"
-      if [ ! -f "$batch_tsv" ] || ! awk -F'\t' -v p="$pr_num" -v c1=1 '$c1==p{found=1; exit} END{exit !found}' "$batch_tsv"; then
+      if ! uberdev_goal_batch_has_pr "$GOAL_ID" "$pr_num"; then
         uberdev_goal_register_batch_pr "$GOAL_ID" "$pr_num" "$issue" \
           || printf 'goal: register_batch_pr deferred-call failed for PR=%s issue=%s (rc=%s)\n' "$pr_num" "$issue" "$?" >&2
       fi
@@ -493,8 +490,7 @@ while true; do
         printf 'goal-pipeline: gh issue view %s failed rc=%d — falling through to timeout backstop\n' \
           "$issue" "$gh_rc" >&2
       fi
-      dispatch_ts="$(awk -v i="$issue" -v c1=1 -v c2=2 -v c3=3 '$c1==i && $c2=="solving"{t=$c3} END{print t+0}' \
-        "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" 2>/dev/null)"
+      dispatch_ts="$(uberdev_goal_issue_ts_in_state "$GOAL_ID" "$issue" solving 2>/dev/null)"
       if [ "$(( now - dispatch_ts ))" -lt "$_UBERDEV_GOAL_SOLVE_TIMEOUT" ]; then
         any_active=1
       else
@@ -555,20 +551,11 @@ while true; do
         # from the pr-states TSV (FIRST pushed-reviewing transition for this PR).
         # D17: never assume GREEN.
         #
-        # B8 (post-impl-review): the awk filter MUST require state == "pushed-
-        # reviewing" AND take the FIRST occurrence — without state filtering,
-        # later transitions (e.g., dispatched→pushed-reviewing→green→...)
-        # leak into seen_ts and the grace-window arithmetic compares "now"
-        # against a much-newer transition timestamp, never crossing the
-        # threshold. The original awk printed every row's ts for the PR and
-        # the shell captured only the LAST line, masking the bug except
-        # under specific transition orderings. `!t{t=$c3}` guards FIRST-seen;
-        # `t+0` coerces empty → 0 so the downstream `$((now - seen_ts))` is
-        # arithmetic-safe even when no row exists. The `-v c1=1 -v c2=2 -v c3=3`
-        # parameterisation (issue #222) prevents the Skill renderer from
-        # substituting positional args of `$ARGUMENTS` into the awk field refs.
-        seen_ts=$(awk -F'\t' -v p="$pr_num" -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="pushed-reviewing" && !t{t=$c3} END{print t+0}' \
-          "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" 2>/dev/null)
+        # seen_ts = FIRST pushed-reviewing transition for this PR (first-wins is
+        # load-bearing for the grace window — see uberdev_goal_pr_first_ts_in_state
+        # doc + issue #222 B8). t+0 coerces absent → 0 so `$((now - seen_ts))` is
+        # arithmetic-safe.
+        seen_ts=$(uberdev_goal_pr_first_ts_in_state "$GOAL_ID" "$pr_num" pushed-reviewing 2>/dev/null)
         # Marker probe (Component 3.2)
         if _uberdev_goal_locked_marker_for_pr_fresh "$pr_num" "$REVIEW_GRACE_SECS"; then
           any_active=1
@@ -610,7 +597,13 @@ while true; do
           print_summary "$cycle"
           exit 1
         else
-          _uberdev_goal_dispatch_review_pr "$pr_num"
+          # #219 — surface a re-dispatch failure as a breadcrumb (mirrors the
+          # register_batch_pr best-effort pattern above). The watch loop re-polls,
+          # so a failed re-dispatch is retried next iteration rather than halting.
+          # Note: the helper returns rc 0 on the intentional cap-reached skip, so
+          # this only warns on a genuine dispatch failure.
+          _uberdev_goal_dispatch_review_pr "$pr_num" \
+            || printf 'goal-pipeline: review-pr re-dispatch for PR %s failed (rc=%s) — will retry next poll\n' "$pr_num" "$?" >&2
           any_active=1
         fi
         ;;
@@ -786,8 +779,7 @@ while true; do
         # is `solve-issue-<pr>` and `agent_busy_for_issue "$pr"` matches it
         # correctly. (The function name says "for_issue" because the SHARED
         # naming convention is solve-issue-<key>; the key here is a PR.)
-        merge_ts="$(awk -v p="$pr" -v c1=1 -v c2=2 -v c3=3 '$c1==p && $c2=="merging"{t=$c3} END{print t+0}' \
-          "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" 2>/dev/null)"
+        merge_ts="$(uberdev_goal_pr_ts_in_state "$GOAL_ID" "$pr" merging 2>/dev/null)"
         if [ "$(( now - merge_ts ))" -ge "$_UBERDEV_GOAL_MERGE_TIMEOUT" ] \
            && ! uberdev_goal_agent_busy_for_issue "$pr"; then
           printf 'goal-pipeline: PR %s merge stalled (%ss, agent idle) -> back to green for retry\n' \
@@ -1064,8 +1056,7 @@ terminal_prs="$(uberdev_goal_list_prs_in_state "$GOAL_ID" merged \
   ; uberdev_goal_list_prs_in_state "$GOAL_ID" merge-failed \
   ; uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held \
   ; uberdev_goal_list_prs_in_state "$GOAL_ID" red-held)"
-all_pr_count="$(awk -v c1=1 '{print $c1}' "$UBERDEV_TMPDIR/goal-$GOAL_ID-pr-states.tsv" \
-  | sort -u | wc -l)"
+all_pr_count="$(uberdev_goal_count_distinct_prs "$GOAL_ID")"
 terminal_count="$(printf '%s\n' "$terminal_prs" | grep -c . || true)"
 if [ "${#new_candidates[@]}" = "0" ] && [ "$terminal_count" = "$all_pr_count" ]; then
   uberdev_goal_audit goal_converged \
@@ -1167,8 +1158,7 @@ print_summary() {
     uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held | sed 's/^/yellow-held\t/'; \
     uberdev_goal_list_prs_in_state "$GOAL_ID" red-held    | sed 's/^/red-held\t/' )"
   prs_held_count="$(printf '%s\n' "$prs_held_lines" | grep -c . || true)"
-  issues_resolved="$(awk -v c1=1 -v c2=2 '$c2=="resolved" || $c2=="resolved-by-no-action" {print $c1}' \
-    "$UBERDEV_TMPDIR/goal-$GOAL_ID-issue-states.tsv" | grep -c . || true)"
+  issues_resolved="$(uberdev_goal_count_resolved_issues "$GOAL_ID")"
   wall_secs="$(( $(date +%s) - watch_start ))"
   printf 'goal %s: cycles=%s/%s prs_merged=%s prs_held=%s issues_resolved=%s wall_secs=%s\n' \
     "$GOAL_ID" "$cycles" "$MAX_CYCLES" "$prs_merged" "$prs_held_count" \

--- a/plugins/uberdev/skills/requesting-code-review/SKILL.md
+++ b/plugins/uberdev/skills/requesting-code-review/SKILL.md
@@ -53,7 +53,7 @@ Use Task tool with uberdev:code-reviewer type, fill template at `code-reviewer.m
 
 You: Let me request code review before proceeding.
 
-BASE_SHA=$(git log --oneline | grep "Task 1" | head -1 | awk -v c1=1 '{print $c1}')
+BASE_SHA=$(git log --oneline | grep "Task 1" | head -1 | cut -d' ' -f1)
 HEAD_SHA=$(git rev-parse HEAD)
 
 [Dispatch uberdev:code-reviewer subagent]

--- a/tests/goal-dispatch-helpers.test.sh
+++ b/tests/goal-dispatch-helpers.test.sh
@@ -136,6 +136,77 @@ case "$pos_out" in
 esac
 rm -rf "$g_dir_pos"
 
+# ---------------------------------------------------------------------------
+# TSV state-read helpers (issues #229/#230/#234/#237 — renderer-collision hoist).
+# These pure readers source ONLY lib/goal-state.sh (dispatch.sh is not needed —
+# no dispatch path is reached). Each helper runs in a fresh `bash -c` with
+# UBERDEV_TMPDIR pointing at a seeded mktemp -d, mirroring the #195 fresh-shell
+# pattern above. Rows are TAB-separated `key<TAB>state<TAB>ts`.
+# ---------------------------------------------------------------------------
+echo "== #229/#230/#234/#237: TSV state-read helpers (hoisted from SKILL.md) =="
+HOIST_GOAL_ID="goaltesthoist"
+hoist_dir="$(mktemp -d 2>/dev/null || printf '/tmp/goal-hoist-%s' "$$")"
+
+# Seed issue-states.tsv: issue 7 transitions solving@100 then pr-pushed@200
+# (last-wins state = pr-pushed); resolved + resolved-by-no-action rows for the
+# resolved-count assertion (issues 11 and 12).
+issue_tsv="$hoist_dir/goal-$HOIST_GOAL_ID-issue-states.tsv"
+printf '7\tsolving\t100\n7\tpr-pushed\t200\n11\tresolved\t300\n12\tresolved-by-no-action\t400\n' > "$issue_tsv"
+
+# Seed pr-states.tsv: pr 42 merging@300 then merging@500 (last-wins ts = 500),
+# pushed-reviewing@10 then @20 (first-wins ts = 10); distinct PRs = {42, 99} = 2.
+pr_tsv="$hoist_dir/goal-$HOIST_GOAL_ID-pr-states.tsv"
+printf '42\tpushed-reviewing\t10\n42\tpushed-reviewing\t20\n42\tmerging\t300\n42\tmerging\t500\n99\tdispatched\t50\n' > "$pr_tsv"
+
+# Seed batch-prs.tsv: pr 42 present, pr 99 absent.
+batch_tsv="$hoist_dir/goal-$HOIST_GOAL_ID-batch-prs.tsv"
+printf '42\t7\t600\tpushed-reviewing\n' > "$batch_tsv"
+
+# Helper to run one reader in a fresh shell sourcing only goal-state.sh.
+_hoist_run() {
+  UBERDEV_TMPDIR="$hoist_dir" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+    bash -c '. "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"; '"$1"
+}
+
+# uberdev_goal_get_issue_state — last-wins + absent.
+got="$(_hoist_run 'uberdev_goal_get_issue_state '"$HOIST_GOAL_ID"' 7')"
+assert_eq "$got" "pr-pushed" "#229 get_issue_state: last-wins (issue 7 → pr-pushed)"
+got="$(_hoist_run 'uberdev_goal_get_issue_state '"$HOIST_GOAL_ID"' 55')"
+assert_eq "$got" "" "#229 get_issue_state: absent issue → empty"
+
+# uberdev_goal_issue_ts_in_state — present state ts + absent → 0.
+got="$(_hoist_run 'uberdev_goal_issue_ts_in_state '"$HOIST_GOAL_ID"' 7 solving')"
+assert_eq "$got" "100" "#230 issue_ts_in_state: issue 7 solving → 100"
+got="$(_hoist_run 'uberdev_goal_issue_ts_in_state '"$HOIST_GOAL_ID"' 7 merging')"
+assert_eq "$got" "0" "#230 issue_ts_in_state: issue 7 absent state → 0"
+
+# uberdev_goal_pr_ts_in_state — LAST-wins (merging@500).
+got="$(_hoist_run 'uberdev_goal_pr_ts_in_state '"$HOIST_GOAL_ID"' 42 merging')"
+assert_eq "$got" "500" "#234 pr_ts_in_state: pr 42 merging LAST-wins → 500"
+
+# uberdev_goal_pr_first_ts_in_state — FIRST-wins (pushed-reviewing@10).
+got="$(_hoist_run 'uberdev_goal_pr_first_ts_in_state '"$HOIST_GOAL_ID"' 42 pushed-reviewing')"
+assert_eq "$got" "10" "#234 pr_first_ts_in_state: pr 42 pushed-reviewing FIRST-wins → 10"
+
+# uberdev_goal_batch_has_pr — present rc 0, absent rc 1, missing file rc 1.
+_hoist_run 'uberdev_goal_batch_has_pr '"$HOIST_GOAL_ID"' 42' ; rc=$?
+assert_eq "$rc" "0" "#237 batch_has_pr: present pr 42 → rc 0"
+_hoist_run 'uberdev_goal_batch_has_pr '"$HOIST_GOAL_ID"' 99' ; rc=$?
+assert_eq "$rc" "1" "#237 batch_has_pr: absent pr 99 → rc 1"
+UBERDEV_TMPDIR="$hoist_dir" CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" \
+  bash -c '. "$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"; uberdev_goal_batch_has_pr nofilegoal 42' ; rc=$?
+assert_eq "$rc" "1" "#237 batch_has_pr: missing registry file → rc 1"
+
+# uberdev_goal_count_distinct_prs — {42, 99} → exact clean string "2" (no pad).
+got="$(_hoist_run 'uberdev_goal_count_distinct_prs '"$HOIST_GOAL_ID")"
+assert_eq "$got" "2" "#234 count_distinct_prs: distinct PRs = 2 (clean int, no leading space)"
+
+# uberdev_goal_count_resolved_issues — resolved + resolved-by-no-action = 2.
+got="$(_hoist_run 'uberdev_goal_count_resolved_issues '"$HOIST_GOAL_ID")"
+assert_eq "$got" "2" "#234 count_resolved_issues: resolved + resolved-by-no-action → 2"
+
+rm -rf "$hoist_dir"
+
 # Summary
 echo
 echo "== Summary =="

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -296,11 +296,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.3) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.35\.3"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.35\.3"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.35\.3-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.35\.3\]'        "G20.changelog"
+echo "== G20: version bump locked (0.35.4) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.35\.4"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.35\.4"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.35\.4-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.35\.4\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/skill-renderer-awk-collision.test.sh
+++ b/tests/skill-renderer-awk-collision.test.sh
@@ -120,6 +120,34 @@ else
   FAIL=$((FAIL+1))
 fi
 
+# R1b — issue #237 audit: command files (plugins/uberdev/commands/*.md) are
+# slash-arg-substituted by the Skill loader exactly like SKILL.md, so an awk
+# script body with a bare `$N` inside an EXECUTED block is the same #222 bug
+# class (concrete prior site: review-pr.md's conflict-file mapfile extraction,
+# `awk '/^UU / {print $2}'`, where `$2` is clobbered by the PR-number argv).
+# agents/*.md are intentionally NOT scanned: agent system prompts receive a
+# task prompt, never positional slash args, so their `awk '{print $1}'` field
+# refs are legitimate and would false-positive here.
+COMMANDS_DIR="$REPO_ROOT/plugins/uberdev/commands"
+cmd_hits=""
+if [ -d "$COMMANDS_DIR" ]; then
+  while IFS= read -r -d '' cmd_file; do
+    flattened="$(tr '\n' ' ' < "$cmd_file")"
+    if printf '%s' "$flattened" | grep -qE "$GUARD_REGEX"; then
+      cmd_hits="$cmd_hits$cmd_file"$'\n'
+    fi
+  done < <(find "$COMMANDS_DIR" -name "*.md" -print0)
+fi
+if [ -z "$cmd_hits" ]; then
+  echo "  PASS  R1b no plugins/uberdev/commands/*.md awk script body contains a bare \$N field ref"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  R1b these command files use bare \$N field refs vulnerable to the renderer:"
+  printf '          %s\n' "$cmd_hits" | sed 's/^/  /'
+  echo "         Fix: add \`-v cN=N\` to the awk invocation and use \`\$cN\` in place of \`\$N\`."
+  FAIL=$((FAIL+1))
+fi
+
 # Fixture setup — single trap install up front covers every mktemp. Bash
 # supports ONE EXIT trap per shell; declaring ALL fixtures + ONE trap before
 # any cat-into-fixture avoids the prior two-trap shape where the second

--- a/tests/skill-renderer-awk-collision.test.sh
+++ b/tests/skill-renderer-awk-collision.test.sh
@@ -162,7 +162,9 @@ fixture_bash_bad="$(mktemp)"
 fixture_bash_safe="$(mktemp)"
 fixture_emit_topic_log_src="$(mktemp)"
 r6_log_tmp="$(mktemp)"
-trap 'rm -f "$fixture_simple" "$fixture_multi" "$fixture_safe" "$fixture_bash_bad" "$fixture_bash_safe" "$fixture_emit_topic_log_src" "$r6_log_tmp"' EXIT
+fixture_cmd_bad="$(mktemp)"
+fixture_cmd_safe="$(mktemp)"
+trap 'rm -f "$fixture_simple" "$fixture_multi" "$fixture_safe" "$fixture_bash_bad" "$fixture_bash_safe" "$fixture_emit_topic_log_src" "$r6_log_tmp" "$fixture_cmd_bad" "$fixture_cmd_safe"' EXIT
 
 # R2 — fixture proof: a synthetic SKILL.md fragment containing the bad shape
 # MUST be detected by the same regex. This is an inside-out check that the
@@ -226,6 +228,39 @@ if grep -qE "$GUARD_REGEX" "$fixture_safe"; then
   FAIL=$((FAIL+1))
 else
   echo "  PASS  R3 the guard regex does NOT false-positive on the safe parameterised shape"
+  PASS=$((PASS+1))
+fi
+
+# R1b.fixture — inverse proof for the R1b command-surface scan (mirrors R2/R3
+# for the SKILL surface). The live R1b above reuses GUARD_REGEX (proven by
+# R2/R3) but its find+flatten loop over commands/*.md is otherwise unexercised;
+# these two fixtures prove the command-surface scan path flags the vulnerable
+# shape and spares the safe parameterised form. Closes the R1b coverage gap
+# (#266 review — pr-test-analyzer).
+cat > "$fixture_cmd_bad" <<'EOF_CMD_BAD'
+# fake command-file awk site — R1b's scan MUST flag this
+mapfile -t conflicted_files < <(git status --porcelain | awk '/^UU / {print $2}')
+EOF_CMD_BAD
+cmd_bad_flat="$(tr '\n' ' ' < "$fixture_cmd_bad")"
+if printf '%s' "$cmd_bad_flat" | grep -qE "$GUARD_REGEX"; then
+  echo "  PASS  R1b.bad the command-surface scan flags a vulnerable awk shape in a command file"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  R1b.bad the command-surface scan no longer flags a vulnerable awk shape"
+  echo "         R1b will silently pass on a regressed commands/*.md."
+  FAIL=$((FAIL+1))
+fi
+cat > "$fixture_cmd_safe" <<'EOF_CMD_SAFE'
+# renderer-safe parameterised command-file awk — R1b's scan must NOT flag this
+mapfile -t conflicted_files < <(git status --porcelain | awk -v c2=2 '/^UU / {print $c2}')
+EOF_CMD_SAFE
+cmd_safe_flat="$(tr '\n' ' ' < "$fixture_cmd_safe")"
+if printf '%s' "$cmd_safe_flat" | grep -qE "$GUARD_REGEX"; then
+  echo "  FAIL  R1b.safe the command-surface scan false-positives on the parameterised \`-v c2=2\` + \$c2 shape"
+  echo "         R1b will red CI on the recommended command-file fix."
+  FAIL=$((FAIL+1))
+else
+  echo "  PASS  R1b.safe the command-surface scan does NOT false-positive on the safe parameterised shape"
   PASS=$((PASS+1))
 fi
 

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.2 -> 0.35.3 propagated =="
+echo "== Version bump 0.35.3 -> 0.35.4 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.35.3"' \
-  "plugin.json bumped to 0.35.3"
+  '"version": "0.35.4"' \
+  "plugin.json bumped to 0.35.4"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.35.3"' \
-  "marketplace.json bumped to 0.35.3"
+  '"version": "0.35.4"' \
+  "marketplace.json bumped to 0.35.4"
 assert_grep "$README" \
-  "version-0\\.35\\.3-blue" \
-  "README version badge bumped to 0.35.3"
+  "version-0\\.35\\.4-blue" \
+  "README version badge bumped to 0.35.4"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.35\.3\]' \
-  "CHANGELOG has [0.35.3] section header"
+  '^## \[0\.35\.4\]' \
+  "CHANGELOG has [0.35.4] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary

Resolves the cluster of `review-pr-finding` issues filed from the PR #223/#224 review fanout, all rooted in the **Skill-renderer awk-collision** footgun (#222): the loader substitutes `$ARGUMENTS` positionals into bare `$1`/`$2`/`$3` inside Skill-rendered awk bodies.

**Core (#229, #230, #234, #237):** hoist all **8** inline awk state-reads out of `skills/goal-pipeline/SKILL.md` into **7 helpers** in the *sourced* `lib/goal-state.sh` (`uberdev_goal_get_issue_state`, `uberdev_goal_{issue,pr,pr_first}_ts_in_state`, `uberdev_goal_batch_has_pr`, `uberdev_goal_count_distinct_prs`, `uberdev_goal_count_resolved_issues`; internal `_uberdev_goal_ts_in_state`). Because the lib is **sourced, never Skill-rendered**, the helpers use clean semantic `$1`/`$2`/`$3` field refs (#230) — retiring the `-v c1=1 -v c2=2 -v c3=3` workaround. SKILL.md call sites now carry **zero awk**, and the per-site `$ARGUMENTS`-collision comment collapses to a single anchor on the first-wins helper (#234). This permanently kills the long-standing `/goal` awk-renderer blocker.

**Renderer-collision audit + fixes folded in:**
- **#237** — `commands/review-pr.md`'s executed `awk '/^UU /{print $2}'` (multi-stage-rebase conflict-file extraction) is slash-arg-substituted → `$2` was clobbered by the PR-number argv. Parameterised to `-v c2=2`+`$c2`. New **R1b** drift-guard in `tests/skill-renderer-awk-collision.test.sh` scans `commands/*.md` so it can't regress. `agents/*.md` deliberately **not** guarded — agent system prompts receive a task prompt, not slash positionals, so their `awk '{print $1}'` field refs are legitimate.
- **#232** — doc-example `awk '{print $1}'` in `requesting-code-review/SKILL.md` → renderer-safe `cut -d' ' -f1`.
- **#219** — the held-PR poll loop's `_uberdev_goal_dispatch_review_pr` call now emits an rc breadcrumb on a genuine dispatch failure (the intentional cap-reached skip stays silent) instead of swallowing the return code.

**Latent bug fixed:** `uberdev_goal_count_distinct_prs` returns a clean integer. The prior `… | sort -u | wc -l` padded with leading spaces under macOS/BSD `wc -l`, and the convergence check compares it with `=` (string equality) against a grep-based terminal count — so the padding could **falsely block convergence on macOS** (#229).

## Tests
- New behavioral coverage for all 7 helpers in `tests/goal-dispatch-helpers.test.sh` (last-wins / first-wins / rc predicate / clean-int / resolved-count): **23 passed**.
- New `R1b` guard + existing `R1` in `tests/skill-renderer-awk-collision.test.sh`: **10 passed**.
- `goal.test.sh` 461 passed · `goal-batch-barrier` 8 · `goal-state-sidecar` 31 — all green. Repo-wide `grep` confirms goal-pipeline/SKILL.md has zero inline awk.

Version bumped 0.35.3 → **0.35.4** (plugin.json, marketplace.json, README badge, CHANGELOG, G20 + solve-claim version-locks).

Closes #237
Closes #229
Closes #230
Closes #234
Closes #232
Closes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS goal-pipeline convergence false-failure issue caused by system-specific string comparison behavior
  * Improved error handling for failed review-pr dispatch attempts with better error logging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->