### PR TITLE
fix(cluster-pipeline): hard-fail on crashed Phase-1/2 producers + Phase-4 stderr diagnostics (v0.35.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.4",
+      "version": "0.35.5",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.5] — 2026-05-29
+
+### Fixed
+- **cluster-pipeline — hard-fail (not silent-zero) on a crashed Phase-1/2 producer** (#265). `TOTAL` (issues.json) and `POOL_SIZE` (cluster-pool.json) previously used the `jq 'length' … 2>/dev/null || echo 0` idiom, which maps a crashed/partial/0-byte producer to `0` — indistinguishable from a legitimately-empty run (the same masking class fixed for the Phase-4 dispatch count in #263). Both now use the `[ -s ]` + `type=="array"` fail-closed shape (mirroring the Phase-4 `CLUSTERS_N` gate), aborting with a FATAL diagnostic instead of flooring to 0. A legitimately-empty pool still writes valid `[]` and proceeds normally.
+- **cluster-pipeline — Phase-4 YAML aggregation emits stderr diagnostics on silent skips** (#265). The python3 aggregation's `except ImportError` (PyYAML missing → empty set), per-file `except Exception` (unparseable `analyses/*.yaml`), and per-cluster `except (TypeError, ValueError)` (non-numeric confidence) blocks each now write a `cluster: WARN …` line to stderr, so an operator can distinguish "0 clusters" from "PyYAML missing / N files unparseable" — without changing the yaml-optional design intent.
+
+### Tests
+- New `tests/cluster-pipeline.test.sh` gates **P20** (issues.json) + **P21** (cluster-pool.json), mirroring the P18 verbatim-fence pattern — each asserts hard-fail (rc≠0 + FATAL on stderr + no DISPATCH/output leak) on missing / 0-byte / non-array inputs and correct counts on valid / empty arrays.
+
 ## [0.35.4] — 2026-05-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.4-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.5-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.4",
+  "version": "0.35.5",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/skills/cluster-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/cluster-pipeline/SKILL.md
@@ -337,9 +337,6 @@ if [ -s "$RUN_DIR/refuse-list.txt" ]; then
   sort -u -n "$RUN_DIR/refuse-list.txt" -o "$RUN_DIR/refuse-list.txt" 2>/dev/null || :
 fi
 
-# Update TOTAL_ISSUES in run-state.txt — rewrite-from-template (safest cross-platform).
-# mktemp failure is fail-CLOSED: run-state.txt is the cross-phase rendezvous
-# point. Without TOTAL_ISSUES every subsequent phase reads zero.
 # issues.json drives TOTAL_ISSUES — the cross-phase rendezvous count every later
 # phase reads. A crashed/partial/0-byte producer must FATAL, not silently floor
 # TOTAL to 0 (#265 — same masking class as #263). `jq 'length'` on a 0-byte file
@@ -350,6 +347,9 @@ if [ ! -s "$RUN_DIR/issues.json" ] \
   echo "cluster: FATAL - cannot read issue count (non-empty JSON array) from $RUN_DIR/issues.json (upstream gh/jq producer crashed or partial-wrote); aborting" >&2
   exit 2
 fi
+# Update TOTAL_ISSUES in run-state.txt — rewrite-from-template (safest cross-platform).
+# mktemp failure is fail-CLOSED: run-state.txt is the cross-phase rendezvous
+# point. Without TOTAL_ISSUES every subsequent phase reads zero.
 RS_TMP="$(mktemp)" || { echo "error: mktemp failed for run-state rewrite (rc=$?)" >&2; exit 2; }
 while IFS='=' read -r k v; do
   case "$k" in

--- a/plugins/uberdev/skills/cluster-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/cluster-pipeline/SKILL.md
@@ -409,7 +409,7 @@ fi
 # still writes valid `[]` (POOL_SIZE=0 → CHUNK_COUNT floored to 1 below).
 if [ ! -s "$RUN_DIR/cluster-pool.json" ] \
    || ! POOL_SIZE="$(jq 'if type == "array" then length else error("cluster-pool.json is not a JSON array") end' "$RUN_DIR/cluster-pool.json")"; then
-  echo "cluster: FATAL - cannot read pool size (non-empty JSON array) from $RUN_DIR/cluster-pool.json (refuse-list filter producer crashed); aborting" >&2
+  echo "cluster: FATAL - cannot read pool size (non-empty JSON array) from $RUN_DIR/cluster-pool.json (refuse-list filter producer crashed or wrote a non-array); aborting" >&2
   exit 2
 fi
 CHUNK_COUNT=$(( (POOL_SIZE + CHUNK_SIZE - 1) / CHUNK_SIZE ))

--- a/plugins/uberdev/skills/cluster-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/cluster-pipeline/SKILL.md
@@ -340,7 +340,16 @@ fi
 # Update TOTAL_ISSUES in run-state.txt — rewrite-from-template (safest cross-platform).
 # mktemp failure is fail-CLOSED: run-state.txt is the cross-phase rendezvous
 # point. Without TOTAL_ISSUES every subsequent phase reads zero.
-TOTAL="$(jq 'length' "$RUN_DIR/issues.json" 2>/dev/null || echo 0)"
+# issues.json drives TOTAL_ISSUES — the cross-phase rendezvous count every later
+# phase reads. A crashed/partial/0-byte producer must FATAL, not silently floor
+# TOTAL to 0 (#265 — same masking class as #263). `jq 'length'` on a 0-byte file
+# exits 0 with empty output, so the `-s` guard AND the `type=="array"` check are
+# both load-bearing (mirrors the Phase-4 CLUSTERS_N gate later in this file).
+if [ ! -s "$RUN_DIR/issues.json" ] \
+   || ! TOTAL="$(jq 'if type == "array" then length else error("issues.json is not a JSON array") end' "$RUN_DIR/issues.json")"; then
+  echo "cluster: FATAL - cannot read issue count (non-empty JSON array) from $RUN_DIR/issues.json (upstream gh/jq producer crashed or partial-wrote); aborting" >&2
+  exit 2
+fi
 RS_TMP="$(mktemp)" || { echo "error: mktemp failed for run-state rewrite (rc=$?)" >&2; exit 2; }
 while IFS='=' read -r k v; do
   case "$k" in
@@ -394,8 +403,15 @@ else
      "$RUN_DIR/issues.json" > "$RUN_DIR/cluster-pool.json"
 fi
 
-# Compute chunk count
-POOL_SIZE="$(jq 'length' "$RUN_DIR/cluster-pool.json" 2>/dev/null || echo 0)"
+# Compute chunk count. cluster-pool.json is always written just above (cp OR jq),
+# so a missing/0-byte/non-array value here means that producer crashed — FATAL
+# rather than silently floor POOL_SIZE to 0 (#265). A legitimately-empty pool
+# still writes valid `[]` (POOL_SIZE=0 → CHUNK_COUNT floored to 1 below).
+if [ ! -s "$RUN_DIR/cluster-pool.json" ] \
+   || ! POOL_SIZE="$(jq 'if type == "array" then length else error("cluster-pool.json is not a JSON array") end' "$RUN_DIR/cluster-pool.json")"; then
+  echo "cluster: FATAL - cannot read pool size (non-empty JSON array) from $RUN_DIR/cluster-pool.json (refuse-list filter producer crashed); aborting" >&2
+  exit 2
+fi
 CHUNK_COUNT=$(( (POOL_SIZE + CHUNK_SIZE - 1) / CHUNK_SIZE ))
 if [ "$CHUNK_COUNT" -lt 1 ]; then
   CHUNK_COUNT=1
@@ -561,6 +577,7 @@ import json, sys, pathlib
 try:
     import yaml
 except ImportError:
+    sys.stderr.write("cluster: WARN PyYAML not importable; emitting empty cluster set (0 clusters). Install pyyaml to enable clustering.\n")
     print('[]')
     sys.exit(0)
 run_dir = pathlib.Path(sys.argv[1])
@@ -569,13 +586,15 @@ clusters = []
 for yf in sorted((run_dir / "analyses").glob("*.yaml")):
     try:
         data = yaml.safe_load(yf.read_text()) or {}
-    except Exception:
+    except Exception as e:
+        sys.stderr.write(f"cluster: WARN skipping unparseable analyses YAML {yf}: {e}\n")
         continue
     for c in data.get("clusters", []) or []:
         try:
             if float(c.get("confidence", 0)) >= min_conf:
                 clusters.append(c)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as e:
+            sys.stderr.write(f"cluster: WARN skipping cluster with non-numeric confidence in {yf}: {e}\n")
             continue
 print(json.dumps(clusters))
 PY

--- a/tests/cluster-pipeline.test.sh
+++ b/tests/cluster-pipeline.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # tests/cluster-pipeline.test.sh — behavioral gates for /uberdev:cluster (issue #247).
 #
-# 19 gates P1-P19 that exercise the actual SKILL.md bash bodies +
+# 21 gates P1-P21 that exercise the actual SKILL.md bash bodies +
 # cluster_propose.py runtime behavior. Uses mock-gh (PATH override pattern
 # borrowed from tests/findings-to-issues.test.sh:51-72) + python3 + mktemp + jq.
 #
@@ -1301,6 +1301,144 @@ if [ "$p19_ok" = "1" ]; then
   PASS=$((PASS+1))
 else
   echo "  FAIL  P19 cluster_propose.py render-validation contract violated"
+  FAIL=$((FAIL+1))
+fi
+
+# ============================================================================
+# P20 — Phase 1 TOTAL read hard-fails on unreadable/zero-byte/non-array issues.json (#265).
+# ============================================================================
+#
+# Mirrors the issues.json guard at SKILL.md:348-352 VERBATIM (modulo the 4-space
+# subshell indent; the BEGIN/END markers below delimit the byte-identical copy —
+# keep in lockstep). issues.json drives TOTAL_ISSUES, the cross-phase rendezvous
+# count every later phase reads. A crashed/partial/0-byte gh|jq producer must
+# FATAL — rc!=0, FATAL on stderr, NO proceed line — rather than silently floor
+# TOTAL to 0 (same masking class as #263). `jq 'length'` on a 0-byte file exits 0
+# with empty output, so the `-s` guard catches the likeliest crash artifact. A
+# genuinely-empty pool still writes valid `[]`, so the fence proceeds with
+# TOTAL=0. The post-guard `echo "TOTAL=$TOTAL"` makes the proceed path observable.
+# Run in a subshell so the production `exit 2` is catchable as the function's rc.
+echo "== P20 Phase 1 TOTAL read hard-fails on missing/zero-byte/non-array issues.json; proceeds on valid/empty"
+P20_DIR="$STAGE/p20"
+
+p20_fence() {
+  ( set -u
+    RUN_DIR="$1"
+    # --- BEGIN verbatim SKILL.md:348-352 ---
+    if [ ! -s "$RUN_DIR/issues.json" ] \
+       || ! TOTAL="$(jq 'if type == "array" then length else error("issues.json is not a JSON array") end' "$RUN_DIR/issues.json")"; then
+      echo "cluster: FATAL - cannot read issue count (non-empty JSON array) from $RUN_DIR/issues.json (upstream gh/jq producer crashed or partial-wrote); aborting" >&2
+      exit 2
+    fi
+    # --- END verbatim SKILL.md:348-352 ---
+    echo "TOTAL=$TOTAL"
+  )
+}
+
+p20_ok=1
+
+# Hard-fail cases: each must abort (rc!=0), leak NO proceed line, and emit FATAL.
+p20_assert_hardfail() {  # $1=label  $2=run_dir
+  local out rc
+  out="$(p20_fence "$2" 2>"$P20_DIR/$1.err")"; rc=$?
+  [ "$rc" -ne 0 ]                    || { echo "  .. $1: expected rc!=0, got 0"; p20_ok=0; }
+  [ -z "$out" ]                      || { echo "  .. $1: leaked proceed line '$out'"; p20_ok=0; }
+  grep -qF 'FATAL' "$P20_DIR/$1.err" || { echo "  .. $1: no FATAL on stderr"; p20_ok=0; }
+}
+# Proceed cases: rc=0 and TOTAL=<expected> ($-anchored so TOTAL=2 != TOTAL=20).
+p20_assert_proceed() {   # $1=label  $2=run_dir  $3=expected_count
+  local out rc
+  out="$(p20_fence "$2" 2>/dev/null)"; rc=$?
+  [ "$rc" -eq 0 ]                           || { echo "  .. $1: expected rc=0, got $rc"; p20_ok=0; }
+  printf '%s' "$out" | grep -qE "TOTAL=$3\$" || { echo "  .. $1: missing TOTAL=$3 ('$out')"; p20_ok=0; }
+}
+
+# (a) missing file (no issues.json)  -> hard-fail
+mkdir -p "$P20_DIR/missing";                                                  p20_assert_hardfail missing "$P20_DIR/missing"
+# (b) zero-byte file                 -> hard-fail (`-s` guard, not jq's rc, catches it)
+mkdir -p "$P20_DIR/zero";    : > "$P20_DIR/zero/issues.json";                  p20_assert_hardfail zero "$P20_DIR/zero"
+# (c) valid JSON, non-array {x:1}    -> hard-fail (type=="array" guard rejects it)
+mkdir -p "$P20_DIR/nonarray"; echo '{"x":1}' > "$P20_DIR/nonarray/issues.json"; p20_assert_hardfail nonarray "$P20_DIR/nonarray"
+# (d) valid array (2 issues)         -> proceed, TOTAL=2
+mkdir -p "$P20_DIR/valid";   echo '[{"number":1},{"number":2}]' > "$P20_DIR/valid/issues.json"
+p20_assert_proceed valid "$P20_DIR/valid" 2
+# (e) legitimate empty pool []       -> proceed, TOTAL=0 (NOT masked)
+mkdir -p "$P20_DIR/empty";   echo '[]' > "$P20_DIR/empty/issues.json"
+p20_assert_proceed empty "$P20_DIR/empty" 0
+
+if [ "$p20_ok" = "1" ]; then
+  echo "  PASS  P20 hard-fail on missing/zero-byte/non-array; proceed on valid([2])/empty([])"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  P20 Phase 1 TOTAL read hard-fail contract violated"
+  FAIL=$((FAIL+1))
+fi
+
+# ============================================================================
+# P21 — Phase 2 POOL_SIZE read hard-fails on unreadable/zero-byte/non-array cluster-pool.json (#265).
+# ============================================================================
+#
+# Mirrors the cluster-pool.json guard at SKILL.md:410-414 VERBATIM (modulo the
+# 4-space subshell indent; the BEGIN/END markers below delimit the byte-identical
+# copy — keep in lockstep). cluster-pool.json is always written just above the
+# guard (cp OR jq), so a missing/0-byte/non-array value here means that producer
+# crashed — FATAL rather than silently floor POOL_SIZE to 0 (#265). A
+# legitimately-empty pool still writes valid `[]`, so the fence proceeds with
+# POOL_SIZE=0. The post-guard `echo "POOL_SIZE=$POOL_SIZE"` makes the proceed path
+# observable. Run in a subshell so the production `exit 2` is catchable as rc.
+echo "== P21 Phase 2 POOL_SIZE read hard-fails on missing/zero-byte/non-array cluster-pool.json; proceeds on valid/empty"
+P21_DIR="$STAGE/p21"
+
+p21_fence() {
+  ( set -u
+    RUN_DIR="$1"
+    # --- BEGIN verbatim SKILL.md:410-414 ---
+    if [ ! -s "$RUN_DIR/cluster-pool.json" ] \
+       || ! POOL_SIZE="$(jq 'if type == "array" then length else error("cluster-pool.json is not a JSON array") end' "$RUN_DIR/cluster-pool.json")"; then
+      echo "cluster: FATAL - cannot read pool size (non-empty JSON array) from $RUN_DIR/cluster-pool.json (refuse-list filter producer crashed); aborting" >&2
+      exit 2
+    fi
+    # --- END verbatim SKILL.md:410-414 ---
+    echo "POOL_SIZE=$POOL_SIZE"
+  )
+}
+
+p21_ok=1
+
+# Hard-fail cases: each must abort (rc!=0), leak NO proceed line, and emit FATAL.
+p21_assert_hardfail() {  # $1=label  $2=run_dir
+  local out rc
+  out="$(p21_fence "$2" 2>"$P21_DIR/$1.err")"; rc=$?
+  [ "$rc" -ne 0 ]                    || { echo "  .. $1: expected rc!=0, got 0"; p21_ok=0; }
+  [ -z "$out" ]                      || { echo "  .. $1: leaked proceed line '$out'"; p21_ok=0; }
+  grep -qF 'FATAL' "$P21_DIR/$1.err" || { echo "  .. $1: no FATAL on stderr"; p21_ok=0; }
+}
+# Proceed cases: rc=0 and POOL_SIZE=<expected> ($-anchored so POOL_SIZE=3 != POOL_SIZE=30).
+p21_assert_proceed() {   # $1=label  $2=run_dir  $3=expected_count
+  local out rc
+  out="$(p21_fence "$2" 2>/dev/null)"; rc=$?
+  [ "$rc" -eq 0 ]                               || { echo "  .. $1: expected rc=0, got $rc"; p21_ok=0; }
+  printf '%s' "$out" | grep -qE "POOL_SIZE=$3\$" || { echo "  .. $1: missing POOL_SIZE=$3 ('$out')"; p21_ok=0; }
+}
+
+# (a) missing file (no cluster-pool.json) -> hard-fail
+mkdir -p "$P21_DIR/missing";                                                        p21_assert_hardfail missing "$P21_DIR/missing"
+# (b) zero-byte file                       -> hard-fail (`-s` guard, not jq's rc, catches it)
+mkdir -p "$P21_DIR/zero";    : > "$P21_DIR/zero/cluster-pool.json";                  p21_assert_hardfail zero "$P21_DIR/zero"
+# (c) valid JSON, non-array {x:1}          -> hard-fail (type=="array" guard rejects it)
+mkdir -p "$P21_DIR/nonarray"; echo '{"x":1}' > "$P21_DIR/nonarray/cluster-pool.json"; p21_assert_hardfail nonarray "$P21_DIR/nonarray"
+# (d) valid array (3 issues)               -> proceed, POOL_SIZE=3
+mkdir -p "$P21_DIR/valid";   echo '[{"number":1},{"number":2},{"number":3}]' > "$P21_DIR/valid/cluster-pool.json"
+p21_assert_proceed valid "$P21_DIR/valid" 3
+# (e) legitimate empty pool []             -> proceed, POOL_SIZE=0 (NOT masked)
+mkdir -p "$P21_DIR/empty";   echo '[]' > "$P21_DIR/empty/cluster-pool.json"
+p21_assert_proceed empty "$P21_DIR/empty" 0
+
+if [ "$p21_ok" = "1" ]; then
+  echo "  PASS  P21 hard-fail on missing/zero-byte/non-array; proceed on valid([3])/empty([])"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  P21 Phase 2 POOL_SIZE read hard-fail contract violated"
   FAIL=$((FAIL+1))
 fi
 

--- a/tests/cluster-pipeline.test.sh
+++ b/tests/cluster-pipeline.test.sh
@@ -1395,7 +1395,7 @@ p21_fence() {
     # --- BEGIN verbatim SKILL.md:410-414 ---
     if [ ! -s "$RUN_DIR/cluster-pool.json" ] \
        || ! POOL_SIZE="$(jq 'if type == "array" then length else error("cluster-pool.json is not a JSON array") end' "$RUN_DIR/cluster-pool.json")"; then
-      echo "cluster: FATAL - cannot read pool size (non-empty JSON array) from $RUN_DIR/cluster-pool.json (refuse-list filter producer crashed); aborting" >&2
+      echo "cluster: FATAL - cannot read pool size (non-empty JSON array) from $RUN_DIR/cluster-pool.json (refuse-list filter producer crashed or wrote a non-array); aborting" >&2
       exit 2
     fi
     # --- END verbatim SKILL.md:410-414 ---

--- a/tests/cluster-pipeline.test.sh
+++ b/tests/cluster-pipeline.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # tests/cluster-pipeline.test.sh — behavioral gates for /uberdev:cluster (issue #247).
 #
-# 21 gates P1-P21 that exercise the actual SKILL.md bash bodies +
+# 22 gates P1-P22 that exercise the actual SKILL.md bash bodies +
 # cluster_propose.py runtime behavior. Uses mock-gh (PATH override pattern
 # borrowed from tests/findings-to-issues.test.sh:51-72) + python3 + mktemp + jq.
 #
@@ -1439,6 +1439,98 @@ if [ "$p21_ok" = "1" ]; then
   PASS=$((PASS+1))
 else
   echo "  FAIL  P21 Phase 2 POOL_SIZE read hard-fail contract violated"
+  FAIL=$((FAIL+1))
+fi
+
+# ============================================================================
+# P22 — Phase 4 python aggregation emits a `cluster: WARN` stderr diagnostic
+#       WITHOUT corrupting the JSON-array stdout (#265 Part 2).
+# ============================================================================
+#
+# PR #267 added three `sys.stderr.write("cluster: WARN …")` diagnostics to the
+# Phase-4 python3 aggregation heredoc (SKILL.md "## Phase 4 — Propose"):
+#   1. PyYAML-not-importable  -> WARN + print('[]') + exit 0 (degrade, not crash)
+#   2. per-file YAML parse error -> WARN + `continue` (skip the bad file)
+#   3. per-cluster non-numeric confidence -> WARN + `continue`
+# Without a gate, a regression that strips a `sys.stderr.write` (turning a
+# loud-skip back into a silent one — the exact #265 masking class) would pass
+# CI. This gate extracts the python body VERBATIM from SKILL.md and runs it
+# against a mock RUN_DIR, asserting a `cluster: WARN` line reaches stderr while
+# stdout stays a valid JSON array (the WARN must NOT pollute the stdout the
+# `>` redirect captures into clusters-filtered.json).
+#
+# Robust to PyYAML being absent on the CI runner (it may or may not be
+# installed): the import-present path seeds a valid + a deliberately-unparseable
+# analyses YAML and asserts the parse-error WARN; the import-absent path runs
+# against an empty analyses/ and asserts the not-importable WARN + exact `[]`.
+echo "== P22 Phase 4 python aggregation WARN reaches stderr without corrupting JSON-array stdout"
+P22_DIR="$STAGE/p22"
+mkdir -p "$P22_DIR/analyses"
+
+# Extract the Phase-4 python heredoc body verbatim. The opener line begins
+# `python3 - "$RUN_DIR" "$MIN_CONFIDENCE"` (unique — the Phase 3.5 aggregator
+# opener at SKILL.md "## Phase 3.5" is `python3 - "$RUN_DIR"` with NO
+# `"$MIN_CONFIDENCE"`, so it does not match); the heredoc closes with a line
+# that is exactly `PY`. awk captures the lines strictly BETWEEN the two markers.
+P22_PY="$(awk '/^python3 - "\$RUN_DIR" "\$MIN_CONFIDENCE"/{f=1;next} f&&/^PY$/{exit} f' "$SKILL_MD")"
+
+P22_OUT="$P22_DIR/out.txt"
+P22_ERR="$P22_DIR/err.txt"
+p22_ok=1
+
+if [ -z "$P22_PY" ]; then
+  echo "  FAIL  P22 could not extract Phase-4 python heredoc body from SKILL.md"
+  p22_ok=0
+fi
+
+if [ "$p22_ok" = "1" ]; then
+  if python3 -c 'import yaml' >/dev/null 2>&1; then
+    # PyYAML PRESENT: seed a valid cluster + a deliberately-unparseable YAML
+    # (unterminated flow sequence reliably raises a yaml parse error). The
+    # python reads argv[1]=run_dir, argv[2]=min_conf, and the SCRIPT from stdin
+    # (the `-`); invoke verbatim with that contract.
+    printf 'clusters:\n  - lead: 1\n    members: [1, 2]\n    confidence: 0.9\n' \
+      > "$P22_DIR/analyses/good.yaml"
+    printf 'clusters: [1, 2\n' > "$P22_DIR/analyses/broken.yaml"
+    printf '%s' "$P22_PY" | python3 - "$P22_DIR" "0.5" > "$P22_OUT" 2>"$P22_ERR"
+    P22_RC=$?
+
+    # (1) stdout must parse as a JSON array — proves the WARN did NOT corrupt it.
+    if ! jq -e 'type=="array"' "$P22_OUT" >/dev/null 2>&1; then
+      echo "  FAIL  P22 (PyYAML present) stdout is not a JSON array (rc=$P22_RC)"
+      p22_ok=0
+    fi
+    # (2) stderr must carry the literal unparseable-YAML WARN diagnostic.
+    if ! grep -qF 'cluster: WARN skipping unparseable analyses YAML' "$P22_ERR"; then
+      echo "  FAIL  P22 (PyYAML present) stderr missing 'cluster: WARN skipping unparseable analyses YAML'"
+      p22_ok=0
+    fi
+  else
+    # PyYAML ABSENT: run against an empty analyses/ — the import guard fires,
+    # WARNs, prints '[]', and exits 0 (degrade, not crash).
+    printf '%s' "$P22_PY" | python3 - "$P22_DIR" "0.5" > "$P22_OUT" 2>"$P22_ERR"
+    P22_RC=$?
+
+    # (1) stdout must be exactly `[]` (the import-guard's degraded output).
+    if [ "$(cat "$P22_OUT")" != "[]" ]; then
+      echo "  FAIL  P22 (PyYAML absent) stdout not exactly '[]' (rc=$P22_RC, got '$(cat "$P22_OUT")')"
+      p22_ok=0
+    fi
+    # (2) stderr must carry the literal not-importable WARN diagnostic.
+    if ! grep -qF 'cluster: WARN PyYAML not importable' "$P22_ERR"; then
+      echo "  FAIL  P22 (PyYAML absent) stderr missing 'cluster: WARN PyYAML not importable'"
+      p22_ok=0
+    fi
+  fi
+fi
+
+if [ "$p22_ok" = "1" ]; then
+  echo "  PASS  P22 Phase-4 aggregation emits cluster: WARN to stderr; JSON-array stdout uncorrupted"
+  PASS=$((PASS+1))
+else
+  echo "  FAIL  P22 Phase-4 python WARN-diagnostic contract violated"
+  [ -s "$P22_OUT" ] && { echo "  -- stdout:"; sed 's/^/     /' "$P22_OUT"; }
+  [ -s "$P22_ERR" ] && { echo "  -- stderr:"; sed 's/^/     /' "$P22_ERR"; }
   FAIL=$((FAIL+1))
 fi
 

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -296,11 +296,11 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.4) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.35\.4"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.35\.4"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.35\.4-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.35\.4\]'        "G20.changelog"
+echo "== G20: version bump locked (0.35.5) =="
+assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.35\.5"'  "G20.plugin-json"
+assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.35\.5"'  "G20.marketplace-json"
+assert_grep "$REPO_ROOT/README.md"                                  'version-0\.35\.5-blue'  "G20.readme-badge"
+assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.35\.5\]'        "G20.changelog"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -262,19 +262,19 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.3 -> 0.35.4 propagated =="
+echo "== Version bump 0.35.4 -> 0.35.5 propagated =="
 assert_grep "$PLUGIN_JSON" \
