### PR TITLE
docs(findings-to-issues): document SEARCH rate-limit guard + drop tautological mock assert (#276)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.13",
+      "version": "0.35.14",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.14] — 2026-05-29
+
+### Fixed
+- **`findings-to-issues` — document the SEARCH-bucket rate-limit guard + drop a tautological test** (#276). The agent's "Refusal triggers" section documented only the **core**-bucket rate-limit guard (`CORE_REMAINING < (2*max_new+50)`) under a stale single `REMAINING` var name, omitting the **SEARCH**-bucket fail-CLOSED condition (`SEARCH_REMAINING < (max_new+5)`) that Process Step 2 mandates (the load-bearing guard against silently mapping dedupe lookups into `blocked_by_dedupe[]` with no issues filed). The section now enumerates BOTH bucket conditions verbatim against Step 2. The Suite-3 "L4 runtime assertion" in `tests/findings-to-issues.test.sh` exercised only the test's own mock `gh()` (a near-tautology); it and its now-orphaned mock scaffolding are removed — the real label-idempotency contract stays locked by the structural L1 assert.
+
+### Tests
+- `tests/findings-to-issues.test.sh` Suite 16 (3 section-bounded asserts) locks both bucket conditions in the Refusal-triggers block and asserts the stale bare-`REMAINING` single-bucket form is gone; mutation-tested (each flips to FAIL when the threshold or section is broken). 53/0.
+
 ## [0.35.13] — 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.13-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.14-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.13",
+  "version": "0.35.14",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/agents/findings-to-issues.md
+++ b/plugins/uberdev/agents/findings-to-issues.md
@@ -299,7 +299,7 @@ Empty arrays are emitted as `[]`. `rationale` is empty string `""` on non-REFUSE
 Return `status: REFUSED` with the matching rationale string when:
 
 - `input-malformed` — `working_dir` not a git worktree, OR both aggregate paths empty, OR envelope marker missing in aggregate file leading bytes.
-- `rate-limit-budget-insufficient` — `REMAINING < (2 * max_new + 50)` OR non-numeric.
+- `rate-limit-budget-insufficient` — fail CLOSED if EITHER bucket probe (Step 2) is empty/non-numeric OR under floor: `CORE_REMAINING < (2 * max_new + 50)` (funds `gh issue create`/`comment`/`label`/`api`) OR `SEARCH_REMAINING < (max_new + 5)` (funds the `gh issue list --search` dedupe in Step 8b). Checking only the core bucket is insufficient — Search exhaustion silently maps every dedupe lookup into `blocked_by_dedupe[]` with no issues filed (`:49`).
 - `secret-scan-lib-unavailable` — `source "${CLAUDE_PLUGIN_ROOT}/lib/secret-scan.sh"` returns non-zero.
 
 ## Failure-mode summary (NOT REFUSAL)

--- a/tests/findings-to-issues.test.sh
+++ b/tests/findings-to-issues.test.sh
@@ -39,38 +39,14 @@ assert_grep() {
 
 echo "## findings-to-issues fixture suites"
 
-# ---------- gh-command mocks (inline functions) ----------
-# All mocks capture argv into MOCK_LOG and return canned JSON when needed.
-MOCK_LOG=$(mktemp -t fti-mock-XXXX)
-trap 'rm -f "$MOCK_LOG"' EXIT INT TERM
-
-MOCK_DEDUPE_HITS=""    # JSON array of pre-existing matches — set per-suite
-MOCK_RATE_LIMIT=5000   # rate_limit core.remaining — set per-suite
-MOCK_LABEL_RC=0        # gh label create rc — set per-suite
-
-gh() {
-  local sub="$1"; shift
-  case "$sub" in
-    issue)
-      local subsub="$1"; shift
-      printf 'gh issue %s %s\n' "$subsub" "$*" >> "$MOCK_LOG"
-      case "$subsub" in
-        list) printf '%s' "${MOCK_DEDUPE_HITS:-[]}"; return 0 ;;
-        create) printf 'https://github.com/owner/repo/issues/%d\n' "$(( $(wc -l <"$MOCK_LOG") + 100 ))"; return 0 ;;
-        comment) return 0 ;;
-      esac
-      ;;
-    label)
-      printf 'gh label %s\n' "$*" >> "$MOCK_LOG"
-      return "$MOCK_LABEL_RC"
-      ;;
-    api)
-      if [[ "$*" == *rate_limit* ]]; then printf '%d\n' "$MOCK_RATE_LIMIT"; return 0; fi
-      ;;
-  esac
-  return 0
-}
-export -f gh
+# NOTE: this suite is intentionally mock-free. The findings-to-issues runtime is
+# the agent .md interpreted by a dispatched Claude agent (no extracted shell
+# helper to source), so every behavioural contract here is locked structurally
+# against the agent .md / command .md prose. An earlier `gh()` argv-capture mock
+# fed a single L4 "two --force calls" assertion that exercised only the stub and
+# never production — a tautology (issue #276). It was removed along with the mock
+# scaffolding it solely existed to serve; the real label-idempotency contract
+# stays locked by the structural L1 assert (Suite 3).
 
 ### Suite 1: Parser ----------
 echo
@@ -119,17 +95,11 @@ assert_in_section "$AGENT_MD" '^## Process' '^## Issue body shape' \
 assert_in_section "$AGENT_MD" '^## Process' '^## Issue body shape' \
   'd93f0b' 'L3 label uses red color d93f0b'
 
