### PR TITLE
fix(review-pr): align Phase-3 gh pr checks probe to the state/bucket field contract (#272)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.9",
+      "version": "0.35.10",
       "category": "workflow",
       "tags": [
         "github",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,7 @@ jobs:
         #   - uberthink.test.sh
         #   - uberthink-report.test.sh
         #   - merge-discovery-resilience.test.sh
+        #   - review-pr-phase3-ci.test.sh
         # === END ci-wiring windows-skip-list ===
         run: |
           bash tests/ci-wiring.test.sh && \
@@ -190,7 +191,6 @@ jobs:
           bash tests/spec-reviewer-plan-aware.test.sh && \
           bash tests/audit-fixups.test.sh && \
           bash tests/review-pr.test.sh && \
-          bash tests/review-pr-phase3-ci.test.sh && \
           bash tests/cluster.test.sh && \
           bash tests/code-fixer-dispatch.test.sh && \
           bash tests/findings-to-issues.test.sh && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.10] — 2026-05-29
+
+### Fixed
+- **`/review-pr` Phase-3 CI probe — align to the real `gh pr checks` field contract** (#272). `commands/review-pr.md` probed `gh pr checks --json name,status,conclusion`, but `gh` 2.83.1 exposes only `name,state,bucket` (no `status`/`conclusion`) — so against real `gh` the probe errored on unknown fields and Phase-3 silently degraded to the `ci_probe_unreachable` carve-out on every run, never gating real red CI on a to-`main` PR. The probe now reads `--json name,state,bucket` and maps terminal/non-terminal off `state` + `bucket` (red outranks pending). The `tests/_fixtures/fake-gh/gh` stub emits `state`/`bucket` to match.
+
+### Tests
+- `tests/review-pr-phase3-ci.test.sh` gains genuine RUNTIME coverage (S15-RUNTIME): prepends the `fake-gh` stub to `PATH`, sets `FAKE_GH_MODE`, runs the real probe, and applies the jq verdict program extracted live from `review-pr.md` (so it cannot drift); a mutation back to the old `status`/`conclusion` shape reds it. Because it now executes the `fake-gh` fixture via `PATH` (committed-`+x` dependency, like `merge-discovery-resilience.test.sh`), it moves to the ubuntu-only CI job and is added to the windows-skip-list marker.
+
 ## [0.35.9] — 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.9-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.10-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/review-pr.md
+++ b/plugins/uberdev/commands/review-pr.md
@@ -349,8 +349,18 @@ Pass `--turbo` (anywhere in the arguments) to acknowledge invocation from `finis
 
     **Probe call:**
 
+    **Field contract (gh ≥ 2.83.1):** `gh pr checks --json` exposes `name`, `state`, and `bucket` — there is **no** `status` and **no** `conclusion` field (those were removed upstream; reading them errors `unknown JSON field`). `bucket` is gh's own canonical categorization of `state` and is the field this probe keys off:
+
+    | `bucket` | `state` values folded into it (gh `aggregateChecks`) | meaning here |
+    |---|---|---|
+    | `pass` | `SUCCESS` | green |
+    | `skipping` | `SKIPPED`, `NEUTRAL` | green-eligible (skipped/neutral never block) |
+    | `pending` | `EXPECTED`, `REQUESTED`, `WAITING`, `QUEUED`, `PENDING`, `IN_PROGRESS`, `STALE` | still running → MONITOR |
+    | `fail` | `ERROR`, `FAILURE`, `TIMED_OUT`, `ACTION_REQUIRED` | red |
+    | `cancel` | `CANCELLED` | red |
+
     ```bash
-    PROBE_JSON="$(gh pr checks "$PR_NUMBER" --json name,status,conclusion 2>&1)" || PROBE_RC=$?
+    PROBE_JSON="$(gh pr checks "$PR_NUMBER" --json name,state,bucket 2>&1)" || PROBE_RC=$?
     # Validate PROBE_JSON is parseable JSON BEFORE the terminal-mapping
     # branches below try to interpret it. On gh failure (non-zero exit),
     # PROBE_JSON contains stderr text; jq parsing would silently produce
@@ -360,17 +370,27 @@ Pass `--turbo` (anywhere in the arguments) to acknowledge invocation from `finis
       audit ci_probe_unreachable subreason=gh_failed_${PROBE_RC}
       # phases.phase3 block omitted entirely; skip to Step 7
     fi
+    # Classify off bucket (gh's canonical state→bucket fold). A single jq pass
+    # collapses the array to one of: empty / green / pending / red. Never
+    # line-grep the buckets — parse as JSON. `red` outranks `pending` so a mix
+    # of failed + still-running checks still routes through MONITOR→CLASSIFY.
+    PROBE_VERDICT="$(jq -r '
+      if (type != "array") or (length == 0) then "empty"
+      elif any(.[].bucket; . == "fail" or . == "cancel") then "red"
+      elif any(.[].bucket; . == "pending") then "pending"
+      else "green" end
+    ' <<<"$PROBE_JSON" 2>/dev/null)"
     ```
 
     Terminal mappings (parsed as JSON; never line-grepped):
 
-    | `PROBE_JSON` content | OUTCOME | Audit event |
-    |---|---|---|
-    | stderr matches `no checks reported on the` (or empty `[]`) | `skipped_no_checks` | `ci_probe_skipped_no_checks` |
-    | all entries `conclusion ∈ {success, neutral, skipped}` | `green` | `ci_phase_outcome` (terminal, payload `outcome=green` — fast-path skip past MONITOR/CLASSIFY) |
-    | any entry `status == in_progress` or `pending` | (proceed to MONITOR) | `ci_probe_started` |
-    | any entry `conclusion ∈ {failure, cancelled, timed_out, action_required}` | (proceed to MONITOR + classify if all settled) | `ci_probe_started` |
-    | `gh` exit non-zero AND no usable JSON | (carve-out — `phases.phase3` block omitted from audit JSON; Step 7 proceeds as if `OUTCOME=skipped_no_checks`) | `ci_probe_unreachable` |
+    | `PROBE_JSON` content | `PROBE_VERDICT` | OUTCOME | Audit event |
+    |---|---|---|---|
+    | stderr matches `no checks reported on the` (or empty `[]`) | `empty` | `skipped_no_checks` | `ci_probe_skipped_no_checks` |
+    | all entries `bucket ∈ {pass, skipping}` | `green` | `green` | `ci_phase_outcome` (terminal, payload `outcome=green` — fast-path skip past MONITOR/CLASSIFY) |
+    | any entry `bucket == pending` (and none `fail`/`cancel`) | `pending` | (proceed to MONITOR) | `ci_probe_started` |
+    | any entry `bucket ∈ {fail, cancel}` | `red` | (proceed to MONITOR + classify if all settled) | `ci_probe_started` |
+    | `gh` exit non-zero AND no usable JSON | — | (carve-out — `phases.phase3` block omitted from audit JSON; Step 7 proceeds as if `OUTCOME=skipped_no_checks`) | `ci_probe_unreachable` |
 
     The `gh pr checks` output MUST be parsed as JSON, never line-grepped.
 
@@ -379,10 +399,10 @@ Pass `--turbo` (anywhere in the arguments) to acknowledge invocation from `finis
     The literals `1200` and `30` below are `CI_MONITOR_TIMEOUT_SEC` and `CI_WATCH_INTERVAL_SEC` respectively (declared in `merge-pipeline/SKILL.md` Constants — kept numeric inline because bash does not dereference markdown constants).
 
     ```bash
-    timeout 1200 gh pr checks "$PR_NUMBER" --watch --interval 30 --json name,status,conclusion
+    timeout 1200 gh pr checks "$PR_NUMBER" --watch --interval 30
     ```
 
-    Wall-clock cap: **20 minutes** (`timeout 1200` = `CI_MONITOR_TIMEOUT_SEC`). On exit code 0 → all green → `OUTCOME=green` → audit `ci_monitor_green`. Exit 8 (still pending after watch terminates — underdocumented gh exit code) → `ci_monitor_timeout` audit; halt loop iteration with `OUTCOME=halted` (carry differentiation in audit `data.subreason=monitor_timeout`; `halted` is the canonical CI_OUTCOME_ENUM member, not a `halted_timeout` synthetic). Non-zero non-8 → at least one check failed → audit `ci_monitor_red`; proceed to CLASSIFY.
+    **`--watch` takes NO `--json`:** gh refuses `--watch` together with `--json` (`cannot use --watch with --json flag`, verified live on gh 2.83.1) — that is why the field list is absent here even though 6c.1 PROBE reads `--json name,state,bucket`. MONITOR keys off the **exit code** (gh's documented `gh pr checks` contract), not parsed JSON, so it needs no field projection. Wall-clock cap: **20 minutes** (`timeout 1200` = `CI_MONITOR_TIMEOUT_SEC`). The watch terminates on its own once every check leaves the `pending` bucket. On exit code 0 → all green → `OUTCOME=green` → audit `ci_monitor_green`. Exit 8 (still pending after watch terminates — `gh pr checks` exit code 8 = "Checks pending", per `gh pr checks --help`) → `ci_monitor_timeout` audit; halt loop iteration with `OUTCOME=halted` (carry differentiation in audit `data.subreason=monitor_timeout`; `halted` is the canonical CI_OUTCOME_ENUM member, not a `halted_timeout` synthetic). Non-zero non-8 → at least one check failed → audit `ci_monitor_red`; proceed to CLASSIFY.
 
     `--fail-fast` is **NOT** used (the classifier needs the complete failure picture). The 30-second `--interval` floor (`CI_WATCH_INTERVAL_SEC`) is intentional (rate-limit guard).
 

--- a/tests/_fixtures/fake-gh/gh
+++ b/tests/_fixtures/fake-gh/gh
@@ -31,16 +31,22 @@
 #   ci-checks-no-checks  : gh pr checks output simulating "no checks reported on the
 #                          'main' branch" — Phase 3 PROBE → skipped_no_checks fast path.
 #                          stderr: 'no checks reported on the ...'; stdout empty array.
-#   ci-checks-pending    : gh pr checks --json output where every entry has
-#                          status: in_progress (drives Phase 3 PROBE → MONITOR transition).
-#   ci-checks-green      : all entries conclusion ∈ {success}; PROBE fast-path → green.
-#   ci-checks-red        : at least one entry conclusion: failure; drives PROBE → MONITOR
+#   ci-checks-pending    : gh pr checks --json name,state,bucket output where every entry
+#                          has bucket: pending (drives Phase 3 PROBE → MONITOR transition).
+#   ci-checks-green      : all entries bucket ∈ {pass, skipping}; PROBE fast-path → green.
+#   ci-checks-red        : at least one entry bucket: fail; drives PROBE → MONITOR
 #                          → CLASSIFY transition.
-#   ci-checks-mixed      : pending + red mix — exercises MONITOR settling-then-classify.
+#   ci-checks-mixed      : pending + fail mix — exercises MONITOR settling-then-classify
+#                          and the red-outranks-pending verdict precedence.
 #   gh-unreachable       : gh exits non-zero with no usable JSON (carve-out test).
 #                          stderr token: 'gh: connection refused'.
 #   ci-rate-limit-low    : gh api rate_limit response with .resources.core.remaining=42
 #                          (below the 200 floor — exercises pre-flight skip).
+#
+# gh field contract (gh >= 2.83.1): `gh pr checks --json` exposes name,state,bucket —
+# NOT status/conclusion (removed upstream). `bucket` is gh's own state→category fold:
+# SUCCESS→pass; SKIPPED|NEUTRAL→skipping; ERROR|FAILURE|TIMED_OUT|ACTION_REQUIRED→fail;
+# CANCELLED→cancel; everything still running (QUEUED|IN_PROGRESS|PENDING|...)→pending.
 #
 # A side-effect log of the call (argv) is written to $FAKE_GH_CALL_LOG when
 # that variable is set; tests can inspect it to verify call shape (e.g. that
@@ -173,10 +179,11 @@ JSON
 
   ci-checks-pending)
     # Phase 3 6c.1 PROBE -> 6c.2 MONITOR transition.
+    # gh >= 2.83.1 shape: {name,state,bucket}. IN_PROGRESS folds to bucket=pending.
     cat <<'JSON'
 [
-  {"name": "build", "status": "in_progress", "conclusion": null},
-  {"name": "test",  "status": "in_progress", "conclusion": null}
+  {"name": "build", "state": "IN_PROGRESS", "bucket": "pending"},
+  {"name": "test",  "state": "QUEUED",      "bucket": "pending"}
 ]
 JSON
     exit 0
@@ -184,11 +191,12 @@ JSON
 
   ci-checks-green)
     # Phase 3 6c.1 PROBE green fast-path.
+    # SUCCESS -> bucket=pass; SKIPPED -> bucket=skipping (both green-eligible).
     cat <<'JSON'
 [
-  {"name": "build", "status": "completed", "conclusion": "success"},
-  {"name": "test",  "status": "completed", "conclusion": "success"},
-  {"name": "lint",  "status": "completed", "conclusion": "skipped"}
+  {"name": "build", "state": "SUCCESS", "bucket": "pass"},
+  {"name": "test",  "state": "SUCCESS", "bucket": "pass"},
+  {"name": "lint",  "state": "SKIPPED", "bucket": "skipping"}
 ]
 JSON
     exit 0
@@ -196,10 +204,11 @@ JSON
 
   ci-checks-red)
     # Phase 3 6c.1 PROBE -> CLASSIFY (one failed check).
+    # FAILURE -> bucket=fail.
     cat <<'JSON'
 [
-  {"name": "build", "status": "completed", "conclusion": "success"},
-  {"name": "test",  "status": "completed", "conclusion": "failure"}
+  {"name": "build", "state": "SUCCESS", "bucket": "pass"},
+  {"name": "test",  "state": "FAILURE", "bucket": "fail"}
 ]
 JSON
     exit 0
@@ -207,11 +216,12 @@ JSON
 
   ci-checks-mixed)
     # Phase 3 6c.2 MONITOR settles -> 6c.3 CLASSIFY (mixed pending + red).
+    # red (fail bucket) MUST outrank pending in the PROBE verdict.
     cat <<'JSON'
 [
-  {"name": "build", "status": "completed",  "conclusion": "success"},
-  {"name": "test",  "status": "completed",  "conclusion": "failure"},
-  {"name": "lint",  "status": "in_progress","conclusion": null}
+  {"name": "build", "state": "SUCCESS",     "bucket": "pass"},
+  {"name": "test",  "state": "FAILURE",     "bucket": "fail"},
+  {"name": "lint",  "state": "IN_PROGRESS", "bucket": "pending"}
 ]
 JSON
     exit 0

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -300,8 +300,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.9) =="
-assert_version_bump "$REPO_ROOT" "0.35.9"
+echo "== G20: version bump locked (0.35.10) =="
+assert_version_bump "$REPO_ROOT" "0.35.10"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/review-pr-phase3-ci.test.sh
+++ b/tests/review-pr-phase3-ci.test.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
-# Functional integration tests for /uberdev:review-pr Phase 3 (CI Health).
-# Scenarios 1-9 from spec Test Plan. Each scenario seeds FAKE_GH_MODE,
-# invokes the structural-assert helpers against the prose contract, and
-# asserts (a) which Task() subagent_type was dispatched and (b) which
-# AUDIT_EVENT_ENUM members landed in the audit log.
+# Tests for /uberdev:review-pr Phase 3 (CI Health). Two layers:
 #
-# Note: this suite asserts STRUCTURAL contract presence in the prose
-# (commands/review-pr.md + agent files), not runtime behaviour — the
-# plugin runtime is the LLM, not bash. The assertions are aggressive
-# grep/regex checks that lock every Phase 3 contract surface.
+#   STRUCTURAL (S1-S14): aggressive grep/regex checks that lock every Phase 3
+#     contract surface in the prose (commands/review-pr.md + agent files). The
+#     plugin "runtime" is the LLM reading that prose, so these assert that the
+#     load-bearing tokens, audit-event names, and dispatch shapes are present.
+#
+#   RUNTIME (S15): exercises the Phase-3 6c.1 PROBE bucket-classification
+#     contract for real. It prepends tests/_fixtures/fake-gh to PATH, sets
+#     FAKE_GH_MODE per scenario, runs `gh pr checks ... --json name,state,bucket`
+#     exactly as review-pr.md specifies, then applies the *prose's own* jq
+#     verdict expression (extracted live from review-pr.md, so the test can
+#     never drift from the documented logic) and asserts the resulting verdict.
+#     It also locks the gh >= 2.83.1 field contract: probe output carries
+#     name/state/bucket and NEVER the removed status/conclusion fields.
+#
+# The fake `gh` is required because the real one is unavailable in CI sandboxes
+# (and we never make network calls in unit tests).
 
 set -u
 set -o pipefail
@@ -308,6 +316,124 @@ if [[ -n "$R_START" && -n "$R_END" ]]; then
 else
   echo "  FAIL  S14.5 — could not locate REFUSED sub-block (R_START=$R_START R_END=$R_END)"
   FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "== S15: field-contract structural guard — probe reads name,state,bucket (NOT status,conclusion) =="
+# Lock the gh >= 2.83.1 field contract in the prose so a future edit can't
+# silently regress the probe back to the removed status,conclusion fields.
+assert_grep "$REVIEW_PR" 'gh pr checks "\$PR_NUMBER" --json name,state,bucket' \
+  "S15.1 — PROBE call reads --json name,state,bucket"
+assert_grep "$REVIEW_PR" 'gh pr checks "\$PR_NUMBER" --watch --interval 30$' \
+  "S15.2 — MONITOR --watch call takes NO --json (gh forbids --watch with --json)"
+# S15.2b — gh 2.83.1 rejects `--watch` together with `--json`
+# ("cannot use --watch with --json flag", verified live). Scope this guard to
+# actual `gh pr checks ... --watch` *command invocations* (not the prose that
+# explains the constraint) by flagging only invocation lines that also carry
+# --json. An invocation line is one where gh pr checks + --watch are not inside
+# backtick-quoted prose: we approximate by requiring the line to NOT contain a
+# backtick (command fences here are plain, prose references are backticked).
+S15_2B_VIOLATIONS="$(awk '
+  /gh pr checks/ && /--watch/ && /--json/ && $0 !~ /`/ { print FILENAME ":" NR ": " $0 }
+' "$REVIEW_PR")"
+if [ -z "$S15_2B_VIOLATIONS" ]; then
+  echo "  PASS  S15.2b — no gh pr checks --watch invocation is combined with --json"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  S15.2b — a gh pr checks --watch invocation is combined with --json (gh rejects this)"
+  printf '%s\n' "$S15_2B_VIOLATIONS" | sed 's/^/          /'
+  FAIL=$((FAIL + 1))
+fi
+assert_no_grep "$REVIEW_PR" '\-\-json name,status,conclusion' \
+  "S15.3 — no probe reads the removed --json name,status,conclusion field set"
+assert_grep "$REVIEW_PR" 'bucket .* \{pass, skipping\}|bucket ∈ \{pass, skipping\}' \
+  "S15.4 — green predicate keyed off bucket ∈ {pass, skipping}"
+assert_grep "$REVIEW_PR" 'bucket ∈ \{fail, cancel\}|bucket .* \{fail, cancel\}' \
+  "S15.5 — red predicate keyed off bucket ∈ {fail, cancel}"
+
+echo
+echo "== S15-RUNTIME: PROBE bucket-classification exercised against fake-gh =="
+# Extract the PROBE verdict jq program *from review-pr.md itself* so this test
+# exercises the documented contract, not a parallel re-implementation. If the
+# prose jq changes, this re-extracts it and re-verifies behaviour.
+JQ_VERDICT_PROG="$(awk '
+  /PROBE_VERDICT="\$\(jq -r .$/ { capture=1; next }
+  capture && /^[[:space:]]*.[[:space:]]*<<<"\$PROBE_JSON"/ { capture=0; exit }
+  capture { print }
+' "$REVIEW_PR")"
+
+if [ -z "$JQ_VERDICT_PROG" ]; then
+  echo "  FAIL  S15-RT.0 — could not extract PROBE_VERDICT jq program from review-pr.md"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  S15-RT.0 — extracted PROBE_VERDICT jq program from review-pr.md prose"
+  PASS=$((PASS + 1))
+fi
+
+FAKE_GH_DIR="$REPO_ROOT/tests/_fixtures/fake-gh"
+if [ ! -x "$FAKE_GH_DIR/gh" ]; then
+  echo "  FAIL  S15-RT.0b — fake-gh stub missing/not executable at $FAKE_GH_DIR/gh"
+  FAIL=$((FAIL + 1))
+fi
+
+# Run the PROBE exactly as Phase 3 6c.1 specifies: fake gh on PATH, FAKE_GH_MODE
+# set, `gh pr checks <n> --json name,state,bucket`. Echo the raw probe JSON on
+# stdout so callers capture it in their own scope (a global set inside the $(...)
+# command-substitution subshell would NOT propagate back to the caller).
+_run_probe() {
+  local mode="$1"
+  PATH="$FAKE_GH_DIR:$PATH" FAKE_GH_MODE="$mode" \
+    gh pr checks 999 --json name,state,bucket 2>/dev/null
+}
+
+assert_verdict() {
+  local mode="$1" expected="$2" desc="$3"
+  local probe got bucket_ok="no"
+  probe="$(_run_probe "$mode")"
+  got="$(jq -r "$JQ_VERDICT_PROG" <<<"$probe" 2>/dev/null)"
+  # Guard against the silent-degradation class the issue pins: a probe whose
+  # entries lack the `bucket` key would fall through the verdict jq's any()
+  # tests to "green" — masking a broken field contract as a passing CI. So a
+  # non-empty verdict is only trusted when every entry actually carries bucket.
+  if printf '%s' "$probe" | jq -e 'type=="array" and length>0 and all(.[]; has("bucket"))' >/dev/null 2>&1; then
+    bucket_ok="yes"
+  fi
+  if [ "$got" = "$expected" ] && [ "$bucket_ok" = "yes" ]; then
+    echo "  PASS  $desc (mode=$mode → $got)"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"; echo "        mode: $mode"; echo "        expected verdict: $expected (bucket-on-every-entry: yes)"; echo "        actual verdict:   $got (bucket-on-every-entry: $bucket_ok)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# S15-RT.1..4 — bucket classification, driven by the now-live ci-checks-* modes.
+assert_verdict ci-checks-green   green   "S15-RT.1 — all bucket ∈ {pass,skipping} → green fast-path"
+assert_verdict ci-checks-pending pending "S15-RT.2 — all bucket pending → MONITOR transition"
+assert_verdict ci-checks-red     red     "S15-RT.3 — any bucket fail → red (CLASSIFY)"
+assert_verdict ci-checks-mixed   red     "S15-RT.4 — fail+pending mix → red (red outranks pending)"
+
+# S15-RT.5 — gh >= 2.83.1 field contract: the probe JSON the stub emits MUST
+# carry name/state/bucket on every entry and NEVER the removed status/conclusion
+# fields. This is the regression that the issue's "verified live" diagnosis pins.
+GREEN_PROBE="$(_run_probe ci-checks-green)"
+if printf '%s' "$GREEN_PROBE" | jq -e 'type=="array" and length>0 and all(.[]; has("name") and has("state") and has("bucket"))' >/dev/null 2>&1; then
+  echo "  PASS  S15-RT.5a — stub probe entries carry name/state/bucket"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  S15-RT.5a — stub probe entries missing name/state/bucket: $GREEN_PROBE"; FAIL=$((FAIL + 1))
+fi
+if printf '%s' "$GREEN_PROBE" | jq -e 'all(.[]; (has("status")|not) and (has("conclusion")|not))' >/dev/null 2>&1; then
+  echo "  PASS  S15-RT.5b — stub probe entries carry NO removed status/conclusion fields"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  S15-RT.5b — stub probe entries still carry removed status/conclusion: $GREEN_PROBE"; FAIL=$((FAIL + 1))
+fi
+
+# S15-RT.6 — no-checks fast path: empty array (and non-zero gh exit + 'no checks
+# reported on the' stderr) maps to the `empty` verdict → skipped_no_checks.
+EMPTY_PROBE="$(_run_probe ci-checks-no-checks)"
+EMPTY_VERDICT="$(jq -r "$JQ_VERDICT_PROG" <<<"$EMPTY_PROBE" 2>/dev/null)"
+if [ "$EMPTY_VERDICT" = "empty" ]; then
+  echo "  PASS  S15-RT.6 — ci-checks-no-checks empty array → empty verdict (skipped_no_checks)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL  S15-RT.6 — expected empty verdict, got '$EMPTY_VERDICT' (probe='$EMPTY_PROBE')"; FAIL=$((FAIL + 1))
 fi
 
 echo

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.8 -> 0.35.9 propagated =="
-assert_version_bump "$REPO_ROOT" "0.35.9"
+echo "== Version bump 0.35.9 -> 0.35.10 propagated =="
+assert_version_bump "$REPO_ROOT" "0.35.10"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
Fixes #272 (**major**). `/review-pr` Phase-3 probed `gh pr checks --json name,status,conclusion`, but `gh` 2.83.1 exposes only `name,state,bucket` (no `status`/`conclusion`) — so against real `gh` the probe errored on unknown fields and Phase-3 silently degraded to the `ci_probe_unreachable` carve-out on every run, never gating real red CI on a to-`main` PR.

## Fix
- `commands/review-pr.md` Phase-3 probe → `--json name,state,bucket`, mapping terminal/non-terminal off `state` + `bucket` (red outranks pending); `--watch` MONITOR keys off exit code (drops `--json`, which `gh` rejects with `--watch`).
- `tests/_fixtures/fake-gh/gh` stub emits `state`/`bucket` objects to match real `gh`.

## Tests
- `tests/review-pr-phase3-ci.test.sh` gains RUNTIME coverage (S15-RUNTIME): prepends the `fake-gh` stub to `PATH`, sets `FAKE_GH_MODE`, runs the real probe, and applies the jq verdict program **extracted live** from `review-pr.md` (cannot drift); a mutation back to `status`/`conclusion` reds it. 97/0 locally.
- Because the test now executes the `fake-gh` fixture via `PATH` (committed-`+x` dependency, same class as `merge-discovery-resilience.test.sh`), it moves to the **ubuntu-only** CI job + windows-skip-list marker (`ci-wiring.test.sh` 5/5).

Independently reviewed (verified live against `gh` 2.83.1; mutation test confirms the guard): **APPROVE**. Version bumped to **0.35.10**.

Closes #272