### PR TITLE
refactor(test): DRY version-lock asserts into assert_version_bump helper (v0.35.7)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.6",
+      "version": "0.35.7",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.7] — 2026-05-29
+
+### Changed
+- **tests — DRY the version-lock assertion block into a shared `assert_version_bump` helper** (#231). The identical four-surface version-propagation asserts duplicated across `tests/goal.test.sh` (G20) and `tests/solve-claim.test.sh` are now a single `assert_version_bump <repo_root> <version>` helper in `tests/_lib_assert_structural.sh`. A release bump is now one `<version>`-arg change per call site instead of lockstep multi-form-regex edits across two files — removing the release footgun that previously required hand-editing plain, single-escaped, and double-escaped regex variants in lockstep.
+
 ## [0.35.6] — 2026-05-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.6-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.7-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.6",
+  "version": "0.35.7",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/tests/_lib_assert_structural.sh
+++ b/tests/_lib_assert_structural.sh
@@ -21,6 +21,13 @@
 #     /<section_start>/,/<section_end>/ of <file>. Use to anchor a string to a
 #     specific section so a prose match elsewhere in the file does not
 #     false-positive.
+#
+#   assert_version_bump <repo_root> <version>
+#     Asserts <version> is propagated to all four manifest surfaces
+#     (plugin.json, marketplace.json, README badge, CHANGELOG header). DRYs the
+#     version-lock block previously duplicated across goal.test.sh (G20) and
+#     solve-claim.test.sh. A release bump is now one <version>-arg change per
+#     call site instead of lockstep multi-form-regex edits (#231).
 
 assert_count() {
   local file="$1" section_start="$2" section_end="$3" pattern="$4" expected="$5" desc="$6"
@@ -53,4 +60,28 @@ assert_in_section() {
     echo "  FAIL  $desc"; echo "        file: $file  section: $section_start..$section_end  pattern: $pattern"
     FAIL=$((FAIL + 1))
   fi
+}
+
+# assert_version_bump <repo_root> <version>
+# DRY the version-lock assertion block that was duplicated across
+# tests/goal.test.sh (G20) and tests/solve-claim.test.sh — asserts <version> is
+# propagated to all four manifest surfaces (plugin.json, marketplace.json,
+# README badge, CHANGELOG header). Self-contained (own grep + $PASS/$FAIL bump,
+# same caller-counter contract as assert_count). A release bump is now ONE
+# <version>-arg change per call site instead of lockstep multi-line regex edits
+# across two files (#231; the exact footgun memory project_uberdev_version_lock_tests tracks).
+_assert_version_bump_one() {  # <abs_file> <grep_pattern> <desc>
+  if grep -qE -e "$2" "$1"; then
+    echo "  PASS  $3"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $3"; echo "        file: $1"; echo "        pattern: $2"; FAIL=$((FAIL + 1))
+  fi
+}
+assert_version_bump() {
+  local root="$1" ver="$2"
+  local v="${ver//./\\.}"   # escape dots so grep -E matches them literally
+  _assert_version_bump_one "$root/plugins/uberdev/.claude-plugin/plugin.json" "\"version\": \"$v\"" "version-bump: plugin.json == $ver"
+  _assert_version_bump_one "$root/.claude-plugin/marketplace.json"            "\"version\": \"$v\"" "version-bump: marketplace.json == $ver"
+  _assert_version_bump_one "$root/README.md"                                  "version-$v-blue"     "version-bump: README badge == $ver"
+  _assert_version_bump_one "$root/CHANGELOG.md"                               "## \[$v\]"           "version-bump: CHANGELOG [$ver] header"
 }

--- a/tests/_lib_assert_structural.sh
+++ b/tests/_lib_assert_structural.sh
@@ -69,12 +69,13 @@ assert_in_section() {
 # README badge, CHANGELOG header). Self-contained (own grep + $PASS/$FAIL bump,
 # same caller-counter contract as assert_count). A release bump is now ONE
 # <version>-arg change per call site instead of lockstep multi-line regex edits
-# across two files (#231; the exact footgun memory project_uberdev_version_lock_tests tracks).
+# across two files (#231).
 _assert_version_bump_one() {  # <abs_file> <grep_pattern> <desc>
-  if grep -qE -e "$2" "$1"; then
-    echo "  PASS  $3"; PASS=$((PASS + 1))
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  PASS  $desc"; PASS=$((PASS + 1))
   else
-    echo "  FAIL  $3"; echo "        file: $1"; echo "        pattern: $2"; FAIL=$((FAIL + 1))
+    echo "  FAIL  $desc"; echo "        file: $file"; echo "        pattern: $pattern"; FAIL=$((FAIL + 1))
   fi
 }
 assert_version_bump() {

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -81,6 +81,10 @@ assert_no_grep() {
   fi
 }
 
+# Shared structural-assertion helpers (assert_version_bump for G20). Fail-loud
+# guard per #209: a missing/unreadable helper aborts rc=2, not vacuous-green.
+source "$REPO_ROOT/tests/_lib_assert_structural.sh" || { echo "FATAL: _lib_assert_structural.sh missing/unreadable" >&2; exit 2; }
+
 echo "== G1: frontmatter (skill + command) =="
 assert_grep "$GOAL_SKILL" '^name: goal-pipeline$'        "G1.skill-name"
 assert_grep "$GOAL_CMD"   '^description: '               "G1.cmd-description"
@@ -296,11 +300,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.6) =="
-assert_grep "$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json" '"version": "0\.35\.6"'  "G20.plugin-json"
-assert_grep "$REPO_ROOT/.claude-plugin/marketplace.json"            '"version": "0\.35\.6"'  "G20.marketplace-json"
-assert_grep "$REPO_ROOT/README.md"                                  'version-0\.35\.6-blue'  "G20.readme-badge"
-assert_grep "$REPO_ROOT/CHANGELOG.md"                               '## \[0\.35\.6\]'        "G20.changelog"
+echo "== G20: version bump locked (0.35.7) =="
+assert_version_bump "$REPO_ROOT" "0.35.7"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -55,6 +55,11 @@ assert_grep_not() {
   fi
 }
 
+# Shared structural-assertion helpers (assert_version_bump for the version-bump
+# block). Fail-loud guard per #209: a missing/unreadable helper aborts rc=2,
+# not vacuous-green.
+source "$REPO_ROOT/tests/_lib_assert_structural.sh" || { echo "FATAL: _lib_assert_structural.sh missing/unreadable" >&2; exit 2; }
+
 echo "== Claim-protocol constants bound shell-side =="
 assert_grep "$SOLVE_PIPELINE" \
   "^UBERDEV_ACTIVE_LABEL='uberdev:active'" \
@@ -262,19 +267,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.5 -> 0.35.6 propagated =="
-assert_grep "$PLUGIN_JSON" \
-  '"version": "0.35.6"' \
-  "plugin.json bumped to 0.35.6"
-assert_grep "$MARKETPLACE_JSON" \
-  '"version": "0.35.6"' \
-  "marketplace.json bumped to 0.35.6"
-assert_grep "$README" \
-  "version-0\\.35\\.6-blue" \
-  "README version badge bumped to 0.35.6"
-assert_grep "$CHANGELOG" \
-  '^## \[0\.35\.6\]' \
-  "CHANGELOG has [0.35.6] section header"
+echo "== Version bump 0.35.6 -> 0.35.7 propagated =="
+assert_version_bump "$REPO_ROOT" "0.35.7"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -22,9 +22,10 @@ MERGE_PIPELINE="$REPO_ROOT/plugins/uberdev/skills/merge-pipeline/SKILL.md"
 TURBO_CMD="$REPO_ROOT/plugins/uberdev/commands/turbo.md"
 SOLVE_CMD="$REPO_ROOT/plugins/uberdev/commands/solve.md"
 CHANGELOG="$REPO_ROOT/CHANGELOG.md"
-PLUGIN_JSON="$REPO_ROOT/plugins/uberdev/.claude-plugin/plugin.json"
-MARKETPLACE_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
-README="$REPO_ROOT/README.md"
+# (PLUGIN_JSON / MARKETPLACE_JSON / README path vars removed in #231 — the
+# version-lock block that used them now delegates to assert_version_bump, which
+# derives those paths internally from $REPO_ROOT. $CHANGELOG is retained: still
+# used by the B2 TOCTOU assertion below.)
 
 PASS=0
 FAIL=0


### PR DESCRIPTION
## Summary

Resolves the version-lock duplication finding: `tests/goal.test.sh` (G20) and `tests/solve-claim.test.sh` asserted **identical** four-surface version-propagation greps against identical paths, so every release required lockstep hand-edits across both — the exact footgun memory `project_uberdev_version_lock_tests` tracks (and the one that's bitten this very `/goal` run repeatedly).

- **SSOT helper** — extracted `assert_version_bump <repo_root> <version>` into the shared `tests/_lib_assert_structural.sh` (self-contained, same `$PASS`/`$FAIL` caller-counter contract as `assert_count`; escapes dots for `grep -E`). Asserts the version on all four manifest surfaces (plugin.json, marketplace.json, README badge, CHANGELOG header).
- **Both files** now `source` the shared lib **with the #209 fail-loud guard** (`|| { echo "FATAL: …" >&2; exit 2; }`) that `test-harness-source-guards.test.sh` auto-discovers and enforces, and replace their inline lock blocks with a single `assert_version_bump "$REPO_ROOT" "0.35.7"` call.
- A release bump is now **one version-arg change per call site** instead of editing plain + single-escaped (`0\.35\.6`) + double-escaped (`0\\.35\\.6`) regex variants in lockstep.

## Tests
- `goal.test.sh` 461/0 (G20 passes via the helper at 0.35.7), `solve-claim.test.sh` 104/0, **`test-harness-source-guards.test.sh` 12/0** (validates both new guarded source lines), full local sweep 0 failed, zsh suite green. Grep-based (no python) → no cross-platform risk.

Version bumped 0.35.6 → **0.35.7** (4 manifests + the two `assert_version_bump` call-site locks).

Closes #231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.35.7 in plugin manifest, marketplace manifest, and README badge.

* **Documentation**
  * Added CHANGELOG entry for version 0.35.7.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->