-# Runtime assertion via mocks: two consecutive gh label create calls both use --force.
-MOCK_LOG_BEFORE=$(wc -l < "$MOCK_LOG")
-gh label create --force review-pr-finding --color d93f0b --description "x" >/dev/null
-gh label create --force review-pr-finding --color d93f0b --description "x" >/dev/null
-MOCK_LOG_AFTER=$(wc -l < "$MOCK_LOG")
-CALLS=$((MOCK_LOG_AFTER - MOCK_LOG_BEFORE))
-if [[ "$CALLS" -eq 2 ]] && [[ "$(grep -c -- '--force' "$MOCK_LOG")" -ge 2 ]]; then
-  echo "  PASS  L4 two consecutive label-create calls both use --force"; PASS=$((PASS+1))
-else
-  echo "  FAIL  L4 expected 2 --force calls, got $CALLS"; FAIL=$((FAIL+1))
-fi
+# (L4 removed — issue #276. It re-invoked the test's own gh() mock and asserted the
+# mock logged two --force tokens: a tautology that exercised the stub, never
+# production code. The idempotency contract is locked by the structural L1 assert
+# above; the agent .md prose at Step 7 documents `gh label create --force` is
+# idempotent.)
 
 ### Suite 4: Opt-out flag ----------
 echo
@@ -440,6 +410,34 @@ if [[ "$S15_4B_OUT" == "OK" ]]; then
 else
   echo "  FAIL  S15.4b envelope() rejected a valid source or errored (marker='$S15_4B_OUT')"; FAIL=$((FAIL+1))
 fi
+
+### Suite 16: Refusal-triggers documents BOTH rate-limit buckets (#276) ----------
+echo
+echo "### Suite 16: rate-limit-budget-insufficient enumerates both buckets (#276)"
+# Process Step 2 probes TWO rate-limit buckets and fails CLOSED on EITHER:
+#   CORE_REMAINING  < (2 * max_new + 50)   — funds gh issue create/comment/label/api
+#   SEARCH_REMAINING < (max_new + 5)        — funds the gh issue list --search dedupe
+# The canonical "Refusal triggers" section MUST enumerate BOTH conditions (and use
+# the Step-2 variable NAMES), else an implementer reading only the refusal list
+# re-introduces the silent-skip hole where Search exhaustion maps every dedupe
+# lookup into blocked_by_dedupe[] with no issues filed. Lock both, plus the
+# absence of the pre-#276 bare-`REMAINING` single-bucket form.
+
+# S16.1 — core-bucket guard present with its real Step-2 variable name + threshold.
+assert_in_section "$AGENT_MD" '^## Refusal triggers' '^## Failure-mode summary' \
+  'CORE_REMAINING < \(2 \* max_new \+ 50\)' \
+  'S16.1 — Refusal-triggers names the CORE_REMAINING < (2*max_new+50) guard (Step 2)'
+
+# S16.2 — search-bucket guard present (the condition #276 found missing).
+assert_in_section "$AGENT_MD" '^## Refusal triggers' '^## Failure-mode summary' \
+  'SEARCH_REMAINING < \(max_new \+ 5\)' \
+  'S16.2 — Refusal-triggers names the SEARCH_REMAINING < (max_new+5) guard (Step 2)'
+
+# S16.3 — the stale single bare-`REMAINING` threshold form (no CORE_/SEARCH_
+# prefix) MUST be gone, so the refusal list cannot drift back to one bucket.
+assert_no_grep "$AGENT_MD" \
+  '`REMAINING < \(2 \* max_new \+ 50\)`' \
+  'S16.3 — stale bare-REMAINING single-bucket threshold removed (#276)'
 
 echo
 echo "## Summary"

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -300,8 +300,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.13) =="
-assert_version_bump "$REPO_ROOT" "0.35.13"
+echo "== G20: version bump locked (0.35.14) =="
+assert_version_bump "$REPO_ROOT" "0.35.14"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.12 -> 0.35.13 propagated =="
-assert_version_bump "$REPO_ROOT" "0.35.13"
+echo "== Version bump 0.35.13 -> 0.35.14 propagated =="
+assert_version_bump "$REPO_ROOT" "0.35.14"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
Fixes #276 (**important**). Two findings in the findings-to-issues area.

## Fixed
- **`agents/findings-to-issues.md` Refusal-triggers** documented only the **core**-bucket rate-limit guard (`CORE_REMAINING < (2*max_new+50)`) under a stale single `REMAINING` var name, omitting the **SEARCH**-bucket fail-CLOSED condition (`SEARCH_REMAINING < (max_new+5)`) that Process Step 2 mandates — the load-bearing guard against silently mapping dedupe lookups into `blocked_by_dedupe[]` with zero issues filed. Now enumerates BOTH bucket conditions verbatim against Step 2.
- **`tests/findings-to-issues.test.sh` Suite-3 L4** exercised only the test's own mock `gh()` (a near-tautology — could never fail for a real-code reason); L4 + its now-orphaned mock scaffolding removed. The real label-idempotency contract stays locked by the structural L1 assert.

## Tests
- Suite 16 (3 section-bounded asserts) locks both bucket conditions in the Refusal-triggers block + asserts the stale bare-`REMAINING` single-bucket form is gone; mutation-tested (each flips to FAIL when the threshold or section is broken). **53/0.**

Independently reviewed: **APPROVE** (mutation-tested, no real coverage lost). Version bumped to **0.35.14**.

Closes #276