### PR TITLE
fix(goal): zsh-runtime bugs in goal-state / goal-pipeline / finish-branch (#270)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.7",
+      "version": "0.35.8",
       "category": "workflow",
       "tags": [
         "github",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
           bash tests/dispatch-claude-bg.test.sh && \
           bash tests/solve-effort-flag.test.sh && \
           zsh tests/solve-pipeline-zsh.test.sh && \
+          zsh tests/goal-state-zsh.test.sh && \
           bash tests/orchestrator-phase1-shortcircuit.test.sh && \
           bash tests/config-override.test.sh && \
           bash tests/orchestrator-phase-6-doc.test.sh && \
@@ -168,6 +169,7 @@ jobs:
         # block below in lockstep; a new Unix-only fixture needs an entry
         # here AND its `bash tests/...` line in the ubuntu job above.
         #   - cluster-pipeline.test.sh
+        #   - goal-state-zsh.test.sh
         #   - solve-pipeline-zsh.test.sh
         #   - testers-pipeline.test.sh
         #   - testers-agent-contract.test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.8] — 2026-05-29
+
+### Fixed
+- **goal-pipeline / finish-branch — five zsh-runtime bugs under the `/bin/zsh`-backed Bash tool** (#270). The `/goal` and `finish-branch` SKILL.md bash fences execute under zsh on macOS, where bash-only syntax misfires; CI only ran the suite under bash, so the breakage escaped. Fixed in `lib/goal-state.sh`: (1) `_uberdev_goal_parse_blocks_line` now reads `${match[1]:-${BASH_REMATCH[1]}}` (the only `Blocks: #N` parser — held-PR unblock was dead under zsh, so the `/goal` merge barrier could clear prematurely); (2) `uberdev_goal_agent_stuck_on_dialog` renames `local status` (zsh's read-only special parameter, which hard-aborted the function on its first line) and routes `${!var}` indirection through a new `_uberdev_goal_indirect_get` helper branching on the live shell (`${(P)name}` / `${!name}`) using only native parameter expansion — no `eval`/`bash -c` (respecting the file's T3 no-shell-eval rule); (3) `write_run_state` replaces `compgen -v` with `env | grep` enumeration so per-PID stuck-dialog samples persist across fences; (4) a `${BASH_SOURCE[0]:-}` guard for `set -u` zsh callers. In `skills/goal-pipeline/SKILL.md`, `print_summary()` is hoisted out of the Phase-4 fence into `lib/goal-state.sh` — it was called from the Phase-1/2/3 fences but a shell function cannot cross a fence boundary, so every circuit-breaker and the convergence exit hit `command not found` (rc 127) and silently dropped the operator summary line + held-PR post-mortem rows. In `skills/finish-branch/SKILL.md`, the PR number is now `${PR_URL##*/}` on the already-`PR_URL_REGEX`-validated URL (sidesteps the `BASH_REMATCH` capture), restoring the #95 `review-pr:pending` backstop label on finish-branch PRs created on macOS.
+
+### Tests
+- New `tests/goal-state-zsh.test.sh` (modeled on `solve-pipeline-zsh.test.sh`) sources `goal-state.sh` under the live shell and asserts the five #270 behaviours plus the two structural must-dos (print_summary hoist; `agent_stuck_on_dialog` free of `read-only`/`bad substitution`); green under both bash and zsh (13/13 each). Wired into the ubuntu CI job under `zsh` (windows-skip — `windows-latest` ships no zsh).
+
 ## [0.35.7] — 2026-05-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.7-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.8-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.7",
+  "version": "0.35.8",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -36,11 +36,13 @@
 #   uberdev_goal_barrier_breaker_check         GOAL_ID BARRIER_TIMEOUT_S   (issue #214)
 #   uberdev_goal_batch_all_terminal            GOAL_ID            (issue #211)
 #   uberdev_goal_batch_unblock_wait_clear      GOAL_ID            (issue #211)
+#   print_summary                              CYCLES             (issue #270; hoisted from goal-pipeline SKILL.md Phase 4 so the per-fence re-source brings it into scope in every phase)
 # Internal:
 #   _uberdev_goal_ts_in_state              FILE KEY STATE [FIRST_WINS]
 #   _uberdev_goal_validate_int             N
 #   _uberdev_goal_validate_id              GOAL_ID
 #   _uberdev_goal_append                   FILE LINE
+#   _uberdev_goal_indirect_get             VARNAME            (issue #270; dual-shell indirect read, no eval)
 #   _uberdev_goal_extract_fingerprint      BODY_TEXT
 #   _uberdev_goal_parse_blocks_line        LINE
 #   _uberdev_goal_count_merge_attempts     GOAL_ID PR
@@ -144,7 +146,12 @@ FINDING_FINGERPRINT_REGEX='<!-- uberdev:review-pr-finding fingerprint=([a-f0-9]{
 # Source discover.sh opportunistically for its stderr-isolation helpers;
 # tolerated absent (the goal-state.sh functions below do not hard-require
 # any discover.sh symbol).
-_UBERDEV_GOAL_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# #270: default ${BASH_SOURCE[0]:-} — under zsh (which runs the goal-pipeline
+# SKILL.md bash fences that source this lib) BASH_SOURCE is unset when a caller
+# has `set -u`/NO_UNSET active, and the bare reference would abort the source
+# with `BASH_SOURCE[0]: parameter not set`. The `:-` default keeps the source
+# robust regardless of the caller's nounset state in BOTH shells.
+_UBERDEV_GOAL_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" && pwd)"
 if [ -z "${_UBERDEV_MERGE_DISCOVER_LOADED:-}" ] && \
    [ -f "$_UBERDEV_GOAL_LIB_DIR/../skills/merge-pipeline/lib/discover.sh" ]; then
   # shellcheck source=/dev/null
@@ -259,12 +266,37 @@ _uberdev_goal_append() {
   fi
 }
 
+# _uberdev_goal_indirect_get VARNAME
+# Dual-shell indirect-variable read (#270). bash `${!name}` indirect expansion is
+# a hard `bad substitution` error under zsh, and this lib is re-sourced inside the
+# goal-pipeline SKILL.md bash fences which run under /bin/zsh on macOS. zsh reads
+# an indirect via `${(P)name}`; bash via `${!name}`. Branch on the live shell so
+# the SAME source works in both, using only native parameter expansion — never a
+# shell-evaluation primitive, which the T3 hard rule (goal.test.sh assertion
+# G19.no-eval) forbids in this file. bash never parse-errors on the un-taken zsh
+# `${(P)...}` arm (the expansion is resolved lazily, only when run), so leaving
+# both arms in one file is safe. Prints the value (empty if unset).
+_uberdev_goal_indirect_get() {
+  local _name="$1"
+  if [ -n "${ZSH_VERSION:-}" ]; then
+    printf '%s' "${(P)_name:-}"
+  else
+    printf '%s' "${!_name:-}"
+  fi
+}
+
 # _uberdev_goal_parse_blocks_line LINE
-# ReDoS-safe (D9 + T1): anchored bash regex; numeric re-validation defense-in-depth.
+# ReDoS-safe (D9 + T1): anchored regex; numeric re-validation defense-in-depth.
+# Dual-shell capture (#270): this file is also re-sourced inside the goal-pipeline
+# SKILL.md bash fences, which run under /bin/zsh on macOS. zsh populates the
+# capture array as `$match`, not `$BASH_REMATCH`, so the bash-only form silently
+# yielded an empty PR number under zsh — the only `Blocks: #N` parser, so held-PR
+# unblock never fired. `${match[1]:-${BASH_REMATCH[1]}}` reads whichever the live
+# shell populated (zsh -> match[1]; bash -> BASH_REMATCH[1]).
 _uberdev_goal_parse_blocks_line() {
   local line="$1"
   if [[ "$line" =~ ^Blocks:\ \#([0-9]+)$ ]]; then
-    local pr_num="${BASH_REMATCH[1]}"
+    local pr_num="${match[1]:-${BASH_REMATCH[1]}}"
     _uberdev_goal_validate_int "$pr_num" || return 1
     printf '%s\n' "$pr_num"
   fi
@@ -987,11 +1019,18 @@ uberdev_goal_review_pr_in_flight() {
 uberdev_goal_agent_stuck_on_dialog() {
   local pid="$1" issue="${2:-}"
   _uberdev_goal_validate_int "$pid" || return 1
-  local status now first_seen prior tmpdir goal_id audit row_count
-  status="$(claude agents --json 2>/dev/null | jq -r --argjson pid "$pid" '
+  # #270: NOT named `status` — under /bin/zsh (which runs the goal-pipeline
+  # SKILL.md bash fences that source this lib) `status` is a special read-only
+  # parameter (an alias for `$?`), so `local status` hard-errors `read-only
+  # variable: status` and aborts the function non-zero on its FIRST statement,
+  # before the body runs. That alone kept the agent_stuck_on_dialog circuit
+  # breaker from ever firing under zsh. `agent_status` is an ordinary name in
+  # both shells.
+  local agent_status now first_seen prior tmpdir goal_id audit row_count
+  agent_status="$(claude agents --json 2>/dev/null | jq -r --argjson pid "$pid" '
     .[]? | select(.pid? == $pid) | .status // ""' 2>/dev/null)"
-  [ -n "$status" ] || return 1
-  case "$status" in
+  [ -n "$agent_status" ] || return 1
+  case "$agent_status" in
     busy|running|starting|working) : ;;
     *) return 1 ;;
   esac
@@ -1020,8 +1059,16 @@ uberdev_goal_agent_stuck_on_dialog() {
   now="$(date +%s)"
   local _prior_key="PRIOR_LAST_ACTIVITY_${pid}"
   local _first_key="FIRST_DIALOG_TS_${pid}"
-  prior="${!_prior_key:-}"
-  first_seen="${!_first_key:-}"
+  # Dual-shell indirect read (#270): bash `${!var}` indirect expansion is a hard
+  # `bad substitution` error under zsh — and this helper is re-sourced inside the
+  # goal-pipeline SKILL.md bash fences, which run under /bin/zsh on macOS. The
+  # parse error aborted uberdev_goal_agent_stuck_on_dialog non-zero every poll, so
+  # the agent_stuck_on_dialog circuit breaker could never fire.
+  # _uberdev_goal_indirect_get branches on the live shell (zsh `${(P)name}` / bash
+  # `${!name}`) using only native parameter expansion — see its header for why no
+  # shell-evaluation primitive is used (the T3 hard rule, goal.test.sh G19).
+  prior="$(_uberdev_goal_indirect_get "$_prior_key")"
+  first_seen="$(_uberdev_goal_indirect_get "$_first_key")"
   if [ -z "$prior" ]; then
     printf -v "$_prior_key" '%s' "$row_count"
     printf -v "$_first_key" '%s' "$now"
@@ -1521,6 +1568,52 @@ _uberdev_goal_fetch_pr_body() {
     | head -c "${_UBERDEV_GOAL_BODY_CAP:-65536}"
 }
 
+# print_summary CYCLES
+# Emits the mandated single operator summary line + one post-mortem row per
+# held PR (each row `pr=<num> state=<yellow-held|red-held> blocks=#<i1>,#<i2>,…`).
+#
+# #270 — HOISTED here from the goal-pipeline SKILL.md Phase-4 bash fence. It is
+# CALLED from the Phase-1/2/3 fences on every /goal exit path (every circuit
+# breaker AND the convergence path), but a shell function does NOT survive a
+# fence boundary: each phase is a fresh shell that re-sources only
+# config-read.sh / dispatch.sh / goal-state.sh. With the def stranded in Phase 4,
+# every non-Phase-4 exit hit `command not found` (rc 127) — the operator summary
+# line + held-PR Blocks post-mortem rows were silently dropped and only the
+# trailing `exit N` ran. Defining it HERE means the per-fence re-source of
+# goal-state.sh brings it into scope in every phase; its only dep,
+# _uberdev_goal_fetch_pr_body, already lives in this file.
+#
+# #171 — print_summary reads GOAL_ID / MAX_CYCLES / watch_start from the calling
+# shell and calls uberdev_goal_* helpers that gate on the UBERDEV_GOAL_ID env.
+# Every caller (the Phase 1/2/3 fences) rehydrates that state via
+# uberdev_goal_read_run_state at fence top (which also re-exports UBERDEV_GOAL_ID
+# + UBERDEV_TMPDIR). Do NOT call print_summary from a block that has not run that
+# rehydration — it is never called from Phase 0.
+print_summary() {
+  local cycles="$1" prs_merged prs_held_lines prs_held_count issues_resolved wall_secs
+  prs_merged="$(uberdev_goal_list_prs_in_state "$GOAL_ID" merged | grep -c . || true)"
+  # Build a `<state>\t<pr>` stream so the per-row printf below can emit the
+  # `state=` field promised at line ~466 ("each row pr=<num> state=<yellow-held
+  # |red-held> blocks=…"). The prior implementation merged the two lists into
+  # bare PR numbers and the `state=` field was silently dropped (S6).
+  prs_held_lines="$( \
+    uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held | sed 's/^/yellow-held\t/'; \
+    uberdev_goal_list_prs_in_state "$GOAL_ID" red-held    | sed 's/^/red-held\t/' )"
+  prs_held_count="$(printf '%s\n' "$prs_held_lines" | grep -c . || true)"
+  issues_resolved="$(uberdev_goal_count_resolved_issues "$GOAL_ID")"
+  wall_secs="$(( $(date +%s) - watch_start ))"
+  printf 'goal %s: cycles=%s/%s prs_merged=%s prs_held=%s issues_resolved=%s wall_secs=%s\n' \
+    "$GOAL_ID" "$cycles" "$MAX_CYCLES" "$prs_merged" "$prs_held_count" \
+    "$issues_resolved" "$wall_secs"
+  printf '%s\n' "$prs_held_lines" | while IFS=$'\t' read -r state p; do
+    [ -z "$p" ] && continue
+    body="$(_uberdev_goal_fetch_pr_body "$p")"
+    blocks="$(printf '%s\n' "$body" | grep -E '^Blocks: #[0-9]+$' \
+      | sed -E 's/^Blocks: #([0-9]+)$/#\1/' | paste -sd, -)"
+    printf '  pr=%s state=%s blocks=%s\n' "$p" "$state" "${blocks:-none}"
+  done
+}
+
 # _uberdev_goal_check_unblock HELD_PR_NUM
 # RFC §3.2.3 unblock rule body: if every `Blocks: #N` issue is CLOSED, kick
 # off a full /review-pr re-review for the held PR.
@@ -1743,15 +1836,24 @@ uberdev_goal_write_run_state() {
     "${REVIEW_GRACE_SECS:-0}" "${CIRCUIT_BREAKER_HALT:-}" > "$tmp"
   # Append per-PID dialog-stuck samples (issue #220, AC ❸).
   # R3 SSOT (issue #220 simplify pass): single iterator over both prefixes —
-  # was two near-identical compgen loops; PRIOR_LAST_ACTIVITY_<pid> and
-  # FIRST_DIALOG_TS_<pid> share identical persistence shape, so the prefix
-  # is the only variant.
+  # PRIOR_LAST_ACTIVITY_<pid> and FIRST_DIALOG_TS_<pid> share identical
+  # persistence shape, so the prefix is the only variant.
+  # Dual-shell enumeration (#270): `compgen -v PREFIX` is a bash builtin that
+  # returns NOTHING under zsh — and write_run_state is re-sourced inside the
+  # goal-pipeline SKILL.md bash fences, which run under /bin/zsh on macOS. The
+  # per-PID stuck-dialog samples were therefore never persisted across fences,
+  # compounding the dead detector. Enumerate via `env` instead: both sample
+  # writers (uberdev_goal_agent_stuck_on_dialog) and the rehydration arm in
+  # read_run_state `export` these keys, so they live in the process environment
+  # in BOTH shells. `${var#$prefix}` strips the prefix; the int-validate on the
+  # suffix rejects any forged/non-PID key; _uberdev_goal_indirect_get does the
+  # dual-shell indirect read with native parameter expansion (T3 hard rule, G19).
   local _prefix _pid_var _pid_suffix _pid_val
   for _prefix in PRIOR_LAST_ACTIVITY_ FIRST_DIALOG_TS_; do
-    for _pid_var in $(compgen -v "$_prefix" 2>/dev/null); do
+    for _pid_var in $(env | grep -oE "^${_prefix}[0-9]+=" | sed 's/=$//'); do
       _pid_suffix="${_pid_var#$_prefix}"
       _uberdev_goal_validate_int "$_pid_suffix" || continue
-      _pid_val="${!_pid_var}"
+      _pid_val="$(_uberdev_goal_indirect_get "$_pid_var")"
       printf '%s=%s\n' "$_pid_var" "$_pid_val" >> "$tmp"
     done
   done

--- a/plugins/uberdev/skills/finish-branch/SKILL.md
+++ b/plugins/uberdev/skills/finish-branch/SKILL.md
@@ -277,21 +277,26 @@ if [[ ! "$PR_URL" =~ $PR_URL_REGEX ]]; then
   exit 1
 fi
 echo "PR created: $PR_URL"
-# Extract PR number from PR_URL using a capture-group variant of PR_URL_REGEX
-# (the existing constant at line 289 has no capture group; this inline form
-# allows single-pass extraction via BASH_REMATCH). Both gh calls are fail-soft
-# per the fire-and-surface contract (issue #11 Q1): a transient gh failure
-# loud-logs to stderr but MUST NOT exit non-zero or roll back the PR.
-if [[ "$PR_URL" =~ ^https://github\.com/[^/]+/[^/]+/pull/([0-9]+)$ ]]; then
-  PR_NUM="${BASH_REMATCH[1]}"
-  if ! gh label create --force review-pr:pending \
-       --color FBCA04 \
-       --description "review-pr has not yet completed for this PR" 2>/dev/null; then
-    echo "warning: failed to create review-pr:pending label; backstop may not fire" >&2
-  fi
-  if ! gh pr edit "$PR_NUM" --add-label review-pr:pending 2>/dev/null; then
-    echo "warning: failed to add review-pr:pending label to PR #$PR_NUM; backstop will not fire if review-pr is missed" >&2
-  fi
+# Extract the PR number from PR_URL by stripping everything up to the final
+# slash. PR_URL already passed PR_URL_REGEX immediately above (it ends in
+# /pull/ then digits), so ${PR_URL##*/} yields exactly those digits with no
+# further parse. This deliberately AVOIDS a capture-group [[ =~ ]] match
+# (#270): finish-branch SKILL.md bash fences run under /bin/zsh on macOS, where
+# the capture lands in the match array, not BASH_REMATCH; the bash-only form left
+# PR_NUM empty, so gh pr edit with an empty arg failed (swallowed by the
+# fail-soft guard) and the #95 review-pr:pending backstop label was never set on
+# any PR created via finish-branch on macOS, defeating the /merge label-present
+# probe. Both gh calls remain fail-soft per the fire-and-surface contract (issue
+# #11 Q1): a transient gh failure loud-logs to stderr but MUST NOT exit non-zero
+# or roll back the PR.
+PR_NUM="${PR_URL##*/}"
+if ! gh label create --force review-pr:pending \
+     --color FBCA04 \
+     --description "review-pr has not yet completed for this PR" 2>/dev/null; then
+  echo "warning: failed to create review-pr:pending label; backstop may not fire" >&2
+fi
+if ! gh pr edit "$PR_NUM" --add-label review-pr:pending 2>/dev/null; then
+  echo "warning: failed to add review-pr:pending label to PR #$PR_NUM; backstop will not fire if review-pr is missed" >&2
 fi
 rm -f "$TITLE_FILE" "$PR_BODY_FILE"
 ```

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -1140,38 +1140,10 @@ goal <GOAL_ID>: cycles=<N>/<MAX> prs_merged=<M> prs_held=<H> issues_resolved=<R>
 
 The held-PR list (each row `pr=<num> state=<yellow-held|red-held> blocks=#<i1>,#<i2>,…`) is the **post-mortem surface** — it tells the operator which PRs need human attention. It is printed after the summary line, one row per held PR.
 
-```bash
-# #171 — print_summary reads GOAL_ID/MAX_CYCLES/watch_start from the calling
-# shell and calls uberdev_goal_* helpers that gate on the UBERDEV_GOAL_ID env.
-# Every caller (the Phase 1/2/3 fences) rehydrates that state via
-# uberdev_goal_read_run_state at fence top (which also re-exports UBERDEV_GOAL_ID
-# + UBERDEV_TMPDIR). Do NOT call print_summary from a block that has not run that
-# rehydration — it is never called from Phase 0.
-print_summary() {
-  local cycles="$1" prs_merged prs_held_lines prs_held_count issues_resolved wall_secs
-  prs_merged="$(uberdev_goal_list_prs_in_state "$GOAL_ID" merged | grep -c . || true)"
-  # Build a `<state>\t<pr>` stream so the per-row printf below can emit the
-  # `state=` field promised at line ~466 ("each row pr=<num> state=<yellow-held
-  # |red-held> blocks=…"). The prior implementation merged the two lists into
-  # bare PR numbers and the `state=` field was silently dropped (S6).
-  prs_held_lines="$( \
-    uberdev_goal_list_prs_in_state "$GOAL_ID" yellow-held | sed 's/^/yellow-held\t/'; \
-    uberdev_goal_list_prs_in_state "$GOAL_ID" red-held    | sed 's/^/red-held\t/' )"
-  prs_held_count="$(printf '%s\n' "$prs_held_lines" | grep -c . || true)"
-  issues_resolved="$(uberdev_goal_count_resolved_issues "$GOAL_ID")"
-  wall_secs="$(( $(date +%s) - watch_start ))"
-  printf 'goal %s: cycles=%s/%s prs_merged=%s prs_held=%s issues_resolved=%s wall_secs=%s\n' \
-    "$GOAL_ID" "$cycles" "$MAX_CYCLES" "$prs_merged" "$prs_held_count" \
-    "$issues_resolved" "$wall_secs"
-  printf '%s\n' "$prs_held_lines" | while IFS=$'\t' read -r state p; do
-    [ -z "$p" ] && continue
-    body="$(_uberdev_goal_fetch_pr_body "$p")"
-    blocks="$(printf '%s\n' "$body" | grep -E '^Blocks: #[0-9]+$' \
-      | sed -E 's/^Blocks: #([0-9]+)$/#\1/' | paste -sd, -)"
-    printf '  pr=%s state=%s blocks=%s\n' "$p" "$state" "${blocks:-none}"
-  done
-}
-```
+**`print_summary` lives in `lib/goal-state.sh`, NOT inline here (issue #270).** It is *called* from the Phase-1/2/3 fences on every exit path (every circuit breaker and the convergence path — see the `print_summary "$cycle"` call sites in those fences), but each phase is a separate fresh shell and a shell function does **not** survive a fence boundary. Defining it in a Phase-4 fence stranded it: every non-Phase-4 exit hit `command not found` (rc 127) and silently dropped the operator summary line + held-PR post-mortem rows. Hoisting it into `lib/goal-state.sh` (which each fence already re-sources at its top) brings it into scope in every phase. Its contract is unchanged:
+
+- It reads `GOAL_ID` / `MAX_CYCLES` / `watch_start` from the calling shell, which every Phase-1/2/3 fence rehydrates via `uberdev_goal_read_run_state` at fence top (that helper also re-exports `UBERDEV_GOAL_ID` + `UBERDEV_TMPDIR`). It is therefore never called from Phase 0 (which has not run that rehydration).
+- It emits the `goal <GOAL_ID>: cycles=… prs_merged=… prs_held=… issues_resolved=… wall_secs=…` line to stdout, then one `  pr=<num> state=<yellow-held|red-held> blocks=#<i1>,…` row per held PR (its only dep, `_uberdev_goal_fetch_pr_body`, also lives in `lib/goal-state.sh`).
 
 ## Unblock rule
 

--- a/tests/finish-branch-auto-chain.test.sh
+++ b/tests/finish-branch-auto-chain.test.sh
@@ -288,9 +288,14 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-# Fail-soft contract: no `exit` inside the new label-add block (sed-based; bounded range)
-LABEL_BLOCK_START=$(grep -n 'Extract PR number from PR_URL using a capture-group variant' "$FINISH_BRANCH" | head -1 | cut -d: -f1)
-LABEL_BLOCK_END=$(awk -v s="$LABEL_BLOCK_START" 'NR > s && /^fi$/ { print NR; exit }' "$FINISH_BRANCH")
+# Fail-soft contract: no `exit` inside the label-add block (sed-based; bounded range).
+# #270: the block no longer extracts PR_NUM via a capture-group `[[ =~ ]]` (BASH_REMATCH
+# is empty under the zsh-backed Bash tool); it now uses `PR_NUM="${PR_URL##*/}"`. The
+# range anchors on the new comment lead-in and ends at the `rm -f "$TITLE_FILE" ...`
+# cleanup line, which bounds the full label-add region (both gh guards) — the prior
+# first-`^fi$` end truncated before the second gh guard.
+LABEL_BLOCK_START=$(grep -n 'Extract the PR number from PR_URL by stripping' "$FINISH_BRANCH" | head -1 | cut -d: -f1)
+LABEL_BLOCK_END=$(awk -v s="$LABEL_BLOCK_START" 'NR > s && /^rm -f "\$TITLE_FILE"/ { print NR; exit }' "$FINISH_BRANCH")
 if [[ -n "$LABEL_BLOCK_START" && -n "$LABEL_BLOCK_END" ]]; then
   EXIT_COUNT=$(sed -n "${LABEL_BLOCK_START},${LABEL_BLOCK_END}p" "$FINISH_BRANCH" | grep -cE '^[[:space:]]*exit')
   if [[ "$EXIT_COUNT" -eq 0 ]]; then

--- a/tests/goal-state-zsh.test.sh
+++ b/tests/goal-state-zsh.test.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Dual-shell runtime regression test for issue #270 — bash-only syntax in
+# lib/goal-state.sh (and the finish-branch PR-number extraction) misfired under
+# the zsh-backed Bash tool (/bin/zsh on macOS), where the goal-pipeline /
+# finish-branch SKILL.md bash fences actually execute. CI runs the *.test.sh
+# suite under bash, which is exactly why the zsh-only breakage escaped — so this
+# fixture is written to run under BOTH bash and zsh:
+#
+#   bash tests/goal-state-zsh.test.sh   # proves the fix stays bash-safe
+#   zsh  tests/goal-state-zsh.test.sh   # catches the zsh-only regressions
+#
+# It SOURCES lib/goal-state.sh under the live shell (exactly as each /goal phase
+# fence does via `. ${CLAUDE_PLUGIN_ROOT}/lib/goal-state.sh`) and asserts the
+# behaviours named in the #270 Verification section, plus the two structural
+# must-dos (print_summary hoist; agent_stuck_on_dialog no `read-only`/`bad
+# substitution`). The companion bash coverage lives in goal.test.sh BT2/BT79/G37
+# and goal-state-sidecar.test.sh S5; together they lock the bash + zsh story.
+#
+# Failure-mode demo (revert any one fix and re-run under zsh):
+#   - parse_blocks `${match[1]:-${BASH_REMATCH[1]}}` -> `${BASH_REMATCH[1]}`  => Z1 empty
+#   - `local agent_status` -> `local status`                                 => Z2 `read-only variable: status`
+#   - `_uberdev_goal_indirect_get` `${(P)..}` arm -> `${!..}` always          => Z2/Z4 `bad substitution`
+#   - `env|grep` enumeration -> `compgen -v`                                  => Z4 zero samples persisted
+#   - print_summary defined in the SKILL.md Phase-4 fence (not the lib)       => Z3 not in scope
+#   - finish-branch `${PR_URL##*/}` -> a `[[ =~ ]]` BASH_REMATCH capture      => Z5 empty PR_NUM
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GOAL_LIB="$REPO_ROOT/plugins/uberdev/lib/goal-state.sh"
+DISPATCH_LIB="$REPO_ROOT/plugins/uberdev/lib/dispatch.sh"
+FINISH_BRANCH="$REPO_ROOT/plugins/uberdev/skills/finish-branch/SKILL.md"
+
+if [ ! -r "$GOAL_LIB" ] || [ ! -r "$DISPATCH_LIB" ] || [ ! -r "$FINISH_BRANCH" ]; then
+  echo "FATAL: required file missing/unreadable: $GOAL_LIB / $DISPATCH_LIB / $FINISH_BRANCH" >&2
+  exit 2
+fi
+
+# Report which shell we are exercising (the whole point: the SAME assertions
+# must pass under bash AND zsh).
+if [ -n "${ZSH_VERSION:-}" ]; then
+  RUN_SHELL="zsh"
+else
+  RUN_SHELL="bash"
+fi
+echo "== goal-state-zsh.test.sh — running under: $RUN_SHELL =="
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL  $1"; FAIL=$((FAIL + 1)); }
+
+# Source dispatch.sh (goal-state.sh hard-requires _uberdev_dispatch_* symbols)
+# then goal-state.sh, exactly as each goal-pipeline phase fence does. A parse
+# error under zsh (e.g. a stray bashism at file scope) would abort here.
+# shellcheck source=/dev/null
+. "$DISPATCH_LIB"
+# shellcheck source=/dev/null
+. "$GOAL_LIB"
+
+echo
+echo "== Z1: _uberdev_goal_parse_blocks_line captures the PR number (BASH_REMATCH vs match) =="
+# #270 finding 1: `${BASH_REMATCH[1]}` is empty under zsh (zsh fills `$match[1]`),
+# and this is the ONLY `Blocks: #N` parser -> held-PR unblock never fired. The
+# dual-shell `${match[1]:-${BASH_REMATCH[1]}}` reads whichever the live shell set.
+Z1_OUT="$(_uberdev_goal_parse_blocks_line 'Blocks: #42')"
+if [ "$Z1_OUT" = "42" ]; then
+  pass "Z1a: parse_blocks 'Blocks: #42' -> 42 under $RUN_SHELL"
+else
+  fail "Z1a: parse_blocks yielded [$Z1_OUT], expected 42 (BASH_REMATCH empty under zsh?)"
+fi
+# Negative shapes still reject (the anchored-regex contract is shell-agnostic).
+if [ -z "$(_uberdev_goal_parse_blocks_line 'Blocks: 42')" ]; then
+  pass "Z1b: 'Blocks: 42' (no #) rejected"
+else
+  fail "Z1b: 'Blocks: 42' must be rejected (no leading #)"
+fi
+if [ -z "$(_uberdev_goal_parse_blocks_line ' Blocks: #42')" ]; then
+  pass "Z1c: ' Blocks: #42' (leading space) rejected"
+else
+  fail "Z1c: ' Blocks: #42' must be rejected (leading space breaks the anchor)"
+fi
+
+echo
+echo "== Z2: uberdev_goal_agent_stuck_on_dialog runs clean (no 'read-only'/'bad substitution') =="
+# #270 findings 2 (+ the `local status` zsh special-parameter collision): the
+# function aborted non-zero on its FIRST statement under zsh (`local status` =>
+# `read-only variable: status`), and later `${!var}` => `bad substitution`, so
+# the agent_stuck_on_dialog circuit breaker could NEVER fire. This mirrors
+# goal.test.sh BT79 but RUNS UNDER THE LIVE SHELL and inspects stderr.
+Z2_TMP="$(mktemp -d)"
+(
+  GOAL_ID="goal-z2abcd01"
+  export GOAL_ID UBERDEV_GOAL_ID="$GOAL_ID"
+  export UBERDEV_TMPDIR="$Z2_TMP"
+  printf '%s\n' '{"event":"goal_dispatched"}' > "$UBERDEV_TMPDIR/goal-$GOAL_ID.jsonl"
+  # Stub `claude agents --json` (busy) and `date +%s` (mockable clock).
+  claude() { printf '%s\n' '[{"pid":12345,"status":"busy"}]'; }
+  date() { case "${1:-}" in +%s) printf '%s\n' "${MOCK_NOW:-1729000000}";; *) command date "$@";; esac; }
+  # First sample -> baseline persisted, rc=1 (not-yet-stuck).
+  err1="$( { MOCK_NOW=1729000000 uberdev_goal_agent_stuck_on_dialog 12345; } 2>&1 1>/dev/null )"
+  rc1=$?
+  # Second sample 65s later, same audit row-count, still busy -> rc=0 (stuck).
+  err2="$( { MOCK_NOW=1729000065 uberdev_goal_agent_stuck_on_dialog 12345; } 2>&1 1>/dev/null )"
+  rc2=$?
+  printf 'rc1=%s rc2=%s err1=[%s] err2=[%s]\n' "$rc1" "$rc2" "$err1" "$err2"
+) > "$Z2_TMP/out.txt" 2>&1
+Z2_LINE="$(cat "$Z2_TMP/out.txt")"
+# Stderr must be free of the two zsh-runtime failure signatures on BOTH samples.
+if printf '%s' "$Z2_LINE" | grep -qiE 'bad substitution|read-only variable'; then
+  fail "Z2a: agent_stuck_on_dialog leaked a zsh-runtime error to stderr ($Z2_LINE)"
+else
+  pass "Z2a: agent_stuck_on_dialog ran clean — no 'bad substitution' / 'read-only variable' ($RUN_SHELL)"
+fi
+# Note: the rc1=1 -> rc2=0 state-machine transition is asserted in Z4 (where the
+# two calls run in the SAME shell so the printf -v/export baseline survives —
+# here Z2 runs each call in a `$(...)` stderr-capture subshell, which by design
+# isolates the baseline, so we assert only the no-error contract here).
+
+echo
+echo "== Z3: print_summary is HOISTED into lib/goal-state.sh and in scope after sourcing =="
+# #270 finding 3 + structural must-do (1): print_summary was DEFINED only in the
+# Phase-4 bash fence but CALLED from Phase 1/2/3 fences. A shell function does not
+# cross a fence boundary, so every non-Phase-4 exit hit `command not found`
+# (rc 127). Hoisting it into goal-state.sh (re-sourced at every fence top) brings
+# it into scope in every phase. Sourcing happened above; assert it is callable.
+if command -v print_summary >/dev/null 2>&1; then
+  pass "Z3a: print_summary is in scope after sourcing goal-state.sh (hoist succeeded)"
+else
+  fail "Z3a: print_summary NOT in scope — still stranded in the SKILL.md Phase-4 fence?"
+fi
+# It must also be ABSENT as a function definition from the goal-pipeline SKILL.md
+# (the def was removed from the Phase-4 fence; only call sites remain).
+GOAL_SKILL="$REPO_ROOT/plugins/uberdev/skills/goal-pipeline/SKILL.md"
+if grep -qE '^print_summary\(\)' "$GOAL_SKILL"; then
+  fail "Z3b: print_summary() is still DEFINED in goal-pipeline/SKILL.md — the hoist must remove the inline def (it cannot cross a fence)"
+else
+  pass "Z3b: no print_summary() definition remains in goal-pipeline/SKILL.md (def lives in the lib)"
+fi
+# And it must be DEFINED exactly once in the lib.
+if grep -qE '^print_summary\(\)' "$GOAL_LIB"; then
+  pass "Z3c: print_summary() is defined in lib/goal-state.sh"
+else
+  fail "Z3c: print_summary() must be defined in lib/goal-state.sh"
+fi
+# End-to-end: a fresh shell that sources the lib and rehydrates the summary
+# scalars can run print_summary and get the mandated one-line summary on stdout.
+Z3_TMP="$(mktemp -d)"
+Z3_OUT="$(
+  GOAL_ID="goal-z3abcd01"
+  export GOAL_ID UBERDEV_GOAL_ID="$GOAL_ID"
+  export UBERDEV_TMPDIR="$Z3_TMP"
+  MAX_CYCLES=8
+  watch_start=1729000000
+  date() { case "${1:-}" in +%s) printf '%s\n' 1729003600;; *) command date "$@";; esac; }
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null 2>&1
+  print_summary 3 2>&1
+)"
+if printf '%s' "$Z3_OUT" | grep -qE '^goal goal-z3abcd01: cycles=3/8 prs_merged=0 prs_held=0 issues_resolved=0 wall_secs=3600$'; then
+  pass "Z3d: print_summary emits the mandated operator summary line under $RUN_SHELL"
+else
+  fail "Z3d: print_summary summary line malformed/missing (got: [$Z3_OUT])"
+fi
+
+echo
+echo "== Z4: write_run_state enumerates + persists per-PID stuck samples (compgen vs env) =="
+# #270 finding 4: `compgen -v PREFIX` (a bash builtin) returns NOTHING under zsh,
+# so the per-PID PRIOR_LAST_ACTIVITY_/FIRST_DIALOG_TS_ samples were never written
+# to the run-state sidecar across fences (compounding the dead detector). The
+# replacement enumerates via `env` (portable) + a dual-shell indirect read. This
+# runs the detector twice IN THE SAME SHELL (baseline survives) and asserts the
+# rc1=1 -> rc2=0 transition AND that write_run_state round-trips the samples.
+Z4_TMP="$(mktemp -d)"
+Z4_OUT="$(
+  GOAL_ID="goal-z4abcd01"
+  export GOAL_ID UBERDEV_GOAL_ID="$GOAL_ID"
+  export UBERDEV_TMPDIR="$Z4_TMP"
+  MAX_CYCLES=8; watch_start=1729000000; cycle=1
+  declare -a queue active_issues 2>/dev/null || true
+  queue=(); active_issues=()
+  claude() { printf '%s\n' '[{"pid":12345,"status":"busy"}]'; }
+  date() { case "${1:-}" in +%s) printf '%s\n' "${MOCK_NOW:-1729000000}";; *) command date "$@";; esac; }
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null 2>&1
+  MOCK_NOW=1729000000 uberdev_goal_agent_stuck_on_dialog 12345; rc1=$?
+  MOCK_NOW=1729000065 uberdev_goal_agent_stuck_on_dialog 12345; rc2=$?
+  # Persist run-state: the env-based enumeration must find the exported
+  # PRIOR_LAST_ACTIVITY_12345 / FIRST_DIALOG_TS_12345 keys and write them.
+  uberdev_goal_write_run_state >/dev/null 2>&1
+  sc="$UBERDEV_TMPDIR/goal-$GOAL_ID-runstate"
+  prior_persisted=0; first_persisted=0
+  grep -qE '^PRIOR_LAST_ACTIVITY_12345=' "$sc" 2>/dev/null && prior_persisted=1
+  grep -qE '^FIRST_DIALOG_TS_12345='     "$sc" 2>/dev/null && first_persisted=1
+  printf 'rc1=%s rc2=%s prior=%s first=%s\n' "$rc1" "$rc2" "$prior_persisted" "$first_persisted"
+)"
+case "$Z4_OUT" in
+  *"rc1=1 rc2=0"*)
+    pass "Z4a: stuck-detector state machine fires under $RUN_SHELL (first sample not-stuck -> 65s-later stuck)" ;;
+  *)
+    fail "Z4a: stuck-detector did not transition rc1=1 -> rc2=0 (got: [$Z4_OUT])" ;;
+esac
+case "$Z4_OUT" in
+  *"prior=1 first=1"*)
+    pass "Z4b: write_run_state persisted both per-PID samples via env-enumeration (compgen-free) under $RUN_SHELL" ;;
+  *)
+    fail "Z4b: write_run_state dropped the per-PID samples — compgen-under-zsh regression? (got: [$Z4_OUT])" ;;
+esac
+
+echo
+echo "== Z5: finish-branch PR-number extraction yields a non-empty value (no BASH_REMATCH) =="
+# #270 finding 5: finish-branch used `${BASH_REMATCH[1]}` to pull the PR number
+# from PR_URL -> empty under zsh -> `gh pr edit "" --add-label review-pr:pending`
+# failed (swallowed) and the #95 backstop label was never set on macOS. The fix
+# sidesteps the regex entirely: `PR_NUM="${PR_URL##*/}"` on the already-validated
+# URL. Z5a runs that exact expansion under the live shell; Z5b/Z5c guard the
+# SKILL.md against a relapse to a capture-group match.
+Z5_PR_URL="https://github.com/owner/repo/pull/12345"
+Z5_PR_NUM="${Z5_PR_URL##*/}"
+if [ -n "$Z5_PR_NUM" ] && [ "$Z5_PR_NUM" = "12345" ]; then
+  pass "Z5a: \${PR_URL##*/} extracts '12345' (non-empty) under $RUN_SHELL"
+else
+  fail "Z5a: PR-number extraction yielded [$Z5_PR_NUM], expected non-empty 12345"
+fi
+# Structural: finish-branch must use the parameter-expansion form, NOT a
+# BASH_REMATCH capture, for the PR-number extraction.
+if grep -qE 'PR_NUM="\$\{PR_URL##\*/\}"' "$FINISH_BRANCH"; then
+  pass "Z5b: finish-branch uses PR_NUM=\${PR_URL##*/} (regex-free, dual-shell-safe)"
+else
+  fail "Z5b: finish-branch must extract PR_NUM via \${PR_URL##*/} (the dual-shell-safe form)"
+fi
+if grep -qE 'PR_NUM="\$\{BASH_REMATCH\[1\]\}"' "$FINISH_BRANCH"; then
+  fail "Z5c: finish-branch still pulls PR_NUM from \${BASH_REMATCH[1]} — empty under zsh, defeats the #95 backstop"
+else
+  pass "Z5c: no \${BASH_REMATCH[1]} PR-number extraction remains in finish-branch"
+fi
+
+# Cleanup
+rm -rf "$Z2_TMP" "$Z3_TMP" "$Z4_TMP" 2>/dev/null || true
+
+echo
+echo "== Summary =="
+echo "  shell:  $RUN_SHELL"
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[ "$FAIL" -eq 0 ]

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -300,8 +300,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.7) =="
-assert_version_bump "$REPO_ROOT" "0.35.7"
+echo "== G20: version bump locked (0.35.8) =="
+assert_version_bump "$REPO_ROOT" "0.35.8"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.6 -> 0.35.7 propagated =="
-assert_version_bump "$REPO_ROOT" "0.35.7"
+echo "== Version bump 0.35.7 -> 0.35.8 propagated =="
+assert_version_bump "$REPO_ROOT" "0.35.8"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
Fixes the five zsh-runtime findings in #270 (**critical**) — all sharing one root cause: bash-only syntax executed under the `/bin/zsh`-backed Bash tool on macOS, where the `/goal` + finish-branch SKILL.md bash fences run and shell functions don't survive a fence boundary. CI ran the suite only under bash, so the breakage escaped.

