### PR TITLE
test: fail-loud count asserts — no missing-file/crash masking (#275)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.12",
+      "version": "0.35.13",
       "category": "workflow",
       "tags": [
         "github",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
           bash tests/solve-effort-flag.test.sh && \
           zsh tests/solve-pipeline-zsh.test.sh && \
           zsh tests/goal-state-zsh.test.sh && \
+          bash tests/lib-assert-count.test.sh && \
           bash tests/crossplatform-shell-wrappers.test.sh && \
           bash tests/docs-accuracy.test.sh && \
           bash tests/orchestrator-phase1-shortcircuit.test.sh && \
@@ -184,6 +185,7 @@ jobs:
         #   - uberthink-report.test.sh
         #   - merge-discovery-resilience.test.sh
         #   - review-pr-phase3-ci.test.sh
+        #   - lib-assert-count.test.sh
         # === END ci-wiring windows-skip-list ===
         run: |
           bash tests/ci-wiring.test.sh && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.13] — 2026-05-29
+
+### Fixed
+- **Test count idioms no longer mask a missing file / tool crash as a passing `0`** (#275). The repo-blacklisted `… | grep -cE … || true` / `… 2>/dev/null || echo 0` idiom collapses three outcomes into one passing `0` — a legitimate zero-count, a missing/unreadable file, and a tool crash. `tests/_lib_assert_structural.sh` `assert_count` (the SSOT helper sourced by 14 test files) now fail-loud-preflights `[ -r "$file" ]` and captures `awk`'s exit status on a separate statement (an `awk` crash FAILs; only `grep` rc ≥ 2 is treated as an error, so a legitimate zero-match on a present file still PASSES). `tests/uberthink.test.sh` (U11) drops the `2>/dev/null || echo 0` mask and adds an explicit `[ -r "$F2I" ]` preflight, restoring the diagnostic that distinguishes a real allow-list regression from brittle-anchor drift.
+
+### Tests
+- New `tests/lib-assert-count.test.sh` (5 assertions): present-file count, legitimate zero-count on a present file (over-correction guard), and the bug — a missing file (AC3) + an unreadable file (AC4) with `expected==0` must FAIL loud, not pass vacuously. Reds against the pre-fix helper (2/5), greens after (5/5). Wired **ubuntu-only** (AC4's `chmod 000` is a no-op under Windows Git Bash) and declared in the windows-skip-list marker.
+
 ## [0.35.12] — 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.12-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.13-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/tests/_lib_assert_structural.sh
+++ b/tests/_lib_assert_structural.sh
@@ -31,8 +31,34 @@
 
 assert_count() {
   local file="$1" section_start="$2" section_end="$3" pattern="$4" expected="$5" desc="$6"
-  local actual
-  actual=$(awk "/$section_start/,/$section_end/" "$file" | grep -cE -e "$pattern" || true)
+  # Fail-loud preflight: a missing/unreadable $file used to make awk emit
+  # nothing, grep -c print "0", and `|| true` swallow the failure — so any
+  # caller with expected==0 (an absence assertion) PASSED vacuously even though
+  # the file it claims to inspect does not exist (#275). Refuse here instead.
+  if [[ ! -r "$file" ]]; then
+    echo "  FAIL  $desc (file missing/unreadable — cannot count, refusing vacuous PASS)"
+    echo "        file: $file  section: $section_start..$section_end  pattern: $pattern"
+    FAIL=$((FAIL + 1)); return
+  fi
+  # Capture awk's exit status SEPARATELY from grep's so an awk crash (bad
+  # range, mid-stream failure) is surfaced as a FAIL rather than masked into a
+  # 0-count by the old `… | grep -c … || true` pipe. grep -c's own exit-1 on a
+  # legitimate 0 match is expected here — we read its stdout for the count, not
+  # its rc — so a genuine absence assertion (present file, 0 matches) still
+  # PASSES. Only a grep *error* (rc>=2) is treated as a failure.
+  local section awk_rc actual grep_rc
+  section=$(awk "/$section_start/,/$section_end/" "$file"); awk_rc=$?
+  if [[ "$awk_rc" -ne 0 ]]; then
+    echo "  FAIL  $desc (awk failed rc=$awk_rc — cannot count, refusing vacuous PASS)"
+    echo "        file: $file  section: $section_start..$section_end  pattern: $pattern"
+    FAIL=$((FAIL + 1)); return
+  fi
+  actual=$(printf '%s\n' "$section" | grep -cE -e "$pattern"); grep_rc=$?
+  if [[ "$grep_rc" -ge 2 ]]; then
+    echo "  FAIL  $desc (grep failed rc=$grep_rc — cannot count, refusing vacuous PASS)"
+    echo "        file: $file  section: $section_start..$section_end  pattern: $pattern"
+    FAIL=$((FAIL + 1)); return
+  fi
   if [[ "$actual" -eq "$expected" ]]; then
     echo "  PASS  $desc (got $actual)"; PASS=$((PASS + 1))
   else

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -300,8 +300,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.12) =="
-assert_version_bump "$REPO_ROOT" "0.35.12"
+echo "== G20: version bump locked (0.35.13) =="
+assert_version_bump "$REPO_ROOT" "0.35.13"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/lib-assert-count.test.sh
+++ b/tests/lib-assert-count.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Tests for issue #275 — the shared SSOT assert_count helper in
+# tests/_lib_assert_structural.sh must NOT pass an absence assertion
+# (expected count 0) vacuously when its target file is missing or unreadable.
+#
+# Root cause: the old body was
+#   actual=$(awk "/$s/,/$e/" "$file" | grep -cE -e "$pattern" || true)
+# A missing $file makes awk emit nothing on stdout (and error on stderr),
+# grep -c reads empty input and prints 0 (exit 1), and `|| true` swallows the
+# whole failure → actual=0 → any caller with expected==0 PASSES vacuously even
+# though the file it claims to inspect does not exist. All three current
+# callers preflight, but assert_count is the SSOT used by 6+ files; a future
+# caller's absence checks would silently pass. The fix adds a fail-loud
+# `[ -r "$file" ]` preflight and captures awk's rc separately so a missing
+# file or an awk crash is surfaced as a FAIL, never masked as a 0-count PASS.
+#
+# Same `set -u; set -o pipefail`, manual PASS/FAIL counter convention as the
+# rest of the suite (NOT `set -e`; see test-harness-source-guards.test.sh).
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$REPO_ROOT/tests/_lib_assert_structural.sh"
+
+if [ ! -r "$HELPER" ]; then
+  echo "FATAL: _lib_assert_structural.sh missing/unreadable: $HELPER" >&2
+  exit 2
+fi
+
+# Source the SSOT helper under test. assert_count mutates the caller's
+# $PASS/$FAIL — so each scenario below runs assert_count inside a SUBSHELL
+# that seeds its own PASS=0/FAIL=0 and echoes the resulting counters, which
+# this outer harness then inspects. That keeps the inner assert_count's
+# bookkeeping from polluting the outer harness's own PASS/FAIL totals.
+# shellcheck source=tests/_lib_assert_structural.sh
+. "$HELPER" || { echo "FATAL: _lib_assert_structural.sh missing/unreadable" >&2; exit 2; }
+
+PASS=0
+FAIL=0
+
+# Outer-harness assertion primitive (independent of assert_count).
+expect() { # $1=label  $2=condition-string(eval'd)  $3=fail-detail
+  if eval "$2"; then
+    echo "  PASS  $1"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $1"; echo "        $3"; FAIL=$((FAIL + 1))
+  fi
+}
+
+# run_assert_count <file> <start> <end> <pattern> <expected>
+# Runs assert_count in a subshell with fresh inner counters and prints a
+# single machine-readable line:  <inner_PASS> <inner_FAIL> :: <assert_count stdout...>
+# so callers can assert which counter the inner call bumped AND inspect its
+# message text.
+#
+# IMPORTANT: assert_count mutates PASS/FAIL in *its own* shell. We must NOT run
+# it inside a `$(...)` command substitution (that spawns yet another subshell,
+# so its counter bump is lost). Instead redirect its output to a temp file and
+# read PASS/FAIL back in the SAME subshell that invoked it.
+run_assert_count() {
+  (
+    PASS=0; FAIL=0
+    local tmp; tmp="$(mktemp)"
+    assert_count "$1" "$2" "$3" "$4" "$5" "lib-assert-count probe" >"$tmp" 2>&1
+    printf '%s %s :: %s\n' "$PASS" "$FAIL" "$(cat "$tmp")"
+    rm -f "$tmp"
+  )
+}
+
+FIXTURE="$(mktemp)"
+trap 'rm -f "$FIXTURE"' EXIT
+cat >"$FIXTURE" <<'EOF'
+START
+match-line one
+noise
+match-line two
+END
+junk-after-end match-line three
+EOF
+
+echo "== AC1: present file, expected==N>0 — happy path still PASSES (regression) =="
+RES="$(run_assert_count "$FIXTURE" '^START$' '^END$' '^match-line' 2)"
+P="${RES%% *}"; rest="${RES#* }"; F="${rest%% *}"
+expect "present file, count 2 inside section → inner PASS" \
+  "[ \"\$P\" = 1 ] && [ \"\$F\" = 0 ]" \
+  "expected inner PASS=1 FAIL=0, got [$RES]"
+
+echo "== AC2: present file, genuine absence (expected==0) — PASSES, NOT masked (regression) =="
+# Pattern that legitimately appears 0 times inside a present, readable file —
+# this is the valid absence assertion that MUST keep passing. (grep -c exits 1
+# here; the fix must treat that as a real 0, not as an error.)
+RES="$(run_assert_count "$FIXTURE" '^START$' '^END$' '^this-pattern-is-absent$' 0)"
+P="${RES%% *}"; rest="${RES#* }"; F="${rest%% *}"
+expect "present file, legit 0-count → inner PASS (not error-masked)" \
+  "[ \"\$P\" = 1 ] && [ \"\$F\" = 0 ]" \
+  "expected inner PASS=1 FAIL=0, got [$RES]"
+
+echo "== AC3: MISSING file with expected==0 — must FAIL LOUD, not pass vacuously (the bug) =="
+MISSING="$REPO_ROOT/tests/__nonexistent_assert_count_fixture__.sh"
+[ ! -e "$MISSING" ] || { echo "FATAL: test fixture path unexpectedly exists: $MISSING" >&2; exit 2; }
+RES="$(run_assert_count "$MISSING" '^START$' '^END$' 'anything' 0)"
+P="${RES%% *}"; rest="${RES#* }"; F="${rest%% *}"
+expect "missing file + expected 0 → inner FAIL (no vacuous PASS)" \
+  "[ \"\$P\" = 0 ] && [ \"\$F\" = 1 ]" \
+  "VACUOUS-PASS BUG: missing file with expected==0 should bump FAIL, got [$RES]"
+expect "missing-file FAIL message names unreadable/missing file" \
+  "printf '%s' \"\$RES\" | grep -qiE 'unreadable|missing|not readable'" \
+  "FAIL diagnostic should identify the unreadable/missing file, got [$RES]"
+
+echo "== AC4: UNREADABLE file with expected==0 — must FAIL LOUD too =="
+# Skip when running as root (chmod 000 is ineffective for uid 0).
+if [ "$(id -u)" -eq 0 ]; then
+  echo "  SKIP  AC4 unreadable-file case (running as root; chmod 000 is a no-op)"
+else
+  UNREADABLE="$(mktemp)"
+  printf 'START\nEND\n' >"$UNREADABLE"
+  chmod 000 "$UNREADABLE"
+  RES="$(run_assert_count "$UNREADABLE" '^START$' '^END$' 'anything' 0)"
+  chmod 644 "$UNREADABLE"; rm -f "$UNREADABLE"
+  P="${RES%% *}"; rest="${RES#* }"; F="${rest%% *}"
+  expect "unreadable file + expected 0 → inner FAIL (no vacuous PASS)" \
+    "[ \"\$P\" = 0 ] && [ \"\$F\" = 1 ]" \
+    "VACUOUS-PASS BUG: unreadable file with expected==0 should bump FAIL, got [$RES]"
+fi
+
+echo
+echo "==================================================================="
+echo "  PASS=$PASS  FAIL=$FAIL"
+echo "==================================================================="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.11 -> 0.35.12 propagated =="
-assert_version_bump "$REPO_ROOT" "0.35.12"
+echo "== Version bump 0.35.12 -> 0.35.13 propagated =="
+assert_version_bump "$REPO_ROOT" "0.35.13"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/uberthink.test.sh
+++ b/tests/uberthink.test.sh
@@ -151,7 +151,17 @@ echo "== U11: findings-to-issues accepts uberthink-aggregate source =="
 # membership is what makes findings-to-issues ACCEPT the source. (Suite 15 in
 # tests/findings-to-issues.test.sh cross-checks the full closed-set ==
 # report_primitives.ACCEPTED_SOURCES frozenset.)
-F2I_IN_CLOSED_SET=$(grep -oE 'closed set `\{[^}]*\}`' "$F2I" | grep -c 'uberthink-aggregate' 2>/dev/null || echo 0)
+# Fail-loud preflight: gate the count on a readable $F2I so a missing/renamed
+# findings-to-issues.md surfaces as its own FAIL with the right message instead
+# of being swallowed into a vacuous "uberthink-aggregate not in the allow-list"
+# (which the old `… 2>/dev/null || echo 0` masked) (#275).
+ck "findings-to-issues.md exists (closed-set source)" "[ -r '$F2I' ]"
+# Drop the `2>/dev/null || echo 0` count-masking idiom: grep -c already prints
+# its natural `0` (and exits 1) when 'uberthink-aggregate' is absent, so the
+# assert still fails CLOSED — but a genuine grep error (e.g. unreadable $F2I)
+# is no longer hidden, restoring the diagnostic that distinguishes a real
+# allow-list regression from brittle-anchor drift (#275).
+F2I_IN_CLOSED_SET=$(grep -oE 'closed set `\{[^}]*\}`' "$F2I" | grep -c 'uberthink-aggregate')
 ck_msg "findings-to-issues.md Step-1 closed set includes uberthink-aggregate" \
   "[ '$F2I_IN_CLOSED_SET' -ge 1 ]" \
   "uberthink-aggregate not in the Step-1 closed-set allow-list of $F2I"


### PR DESCRIPTION
Fixes #275 (**important**). The repo-blacklisted `… | grep -cE … || true` / `… 2>/dev/null || echo 0` idiom collapses three outcomes into one passing `0` — a legitimate zero-count, a missing/unreadable file, and a tool crash — so an absence assertion (`expected==0`) passes **vacuously** on a missing file.

## Fixed
- `tests/_lib_assert_structural.sh` `assert_count` (the SSOT helper sourced by **14** test files): fail-loud `[ -r "$file" ]` preflight + captures `awk`'s exit status on a separate statement (awk crash → FAIL); only `grep` rc ≥ 2 is an error, so a legitimate zero-match on a present file still PASSES.
- `tests/uberthink.test.sh` (U11): drops the `2>/dev/null || echo 0` mask + adds `[ -r "$F2I" ]` preflight, restoring the diagnostic that distinguishes a real allow-list regression from brittle-anchor drift.

## Tests
- New `tests/lib-assert-count.test.sh` (5): present-file count, legit zero-count (over-correction guard), and the bug — missing (AC3) + unreadable (AC4) file with `expected==0` must FAIL loud. Reds against the pre-fix helper (2/5), greens after (5/5).
- Wired **ubuntu-only** (AC4's `chmod 000` is a no-op under Windows Git Bash) + windows-skip-list marker.

**Regression sweep: all 14 `_lib_assert_structural`-sourcing tests pass; `post-impl-review` (the live `assert_count` caller) 45/0; both version-lock consumers green.** Independently reviewed: APPROVE (blocker = unwired test, resolved here). Version bumped to **0.35.13**.

Closes #275