-  '"version": "0.35.4"' \
-  "plugin.json bumped to 0.35.4"
+  '"version": "0.35.5"' \
+  "plugin.json bumped to 0.35.5"
 assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.35.4"' \
-  "marketplace.json bumped to 0.35.4"
+  '"version": "0.35.5"' \
+  "marketplace.json bumped to 0.35.5"
 assert_grep "$README" \
-  "version-0\\.35\\.4-blue" \
-  "README version badge bumped to 0.35.4"
+  "version-0\\.35\\.5-blue" \
+  "README version badge bumped to 0.35.5"
 assert_grep "$CHANGELOG" \
-  '^## \[0\.35\.4\]' \
-  "CHANGELOG has [0.35.4] section header"
+  '^## \[0\.35\.5\]' \
+  "CHANGELOG has [0.35.5] section header"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary

Follow-up to #263 — hardens the **remaining** silent-failure paths in `skills/cluster-pipeline/SKILL.md` that the `/review-pr` Phase-1 fanout on PR #264 flagged (same `jq 'length' … 2>/dev/null || echo 0` masking class #263 fixed at the Phase-4 dispatch).

**Part 1 — fail-closed counts (was silent-zero):**
- `:343` `TOTAL` (issues.json) and `:398` `POOL_SIZE` (cluster-pool.json) now use the `[ -s ]` + `type=="array"` shape (mirroring the Phase-4 `CLUSTERS_N` gate at `:598-603`). A crashed / partial / 0-byte producer now **FATALs with `exit 2` + a diagnostic** instead of flooring the count to `0` (which every later phase reads). `jq 'length'` on a 0-byte file exits 0 with empty output, so both the `-s` guard and the `type=="array"` check are load-bearing. A legitimately-empty pool still writes valid `[]` → `POOL_SIZE=0` → `CHUNK_COUNT` floored to 1 (normal empty path). `cluster-pool.json` is always written just above the read (the `cp`/`jq` branch), so the guard only trips on a genuine producer crash.