## Fixes (`lib/goal-state.sh`, `goal-pipeline/SKILL.md`, `finish-branch/SKILL.md`)
- `_uberdev_goal_parse_blocks_line`: `${BASH_REMATCH[1]}` → `${match[1]:-${BASH_REMATCH[1]}}` — the only `Blocks: #N` parser, so held-PR unblock was dead under zsh (merge barrier could clear prematurely).
- `uberdev_goal_agent_stuck_on_dialog`: `local status` → `local agent_status` (zsh's read-only special parameter aborted the function on its first line) + `${!var}` indirection via a new `_uberdev_goal_indirect_get` helper (`${(P)}` / `${!}`, native expansion — **no `eval`/`bash -c`**, per the file's T3 rule).
- `write_run_state`: `compgen -v` → `env | grep` enumeration (per-PID stuck-dialog samples now persist across fences).
- `print_summary()` hoisted from the Phase-4 fence into `lib/goal-state.sh` — it was *called* from the Phase-1/2/3 fences → `command not found` (rc 127) on every circuit-breaker and convergence exit, silently dropping the operator summary + held-PR post-mortem rows.
- finish-branch PR number: `${PR_URL##*/}` on the already-`PR_URL_REGEX`-validated URL (restores the #95 `review-pr:pending` backstop label on macOS-created PRs).
- defensive `${BASH_SOURCE[0]:-}` guard for `set -u` zsh callers.

## Tests
- New `tests/goal-state-zsh.test.sh` (modeled on `solve-pipeline-zsh.test.sh`): sources `goal-state.sh` under the live shell, **13/13 under both bash and zsh**; each pre-fix form proven red under zsh. Wired into the ubuntu CI job under `zsh` (windows-skip — `windows-latest` has no zsh).

Version bumped to **0.35.8** across all four surfaces + the two release-ratchet test-locks. Independently adversarially reviewed (verdict: approve).

Closes #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed zsh runtime compatibility issues affecting block parsing, variable indirection, and stuck-dialog detection on macOS
  * Improved PR number extraction in finish-branch workflow for cross-shell reliability

* **Tests**
  * Added comprehensive zsh regression test suite to prevent future shell compatibility issues

* **Chores**
  * Version bumped to 0.35.8
  * Updated CI pipeline to validate zsh behavior across test suite

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->