### PR TITLE
fix(uberthink): clamp ambition_score axes to avoid complex-number dossier-sort crash (#277)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.14",
+      "version": "0.35.15",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.15] — 2026-05-29
+
+### Fixed
+- **`uberthink` report.py — clamp `ambition_score` axes to avoid a complex-number dossier-sort crash** (#277). `ambition_score` applied fractional exponents (`BETA/GAMMA/DELTA = 1.2/1.3/1.2`) to axes that can be negative; in Python a negative base with a fractional exponent returns a `complex` rather than raising, so `round(complex)` raised `TypeError` and `rank()`'s `sorted(key=ambition)` raised `'<' not supported between instances of 'complex' and 'complex'`, aborting the Wave-7 dossier render with no cause-specific message (`feasibility_floor_fails()` cuts only `feas < 4.0`, so a negative `novelty`/`combination`/`impact` from the Arbiter's `ranked.yaml` survived to the exponent). Each axis is now clamped with `max(0.0, float(x))` before the power — a negative axis fails closed to `0` (worse than zero → product `0` → ambition tanks → still a real, sortable float), matching the existing zero-floor semantics; the clamp is identity for in-domain `[0,10]` values.
+
+### Tests
+- `tests/uberthink-report.test.sh` gains a negative-axis regression block: asserts `ambition_score` returns a real float (`== 0.0`) for a negative on every axis, that in-domain scores are unchanged, and that `rank()` does not raise on a `ranked.yaml` whose negative axes survive the feasibility floor. Reds pre-fix (`-771.29…`), greens after. 13/0.
+
 ## [0.35.14] — 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.14-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.15-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.14",
+  "version": "0.35.15",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/skills/uberthink-pipeline/report.py
+++ b/plugins/uberdev/skills/uberthink-pipeline/report.py
@@ -87,12 +87,25 @@ def ambition_score(novelty: float, feasibility: float, combination: float, impac
 
     Product form so a near-zero on any axis tanks the score — you can't win on
     novelty alone. Returns 0 if any input is 0 (kept implicit by the product).
+
+    Each axis is clamped to non-negative (``max(0.0, float(x))``) BEFORE the
+    fractional power. A negative base with a fractional exponent (BETA/GAMMA/
+    DELTA = 1.2/1.3/1.2) does NOT raise in Python — it returns a ``complex``
+    (e.g. ``(-2.0) ** 1.2`` is complex), which then makes ``round(...)`` raise
+    ``TypeError`` here and, if it ever reached the caller, makes ``rank()``'s
+    ``sorted(..., key=ambition)`` raise ``'<' not supported ... complex`` and
+    abort the dossier render. ``feasibility_floor_fails()`` only cuts ``feas <
+    4.0``, so a negative novelty/combination/impact from the Arbiter's
+    ``ranked.yaml`` survives the floor and would otherwise reach the exponent.
+    Clamping to 0 fails closed (a negative axis is worse than zero → product 0
+    → ambition tanks → still sortable), matching the existing zero-floor
+    semantics above.
     """
     return round(
-        float(novelty) ** ALPHA
-        * float(feasibility) ** BETA
-        * float(combination) ** GAMMA
-        * float(impact) ** DELTA,
+        max(0.0, float(novelty)) ** ALPHA
+        * max(0.0, float(feasibility)) ** BETA
+        * max(0.0, float(combination)) ** GAMMA
+        * max(0.0, float(impact)) ** DELTA,
         6,
     )
 

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -300,8 +300,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.14) =="
-assert_version_bump "$REPO_ROOT" "0.35.14"
+echo "== G20: version bump locked (0.35.15) =="
+assert_version_bump "$REPO_ROOT" "0.35.15"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.13 -> 0.35.14 propagated =="
-assert_version_bump "$REPO_ROOT" "0.35.14"
+echo "== Version bump 0.35.14 -> 0.35.15 propagated =="
+assert_version_bump "$REPO_ROOT" "0.35.15"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/uberthink-report.test.sh
+++ b/tests/uberthink-report.test.sh
@@ -58,6 +58,63 @@ PY
 SCORING_RC=$?
 check "scoring contract: all 6 spec §3 asserts pass" "[ $SCORING_RC -eq 0 ]"
 
+# === Negative-axis clamp (issue #277): a negative axis must NOT become a Python
+# complex and crash the dossier sort. Before the fix, ambition_score() applied a
+# fractional exponent (BETA/GAMMA/DELTA = 1.2/1.3/1.2) to a negative base, which
+# returns a complex; round(complex) raises TypeError inside ambition_score(), and
+# any complex that escaped made rank()'s sorted(key=ambition) raise
+# "'<' not supported between instances of 'complex' and 'complex'", aborting the
+# Wave-7 render. The fix clamps each axis with max(0.0, float(x)) BEFORE the power
+# so a negative axis fails closed to 0 (worse than zero -> product 0 -> sortable). ===
+PYTHONPATH="$PIPELINE_DIR" python3 - <<'PY'
+import report
+
+# (a) ambition_score must return a real float (never complex) for a negative on
+#     EVERY axis — including feasibility/combination/impact whose exponents are
+#     fractional (the bases that previously went complex).
+for axis, args in {
+    "novelty":     (-2.0, 5.0, 5.0, 5.0),
+    "feasibility": (5.0, -2.0, 5.0, 5.0),
+    "combination": (5.0, 5.0, -2.0, 5.0),
+    "impact":      (5.0, 5.0, 5.0, -2.0),
+    "all":         (-1.0, -1.0, -1.0, -1.0),
+}.items():
+    v = report.ambition_score(*args)
+    assert isinstance(v, float) and not isinstance(v, complex), \
+        f"negative {axis}: ambition_score returned non-float {v!r} ({type(v).__name__})"
+    # Clamp-to-zero on a negative axis means the product collapses to 0 (fail-closed).
+    assert v == 0.0, f"negative {axis}: expected clamped 0.0, got {v!r}"
+
+# (b) Positive/zero inputs are unchanged — the clamp is a no-op above zero, so the
+#     existing scoring contract still holds (regression guard for the fix itself).
+assert abs(report.ambition_score(6, 6, 6, 6)
+           - round(6.0**1.0 * 6.0**1.2 * 6.0**1.3 * 6.0**1.2, 6)) < 1e-9
+assert report.ambition_score(0, 5, 5, 5) == 0.0
+
+# (c) rank() must NOT raise on a ranked.yaml carrying a negative axis that survives
+#     the feasibility floor (feas >= 4.0, every feas_sub > 0). A negative COMBINATION
+#     used to make ambition complex and crash the sort; now the design ranks last.
+designs = [
+    {"id": "NEG_COMB", "novelty": 7, "feasibility": 6, "combination": -3, "impact": 6,
+     "feas_subs": {"hard_constraint": 6, "survives_adversary": 6, "buildability": 6,
+                   "premortem_resilience": 6, "deployment_reality": 6}},
+    {"id": "NEG_IMP", "novelty": 7, "feasibility": 6, "combination": 6, "impact": -3,
+     "feas_subs": {"hard_constraint": 6, "survives_adversary": 6, "buildability": 6,
+                   "premortem_resilience": 6, "deployment_reality": 6}},
+    {"id": "OK", "novelty": 7, "feasibility": 7, "combination": 7, "impact": 7,
+     "feas_subs": {"hard_constraint": 7, "survives_adversary": 7, "buildability": 7,
+                   "premortem_resilience": 7, "deployment_reality": 7}},
+]
+ranked = report.rank(designs)   # must not raise TypeError
+ids = [d["id"] for d in ranked]
+assert ids[0] == "OK", f"positive design must rank first, got {ids}"
+assert all(isinstance(d["ambition"], float) for d in ranked), \
+    "every ranked design must carry a real-float ambition"
+print("NEGATIVE-AXIS CLAMP OK")
+PY
+CLAMP_RC=$?
+check "negative axis clamps to a real float (no complex -> no dossier sort crash) [#277]" "[ $CLAMP_RC -eq 0 ]"
+
 # === CLI smoke: --emit dossier writes the spec §6 layout (moonshot lane FIRST) ===
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 # Stage the shared fixture as $RUN_DIR/ranked.yaml so the CLI loads it via the


### PR DESCRIPTION
Fixes #277 (**important**). `ambition_score` applied fractional exponents (`BETA/GAMMA/DELTA = 1.2/1.3/1.2`) to axes that can be negative. In Python a negative base with a fractional exponent returns a `complex` (it does NOT raise), so `round(complex)` raised `TypeError` and `rank()`'s `sorted(key=ambition)` raised `'<' not supported between instances of 'complex' and 'complex'` — aborting the Wave-7 dossier render with no cause-specific message. `feasibility_floor_fails()` cuts only `feas < 4.0`, so a negative `novelty`/`combination`/`impact` from the Arbiter's `ranked.yaml` survived to the exponent.

## Fix
- `report.py` `ambition_score`: clamp each axis with `max(0.0, float(x))` **before** the power. A negative axis fails closed to `0` (worse than zero → product `0` → ambition tanks → still a real, sortable float), matching the function's existing zero-floor semantics. The clamp is identity for in-domain `[0,10]` values, so the scoring contract is unchanged.

## Tests
- `tests/uberthink-report.test.sh` negative-axis regression block: asserts `ambition_score` returns a real float (`== 0.0`) for a negative on every axis, in-domain scores unchanged, and `rank()` does not raise on a `ranked.yaml` whose negative axes survive the feasibility floor. Reds pre-fix (`-771.29…`), greens after. **13/0.**

Independently reviewed (reproduced the complex/TypeError; confirmed clamp is identity in-domain): **APPROVE**. Version bumped to **0.35.15**.

Closes #277