### PR TITLE
fix(hooks): cross-platform run-hook.cmd arg forwarding + portable ANSI strip (#274)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.11",
+      "version": "0.35.12",
       "category": "workflow",
       "tags": [
         "github",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
           bash tests/solve-effort-flag.test.sh && \
           zsh tests/solve-pipeline-zsh.test.sh && \
           zsh tests/goal-state-zsh.test.sh && \
+          bash tests/crossplatform-shell-wrappers.test.sh && \
           bash tests/docs-accuracy.test.sh && \
           bash tests/orchestrator-phase1-shortcircuit.test.sh && \
           bash tests/config-override.test.sh && \
@@ -189,6 +190,7 @@ jobs:
           bash tests/turbo-flow.test.sh && \
           bash tests/issue-causal-fanout.test.sh && \
           bash tests/post-impl-review.test.sh && \
+          bash tests/crossplatform-shell-wrappers.test.sh && \
           bash tests/docs-accuracy.test.sh && \
           bash tests/spec-reviewer-plan-aware.test.sh && \
           bash tests/audit-fixups.test.sh && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.12] — 2026-05-29
+
+### Fixed
+- **Cross-platform shell portability — `run-hook.cmd` Windows args + GNU-sed `probe` dependency** (#274). The Windows `cmd.exe` arm of `plugins/uberdev/hooks/run-hook.cmd` forwarded args as bare `%2 %3 … %9` (re-splitting spaced/quoted args, capping at 8 trailing args), asymmetric with the Unix arm's `exec bash … "$@"`; it now uses a `SHIFT`-based `goto` loop accumulating `HOOK_ARGS` with quoting, mirroring the `"$@"` contract (the `: << 'CMDBLOCK'` polyglot heredoc stays balanced under both `bash -n` and `zsh -n`). `tests/manual/probe-prompt-file-slash-expansion.sh` used GNU-sed-only `\x1B` in its ANSI strip (treated literally by BSD/macOS sed → escapes survive → empty `SESSION_ID` → spurious `INDETERMINATE`); replaced with a portable `tr -d '\033'` + POSIX-sed strip.
+
+### Tests
+- New `tests/crossplatform-shell-wrappers.test.sh` (21 assertions): structural asserts the broken forms are gone + portable forms present, a POSIX model of the `cmd` SHIFT-loop proving 8/11/spaced-arg forwarding, a `bash -n`/`zsh -n` heredoc-balance check (the `zsh -n` arm self-skips when zsh is absent — Windows-safe), and a platform-independent ANSI-strip regression kernel. Reds pre-fix (8 fails), greens post-fix (21/21). Portable — wired into both CI jobs.
+
 ## [0.35.11] — 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.11-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.12-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.11",
+  "version": "0.35.12",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/hooks/run-hook.cmd
+++ b/plugins/uberdev/hooks/run-hook.cmd
@@ -16,21 +16,38 @@ if "%~1"=="" (
 )
 
 set "HOOK_DIR=%~dp0"
+set "HOOK_SCRIPT=%~1"
 
+REM Forward every argument after the script name to bash, mirroring the Unix
+REM arm's `exec bash ... "$@"` contract. The bare `%2 %3 ... %9` form was wrong
+REM twice over: it dropped any 10th+ argument and re-split/mis-quoted args that
+REM contain spaces. SHIFT past %1 (the script name) and accumulate the rest as
+REM individually de-quoted-then-re-quoted tokens so each survives as one arg.
+REM A goto-loop (not a parenthesised block) reads %HOOK_ARGS% fresh each pass,
+REM so no delayed expansion is needed.
+set "HOOK_ARGS="
+shift
+:collect_hook_args
+if "%~1"=="" goto run_hook
+set HOOK_ARGS=%HOOK_ARGS% "%~1"
+shift
+goto collect_hook_args
+
+:run_hook
 REM Try Git for Windows bash in standard locations
 if exist "C:\Program Files\Git\bin\bash.exe" (
-    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%HOOK_SCRIPT%"%HOOK_ARGS%
     exit /b %ERRORLEVEL%
 )
 if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
-    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%HOOK_SCRIPT%"%HOOK_ARGS%
     exit /b %ERRORLEVEL%
 )
 
 REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
 where bash >nul 2>nul
 if %ERRORLEVEL% equ 0 (
-    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    bash "%HOOK_DIR%%HOOK_SCRIPT%"%HOOK_ARGS%
     exit /b %ERRORLEVEL%
 )
 

--- a/tests/crossplatform-shell-wrappers.test.sh
+++ b/tests/crossplatform-shell-wrappers.test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Shape + mechanism checks for the two cross-platform shell-portability fixes
+# in issue #274 (disjoint file-set, one PR):
+#
+#   1. plugins/uberdev/hooks/run-hook.cmd — the Windows cmd.exe arm must forward
+#      args via a SHIFT-based loop (mirroring the Unix `exec bash … "$@"`),
+#      NOT the bare `%2 %3 … %9` form that capped at 8 args and re-split spaced
+#      ones. We assert the broken form is gone, the SHIFT-loop is present, the
+#      Unix arm still uses "$@", AND we model the cmd SHIFT-loop to prove it
+#      forwards 11 args (incl. a spaced one) intact.
+#
+#   2. tests/manual/probe-prompt-file-slash-expansion.sh — the ANSI-strip must
+#      remove ESC bytes portably (`tr -d '\033'`), NOT via GNU sed's `\x1B`
+#      escape, which BSD/macOS sed historically treats as the literal chars
+#      `x1B`, leaving the escapes in place → empty SESSION_ID → spurious
+#      INDETERMINATE/exit-3 on the macOS operator. We assert the GNU-only form
+#      is gone, the portable `tr` strip is present, prove the live pipeline
+#      extracts a non-empty id, and prove (deterministically, on any platform)
+#      that a literal-\x strip mis-extracts while the tr-based strip succeeds.
+#
+# Portable grep-and-assert + runtime model — runs green on ubuntu (GNU sed),
+# windows-latest Git Bash (GNU sed), and macOS (BSD sed) alike.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUN_HOOK_CMD="$REPO_ROOT/plugins/uberdev/hooks/run-hook.cmd"
+PROBE="$REPO_ROOT/tests/manual/probe-prompt-file-slash-expansion.sh"
+
+PASS=0
+FAIL=0
+
+assert_grep() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        pattern: $pattern"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_grep_not() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE -e "$pattern" "$file"; then
+    echo "  FAIL  $desc"
+    echo "        pattern (must NOT appear): $pattern"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_eq() {
+  local got="$1" want="$2" desc="$3"
+  if [ "$got" = "$want" ]; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc (got '$got', want '$want')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_nonempty() {
+  local got="$1" desc="$2"
+  if [ -n "$got" ]; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc (got empty)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "== run-hook.cmd: Windows arg-forwarding mirrors the Unix \"\$@\" contract =="
+
+# The broken bare-arg form must be gone from EVERY bash-invocation arm.
+assert_grep_not "$RUN_HOOK_CMD" \
+  '%2 %3 %4 %5 %6 %7 %8 %9' \
+  "broken bare '%2 %3 … %9' arg-forwarding form is removed (no 8-arg cap, no re-split)"
+
+# A SHIFT-based accumulation loop must be present.
+assert_grep "$RUN_HOOK_CMD" \
+  '^shift$' \
+  "cmd arm SHIFTs past the script name (%1) before accumulating the rest"
+assert_grep "$RUN_HOOK_CMD" \
+  '^:collect_hook_args$' \
+  "cmd arm has a goto-loop label to accumulate remaining args"
+assert_grep "$RUN_HOOK_CMD" \
+  'set HOOK_ARGS=%HOOK_ARGS% "%~1"' \
+  "each forwarded arg is de-quoted then re-quoted (survives spaces as one token)"
+assert_grep "$RUN_HOOK_CMD" \
+  'bash.exe" "%HOOK_DIR%%HOOK_SCRIPT%"%HOOK_ARGS%' \
+  "Git-for-Windows arm forwards the accumulated %HOOK_ARGS%"
+assert_grep "$RUN_HOOK_CMD" \
+  '^    bash "%HOOK_DIR%%HOOK_SCRIPT%"%HOOK_ARGS%$' \
+  "PATH-bash arm forwards the accumulated %HOOK_ARGS%"
+
+# The Unix arm must still use the symmetric "$@" contract (regression guard).
+assert_grep "$RUN_HOOK_CMD" \
+  'exec bash "\$\{SCRIPT_DIR\}/\$\{SCRIPT_NAME\}" "\$@"' \
+  "Unix arm still forwards all args via \"\$@\""
+
+# The polyglot heredoc must stay balanced and parse as a valid shell script
+# under both bash and zsh (hooks are invoked through this wrapper at runtime).
+if bash -n "$RUN_HOOK_CMD" 2>/dev/null; then
+  echo "  PASS  run-hook.cmd parses under bash -n (heredoc balanced)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  run-hook.cmd fails bash -n (heredoc unbalanced / Unix arm broken)"
+  FAIL=$((FAIL + 1))
+fi
+if command -v zsh >/dev/null 2>&1; then
+  if zsh -n "$RUN_HOOK_CMD" 2>/dev/null; then
+    echo "  PASS  run-hook.cmd parses under zsh -n"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  run-hook.cmd fails zsh -n"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "  SKIP  zsh -n (zsh not on PATH)"
+fi
+
+echo
+echo "== run-hook.cmd: model the cmd SHIFT-loop, prove N-arg + spaced forwarding =="
+# Faithful POSIX model of the run-hook.cmd loop semantics:
+#   set HOOK_SCRIPT=%~1 ; shift ; while %~1 nonempty: HOOK_ARGS+= " "%~1"" ; shift
+# cmd `%~1` strips one layer of surrounding quotes; we pass already-bare argv and
+# re-quote each token exactly as the .cmd does. The forwarded command line must
+# match what the Unix `"$@"` arm would produce.
+model_cmd_forward() {
+  local script="$1"; shift
+  local hook_args=""
+  while [ "$#" -gt 0 ]; do
+    hook_args="$hook_args \"$1\""
+    shift
+  done
+  printf '%s' "bash \"DIR/$script\"$hook_args"
+}
+
+assert_eq "$(model_cmd_forward session-start)" \
+          'bash "DIR/session-start"' \
+          "0 extra args -> no trailing args (today's real single-token hook usage)"
+assert_eq "$(model_cmd_forward myhook a1 a2 a3 a4 a5 a6 a7 a8)" \
+          'bash "DIR/myhook" "a1" "a2" "a3" "a4" "a5" "a6" "a7" "a8"' \
+          "8 extra args all forwarded (old %9-cap boundary)"
+assert_eq "$(model_cmd_forward myhook a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11)" \
+          'bash "DIR/myhook" "a1" "a2" "a3" "a4" "a5" "a6" "a7" "a8" "a9" "a10" "a11"' \
+          "11 extra args forwarded (old bare form would silently DROP a10/a11)"
+assert_eq "$(model_cmd_forward myhook one "two words" three)" \
+          'bash "DIR/myhook" "one" "two words" "three"' \
+          "spaced arg survives as ONE token (old bare %N would re-split it)"
+
+echo
+echo "== probe: ANSI-strip is portable (tr -d '\\033'), not the GNU-only sed \\x1B =="
+
+# The GNU-only `\x1B` sed escape must be gone from the probe's STRIP PIPELINE.
+# Match only active pipeline-continuation lines (leading-whitespace `| …`), so a
+# `\x1B` mention inside the explanatory comment cannot mask a real regression.
+assert_grep_not "$PROBE" \
+  "^[[:space:]]*\| sed -E 's/.x1B" \
+  "GNU-only 'sed -E s/\\x1B…' ANSI-strip pipeline stage is removed"
+# The portable ESC-byte strip must be present as a pipeline stage. The source
+# text is `tr -d '\033'` — backslash (one char) then literal 033.
+assert_grep "$PROBE" \
+  "^[[:space:]]*\| tr -d '.033'" \
+  "portable 'tr -d \\033' ESC-byte strip pipeline stage is present"
+# The residual CSI body is stripped by a POSIX sed matching only a literal '['.
+assert_grep "$PROBE" \
+  "^[[:space:]]*\| sed -E 's/.\[\[0-9;\]\*\[a-zA-Z\]//g'" \
+  "residual CSI body stripped by POSIX sed pipeline stage (literal '[' only, no \\xHH escape)"
+
+echo
+echo "== probe: live + deterministic mechanism proof =="
+
+# Build a realistic ANSI-decorated `claude --bg` launch banner. \xc2\xb7 is the
+# UTF-8 middle dot '·'; \033[36m / \033[39m are SGR colour codes around the id.
+probe_out="$(printf 'Launching agent...\nbackgrounded \xc2\xb7 \033[36ma1b2c3d4\033[39m\n')"
+
+# (1) The FIXED pipeline (exactly as in the probe) extracts a non-empty id on
+#     the live platform's sed, BSD or GNU.
+sid_fixed="$(printf '%s\n' "$probe_out" \
+  | tr -d '\033' \
+  | sed -E 's/\[[0-9;]*[a-zA-Z]//g' \
+  | awk '/backgrounded · [0-9a-f]{8}/ { print $3; exit }')"
+assert_nonempty "$sid_fixed" "fixed tr-based pipeline yields non-empty SESSION_ID on live sed"
+assert_eq "$sid_fixed" "a1b2c3d4" "fixed tr-based pipeline extracts the correct 8-hex id"
+
+# (2) Deterministic, platform-independent regression kernel: when the ANSI strip
+#     treats `\x` as a LITERAL backslash-x (old BSD-sed semantics), the ESC
+#     bytes survive and the awk $3 mis-extracts. We force that semantics on ANY
+#     sed by DOUBLING the backslash (`\\x1B`) so even a \xHH-aware sed sees the
+#     literal token — reproducing the pre-fix failure mode deterministically.
+sid_literal_x="$(printf '%s\n' "$probe_out" \
+  | sed -E 's/\\x1B\[[0-9;]*[a-zA-Z]//g' \
+  | awk '/backgrounded · [0-9a-f]{8}/ { print $3; exit }')"
+if [ "$sid_literal_x" != "a1b2c3d4" ]; then
+  echo "  PASS  literal-\\x strip mis-extracts (got '${sid_literal_x:-<empty>}') — the pre-fix bug, now avoided"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  literal-\\x strip unexpectedly succeeded — regression kernel is not exercising the bug"
+  FAIL=$((FAIL + 1))
+fi
+
+# (3) `tr -d '\033'` removes ESC bytes unconditionally (the portability anchor):
+#     ESC-byte count must drop to zero regardless of sed.
+esc_before="$(printf '%s' "$probe_out" | LC_ALL=C tr -cd '\033' | wc -c | tr -d ' ')"
+esc_after="$(printf '%s' "$probe_out" | tr -d '\033' | LC_ALL=C tr -cd '\033' | wc -c | tr -d ' ')"
+assert_eq "$esc_before" "2" "fixture carries 2 ESC bytes pre-strip"
+assert_eq "$esc_after" "0" "tr -d '\\033' removes all ESC bytes (platform-independent)"
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+
+[ "$FAIL" -eq 0 ]

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -300,8 +300,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.11) =="
-assert_version_bump "$REPO_ROOT" "0.35.11"
+echo "== G20: version bump locked (0.35.12) =="
+assert_version_bump "$REPO_ROOT" "0.35.12"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/manual/probe-prompt-file-slash-expansion.sh
+++ b/tests/manual/probe-prompt-file-slash-expansion.sh
@@ -75,8 +75,17 @@ probe_out="$(claude --bg --prompt-file "$PROBE_FILE" 2>&1)" || {
   write_verdict INDETERMINATE; exit 3;
 }
 
+# ANSI-strip portably. The previous `sed -E 's/\x1B\[…//g'` relied on GNU sed's
+# `\xHH` escape, which BSD/macOS sed treats as the literal chars `x1B` — the ESC
+# (0x1B) bytes then survived into the awk extraction, yielding an empty
+# SESSION_ID and a spurious INDETERMINATE/exit-3 on the macOS operator's box.
+# `tr -d '\033'` removes the ESC control byte on every platform (octal escape is
+# POSIX tr); the residual CSI body (`[<params><final>`) is then stripped with a
+# POSIX-portable sed that matches only literal `[`. Mirrors the canonical
+# ANSI-strip contract in lib/dispatch.sh without the GNU-only escape.
 SESSION_ID="$(printf '%s\n' "$probe_out" \
-  | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g' \
+  | tr -d '\033' \
+  | sed -E 's/\[[0-9;]*[a-zA-Z]//g' \
   | awk '/backgrounded · [0-9a-f]{8}/ { print $3; exit }')"
 if [[ -z "$SESSION_ID" ]]; then
   write_verdict INDETERMINATE; exit 3

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.10 -> 0.35.11 propagated =="
-assert_version_bump "$REPO_ROOT" "0.35.11"
+echo "== Version bump 0.35.11 -> 0.35.12 propagated =="
+assert_version_bump "$REPO_ROOT" "0.35.12"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
Fixes #274 (**major**). Two cross-platform shell-portability defects.

## Fixed
- **`hooks/run-hook.cmd`** — the Windows `cmd.exe` arm forwarded args as bare `%2 %3 … %9` (re-split spaced/quoted args, capped at 8), asymmetric with the Unix arm's `exec bash … "$@"`. Now a `SHIFT`-based `goto` loop accumulates `HOOK_ARGS` with quoting, mirroring the `"$@"` contract; the `: << 'CMDBLOCK'` polyglot heredoc stays balanced (`bash -n` + `zsh -n` clean).
- **`tests/manual/probe-prompt-file-slash-expansion.sh`** — ANSI strip used GNU-sed-only `\x1B` (literal no-op on BSD/macOS sed → escapes survive → empty `SESSION_ID` → spurious `INDETERMINATE`). Replaced with portable `tr -d '\033'` + POSIX sed.

## Tests
- New `tests/crossplatform-shell-wrappers.test.sh` (21 assertions): broken-form-gone + portable-form-present greps, a POSIX model of the `cmd` SHIFT-loop (8/11/spaced-arg forwarding), a `bash -n`/`zsh -n` heredoc-balance check (the `zsh -n` arm self-skips when zsh is absent → Windows-safe), and a platform-independent ANSI-strip regression kernel. **Reds pre-fix (8 fails), greens post-fix (21/21).** Portable grep — **wired into both CI jobs**.

Independently reviewed: fixes APPROVE; the one blocker (new test unwired) resolved here. Version bumped to **0.35.12**.

Closes #274