**Part 2 — diagnostics on silent python skips:**
- The Phase-4 YAML aggregation's `except ImportError` (PyYAML missing → empty set), per-file `except Exception` (unparseable `analyses/*.yaml`), and per-cluster `except (TypeError, ValueError)` (non-numeric confidence) blocks each now emit a `cluster: WARN …` line to **stderr**, so an operator can distinguish "0 clusters" from "dep missing / N files unparseable". Control flow is unchanged (yaml-optional design intent preserved).

**Deferred (per the issue's own scoping):** Part 3a (mirror-drift CI gate / shared lib for the P-gate↔SKILL.md verbatim mirror) and Part 3b (orchestrator-side caller-honors-`exit 2` integration test, "belongs with the feat/247 completion") are out of this unit-fix's scope.

## Tests
- New `tests/cluster-pipeline.test.sh` gates **P20** (issues.json) + **P21** (cluster-pool.json), mirroring the P18 verbatim-fence pattern — each asserts hard-fail (rc≠0 + `FATAL` on stderr + no output leak) on missing / 0-byte / non-array inputs and correct counts on valid / empty arrays. Suite: **21 pass, 0 fail**. `cluster.test.sh` 47 pass, `ci-wiring` 5 pass, python heredoc still parses.

Version bumped 0.35.4 → **0.35.5** (all 6 locations + G20/solve-claim version-locks).

Closes #265