### PR TITLE
docs: accuracy sweep — real testing.md, CONTRIBUTING fixes, RFC 0004→0011 renumber (#273)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.10",
+      "version": "0.35.11",
       "category": "workflow",
       "tags": [
         "github",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
           bash tests/solve-effort-flag.test.sh && \
           zsh tests/solve-pipeline-zsh.test.sh && \
           zsh tests/goal-state-zsh.test.sh && \
+          bash tests/docs-accuracy.test.sh && \
           bash tests/orchestrator-phase1-shortcircuit.test.sh && \
           bash tests/config-override.test.sh && \
           bash tests/orchestrator-phase-6-doc.test.sh && \
@@ -188,6 +189,7 @@ jobs:
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \
           bash tests/post-impl-review.test.sh && \
+          bash tests/docs-accuracy.test.sh && \
           bash tests/spec-reviewer-plan-aware.test.sh && \
           bash tests/audit-fixups.test.sh && \
           bash tests/review-pr.test.sh && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.11] — 2026-05-29
+
+### Fixed
+- **Docs-accuracy sweep — vendored `testing.md`, stale `CONTRIBUTING`, dead link, RFC 0004 collision** (#273). `plugins/uberdev/docs/testing.md` was verbatim-upstream Superpowers (documented `tests/claude-code/`, `run-skill-tests.sh`, `superpowers@superpowers-dev` — none exist here); rewritten to describe the real `tests/*.test.sh` shape-check harness and the `.github/workflows/test.yml` two-job (ubuntu + windows) matrix, with `uberdev@uberdev` as the marketplace key. `CONTRIBUTING.md` now points at `test.yml` as the test-suite SSOT (dropping the false "no behavioral tests yet" claim and the partial 4-file list) and its dead `[Repo layout](README.md#repo-layout)` link is fixed. The **RFC 0004 number collision** is resolved by renumbering the alias-reliability draft to **RFC 0011** (the dispatch-backends RFC keeps 0004 — shipped code + CHANGELOG cite it), with cross-refs updated in `hooks/session-start`, `lib/aliases-sync.sh`, and the CHANGELOG; the dispatch RFC's internal §4/§5 version refs are corrected to `0.29.0 → 0.30.0`.
+
+### Tests
+- New `tests/docs-accuracy.test.sh` (fail-loud on missing inputs; dynamic duplicate-RFC-number detection) guards against re-vendoring `testing.md`, the dead README link, and RFC-number collisions. Portable grep-and-assert — wired into both the ubuntu and windows CI jobs.
+
 ## [0.35.10] — 2026-05-29
 
 ### Fixed
@@ -581,7 +589,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ### Fixed
 
-- **Alias auto-install no longer silently depends on `jq`.** The `SessionStart` hook (`plugins/uberdev/hooks/session-start`) hard-requires `jq` to JSON-encode its context injection and `exit 0`s early when `jq` is absent — previously *before* the auto-alias-sync block ever ran, so a new user on a machine without `jq` got zero short-form aliases (`/issue`, `/solve`, `/turbo`, …) and no warning. The alias-sync block now runs **before** the `jq` guard, and `lib/aliases-sync.sh` no longer calls `jq` at all: its one use (`jq -r .version` on `plugin.json`) is replaced by a jq-free `_aliases_read_version()` `sed` parse of the plugin's own manifest. Forwarders now install regardless of `jq`. See `docs/rfc/0004-alias-install-reliability.md`.
+- **Alias auto-install no longer silently depends on `jq`.** The `SessionStart` hook (`plugins/uberdev/hooks/session-start`) hard-requires `jq` to JSON-encode its context injection and `exit 0`s early when `jq` is absent — previously *before* the auto-alias-sync block ever ran, so a new user on a machine without `jq` got zero short-form aliases (`/issue`, `/solve`, `/turbo`, …) and no warning. The alias-sync block now runs **before** the `jq` guard, and `lib/aliases-sync.sh` no longer calls `jq` at all: its one use (`jq -r .version` on `plugin.json`) is replaced by a jq-free `_aliases_read_version()` `sed` parse of the plugin's own manifest. Forwarders now install regardless of `jq`. See `docs/rfc/0011-alias-install-reliability.md`.
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,12 +14,17 @@ When you change a plugin file, re-run `/plugin install uberdev@uberdev` to pick 
 
 ## Repo layout
 
-See [Repo layout](README.md#repo-layout) in the README. Contributor-only additions:
+The marketplace manifest is `.claude-plugin/marketplace.json` (top-level); the single bundled plugin lives under `plugins/uberdev/`, with the canonical version in `plugins/uberdev/.claude-plugin/plugin.json`. The directories a contributor touches:
 
+- `plugins/uberdev/commands/` — slash-command prompt files (`/uberdev:<command>`); frontmatter declares argument hints + allowed tools, the body is the prompt.
 - `plugins/uberdev/agents/` — reusable subagent prompts that orchestrator commands compose.
 - `plugins/uberdev/skills/` — discoverable workflow skills (each is a folder with `SKILL.md` + optional supporting files).
 - `plugins/uberdev/hooks/` — `SessionStart` / `PreToolUse` / `SessionEnd` / `PreCompact` event handlers, wired in `hooks.json`.
+- `plugins/uberdev/lib/` — sourced shell helpers shared across pipelines (e.g. `dispatch.sh`, `config-read.sh`, `aliases-sync.sh`).
+- `plugins/uberdev/docs/` — plugin-internal docs, including this `testing.md`.
 - `plugins/uberdev/licenses/` — bundled upstream license texts (Anthropic, Jesse Vincent) for the verbatim/adapted components listed in the README's "Bundled" section.
+- `tests/` — the `*.test.sh` shape-check suite (see _Local testing_).
+- `docs/rfc/` — published design RFCs (everything else under `docs/` is local-only per `.gitignore`).
 
 ---
 
@@ -61,22 +66,28 @@ CI is light by design (this plugin is markdown + shell scripts, not a build pipe
 
 ## Local testing
 
-`plugins/uberdev/docs/testing.md` documents the smoke-test matrix — run it after non-trivial changes to `/solve`, `/issue`, or any skill that the spawned agents invoke.
+`plugins/uberdev/docs/testing.md` documents the `tests/*.test.sh` shape-check harness and the two-job CI matrix — read it before adding or changing a test, and run the affected tests after non-trivial changes to `/solve`, `/issue`, or any skill that the spawned agents invoke.
 
 For pure markdown / docs edits, install the plugin locally and confirm the affected command or skill loads without warning (`/plugin` → Installed → `uberdev` shows no errors).
 
 ### Running tests locally
 
-Run all shape-check tests with:
+`.github/workflows/test.yml` is the **single source of truth** for the active test set — do not maintain a hand-curated list here that can drift from it. Run the affected test directly:
 
 ```bash
-bash tests/turbo-flow.test.sh
-bash tests/issue-causal-fanout.test.sh
-bash tests/post-impl-review.test.sh
-bash tests/spec-reviewer-plan-aware.test.sh
+bash tests/<name>.test.sh
 ```
 
-These also run in CI on every push and PR (`.github/workflows/test.yml`). All four are shape-checks against prompt files — no runtime behavioral tests yet.
+…or run the whole suite the way CI does (one fixture, `solve-pipeline-zsh.test.sh`, runs under `zsh` — `tests/ci-wiring.test.sh` asserts every file on disk is wired into both CI jobs):
+
+```bash
+for t in tests/*.test.sh; do
+  echo "== $t =="
+  if [ "$t" = "tests/solve-pipeline-zsh.test.sh" ]; then zsh "$t" || exit 1; else bash "$t" || exit 1; fi
+done
+```
+
+These run in CI on every push and PR via the two-job matrix in `.github/workflows/test.yml` (`shape-checks` on `ubuntu-latest` runs the full suite; `shape-checks-windows` on `windows-latest` / Git Bash runs it minus the Unix-only runtime fixtures). Most checks are structural greps against prompt and lib files, but the suite **does** include runtime behavioral fixtures (`solve-pipeline-zsh.test.sh`, `goal.test.sh` BT84/BT85, `config-override.test.sh`) and the release-ratchet version-lock tests (`goal.test.sh` G20, `solve-claim.test.sh`) that turn CI red on a missed version bump — so don't skip the full run before a release.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.10-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.11-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/docs/rfc/0004-cross-platform-dispatch-backends.md
+++ b/docs/rfc/0004-cross-platform-dispatch-backends.md
@@ -177,13 +177,13 @@ Backend-independent — the pipeline is bash and must run under Git Bash on nati
 | `plugins/uberdev/skills/using-uberdev/SKILL.md` | MOD — document the `dispatch_backend:` config key. |
 | `tests/dispatch-claude-bg.test.sh` | MOD — re-anchor for the extract-to-`lib/dispatch.sh` move. |
 | `.github/workflows/test.yml` | MOD — add a `windows-latest` job running the suite under Git Bash. |
-| `README.md` / `CHANGELOG.md` / `.claude-plugin/marketplace.json` / `plugins/uberdev/.claude-plugin/plugin.json` | MOD — version bump `0.28.0 → 0.29.0`. |
+| `README.md` / `CHANGELOG.md` / `.claude-plugin/marketplace.json` / `plugins/uberdev/.claude-plugin/plugin.json` | MOD — version bump `0.29.0 → 0.30.0`. |
 
 **Testing strategy.** Shape-check bash tests mirroring `dispatch-claude-bg.test.sh`'s `assert_grep`/`assert_grep_not` style. `dispatch-wezterm.test.sh`: `wezterm cli spawn` + `--domain-name` present, the mux-preflight `list-clients` poll present, `.wezterm.lua` managed-block + `exit_behavior` Hold present, `claude --bg` **absent** from the wezterm arm. `dispatch-background.test.sh`: `git worktree add` + detached `claude -p` + `nohup`/`disown` + status-file writes present, `claude --bg` **absent**. `dispatch-fallback.test.sh`: the per-OS preference order, the WSL2 same-OS guard, and single-resolution (no mid-fanout switch). `.github/workflows/test.yml` gains a `windows-latest` job (`shell: bash`) — proving the shape-check harness is Git-Bash-portable; runtime dispatch validation stays out of scope (the suite is grep-and-assert throughout).
 
 ## 5. Migration / rollout
 
-Per the project `CLAUDE.md` "bump version EVERYWHERE" mandate, this is a user-facing feature → a **minor** bump `0.28.0 → 0.29.0` across all six locations: `plugin.json`, `marketplace.json`, the `README.md` badge, a `CHANGELOG.md` `## [0.29.0]` section, the git tag `v0.29.0`, and the GitHub Release.
+Per the project `CLAUDE.md` "bump version EVERYWHERE" mandate, this is a user-facing feature → a **minor** bump `0.29.0 → 0.30.0` across all six locations: `plugin.json`, `marketplace.json`, the `README.md` badge, a `CHANGELOG.md` `## [0.30.0]` section, the git tag `v0.30.0`, and the GitHub Release.
 
 **Additive and backward-compatible.** `auto` resolves to `claude-bg` on macOS, so existing macOS users see **no behaviour change**. Windows users gain working `/solve` and `/turbo`. Implementation may split into two PRs — PR1: pipeline hardening + `lib/dispatch.sh` scaffold + `claude-bg` extract + `background` backend + Windows CI; PR2: the `wezterm` backend — `write-plan` will wave-decompose.
 
@@ -218,7 +218,7 @@ None. The Windows-support strategy, the three-backend set, the fallback chain, a
 - **Risk: WezTerm cold-start race.** *Mitigation:* §3.6 mandates the `list-clients` poll before the first spawn.
 - **Risk: `background` agents are unmonitorable if PID/log files are lost.** *Mitigation:* per-issue namespaced status files; the Step 6 summary prints their paths; the worktree + branch persist regardless.
 - **Risk: Windows `claude --bg` regresses again.** *Mitigation:* it is not in the Windows `auto` chain — `background` is; `claude-bg` on Windows is opt-in only (D8).
-- **Rollback:** additive. Reverting `lib/dispatch.sh` + the SKILL.md Step 5b' hunk + the new flag restores the v0.28.0 inline `claude --bg` dispatch with zero data migration.
+- **Rollback:** additive. Reverting `lib/dispatch.sh` + the SKILL.md Step 5b' hunk + the new flag restores the v0.29.0 inline `claude --bg` dispatch with zero data migration.
 
 ## 9. Decision log
 

--- a/docs/rfc/0011-alias-install-reliability.md
+++ b/docs/rfc/0011-alias-install-reliability.md
@@ -1,11 +1,11 @@
-# RFC 0004 — Alias-Install Reliability
+# RFC 0011 — Alias-Install Reliability
 
 | Field          | Value                                                                                                                                                                                                                                       |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Status**     | Draft (2026-05-19 — awaiting implementation)                                                                                                                                                                                                 |
 | **Author**     | TheFJK                                                                                                                                                                                                                                       |
 | **Created**    | 2026-05-19                                                                                                                                                                                                                                   |
-| **Targets**    | NEW: `docs/rfc/0004-alias-install-reliability.md`. MODIFIED: `plugins/uberdev/lib/aliases-sync.sh`, `plugins/uberdev/hooks/session-start`, `tests/aliases.test.sh`, `tests/solve-claim.test.sh`, `README.md`, `CHANGELOG.md`, `.claude-plugin/marketplace.json`, `plugins/uberdev/.claude-plugin/plugin.json` |
+| **Targets**    | NEW: `docs/rfc/0011-alias-install-reliability.md`. MODIFIED: `plugins/uberdev/lib/aliases-sync.sh`, `plugins/uberdev/hooks/session-start`, `tests/aliases.test.sh`, `tests/solve-claim.test.sh`, `README.md`, `CHANGELOG.md`, `.claude-plugin/marketplace.json`, `plugins/uberdev/.claude-plugin/plugin.json` |
 | **Supersedes** | —                                                                                                                                                                                                                                            |
 | **Builds on**  | Issue #21 (auto-alias sync via the `SessionStart` hook) — this RFC hardens that mechanism, it does not replace it.                                                                                                                            |
 | **Tracking**   | none — ad-hoc design (reliability hardening, not an issue resolution)                                                                                                                                                                        |
@@ -92,7 +92,7 @@ The comment at `session-start:45-46` still enumerates only five of the seven ali
 
 | File                                          | Change                                                                                                                |
 | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `docs/rfc/0004-alias-install-reliability.md`  | NEW — this RFC.                                                                                                       |
+| `docs/rfc/0011-alias-install-reliability.md`  | NEW — this RFC.                                                                                                       |
 | `plugins/uberdev/lib/aliases-sync.sh`         | MOD — add `_aliases_read_version()`; remove the `jq` gate; build and export `UBERDEV_ALIAS_NOTICE`.                   |
 | `plugins/uberdev/hooks/session-start`         | MOD — move alias-sync above the `jq` guard; inject the notice (jq-present path); emit the constant jq-missing notice; fix the stale five-of-seven comment. |
 | `tests/aliases.test.sh`                       | MOD — new cases: version-read parity, notice composition, jq-masked install, notice surfaced on collision and on first run. |

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/docs/testing.md
+++ b/plugins/uberdev/docs/testing.md
@@ -1,303 +1,114 @@
-# Testing Superpowers Skills
+# Testing UberDev
 
-This document describes how to test Superpowers skills, particularly the integration tests for complex skills like `subagent-driven-development`.
+UberDev's product is **markdown prompt files, shell libraries, and a little Python** — there is no application server and no build step. The test suite reflects that: it is a set of **shape-check scripts** (`tests/*.test.sh`) that grep the shipped command / agent / skill / lib files for the exact tokens, contracts, and invariants each change is supposed to preserve. A few fixtures additionally *execute* a sourced `lib/` helper to lock a runtime behaviour, but the suite is grep-and-assert throughout — it never spins up a real Claude Code session.
 
-## Overview
+## The harness at a glance
 
-Testing skills that involve subagents, workflows, and complex interactions requires running actual Claude Code sessions in headless mode and verifying their behavior through session transcripts.
+- **Where:** every test lives in `tests/` and is named `<name>.test.sh`.
+- **Runner:** there is no separate runner binary — each file is self-contained and run directly with `bash tests/<name>.test.sh` (one fixture, `solve-pipeline-zsh.test.sh`, runs under `zsh` — see below).
+- **What CI runs:** `.github/workflows/test.yml` is the **single source of truth** for the active test set. Do not maintain a second hand-curated list anywhere — read `test.yml`.
+- **Shared assertion library:** `tests/_lib_assert_structural.sh` provides the section-scoped `assert_in_section` / structural helpers that many tests `source`.
 
-## Test Structure
+## Running tests locally
 
-```
-tests/
-├── claude-code/
-│   ├── test-helpers.sh                    # Shared test utilities
-│   ├── test-subagent-driven-development-integration.sh
-│   ├── analyze-token-usage.py             # Token analysis tool
-│   └── run-skill-tests.sh                 # Test runner (if exists)
-```
-
-## Running Tests
-
-### Integration Tests
-
-Integration tests execute real Claude Code sessions with actual skills:
+The canonical list of tests is whatever `.github/workflows/test.yml` runs. To run the whole suite locally the way CI does, drive it from that file rather than copying file names by hand:
 
 ```bash
-# Run the subagent-driven-development integration test
-cd tests/claude-code
-./test-subagent-driven-development-integration.sh
+# Run every tests/*.test.sh on disk (mirrors what CI gates on; needs zsh for
+# the one zsh-runtime fixture — see below).
+for t in tests/*.test.sh; do
+  echo "== $t =="
+  if [ "$t" = "tests/solve-pipeline-zsh.test.sh" ]; then
+    zsh "$t" || exit 1          # zsh-runtime fixture
+  else
+    bash "$t" || exit 1
+  fi
+done
 ```
 
-**Note:** Integration tests can take 10-30 minutes as they execute real implementation plans with multiple subagents.
-
-### Requirements
-
-- Must run from the **superpowers plugin directory** (not from temp directories)
-- Claude Code must be installed and available as `claude` command
-- Local dev marketplace must be enabled: `"superpowers@superpowers-dev": true` in `~/.claude/settings.json`
-
-## Integration Test: subagent-driven-development
-
-### What It Tests
-
-The integration test verifies the `subagent-driven-development` skill correctly:
-
-1. **Plan Loading**: Reads the plan once at the beginning
-2. **Full Task Text**: Provides complete task descriptions to subagents (doesn't make them read files)
-3. **Self-Review**: Ensures subagents perform self-review before reporting
-4. **Review Order**: Runs spec compliance review before code quality review
-5. **Review Loops**: Uses review loops when issues are found
-6. **Independent Verification**: Spec reviewer reads code independently, doesn't trust implementer reports
-
-### How It Works
-
-1. **Setup**: Creates a temporary Node.js project with a minimal implementation plan
-2. **Execution**: Runs Claude Code in headless mode with the skill
-3. **Verification**: Parses the session transcript (`.jsonl` file) to verify:
-   - Skill tool was invoked
-   - Subagents were dispatched (Task tool)
-   - TodoWrite was used for tracking
-   - Implementation files were created
-   - Tests pass
-   - Git commits show proper workflow
-4. **Token Analysis**: Shows token usage breakdown by subagent
-
-### Test Output
-
-```
-========================================
- Integration Test: subagent-driven-development
-========================================
-
-Test project: /tmp/tmp.xyz123
-
-=== Verification Tests ===
-
-Test 1: Skill tool invoked...
-  [PASS] subagent-driven-development skill was invoked
-
-Test 2: Subagents dispatched...
-  [PASS] 7 subagents dispatched
-
-Test 3: Task tracking...
-  [PASS] TodoWrite used 5 time(s)
-
-Test 6: Implementation verification...
-  [PASS] src/math.js created
-  [PASS] add function exists
-  [PASS] multiply function exists
-  [PASS] test/math.test.js created
-  [PASS] Tests pass
-
-Test 7: Git commit history...
-  [PASS] Multiple commits created (3 total)
-
-Test 8: No extra features added...
-  [PASS] No extra features added
-
-=========================================
- Token Usage Analysis
-=========================================
-
-Usage Breakdown:
-----------------------------------------------------------------------------------------------------
-Agent           Description                          Msgs      Input     Output      Cache     Cost
-----------------------------------------------------------------------------------------------------
-main            Main session (coordinator)             34         27      3,996  1,213,703 $   4.09
-3380c209        implementing Task 1: Create Add Function     1          2        787     24,989 $   0.09
-34b00fde        implementing Task 2: Create Multiply Function     1          4        644     25,114 $   0.09
-3801a732        reviewing whether an implementation matches...   1          5        703     25,742 $   0.09
-4c142934        doing a final code review...                    1          6        854     25,319 $   0.09
-5f017a42        a code reviewer. Review Task 2...               1          6        504     22,949 $   0.08
-a6b7fbe4        a code reviewer. Review Task 1...               1          6        515     22,534 $   0.08
-f15837c0        reviewing whether an implementation matches...   1          6        416     22,485 $   0.07
-----------------------------------------------------------------------------------------------------
-
-TOTALS:
-  Total messages:         41
-  Input tokens:           62
-  Output tokens:          8,419
-  Cache creation tokens:  132,742
-  Cache read tokens:      1,382,835
-
-  Total input (incl cache): 1,515,639
-  Total tokens:             1,524,058
-
-  Estimated cost: $4.67
-  (at $3/$15 per M tokens for input/output)
-
-========================================
- Test Summary
-========================================
-
-STATUS: PASSED
-```
-
-## Token Analysis Tool
-
-### Usage
-
-Analyze token usage from any Claude Code session:
+To run a single test (the normal inner-loop while editing one command or skill):
 
 ```bash
-python3 tests/claude-code/analyze-token-usage.py ~/.claude/projects/<project-dir>/<session-id>.jsonl
+bash tests/review-pr.test.sh
 ```
 
-### Finding Session Files
+The shape-checks read the files in your checkout directly, so they need no plugin install. To additionally smoke-test that an edited command or skill still *loads* in Claude Code, reinstall the local plugin (the marketplace key is `uberdev@uberdev`): `/plugin install uberdev@uberdev`, then confirm `/plugin` → Installed → `uberdev` reports no errors.
 
-Session transcripts are stored in `~/.claude/projects/` with the working directory path encoded:
+Each test prints a `PASS` / `FAIL` line per assertion and a `== Summary ==` block, and **exits non-zero if any assertion failed** — so `&&`-chaining them (as `test.yml` does) stops at the first red file.
 
-```bash
-# Example for /Users/jesse/Documents/GitHub/superpowers/superpowers
-SESSION_DIR="$HOME/.claude/projects/-Users-jesse-Documents-GitHub-superpowers-superpowers"
+### The zsh-runtime fixture
 
-# Find recent sessions
-ls -lt "$SESSION_DIR"/*.jsonl | head -5
-```
+`tests/solve-pipeline-zsh.test.sh` is run with **`zsh`**, not `bash`. SKILL.md `bash` fences execute under Claude Code's Bash tool, which is `/bin/zsh` at runtime, so this fixture locks behaviour that only manifests under zsh's word-splitting and array semantics (e.g. the v0.22.2 regression where a scalar `EFFORT_FLAG="--effort max"` broke under `SH_WORD_SPLIT=off`). `ubuntu-latest` does not ship `zsh` by default, so the CI job installs it before running the suite. Run it locally with `zsh tests/solve-pipeline-zsh.test.sh`.
 
-### What It Shows
+## What the tests check (and what they don't)
 
-- **Main session usage**: Token usage by the coordinator (you or main Claude instance)
-- **Per-subagent breakdown**: Each Task invocation with:
-  - Agent ID
-  - Description (extracted from prompt)
-  - Message count
-  - Input/output tokens
-  - Cache usage
-  - Estimated cost
-- **Totals**: Overall token usage and cost estimate
+These are **structural / contract** checks, not end-to-end behavioural tests of a running agent:
 
-### Understanding the Output
+- **Prompt-file contracts** — that a command or agent file still names every dispatch slot, every required flag, every documented argument, and every guard rail it is supposed to (e.g. `review-pr.test.sh` asserts all six Phase-1 reviewer slots are dispatched in a single message).
+- **Runtime behavioural fixtures** — a subset `source` a real `lib/` helper and assert its output. Examples: `solve-pipeline-zsh.test.sh` (zsh word-splitting), `goal.test.sh` BT84 / BT85 (goal-pipeline behaviour), `config-override.test.sh` (config precedence), `secret-scan.test.sh` (the pre-push scanner). So the suite is **not** purely static — the claim "no behavioural tests" is false.
+- **Release-ratchet version locks** — `goal.test.sh` (the `G20: version bump locked` block) and `solve-claim.test.sh` (the `Version bump A.B.C -> X.Y.Z propagated` block) hardcode the current version and **turn CI red on a missed bump**. They are part of the mandatory bump-everywhere ritual (see the project `CLAUDE.md`). A contributor who skips the full suite skips exactly the tests that catch a forgotten version bump.
+- **CI-wiring invariant** — `tests/ci-wiring.test.sh` asserts that *every* `tests/*.test.sh` on disk is wired into the workflow, so a new test that is forgotten in `test.yml` fails CI rather than silently never running.
 
-- **High cache reads**: Good - means prompt caching is working
-- **High input tokens on main**: Expected - coordinator has full context
-- **Similar costs per subagent**: Expected - each gets similar task complexity
-- **Cost per task**: Typical range is $0.05-$0.15 per subagent depending on task
+They deliberately do **not** launch real `claude` sessions, parse session transcripts, or measure token usage. UberDev ships no headless-integration runner and no token-analysis script — the suite is the `tests/*.test.sh` shape-checks and nothing else.
 
-## Troubleshooting
+## The two-job CI matrix
 
-### Skills Not Loading
+`.github/workflows/test.yml` runs on every push and pull request, with **two jobs**:
 
-**Problem**: Skill not found when running headless tests
+| Job | Runner | Shell | Scope |
+| --- | --- | --- | --- |
+| `shape-checks` | `ubuntu-latest` | `bash` (+ `zsh` installed for the one zsh fixture) | The **full** suite — every `tests/*.test.sh`. |
+| `shape-checks-windows` | `windows-latest` | Git Bash (`shell: bash`) | The full suite **minus** the Unix-only runtime fixtures Git Bash can't run reliably. |
 
-**Solutions**:
-1. Ensure you're running FROM the superpowers directory: `cd /path/to/superpowers && tests/...`
-2. Check `~/.claude/settings.json` has `"superpowers@superpowers-dev": true` in `enabledPlugins`
-3. Verify skill exists in `skills/` directory
+The Windows job exists to prove the shape-check harness is Git-Bash-portable (RFC 0004 §3.8). The Unix-only fixtures it skips (zsh, and the `python3 -c` + `mktemp -d` path-translation cases) are enumerated in the canonical **`ci-wiring windows-skip-list`** marker block inside `test.yml`. `tests/ci-wiring.test.sh` enforces that `(ubuntu − windows)` equals exactly that list — so the two jobs cannot drift.
 
-### Permission Errors
+> **When you add or remove a test file:** wire it into **both** jobs in `test.yml` by hand (and add it to the Windows skip-list block if it is a Unix-only runtime fixture). `ci-wiring.test.sh` runs first in both jobs and fails fast on any wiring drift.
 
-**Problem**: Claude blocked from writing files or accessing directories
+## Writing a new test
 
-**Solutions**:
-1. Use `--permission-mode bypassPermissions` flag
-2. Use `--add-dir /path/to/temp/dir` to grant access to test directories
-3. Check file permissions on test directories
-
-### Test Timeouts
-
-**Problem**: Test takes too long and times out
-
-**Solutions**:
-1. Increase timeout: `timeout 1800 claude ...` (30 minutes)
-2. Check for infinite loops in skill logic
-3. Review subagent task complexity
-
-### Session File Not Found
-
-**Problem**: Can't find session transcript after test run
-
-**Solutions**:
-1. Check the correct project directory in `~/.claude/projects/`
-2. Use `find ~/.claude/projects -name "*.jsonl" -mmin -60` to find recent sessions
-3. Verify test actually ran (check for errors in test output)
-
-## Writing New Integration Tests
-
-### Template
+Copy the shape of an existing test (e.g. `tests/review-pr.test.sh`). The conventions reviewers expect:
 
 ```bash
 #!/usr/bin/env bash
-set -euo pipefail
+set -u
+set -o pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-source "$SCRIPT_DIR/test-helpers.sh"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="$REPO_ROOT/plugins/uberdev/commands/your-command.md"
 
-# Create test project
-TEST_PROJECT=$(create_test_project)
-trap "cleanup_test_project $TEST_PROJECT" EXIT
+# Hard-fail (exit 2) if a required input file is missing — a moved/renamed
+# target should be an explicit failure, not silently zero assertions.
+for f in "$TARGET"; do
+  [ -r "$f" ] || { echo "FATAL: required file missing or unreadable: $f" >&2; exit 2; }
+done
 
-# Set up test files...
-cd "$TEST_PROJECT"
-
-# Run Claude with skill
-PROMPT="Your test prompt here"
-cd "$SCRIPT_DIR/../.." && timeout 1800 claude -p "$PROMPT" \
-  --allowed-tools=all \
-  --add-dir "$TEST_PROJECT" \
-  --permission-mode bypassPermissions \
-  2>&1 | tee output.txt
-
-# Find and analyze session
-WORKING_DIR_ESCAPED=$(echo "$SCRIPT_DIR/../.." | sed 's/\\//-/g' | sed 's/^-//')
-SESSION_DIR="$HOME/.claude/projects/$WORKING_DIR_ESCAPED"
-SESSION_FILE=$(find "$SESSION_DIR" -name "*.jsonl" -type f -mmin -60 | sort -r | head -1)
-
-# Verify behavior by parsing session transcript
-if grep -q '"name":"Skill".*"skill":"your-skill-name"' "$SESSION_FILE"; then
-    echo "[PASS] Skill was invoked"
-fi
-
-# Show token analysis
-python3 "$SCRIPT_DIR/analyze-token-usage.py" "$SESSION_FILE"
-```
-
-### Best Practices
-
-1. **Always cleanup**: Use trap to cleanup temp directories
-2. **Parse transcripts**: Don't grep user-facing output - parse the `.jsonl` session file
-3. **Grant permissions**: Use `--permission-mode bypassPermissions` and `--add-dir`
-4. **Run from plugin dir**: Skills only load when running from the superpowers directory
-5. **Show token usage**: Always include token analysis for cost visibility
-6. **Test real behavior**: Verify actual files created, tests passing, commits made
-
-## Session Transcript Format
-
-Session transcripts are JSONL (JSON Lines) files where each line is a JSON object representing a message or tool result.
-
-### Key Fields
-
-```json
-{
-  "type": "assistant",
-  "message": {
-    "content": [...],
-    "usage": {
-      "input_tokens": 27,
-      "output_tokens": 3996,
-      "cache_read_input_tokens": 1213703
-    }
-  }
+PASS=0; FAIL=0
+assert_grep() {           # or: source "$REPO_ROOT/tests/_lib_assert_structural.sh"
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  PASS  $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"; echo "        file: $file"; echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
 }
+
+assert_grep "$TARGET" 'some-required-token' "names the required token"
+
+echo; echo "== Summary =="; echo "  passed: $PASS"; echo "  failed: $FAIL"
+[ "$FAIL" -eq 0 ]          # non-zero exit on any failure
 ```
 
-### Tool Results
+Conventions worth honouring:
 
-```json
-{
-  "type": "user",
-  "toolUseResult": {
-    "agentId": "3380c209",
-    "usage": {
-      "input_tokens": 2,
-      "output_tokens": 787,
-      "cache_read_input_tokens": 24989
-    },
-    "prompt": "You are implementing Task 1...",
-    "content": [{"type": "text", "text": "..."}]
-  }
-}
-```
+1. **Fail loud on missing inputs.** Guard required files with an `exit 2` FATAL — a count-based test that finds zero assertions because the file moved must not report PASS.
+2. **Anchor on the real token.** If you assert on a literal string the source ships, and you later rename that token, update the test in the same change. Relax start-anchored patterns (`^foo`) to tolerate leading whitespace (`^[[:space:]]*foo`) when the matched line may be indented.
+3. **Mind the runtime shell.** SKILL.md `bash` fences run under **zsh** in production. If you are locking a runtime behaviour of a fence, prefer a `zsh`-run fixture (and add it to the zsh path in `test.yml`), because bashisms (`BASH_REMATCH`, `${!var}` indirection, `compgen`, `type -t`) misfire under zsh.
+4. **Wire it into CI.** Add the new file to **both** jobs in `.github/workflows/test.yml`; `ci-wiring.test.sh` will otherwise fail.
 
-The `agentId` field links to subagent sessions, and the `usage` field contains token usage for that specific subagent invocation.
+## See also
+
+- `.github/workflows/test.yml` — the authoritative test set and the two-job matrix.
+- `tests/ci-wiring.test.sh` — the wiring invariant that keeps the workflow and the on-disk test set in sync.
+- `tests/_lib_assert_structural.sh` — shared section-scoped assertion helpers.
+- The project `CLAUDE.md` — the bump-version-everywhere ritual the version-lock tests enforce.

--- a/plugins/uberdev/hooks/session-start
+++ b/plugins/uberdev/hooks/session-start
@@ -7,11 +7,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-# ── auto-alias sync (issue #21; RFC 0004) ────────────────────────────
+# ── auto-alias sync (issue #21; RFC 0011) ────────────────────────────
 # Install / refresh the seven top-level forwarders (/issue, /solve, /turbo,
 # /simplify, /review-pr, /merge, /dev) in ~/.claude/commands. This runs
 # BEFORE the jq guard below on purpose: alias sync has no jq dependency
-# (RFC 0004), so a machine without jq still gets its aliases. Idempotent:
+# (RFC 0011), so a machine without jq still gets its aliases. Idempotent:
 # if installed_version == plugin_version the helper returns immediately.
 # Opt out with UBERDEV_NO_AUTO_ALIAS=1 or `auto_install_aliases: false` in
 # .claude/uberdev.local.md. The helper handles all error paths internally

--- a/plugins/uberdev/lib/aliases-sync.sh
+++ b/plugins/uberdev/lib/aliases-sync.sh
@@ -103,7 +103,7 @@ _aliases_check_marker() {
 # top-level one; this is safe because the manifest is the plugin's own
 # shipped, controlled file, where `"version": "x.y.z"` sits on a single
 # top-level line. Prints nothing on any failure; the caller treats an empty
-# result as "version undeterminable" and fails open (RFC 0004).
+# result as "version undeterminable" and fails open (RFC 0011).
 _aliases_read_version() {
   local file="$1"
   [ -r "$file" ] || return 0
@@ -143,7 +143,7 @@ aliases_sync_main() {
   local DEST_DIR="$HOME/.claude/commands"
   local MARKER="$HOME/.claude/.uberdev-aliases-version"
   local VERSION INSTALLED FIRST_RUN
-  # jq-free read of the plugin's own manifest version (RFC 0004) — alias
+  # jq-free read of the plugin's own manifest version (RFC 0011) — alias
   # sync has no external dependency, so it works without jq on PATH.
   VERSION="$(_aliases_read_version "$PLUGIN_ROOT_LOCAL/.claude-plugin/plugin.json")"
   [ -n "$VERSION" ] || return 0
@@ -222,7 +222,7 @@ aliases_sync_main() {
     echo "first run: installed ${#INSTALLED_LIST[@]} aliases, skipped ${#SKIPPED_LIST[@]} conflicts (${skipped_str})${failed_str}; opt out with UBERDEV_NO_AUTO_ALIAS=1" >&2
   fi
 
-  # 8. User-facing notice (RFC 0004) — consumed by the SessionStart hook and
+  # 8. User-facing notice (RFC 0011) — consumed by the SessionStart hook and
   # injected into the session context. Reached only when the per-alias loop
   # ran (first install or a version refresh); the idempotency early-return at
   # step 3 means a steady-state session never gets here, so the notice is

--- a/tests/docs-accuracy.test.sh
+++ b/tests/docs-accuracy.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Guard against the documentation-drift class fixed in issue #273:
+#   1. plugins/uberdev/docs/testing.md must describe the REAL harness
+#      (tests/*.test.sh shape-checks + test.yml two-job matrix; marketplace key
+#      uberdev@uberdev) — not verbatim upstream Superpowers (tests/claude-code/,
+#      test-helpers.sh, analyze-token-usage.py, run-skill-tests.sh,
+#      superpowers@superpowers-dev, "run FROM the superpowers directory").
+#   2. CONTRIBUTING.md must not carry the dead [Repo layout](README.md#repo-layout)
+#      link (README has no such anchor) nor the false "no behavioral tests" claim,
+#      and must point at .github/workflows/test.yml as the test-set SSOT.
+#   3. docs/rfc/ must have NO duplicate RFC numbers (the 0004 collision: the
+#      alias RFC was renumbered to 0011; the dispatch RFC keeps 0004).
+#   4. The dispatch RFC (0004) §4/§5 version refs must agree with its Status
+#      line + the CHANGELOG: target v0.30.0, not v0.29.0.
+#   5. The alias-RFC cross-refs in hooks/session-start + lib/aliases-sync.sh must
+#      point at RFC 0011, and no stale 0004-alias-install path ref may survive.
+#
+# These are structural greps over the shipped docs/shell files — they exercise
+# the source bytes, not a running session. Every assertion below FAILS on the
+# pre-#273 tree and PASSES after the fix.
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TESTING_MD="$REPO_ROOT/plugins/uberdev/docs/testing.md"
+CONTRIBUTING_MD="$REPO_ROOT/CONTRIBUTING.md"
+RFC_DIR="$REPO_ROOT/docs/rfc"
+DISPATCH_RFC="$RFC_DIR/0004-cross-platform-dispatch-backends.md"
+ALIAS_RFC="$RFC_DIR/0011-alias-install-reliability.md"
+SESSION_START="$REPO_ROOT/plugins/uberdev/hooks/session-start"
+ALIASES_SYNC="$REPO_ROOT/plugins/uberdev/lib/aliases-sync.sh"
+TEST_YML="$REPO_ROOT/.github/workflows/test.yml"
+
+# Hard-fail (exit 2) on a missing input — a moved/renamed file must be an
+# explicit failure, never silently-zero-assertions PASS.
+for f in "$TESTING_MD" "$CONTRIBUTING_MD" "$DISPATCH_RFC" "$ALIAS_RFC" \
+         "$SESSION_START" "$ALIASES_SYNC" "$TEST_YML"; do
+  [ -r "$f" ] || { echo "FATAL: required file missing or unreadable: $f" >&2; exit 2; }
+done
+
+PASS=0
+FAIL=0
+
+# Assert a regex IS present in a file.
+assert_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  PASS  $desc"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"; echo "        file: $file"; echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Assert a fixed string is ABSENT from a file (grep -F: literal, no regex).
+assert_absent_fixed() {
+  local file="$1" needle="$2" desc="$3"
+  if grep -qF -e "$needle" "$file"; then
+    echo "  FAIL  $desc"; echo "        file: $file"; echo "        unexpected literal: $needle"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  $desc"; PASS=$((PASS + 1))
+  fi
+}
+
+echo "== testing.md describes the REAL harness, not vendored Superpowers =="
+# Vendored-upstream tokens that must NOT survive (the whole pre-#273 file).
+assert_absent_fixed "$TESTING_MD" "tests/claude-code/"        "T1.1 testing.md drops the upstream tests/claude-code/ path"
+assert_absent_fixed "$TESTING_MD" "test-helpers.sh"           "T1.2 testing.md drops upstream test-helpers.sh"
+assert_absent_fixed "$TESTING_MD" "analyze-token-usage.py"    "T1.3 testing.md drops upstream analyze-token-usage.py"
+assert_absent_fixed "$TESTING_MD" "run-skill-tests.sh"        "T1.4 testing.md drops upstream run-skill-tests.sh"
+assert_absent_fixed "$TESTING_MD" "superpowers@superpowers-dev" "T1.5 testing.md drops upstream superpowers@superpowers-dev marketplace key"
+# Case-insensitive: kill any 'superpowers directory' instruction in any casing.
+if grep -qiE 'superpowers (plugin )?directory' "$TESTING_MD"; then
+  echo "  FAIL  T1.6 testing.md drops the 'run FROM the superpowers directory' instruction"
+  echo "        file: $TESTING_MD"; FAIL=$((FAIL + 1))
+else
+  echo "  PASS  T1.6 testing.md drops the 'run FROM the superpowers directory' instruction"; PASS=$((PASS + 1))
+fi
+# Real harness IS described.
+assert_grep "$TESTING_MD" 'tests/\*\.test\.sh'              "T1.7 testing.md names the real tests/*.test.sh shape-checks"
+assert_grep "$TESTING_MD" '\.github/workflows/test\.yml'    "T1.8 testing.md points at .github/workflows/test.yml"
+assert_grep "$TESTING_MD" 'uberdev@uberdev'                 "T1.9 testing.md uses the real uberdev@uberdev marketplace key"
+assert_grep "$TESTING_MD" 'shape-checks-windows|two-job|windows-latest' "T1.10 testing.md documents the two-job CI matrix"
+assert_grep "$TESTING_MD" 'solve-pipeline-zsh\.test\.sh'    "T1.11 testing.md names the zsh-runtime fixture"
+
+echo
+echo "== CONTRIBUTING.md: no dead link, no false claim, test.yml is SSOT =="
+assert_absent_fixed "$CONTRIBUTING_MD" "README.md#repo-layout" "T2.1 CONTRIBUTING drops the dead README.md#repo-layout link"
+# The false 'no runtime behavioral tests' sentence must be gone.
+if grep -qiE 'no runtime behavioral tests' "$CONTRIBUTING_MD"; then
+  echo "  FAIL  T2.2 CONTRIBUTING drops the false 'no runtime behavioral tests' sentence"
+  echo "        file: $CONTRIBUTING_MD"; FAIL=$((FAIL + 1))
+else
+  echo "  PASS  T2.2 CONTRIBUTING drops the false 'no runtime behavioral tests' sentence"; PASS=$((PASS + 1))
+fi
+assert_grep "$CONTRIBUTING_MD" '\.github/workflows/test\.yml' "T2.3 CONTRIBUTING points at test.yml"
+assert_grep "$CONTRIBUTING_MD" 'single source of truth|source of truth' "T2.4 CONTRIBUTING frames test.yml as the test-set SSOT"
+
+echo
+echo "== docs/rfc/: no duplicate RFC numbers =="
+# Extract the leading 4-digit number from every docs/rfc/NNNN-*.md filename and
+# assert each appears exactly once. Catches the 0004 collision (and any future
+# one) dynamically, without hardcoding the current RFC set.
+DUP_NUMS="$(
+  for f in "$RFC_DIR"/[0-9][0-9][0-9][0-9]-*.md; do
+    [ -e "$f" ] || continue
+    base="$(basename "$f")"
+    echo "${base%%-*}"
+  done | sort | uniq -d
+)"
+if [ -n "$DUP_NUMS" ]; then
+  echo "  FAIL  T3.1 every docs/rfc/ number is unique"
+  echo "        duplicate RFC number(s): $(echo "$DUP_NUMS" | tr '\n' ' ')"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS  T3.1 every docs/rfc/ number is unique (no NNNN collision)"; PASS=$((PASS + 1))
+fi
+# The renumbered alias RFC exists at 0011 and self-identifies as RFC 0011.
+assert_grep "$ALIAS_RFC" '^# RFC 0011 — Alias-Install Reliability' "T3.2 alias RFC header self-identifies as RFC 0011"
+# The dispatch RFC keeps 0004.
+assert_grep "$DISPATCH_RFC" '^# RFC 0004 — Cross-Platform Dispatch' "T3.3 dispatch RFC keeps RFC 0004 header"
+
+echo
+echo "== dispatch RFC 0004: internal version refs agree on v0.30.0 =="
+# Status line is the anchor of truth (already v0.30.0); §4/§5 must match it.
+assert_grep "$DISPATCH_RFC" 'Status.*Implemented — v0\.30\.0' "T4.1 dispatch RFC Status is v0.30.0"
+# NOTE: the RFC uses a multibyte UTF-8 arrow (U+2192) between versions. Match
+# it with `.*` (not a single `.`) so the pattern holds in a C/POSIX locale too
+# (where `.` is one byte and the arrow is three) — env -i / Git Bash safe.
+assert_grep "$DISPATCH_RFC" 'version bump .0\.29\.0.*0\.30\.0' "T4.2 §4 File-impact bump reads 0.29.0 -> 0.30.0"
+assert_grep "$DISPATCH_RFC" 'CHANGELOG\.md.*## \[0\.30\.0\].*section' "T4.3 §5 Migration cites the [0.30.0] CHANGELOG section"
+assert_grep "$DISPATCH_RFC" 'git tag .v0\.30\.0' "T4.4 §5 Migration cites tag v0.30.0"
+# The wrong target version must be gone from §4/§5 (the contradiction). A bare
+# 0.28.0/0.29.0 as the bump TARGET '-> 0.29.0' or tag 'v0.29.0' must not survive.
+if grep -qE '0\.28\.0.*0\.29\.0|## \[0\.29\.0\] section|git tag .v0\.29\.0' "$DISPATCH_RFC"; then
+  echo "  FAIL  T4.5 dispatch RFC carries no stale 0.28.0->0.29.0 / v0.29.0 target refs"
+  echo "        file: $DISPATCH_RFC"; FAIL=$((FAIL + 1))
+else
+  echo "  PASS  T4.5 dispatch RFC carries no stale 0.28.0->0.29.0 / v0.29.0 target refs"; PASS=$((PASS + 1))
+fi
+
+echo
+echo "== alias-RFC cross-refs repointed to RFC 0011; no stale 0004-alias path =="
+assert_grep "$SESSION_START" 'RFC 0011' "T5.1 hooks/session-start cites RFC 0011"
+assert_grep "$ALIASES_SYNC"  'RFC 0011' "T5.2 lib/aliases-sync.sh cites RFC 0011"
+# The cross-ref files must no longer cite the alias work as 'RFC 0004' (the
+# dispatch RFC owns 0004; neither of these two files references dispatch).
+assert_absent_fixed "$SESSION_START" "RFC 0004" "T5.3 hooks/session-start no longer cites the (dispatch-owned) RFC 0004"
+assert_absent_fixed "$ALIASES_SYNC"  "RFC 0004" "T5.4 lib/aliases-sync.sh no longer cites the (dispatch-owned) RFC 0004"
+# No surviving path reference to the old alias-RFC filename anywhere in the two
+# cross-ref files or the renamed RFC itself.
+for f in "$SESSION_START" "$ALIASES_SYNC" "$ALIAS_RFC"; do
+  assert_absent_fixed "$f" "0004-alias-install-reliability" "T5.5 no stale 0004-alias-install-reliability path in $(basename "$f")"
+done
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[ "$FAIL" -eq 0 ]

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -300,8 +300,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.10) =="
-assert_version_bump "$REPO_ROOT" "0.35.10"
+echo "== G20: version bump locked (0.35.11) =="
+assert_version_bump "$REPO_ROOT" "0.35.11"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.9 -> 0.35.10 propagated =="
-assert_version_bump "$REPO_ROOT" "0.35.10"
+echo "== Version bump 0.35.10 -> 0.35.11 propagated =="
+assert_version_bump "$REPO_ROOT" "0.35.11"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
Fixes #273 (**major / docs accuracy**).

## Fixed
- **`testing.md`** rewritten from verbatim-upstream Superpowers (referenced `tests/claude-code/`, `run-skill-tests.sh`, `superpowers@superpowers-dev` — none exist here) to the real `tests/*.test.sh` shape-check harness + the `test.yml` two-job (ubuntu/windows) matrix; marketplace key `uberdev@uberdev`.
- **`CONTRIBUTING.md`** now points at `test.yml` as the test-suite SSOT (drops the false "no behavioral tests yet" line + the partial 4-file list); dead `[Repo layout](README.md#repo-layout)` link fixed.
- **RFC 0004 number collision** resolved: the alias-reliability draft renumbered to **RFC 0011** (the dispatch-backends RFC keeps 0004 — shipped code + CHANGELOG cite it); cross-refs updated in `hooks/session-start`, `lib/aliases-sync.sh`, and the CHANGELOG (dead `0004-alias-install-reliability.md` link repointed to `0011-`). Dispatch RFC §4/§5 internal version refs corrected to `0.29.0 → 0.30.0`.

## Tests
- New `tests/docs-accuracy.test.sh` (30 assertions; fail-loud on missing inputs; dynamic duplicate-RFC-number detection) — guards against re-vendoring, the dead README link, and RFC-number collisions. Portable grep — **wired into both CI jobs** (orchestrator-owned shared-surface step; the reviewer's sole blocker).

Independently reviewed: content APPROVE; the one blocker (new test unwired) is resolved here by the test.yml wiring. Version bumped to **0.35.11**.

Closes #273