### PR TITLE
fix(goal): harden goal-state.sh external reads + serialize the Phase-2c merge barrier

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.17",
+      "version": "0.35.18",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.18] — 2026-05-29
+
+### Fixed
+- **`/goal` advanced PRs on stale reviews (#290.1)** — `uberdev_goal_read_trust_signal` now binds the `/review-pr` verdict to the PR's live `headRefOid` and returns `stale` when a commit landed after the GREEN verdict (fail-safe on a gh outage; backward-compatible when the verdict predates the `.sha` field), instead of driving `pushed-reviewing→green→merging` off a stale review.
+- **`/goal` merge-result audit read missed the merge worktree (#290.2)** — `read_merge_result` now scans the worktree-mirror audit set (the same prefix glob the verdict locator uses) instead of cwd-only `.uberdev/audit.jsonl`, so the `merge_failed` breaker fires on the conflict/hook-failed path instead of looping the 60 m timeout.
+- **`/goal` rode out sustained gh outages silently (#290.3)** — a consecutive-gh-failure breaker now records failures in `find_pr_for_issue` / `pr_state_gh` and fires `gh_api_failed` via `uberdev_goal_gh_failure_breaker_check`, rather than abandoning a solved-and-pushed issue to the solve-timeout.
+- **`/goal` could bind the wrong PR (#290.4)** — `find_pr_for_issue` now scans `--state open` and prefers the `closingIssuesReferences` match over the `feat/N-` head-ref heuristic, so a stale closed branch can't corrupt batch-registry accounting.
+- **`/goal` mutual-`Blocks:` deadlock (#292.1)** — new `uberdev_goal_detect_blocks_cycle` SCC detector surfaces `stuck_loop phase=blocks_cycle` instead of spinning two mutually-blocking held PRs to the 4 h cap.
+- **`/goal` merge-attempt cap was per-PR-lifetime (#292.2)** — the per-PR cap now resets on a held→green recovery (`uberdev_goal_reset_merge_attempts`), so a PR legitimately blocked for cycles isn't permanently locked out of auto-merge by transient stalls.
+- **`/goal` merge barrier deadlocked on a phantom label (#289.1)** — `batch_unblock_wait_clear` now gates on the `uberdev-approved` label `/review-pr` actually emits (the old `review-pr:green` had zero producers, so a held batch row returned rc 1 forever and blocked every co-batched GREEN PR until the 4 h `stuck_loop`); a blocker-closed-but-still-held PR is now pseudo-terminal so it stops gating others.
+- **`/goal` didn't serialize version-bump merges (#289.2)** — the green-PR loop now dispatches the lowest green PR and waits (a non-terminal `MERGING` batch-sentinel interlock) for it to land on fresh main before the next `/merge`, so two version-bump PRs can't both land `vN+1` and silently eat the second bump.
+- **`/goal` multi-blocker unblock inconsistency (#289.3)** — `batch_unblock_wait_clear` now requires ALL `Blocks:` issues closed (was break-after-first), matching `check_unblock`.
+- **Cross-shell worktree-glob hardening (#270 class)** — the `_UBERDEV_GOAL_WORKTREE_PREFIXES` globs never expanded under the zsh Bash tool; all three consumers now route through `_uberdev_goal_glob_worktree` (zsh `${~pat}` + `nonomatch` / bash bare), and loop-body `local` decls are hoisted to function scope.
+
+### Tests
+- `tests/goal-batch-barrier.test.sh` (B10–B18), `tests/goal.test.sh` (BT23a–e + repoints), and `tests/goal-state-zsh.test.sh` (Z6–Z9, dual-shell) cover each fix; every fix red-checked via revert. Full `tests/*.test.sh` suite 58/0 under bash and zsh.
+
 ## [0.35.17] — 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.17-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.18-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.17",
+  "version": "0.35.18",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/goal.md
+++ b/plugins/uberdev/commands/goal.md
@@ -26,9 +26,12 @@ Autonomous convergence orchestrator that drives one or more GitHub issues to mer
 Instead, `/goal` holds until every PR in the cycle's batch is in a terminal state
 (`merged`, `merge-failed`, `yellow-held`, `red-held`, or `green`). PRs touching shared
 mutable manifests (e.g. the uberdev version-bump triplet) merge sequentially in
-PR-number-ascending order, with `git fetch origin main` + rebase between each. When a
-held PR's `review-pr-finding` unblock-issue is in flight, the barrier holds until the
-unblock-issue closes AND the held PR's trust-trail label transitions to `review-pr:green`.
+PR-number-ascending order: exactly ONE merge is dispatched at a time and the next
+green PR becomes eligible only after the prior one lands (a `git fetch origin main`
++ rebase happens between each). A held PR holds the barrier only while one of its
+`Blocks: #N` unblock-issues is still open; once all its blockers close it becomes
+pseudo-terminal and stops gating the other PRs (its re-review either cleared it
+green — detected via the `uberdev-approved` trust-trail label — or it stays held).
 A wall-clock cap (default 4h, see `--barrier-timeout=N`) escalates a stuck barrier to
 `stuck_loop` halt.
 

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -10,6 +10,7 @@
 #   uberdev_goal_read_trust_signal             AUDIT_JSON_PATH
 #   uberdev_goal_check_fingerprint_repeat      GOAL_ID CYCLE FINGERPRINT
 #   uberdev_goal_should_automerge              GOAL_ID PR
+#   uberdev_goal_reset_merge_attempts          GOAL_ID PR            (issue #292.2)
 #   uberdev_goal_audit                         EVENT PAYLOAD_JSON
 #   uberdev_goal_locate_review_pr_audit        ISSUE_NUM
 #   uberdev_goal_locate_review_pr_audit_by_pr  PR_NUM
@@ -23,9 +24,10 @@
 #   uberdev_goal_count_resolved_issues         GOAL_ID
 #   uberdev_goal_record_held_audit             GOAL_ID PR AUDIT_PATH
 #   uberdev_goal_get_last_held_audit           GOAL_ID PR
-#   uberdev_goal_find_pr_for_issue             ISSUE_NUM   (gh; issue #180)
+#   uberdev_goal_find_pr_for_issue             ISSUE_NUM   (gh; issue #180/#290.4)
 #   uberdev_goal_pr_state_gh                   PR_NUM      (gh; issue #180)
 #   uberdev_goal_pr_is_merged                  PR_NUM      (gh; issue #180)
+#   uberdev_goal_gh_failure_breaker_check      GOAL_ID [THRESHOLD]   (issue #290.3)
 #   uberdev_goal_agent_busy_for_issue          ISSUE_NUM   (claude agents; issue #180)
 #   uberdev_goal_list_prs_in_state             GOAL_ID STATE
 #   uberdev_goal_read_merge_result             PR_NUM
@@ -35,7 +37,8 @@
 #   uberdev_goal_register_batch_pr             GOAL_ID PR ISSUE   (issue #211)
 #   uberdev_goal_barrier_breaker_check         GOAL_ID BARRIER_TIMEOUT_S   (issue #214)
 #   uberdev_goal_batch_all_terminal            GOAL_ID            (issue #211)
-#   uberdev_goal_batch_unblock_wait_clear      GOAL_ID            (issue #211)
+#   uberdev_goal_batch_unblock_wait_clear      GOAL_ID            (issue #211/#289)
+#   uberdev_goal_detect_blocks_cycle           GOAL_ID            (issue #292.1)
 #   print_summary                              CYCLES             (issue #270; hoisted from goal-pipeline SKILL.md Phase 4 so the per-fence re-source brings it into scope in every phase)
 # Internal:
 #   _uberdev_goal_ts_in_state              FILE KEY STATE [FIRST_WINS]
@@ -57,6 +60,10 @@
 #   _uberdev_goal_set_batch_terminal_state GOAL_ID PR STATE       (issue #211)
 #   _uberdev_goal_batch_green_prs_ordered  GOAL_ID                (issue #211)
 #   _uberdev_goal_rebase_collision_chain   GOAL_ID JUST_MERGED_PR (issue #211)
+#   _uberdev_goal_gh_failure_counter_path                         (issue #290.3)
+#   _uberdev_goal_record_gh_failure                              (issue #290.3)
+#   _uberdev_goal_reset_gh_failure                               (issue #290.3)
+#   _uberdev_goal_glob_worktree            SUFFIX                 (issue #290.2; cross-shell glob)
 # External imports:
 #   - lib/dispatch.sh :: _uberdev_dispatch_prepare_tmp_target, uberdev_dispatch_one
 #     — both REQUIRED, both live in lib/dispatch.sh (NOT in this file).
@@ -95,12 +102,14 @@ if [ "${_UBERDEV_GOAL_STATE_LOADED:-0}" = "1" ]; then
 fi
 _UBERDEV_GOAL_STATE_LOADED=1
 
-# Worktree-mirror prefixes for .uberdev/runs discovery (issue #220 simplify
-# pass — R2 SSOT). Used by helpers that scan for /review-pr artifacts (verdicts,
-# locked markers). The empty prefix covers the main checkout; the three worktree
-# variants cover the using-git-worktrees skill's documented layouts. Mirrored
-# previously by uberdev_goal_locate_review_pr_audit_by_pr and
-# _uberdev_goal_locked_marker_for_pr_fresh — now read from this array.
+# Worktree-mirror prefixes for .uberdev discovery (issue #220 simplify pass —
+# R2 SSOT). Used by helpers that scan for /review-pr + /merge artifacts (verdicts,
+# locked markers, merge-result audit). The empty prefix covers the main checkout;
+# the three worktree variants cover the using-git-worktrees skill's documented
+# layouts. Consumed ONLY via _uberdev_goal_glob_worktree (issue #290.2), which
+# does the cross-shell glob expansion — the bare `${prefix}` form does NOT
+# glob-expand a variable-derived `*` under the zsh Bash tool, so the worktree
+# mirrors were silently invisible there before the helper.
 _UBERDEV_GOAL_WORKTREE_PREFIXES=("" ".claude/worktrees/*/" ".worktrees/*/" "worktrees/*/")
 
 # Stuck-on-dialog detector window (issue #220 simplify pass — Q1). Promoted
@@ -130,6 +139,13 @@ _UBERDEV_GOAL_WORKTREE_PREFIXES=("" ".claude/worktrees/*/" ".worktrees/*/" "work
 : "${_UBERDEV_GOAL_MERGE_TIMEOUT:=3600}"                  # 60m — merging w/o MERGED AND agent idle => back to green for retry (#180)
 : "${_UBERDEV_GOAL_BODY_CAP:=65536}"                      # 64 KiB
 : "${FINDING_LABEL:=review-pr-finding}"
+# #290.3 — consecutive gh-failure breaker threshold. The Phase-2a/2d polling
+# helpers (find_pr_for_issue / pr_state_gh) fail OPEN (empty+rc0) on a gh
+# outage so a transient blip just re-polls; a SUSTAINED outage, however, must
+# not ride the 150m solve-timeout / 60m merge-timeout to a false `failed`.
+# After this many CONSECUTIVE failures (any success resets the counter), the
+# breaker fires gh_api_failed. Default 5 ≈ 5 min at the 60s poll cadence.
+: "${_UBERDEV_GOAL_MAX_GH_FAILURES:=5}"
 
 # Regex constants — PLAIN assignment, NOT := (Q2 security advisory: := would
 # let a hostile env override the regex shape and widen the ReDoS attack
@@ -229,6 +245,45 @@ _uberdev_goal_pid_for_issue() {
   pid="$(jq -r '.pid // empty' < "$status_file" 2>/dev/null)" || return 1
   _uberdev_goal_validate_int "$pid" || return 1
   printf '%s' "$pid"
+}
+
+# _uberdev_goal_glob_worktree SUFFIX
+# Emit (one per line, on stdout) every READABLE path matching
+# `<prefix><SUFFIX>` for each prefix in _UBERDEV_GOAL_WORKTREE_PREFIXES, in
+# array order (empty/project-root prefix first, worktree mirrors after).
+#
+# #270/#290.2 cross-shell glob: the prefixes carry a `*` worktree wildcard and
+# come from a VARIABLE. bash glob-expands `${prefix}${SUFFIX}` after
+# substitution, but zsh does NOT expand `*` that arrives via a parameter unless
+# the expansion is flagged `${~var}` (GLOB_SUBST). Since this lib is re-sourced
+# inside the goal-pipeline SKILL.md bash fences that run under /bin/zsh on
+# macOS, the bare-`${prefix}` form silently matched NOTHING for the three
+# worktree-mirror prefixes under zsh — so worktree verdict/audit/lock discovery
+# never fired there (only the empty cwd prefix worked). Branch on the live shell
+# and use `${~pat}` under zsh / bare `$pat` under bash (bash hard-errors on
+# `${~pat}`: `bad substitution`). Unmatched globs leave the literal pattern,
+# which the `[ -r ]` guard rejects (no nullglob assumed) — identical to the
+# inline call sites' prior behaviour.
+_uberdev_goal_glob_worktree() {
+  local suffix="$1" prefix pat c
+  if [ -n "${ZSH_VERSION:-}" ]; then
+    # zsh: `${~pat}` re-enables glob on the variable-derived pattern;
+    # `localoptions nonomatch` makes an UNMATCHED glob yield the literal
+    # (function-scoped — does not leak to the caller) instead of zsh's default
+    # NOMATCH hard-error, matching bash's no-nullglob behaviour so the `[ -r ]`
+    # guard can reject the un-expanded literal uniformly in both shells.
+    setopt localoptions nonomatch 2>/dev/null || true
+    for prefix in "${_UBERDEV_GOAL_WORKTREE_PREFIXES[@]}"; do
+      pat="${prefix}${suffix}"
+      for c in ${~pat}; do [ -r "$c" ] && printf '%s\n' "$c"; done
+    done
+  else
+    for prefix in "${_UBERDEV_GOAL_WORKTREE_PREFIXES[@]}"; do
+      pat="${prefix}${suffix}"
+      for c in $pat; do [ -r "$c" ] && printf '%s\n' "$c"; done
+    done
+  fi
+  return 0
 }
 
 # _uberdev_goal_validate_id GOAL_ID
@@ -349,6 +404,28 @@ _uberdev_goal_count_merge_attempts() {
   local f="$tmpdir/goal-$goal_id-merge-attempts.tsv"
   [ -f "$f" ] || { printf '0\n'; return 0; }
   awk -v p="$pr" '$1==p {c=$2} END {print c+0}' "$f"
+}
+
+# uberdev_goal_reset_merge_attempts GOAL_ID PR   (issue #292.2)
+# Zero the per-PR merge-attempt counter by appending a `PR<TAB>0` row — the
+# count reader above is last-write-wins (`$1==p {c=$2}`), so the appended 0
+# supersedes all prior ticks for this PR. Called when a PR transitions back to
+# `green` from a HELD state (Phase 2e held→green): the merge-attempt cap
+# (uberdev_goal_should_automerge, default 3) is otherwise per-PR-LIFETIME and
+# never reset, so a PR legitimately blocked for 2 cycles — then unblocked and
+# cleanly GREEN — could hit the cap from transient merge stalls accumulated
+# across its hold and never auto-merge again, stalling convergence into
+# queue_empty_not_converged with a GREEN-but-unmergeable PR. Resetting on the
+# held→green recovery scopes the cap to the PR's CURRENT green lifetime.
+# rc 0 on success; rc 1 on validation; propagates the append's rc on a write
+# failure (fail-loud, uniform with the state-transition writers — #157).
+uberdev_goal_reset_merge_attempts() {
+  local goal_id="$1" pr="$2"
+  _uberdev_goal_validate_id "$goal_id" || return 1
+  _uberdev_goal_validate_int "$pr"     || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  local row; printf -v row '%s\t%s' "$pr" 0
+  _uberdev_goal_append "$tmpdir/goal-$goal_id-merge-attempts.tsv" "$row"
 }
 
 # _uberdev_goal_count_review_pr_attempts GOAL_ID PR
@@ -533,9 +610,53 @@ uberdev_goal_issue_state_transition() {
 # assume GREEN on an unreadable trust artifact, per D17). Empty stdout
 # with rc=0 means jq ran but returned empty (phase2_5 absent) — that's
 # the legacy/pre-v0.26.0 audit shape, treated as `stale`.
+#
+# #290.1 (CRITICAL) — HEAD-SHA binding. The verdict JSON carries both `.pr`
+# and `.sha` (the post-emission anchor `headRefOid` written at
+# commands/review-pr.md:954). A commit pushed AFTER a GREEN verdict leaves a
+# stale-but-green verdict on disk; without binding, /goal advanced
+# pushed-reviewing→green→merging on that stale review and churned the PR into
+# the retry / queue_empty_not_converged path (/merge's trust-trail-evaluator
+# DOES re-validate the SHA, so the merge itself is safe — but /goal
+# mis-classifies). Self-contained fix: read `.pr` + `.sha` from the SAME file,
+# fetch the live `gh pr view <pr> --json headRefOid`, and on mismatch return
+# `stale` (the whole review is invalidated by a new push, regardless of colour)
+# so the caller re-dispatches /review-pr instead of advancing to green.
+# Fail-SAFE on a gh outage reading headRefOid: a rate-limit / network error
+# must NOT masquerade as a SHA mismatch (that would churn the PR), so skip the
+# binding and fall through to the colour decision with a one-line breadcrumb —
+# identical to the pre-#290 behaviour for that transient window. The check is
+# also skipped when the verdict has no `.sha` (legacy/pre-anchor JSON) or no
+# `.pr`, preserving backward compatibility (and the audit-path-only test
+# fixtures that never set a PR).
 uberdev_goal_read_trust_signal() {
   local audit_path="$1"
   [ -f "$audit_path" ] || { printf 'missing\n'; return 0; }
+  # #290.1 — bind the verdict to the live PR HEAD before trusting its colour.
+  # Both reads come from the same verdict file (no extra disk I/O beyond two
+  # jq passes). A jq failure here is non-fatal: it degrades to "no binding"
+  # rather than "missing", because the by_severity projection below has its
+  # own fail-closed `missing` arm and is the authoritative readability gate.
+  local verdict_pr verdict_sha
+  verdict_pr="$(jq -r '.pr // empty' "$audit_path" 2>/dev/null)"
+  verdict_sha="$(jq -r '.sha // empty' "$audit_path" 2>/dev/null)"
+  if [ -n "$verdict_pr" ] && [ -n "$verdict_sha" ] \
+     && _uberdev_goal_validate_int "$verdict_pr"; then
+    local head_oid head_rc
+    head_oid="$(gh pr view "$verdict_pr" --json headRefOid --jq '.headRefOid' 2>/dev/null)"
+    head_rc=$?
+    if [ "$head_rc" -ne 0 ] || [ -z "$head_oid" ]; then
+      # gh outage / empty — fail-SAFE: do NOT declare stale on a transient
+      # failure (would churn the PR); fall through to the colour decision.
+      printf 'goal-state: gh pr view %s headRefOid unreadable (rc=%s); skipping SHA-binding for this read\n' \
+        "$verdict_pr" "$head_rc" >&2
+    elif [ "$head_oid" != "$verdict_sha" ]; then
+      # A commit landed after this verdict — the whole review is stale.
+      printf 'goal-state: trust verdict for PR %s is bound to %s but HEAD is %s; treating as stale (re-review needed)\n' \
+        "$verdict_pr" "$verdict_sha" "$head_oid" >&2
+      printf 'stale\n'; return 0
+    fi
+  fi
   local p25
   if ! p25="$(gh_jq_or_jq "$audit_path" '.phases.phase2_5 // empty')"; then
     printf 'missing\n'; return 0
@@ -669,21 +790,23 @@ uberdev_goal_locate_review_pr_audit() {
 uberdev_goal_locate_review_pr_audit_by_pr() {
   local pr="$1"
   _uberdev_goal_validate_int "$pr" || return 1
-  local prefix candidate_file run_id pr_field
+  local candidate_file run_id pr_field
   # R2 SSOT (issue #220 simplify pass): glob set read from
-  # _UBERDEV_GOAL_WORKTREE_PREFIXES so this and _uberdev_goal_locked_marker_for_pr_fresh
-  # cannot drift. Empty prefix = main checkout; three worktree prefixes mirror
-  # the using-git-worktrees skill's documented layouts.
-  for prefix in "${_UBERDEV_GOAL_WORKTREE_PREFIXES[@]}"; do
-    for candidate_file in ${prefix}.uberdev/runs/*/review-pr-verdict.json; do
-      [ -r "$candidate_file" ] || continue
-      pr_field="$(jq -r '.pr // empty' "$candidate_file" 2>/dev/null)" || continue
-      [ "$pr_field" = "$pr" ] || continue
-      run_id="$(basename "$(dirname "$candidate_file")")"
-      [[ "$run_id" =~ ^[0-9]{8}-[0-9]{6}-[a-f0-9]+$ ]] || continue
-      printf '%s\t%s\n' "$run_id" "$candidate_file"
-    done
-  done | sort -r | head -n 1 | cut -f2
+  # _UBERDEV_GOAL_WORKTREE_PREFIXES. #270/#290.2 cross-shell: route the
+  # prefix-glob through _uberdev_goal_glob_worktree — the bare `${prefix}` glob
+  # silently matched no worktree mirror under the zsh Bash tool (a variable-
+  # derived `*` is not glob-expanded by zsh), so worktree-mirror verdict
+  # discovery never fired there. Empty prefix = main checkout; three worktree
+  # prefixes mirror the using-git-worktrees skill's documented layouts.
+  while IFS= read -r candidate_file; do
+    [ -r "$candidate_file" ] || continue
+    pr_field="$(jq -r '.pr // empty' "$candidate_file" 2>/dev/null)" || continue
+    [ "$pr_field" = "$pr" ] || continue
+    run_id="$(basename "$(dirname "$candidate_file")")"
+    [[ "$run_id" =~ ^[0-9]{8}-[0-9]{6}-[a-f0-9]+$ ]] || continue
+    printf '%s\t%s\n' "$run_id" "$candidate_file"
+  done < <(_uberdev_goal_glob_worktree ".uberdev/runs/*/review-pr-verdict.json") \
+    | sort -r | head -n 1 | cut -f2
 }
 
 # uberdev_goal_get_pr_state GOAL_ID PR
@@ -859,12 +982,26 @@ uberdev_goal_get_last_held_audit() {
 }
 
 # uberdev_goal_find_pr_for_issue ISSUE_NUM   (issue #180)
-# GitHub-native issue->PR resolver. Echoes the highest PR number whose
-# `closingIssuesReferences` includes issue N (the `Closes #N` link every solver
-# PR carries) OR whose head branch is `feat/N-…`. Replaces the retired
-# solve-bg `pushed PR #N` log parser: that marker has ZERO producers and
-# `claude --bg` stdout is a detached banner on CLI 2.1.150, so the loop keying
-# on it never advanced (issue #180).
+# GitHub-native issue->PR resolver. Echoes the highest OPEN PR number that
+# closes issue N (its `closingIssuesReferences` carries the `Closes #N` link
+# every solver PR adds); if no closes-match exists it FALLS BACK to the highest
+# OPEN PR whose head branch is `feat/N-…`. Replaces the retired solve-bg
+# `pushed PR #N` log parser: that marker has ZERO producers and `claude --bg`
+# stdout is a detached banner on CLI 2.1.150, so the loop keying on it never
+# advanced (issue #180).
+#
+# #290.4 (MAJOR) — bind to the LIVE PR, prefer the authoritative link:
+#   (a) `--state open` (was `--state all`): a stale CLOSED `feat/N-` branch from
+#       a prior failed attempt, or a re-dispatched issue's abandoned PR, could
+#       otherwise win the `max` and corrupt batch-registry accounting / verdict
+#       location (the locator keys on this result). Merge-completion detection
+#       is unaffected — uberdev_goal_pr_state_gh / pr_is_merged issue their own
+#       `gh pr view <pr>` against the known PR number, never this finder.
+#   (b) prefer the `closingIssuesReferences` match over the `feat/N-` head-ref
+#       heuristic: the head-ref arm is a best-effort fallback for PRs whose
+#       Closes-link was dropped, but a branch *named* feat/N- that does NOT
+#       close N (a re-used branch) must never outrank a real closes-match. The
+#       jq below computes both maxes and takes `$byclose // $byhead`.
 #
 # ISSUE_NUM is digits-only validated BEFORE interpolation into the gh --jq
 # filter (R3 gh-argument-injection guard — the same int gate Phase 0 applies
@@ -872,33 +1009,41 @@ uberdev_goal_get_last_held_audit() {
 # so gh progress bytes cannot pollute the result. Empty stdout + rc 0 when no
 # PR exists yet — a not-yet-pushed solver must NOT read as an error. A gh
 # failure also yields empty (fail-open; the caller treats "no PR" as "keep
-# waiting", bounded by the per-issue solve-timeout).
+# waiting", bounded by the per-issue solve-timeout) BUT now ALSO records a
+# consecutive-failure tick (#290.3) so uberdev_goal_gh_failure_breaker_check
+# can fire gh_api_failed before the solve-timeout misattributes the outage as
+# "agent idle / no PR".
 uberdev_goal_find_pr_for_issue() {
   local n="$1"
   _uberdev_goal_validate_int "$n" || return 1
   # `any(.closingIssuesReferences[]?; .number == N)` is deliberate: a bare
   # `.closingIssuesReferences[]?.number == N` yields an EMPTY stream when the
-  # array is empty (a PR whose Closes-link was dropped), and `empty or X`
-  # collapses to empty in jq — silently discarding a row that the `feat/N-`
-  # head-ref arm would have matched. `any/2` returns a concrete `false` on an
-  # empty generator, so the `or` stays boolean and the head-ref fallback works.
+  # array is empty (a PR whose Closes-link was dropped). `any/2` returns a
+  # concrete `false` on an empty generator, so the select stays boolean. The
+  # input array is bound to `$prs` so both the closes-match and head-ref maxes
+  # read the SAME list (jq cannot reference the original input after the first
+  # `[...]` reduction).
   #
   # Capture gh's rc so a gh FAILURE (auth expiry, rate-limit 403, network) is
   # surfaced as a one-line breadcrumb rather than masquerading as "no PR yet"
   # (rc 0 + empty) — without it a transient gh outage stalls the goal until the
   # 150m solve-timeout with a MISattributed "agent idle" diagnostic. Still
-  # fail-open (return empty, rc 0) so the caller keeps waiting/re-polls; the
-  # breadcrumb only distinguishes the two empty cases in the operator's log.
+  # fail-open (return empty, rc 0) so the caller keeps waiting/re-polls.
   local out rc
-  out="$(gh pr list --state all --limit 200 \
+  out="$(gh pr list --state open --limit 200 \
     --json number,closingIssuesReferences,headRefName \
-    --jq "[.[] | select(any(.closingIssuesReferences[]?; .number == ${n}) or (.headRefName | test(\"^feat/${n}-\"))) | .number] | max // empty" \
+    --jq ". as \$prs
+          | ([\$prs[] | select(any(.closingIssuesReferences[]?; .number == ${n})) | .number] | max) as \$byclose
+          | ([\$prs[] | select(.headRefName | test(\"^feat/${n}-\")) | .number] | max) as \$byhead
+          | (\$byclose // \$byhead // empty)" \
     2>/dev/null)"
   rc=$?
   if [ "$rc" -ne 0 ]; then
     printf 'goal-state: gh pr list failed (rc=%s) resolving PR for issue %s; treating as no-PR-yet (will re-poll)\n' "$rc" "$n" >&2
+    _uberdev_goal_record_gh_failure                                # #290.3
     return 0
   fi
+  _uberdev_goal_reset_gh_failure                                   # #290.3 — gh healthy
   printf '%s' "$out"
 }
 
@@ -918,8 +1063,10 @@ uberdev_goal_pr_state_gh() {
   rc=$?
   if [ "$rc" -ne 0 ]; then
     printf 'goal-state: gh pr view failed (rc=%s) reading state for PR %s; treating as not-merged/not-closed (will re-poll)\n' "$rc" "$pr" >&2
+    _uberdev_goal_record_gh_failure                                # #290.3
     return 0
   fi
+  _uberdev_goal_reset_gh_failure                                   # #290.3 — gh healthy
   printf '%s' "$out"
 }
 
@@ -931,6 +1078,79 @@ uberdev_goal_pr_is_merged() {
   local pr="$1"
   _uberdev_goal_validate_int "$pr" || return 1
   [ "$(uberdev_goal_pr_state_gh "$pr")" = "MERGED" ]
+}
+
+# ---------------------------------------------------------------------------
+# Consecutive gh-failure breaker (#290.3 MAJOR).
+# The Phase-2a/2d polling helpers (find_pr_for_issue / pr_state_gh) fail OPEN
+# on a gh outage — the right call for a transient blip (just re-poll). But a
+# SUSTAINED outage left a solved-and-pushed issue to be abandoned to `failed`
+# after the 150m solve-timeout, or churned a merged PR, because gh_api_failed
+# only guarded the Phase-3 `gh issue list`. These helpers maintain a tiny
+# single-int counter keyed on UBERDEV_GOAL_ID: every helper failure bumps it,
+# every helper success resets it, and the breaker-check fires gh_api_failed
+# once the count crosses the threshold. The counter file lives alongside the
+# other per-goal state under $UBERDEV_TMPDIR and is best-effort (a write
+# failure must never crash the fail-open helper that called it — the goal still
+# rides the timeout as before, just without the early breaker).
+# ---------------------------------------------------------------------------
+
+# _uberdev_goal_gh_failure_counter_path  — internal path resolver. Empty
+# stdout (rc 1) when no valid UBERDEV_GOAL_ID is in scope (so callers no-op).
+_uberdev_goal_gh_failure_counter_path() {
+  local goal_id="${UBERDEV_GOAL_ID:-}"
+  _uberdev_goal_validate_id "$goal_id" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  printf '%s' "$tmpdir/goal-$goal_id-gh-failures.txt"
+}
+
+# _uberdev_goal_record_gh_failure  — bump the consecutive-failure counter.
+# Best-effort: never returns non-zero in a way that disturbs the fail-open
+# caller (a counter-write failure is logged once, the goal still re-polls).
+_uberdev_goal_record_gh_failure() {
+  local f; f="$(_uberdev_goal_gh_failure_counter_path)" || return 0
+  local cur=0
+  [ -r "$f" ] && cur="$(cat "$f" 2>/dev/null)"
+  _uberdev_goal_validate_int "$cur" || cur=0
+  printf '%s\n' "$(( cur + 1 ))" > "$f" 2>/dev/null || \
+    printf 'goal-state: could not record gh-failure tick (unwritable UBERDEV_TMPDIR?)\n' >&2
+  return 0
+}
+
+# _uberdev_goal_reset_gh_failure  — clear the counter after a healthy gh call.
+_uberdev_goal_reset_gh_failure() {
+  local f; f="$(_uberdev_goal_gh_failure_counter_path)" || return 0
+  # Only rewrite when a non-zero count is on disk — avoids a needless write
+  # (and its potential ENOSPC noise) on every healthy poll once the file is 0.
+  [ -r "$f" ] || return 0
+  local cur; cur="$(cat "$f" 2>/dev/null)"
+  [ "$cur" = "0" ] && return 0
+  printf '0\n' > "$f" 2>/dev/null || true
+  return 0
+}
+
+# uberdev_goal_gh_failure_breaker_check GOAL_ID [THRESHOLD]
+# rc 0 (FIRE) iff the consecutive gh-failure counter for GOAL_ID is >= THRESHOLD
+# (default _UBERDEV_GOAL_MAX_GH_FAILURES). On fire, emits ONE goal_circuit_breaker
+# audit event {"reason":"gh_api_failed","phase":"poll","consecutive_failures":N}
+# — mirrors uberdev_goal_barrier_breaker_check's shape so the watch loop can
+# treat both identically (print_summary + exit). rc 1 when under threshold or
+# the counter file is absent (no failures recorded yet). Pure read of the
+# counter file + one audit append; no gh calls.
+uberdev_goal_gh_failure_breaker_check() {
+  local goal_id="${1:?goal_id required}"
+  local threshold="${2:-${_UBERDEV_GOAL_MAX_GH_FAILURES:-5}}"
+  _uberdev_goal_validate_id "$goal_id" || return 1
+  _uberdev_goal_validate_int "$threshold" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-/tmp}"
+  local f="$tmpdir/goal-$goal_id-gh-failures.txt"
+  [ -r "$f" ] || return 1
+  local count; count="$(cat "$f" 2>/dev/null)"
+  _uberdev_goal_validate_int "$count" || return 1
+  [ "$count" -ge "$threshold" ] || return 1
+  uberdev_goal_audit goal_circuit_breaker \
+    "$(printf '{"reason":"gh_api_failed","phase":"poll","consecutive_failures":%s}' "$count")"
+  return 0
 }
 
 # uberdev_goal_agent_busy_for_issue ISSUE_NUM   (issue #180)
@@ -1134,26 +1354,26 @@ _uberdev_goal_locked_marker_for_pr_fresh() {
   local pr="$1" grace="$2"
   _uberdev_goal_validate_int "$pr" || return 1
   _uberdev_goal_validate_int "$grace" || return 1
-  local now matched_mtime prefix marker_dir ctx mtime
+  local now matched_mtime marker_dir ctx mtime pr_match
   now="$(date +%s)"
   matched_mtime=0
   # R2 SSOT (issue #220 simplify pass): glob set read from
-  # _UBERDEV_GOAL_WORKTREE_PREFIXES so this and uberdev_goal_locate_review_pr_audit_by_pr
-  # cannot drift.
-  for prefix in "${_UBERDEV_GOAL_WORKTREE_PREFIXES[@]}"; do
-    for marker_dir in ${prefix}.uberdev/runs/*/; do
-      [ -d "$marker_dir" ] || continue
-      ctx="${marker_dir}pr-context.json"
-      [ -r "${marker_dir}locked" ] && [ -r "$ctx" ] || continue
-      _uberdev_dispatch_tmp_target_safe "$ctx" || continue
-      local pr_match
-      pr_match="$(jq -r --argjson pr "$pr" 'select(.pr == $pr) | .pr // empty' < "$ctx" 2>/dev/null)" || continue
-      [ "$pr_match" = "$pr" ] || continue
-      mtime="$(stat -c %Y "${marker_dir}locked" 2>/dev/null || stat -f %m "${marker_dir}locked" 2>/dev/null || echo 0)"
-      _uberdev_goal_validate_int "$mtime" || continue
-      [ "$mtime" -gt "$matched_mtime" ] && matched_mtime="$mtime"
-    done
-  done
+  # _UBERDEV_GOAL_WORKTREE_PREFIXES. #270/#290.2 cross-shell: route the dir-glob
+  # through _uberdev_goal_glob_worktree — the bare `${prefix}` glob silently
+  # matched no worktree mirror under the zsh Bash tool, so a /review-pr running
+  # in a worktree never registered as in-flight for the project-root poll loop
+  # (the exact gap AC ❶ was filed to close, latent under zsh until now).
+  while IFS= read -r marker_dir; do
+    [ -d "$marker_dir" ] || continue
+    ctx="${marker_dir}pr-context.json"
+    [ -r "${marker_dir}locked" ] && [ -r "$ctx" ] || continue
+    _uberdev_dispatch_tmp_target_safe "$ctx" || continue
+    pr_match="$(jq -r --argjson pr "$pr" 'select(.pr == $pr) | .pr // empty' < "$ctx" 2>/dev/null)" || continue
+    [ "$pr_match" = "$pr" ] || continue
+    mtime="$(stat -c %Y "${marker_dir}locked" 2>/dev/null || stat -f %m "${marker_dir}locked" 2>/dev/null || echo 0)"
+    _uberdev_goal_validate_int "$mtime" || continue
+    [ "$mtime" -gt "$matched_mtime" ] && matched_mtime="$mtime"
+  done < <(_uberdev_goal_glob_worktree ".uberdev/runs/*/")
   [ "$matched_mtime" -gt 0 ] || return 1
   [ "$(( now - matched_mtime ))" -lt "$grace" ]
 }
@@ -1188,6 +1408,22 @@ uberdev_goal_list_prs_in_state() {
 #        - `pr_parked` reason ∈ {refused, ambiguous, push-non-ff} -> conflict
 #        - `pr_parked` reason == test-fail-exhausted             -> hook_failed
 #        - no matching row                                       -> missing
+#
+# #290.2 (CRITICAL) — worktree-anchored audit read. /merge runs in its OWN
+# dispatched worktree (cwd = the merge agent's `solve-issue-<pr>` worktree per
+# lib/dispatch.sh), so it writes the `merge_executed` / `pr_parked` rows to
+# THAT worktree's relative `.uberdev/audit.jsonl`. The /goal watcher polls from
+# the project-root checkout, where the bare relative `.uberdev/audit.jsonl`
+# resolved to a DIFFERENT (often absent / stale) file. The gh-MERGED happy path
+# (tier 1) masks this, but on the conflict / hook-failed path tier 2 read the
+# wrong file → returned `missing` forever → the merge_failed breaker never fired
+# and the PR looped the 60m merge-timeout. Fix: scan the SAME worktree-mirror
+# glob set the verdict locator uses (_UBERDEV_GOAL_WORKTREE_PREFIXES), passing
+# every readable candidate to one `jq --slurp` in glob order — the empty
+# (cwd / project-root) prefix FIRST, the worktree mirrors AFTER, so the merge
+# agent worktree's row lands LAST and `last` (the existing, BT46-locked
+# line-order tiebreak) picks it over any stale project-root row. No `.ts`
+# dependency (BT46 fixtures carry none) — within-file selection stays line-order.
 uberdev_goal_read_merge_result() {
   local pr="$1"
   _uberdev_goal_validate_int "$pr" || return 1
@@ -1199,17 +1435,25 @@ uberdev_goal_read_merge_result() {
     printf 'success\n'; return 0
   fi
   # Tier 2 — local audit classifies failures for PRs that did not merge.
-  local audit=".uberdev/audit.jsonl"
-  [ -f "$audit" ] || { printf 'missing\n'; return 0; }
-  # Pick the LAST matching JSONL line (most recent). Use a single jq pass
-  # to project `event\treason` for the final matching row; gh_jq_or_jq's
-  # `-r` mode + file argument is the wrong tool here (audit.jsonl is JSONL,
-  # not a single JSON document), so call jq directly with `--slurp` to
-  # treat the stream as an array.
+  # #290.2 — collect every readable .uberdev/audit.jsonl across the worktree-
+  # mirror prefixes (empty prefix = project root, first; worktree mirrors after)
+  # via the cross-shell glob helper (the bare `${prefix}` glob does NOT expand
+  # under the zsh Bash tool — see _uberdev_goal_glob_worktree).
+  local candidate audit_files=()
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] && audit_files+=("$candidate")
+  done < <(_uberdev_goal_glob_worktree ".uberdev/audit.jsonl")
+  [ "${#audit_files[@]}" -gt 0 ] || { printf 'missing\n'; return 0; }
+  # Pick the LAST matching JSONL line (most recent) across all candidate files.
+  # jq --slurp concatenates the files into ONE array in argument order, so the
+  # cross-file ordering is glob order (cwd first, worktrees after) and `last`
+  # picks the merge agent worktree's row over a stale project-root row.
+  # gh_jq_or_jq's `-r` mode + single-file arg is the wrong tool here (audit.jsonl
+  # is JSONL, not one JSON document), so call jq directly with --slurp.
   local row
   row="$(jq -r --argjson pr "$pr" \
     '[.[] | select(.event=="merge_executed" or .event=="pr_parked") | select(.data.pr == $pr) | {event,reason:(.data.reason // "")}] | last | if . == null then "" else "\(.event)\t\(.reason)" end' \
-    --slurp "$audit" 2>/dev/null)"
+    --slurp "${audit_files[@]}" 2>/dev/null)"
   [ -n "$row" ] || { printf 'missing\n'; return 0; }
   local event="${row%%	*}" reason="${row#*	}"
   case "$event" in
@@ -1386,49 +1630,101 @@ uberdev_goal_batch_all_terminal() {
 }
 
 # uberdev_goal_batch_unblock_wait_clear GOAL_ID
-# rc 0 iff every HELD row has either NO unblock-issue OR (unblock-issue closed
-# AND PR-trust-label review-pr:green present). The unblock-issue id is inferred
-# from the PR body's `Blocks: #N` line (body capped at 64 KiB per R1/T1).
-# Pure read of label/issue state. Stale or 404 label/issue data is treated as
-# "still waiting" (rc 1) per spec B11 — never assume CLOSED on a gh failure.
+# rc 0 (barrier MAY proceed) iff NO HELD row is still actively waiting on an
+# OPEN blocking issue. A HELD row gates the barrier (rc 1, "keep waiting") ONLY
+# while at least one of its `Blocks: #N` issues is still OPEN — the legitimate
+# hold-and-unblock window (RFC 0005 §3.2.3), bounded by the 4h barrier breaker.
+# All other HELD rows are PSEUDO-TERMINAL and do NOT gate co-batched GREEN PRs:
+#   - NO Blocks: line                                  → permanent hold
+#   - ALL Blocks issues CLOSED + `uberdev-approved`    → re-review cleared it green
+#   - ALL Blocks issues CLOSED + no `uberdev-approved` → re-review fired but did
+#     not produce GREEN (PR stays held) → permanent hold
+# The unblock-issue ids come from the PR body's `Blocks: #N` lines (body capped
+# at 64 KiB per R1/T1). Pure read of label/issue state.
+#
+# #289.1 (BLOCKER) — the gate previously required the label `review-pr:green`,
+# which has ZERO producers (/review-pr emits `uberdev-approved` /
+# `uberdev-approved-with-concerns`, never `review-pr:green` — see
+# commands/review-pr.md:895). So a HELD row whose blocker CLOSED but which stayed
+# held returned rc 1 FOREVER, blocking every co-batched GREEN PR until the 4h
+# stuck_loop and defeating the core hold-and-unblock feature. Fix: gate on the
+# label /review-pr actually writes (`uberdev-approved`), and treat a held PR
+# whose blockers all closed as pseudo-terminal (it no longer gates) regardless
+# of whether the re-review went green — consistent with the Phase-3 convergence
+# calculus where both held states are terminal.
+#
+# #289.3 (MAJOR) — collect and require ALL `Blocks:` issues (the prior loop
+# `break`-ed after the FIRST match while _uberdev_goal_check_unblock requires
+# ALL closed; a >1-blocker held PR could unblock the barrier prematurely or
+# wedge). Mirror check_unblock's all-closed loop, including its 404→CLOSED /
+# other-gh-error→wait classification (spec B11: never assume CLOSED on a gh
+# failure).
 uberdev_goal_batch_unblock_wait_clear() {
   local goal_id="$1"
   _uberdev_goal_validate_id "$goal_id" || return 1
   local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
   local tsv="$tmpdir/goal-$goal_id-batch-prs.tsv"
   [ -r "$tsv" ] && [ -s "$tsv" ] || return 0   # empty registry → trivially clear
-  local pr issue _ts state line
+  # #270 cross-shell: ALL locals declared ONCE at function scope. Re-running
+  # `local var` (no value) inside the per-row loop ECHOES `var=<value>` to
+  # stdout under zsh (= `typeset var` on an existing var), which polluted this
+  # function's stdout from the 2nd HELD row onward. Declaring up front + bare
+  # assignment inside the loop keeps stdout clean in bash AND zsh.
+  local pr issue _ts state line body n any_open i issue_state issue_raw issue_rc has_approved
+  local blocking=()
   while IFS=$'\t' read -r pr issue _ts state; do
     [ -n "$state" ] || continue
     [ "$state" = "HELD" ] || continue
-    # Fetch PR body (capped at 64 KiB) and look for Blocks: #N.
+    # Fetch PR body (capped at 64 KiB) and collect ALL Blocks: #N issues.
     # F17 simplify-lens: reuse the centralized helpers
     # _uberdev_goal_fetch_pr_body + _uberdev_goal_parse_blocks_line (same
     # primitives used by sibling _uberdev_goal_check_unblock); the cap +
-    # ReDoS-safe anchored regex + numeric re-validation now flow from a
-    # single source of truth.
-    local body blocking_issue n
+    # ReDoS-safe anchored regex + numeric re-validation flow from one source.
+    blocking=()                              # reset per HELD row
     body="$(_uberdev_goal_fetch_pr_body "$pr")"
-    blocking_issue=""
     while IFS= read -r line; do
       n="$(_uberdev_goal_parse_blocks_line "$line")"
-      if [ -n "$n" ]; then
-        blocking_issue="$n"
-        break
-      fi
+      [ -n "$n" ] && blocking+=("$n")
     done <<< "$body"
-    # No unblock-issue → this HELD PR doesn't gate the barrier.
-    [ -n "$blocking_issue" ] || continue
-    # Verify issue is CLOSED.
-    local issue_state
-    issue_state="$(gh issue view "$blocking_issue" --json state --jq .state 2>/dev/null)" || return 1
-    [ "$issue_state" = "CLOSED" ] || return 1
-    # Verify trust label review-pr:green is present. In-process jq filter
-    # (length on a select-filtered array) avoids the post-jq `grep -c` fork
-    # and eliminates the pipeline-pollution surface (per /merge memory).
-    local has_green
-    has_green="$(gh pr view "$pr" --json labels --jq '[.labels[].name | select(. == "review-pr:green")] | length' 2>/dev/null || true)"
-    [ "${has_green:-0}" -ge 1 ] || return 1
+    # No unblock-issue → permanent hold → pseudo-terminal (doesn't gate).
+    [ "${#blocking[@]}" -gt 0 ] || continue
+    # Are ALL blocking issues CLOSED? (mirror _uberdev_goal_check_unblock — #289.3)
+    # any_open=1 means at least one blocker is still OPEN → genuine wait window.
+    # A gh failure other than 404 → wait (rc 1; B11 — never assume CLOSED).
+    any_open=0
+    for i in "${blocking[@]}"; do
+      issue_raw="$(gh issue view "$i" --json state --jq '.state' 2>&1)"
+      issue_rc=$?
+      if [ "$issue_rc" -ne 0 ]; then
+        if printf '%s' "$issue_raw" | grep -q 'Could not resolve to an Issue'; then
+          issue_state="CLOSED"   # 404 → deleted upstream → treat as closed
+        else
+          return 1               # transient gh error → keep waiting (B11)
+        fi
+      else
+        issue_state="$issue_raw"
+      fi
+      if [ "$issue_state" != "CLOSED" ]; then any_open=1; break; fi
+    done
+    # At least one blocker still OPEN → this held PR is in its legitimate
+    # hold-and-unblock wait window → gate the barrier.
+    [ "$any_open" = "0" ] || return 1
+    # All blockers CLOSED → pseudo-terminal regardless of re-review outcome
+    # (#289.1). Read the trust label /review-pr actually writes
+    # (`uberdev-approved` — NOT the zero-producer `review-pr:green`) purely to
+    # classify the breadcrumb: present ⇒ the re-review cleared it green; absent
+    # ⇒ the re-review fired but did not produce green and the PR stays held. In
+    # BOTH cases the row is pseudo-terminal and `continue`s — it does NOT gate
+    # co-batched GREEN PRs (the #289.1 anti-deadlock fix; #289.2's sequential
+    # green-PR merge loop serializes any version bumps so an early-merging
+    # GREEN PR cannot collide with a freshly-cleared held PR).
+    has_approved="$(gh pr view "$pr" --json labels \
+      --jq '[.labels[].name | select(. == "uberdev-approved")] | length' 2>/dev/null || true)"
+    if [ "${has_approved:-0}" -ge 1 ]; then
+      : # cleared green via re-review — no longer gates
+    else
+      printf 'goal-state: held PR %s has all Blocks closed but no uberdev-approved label (stays held, pseudo-terminal — not gating barrier)\n' "$pr" >&2
+    fi
   done < "$tsv"
   return 0
 }
@@ -1673,6 +1969,103 @@ _uberdev_goal_check_unblock() {
   fi
 }
 
+# uberdev_goal_detect_blocks_cycle GOAL_ID   (issue #292.1)
+# rc 0 (CYCLE FOUND) + echo the cycle's PR numbers CSV on stdout iff the
+# Blocks: dependency graph over the batch's HELD PRs contains a cycle (an SCC of
+# size ≥1 including a self-loop); rc 1 + empty stdout when the graph is acyclic.
+#
+# WHY: _uberdev_goal_check_unblock re-reviews a held PR only when ALL its
+# `Blocks: #N` issues are CLOSED, with NO cycle guard. A-blocks-B + B-blocks-A
+# (A held on an issue that only B's merge closes, and vice-versa) → neither
+# issue ever closes → both held PRs spin to the 4h stuck_loop with no diagnostic
+# naming the deadlock. RFC §4.3 claims "arbitrary depth" but only handles
+# ACYCLIC chains (the dependency graph had no SCC guard). This detector lets the
+# watch loop surface a distinct halt + print_summary row instead of riding the
+# wall-clock cap.
+#
+# Graph: nodes = HELD PRs. Edge P→Q iff P's body carries `Blocks: #N` and issue
+# N is closed by Q (Q's merge closes N — resolved via uberdev_goal_find_pr_for_issue,
+# i.e. the OPEN PR whose closingIssuesReferences include N) AND Q is itself a
+# HELD PR in this batch. A cycle over these edges is a merge deadlock.
+#
+# Cross-shell (#270): indexed arrays + newline-delimited string sets only — NO
+# associative arrays (bash `declare -A` / zsh `typeset -A` diverge in key
+# enumeration and would reintroduce the dual-shell fragility class). Reachability
+# is computed by fixpoint closure; the held-PR set is batch-bounded (small), so
+# the O(V·E) closure is cheap. Best-effort on gh failure: an unresolved edge is
+# simply omitted (a transient gh outage must not fabricate or hide a cycle — the
+# next poll re-evaluates).
+uberdev_goal_detect_blocks_cycle() {
+  local goal_id="$1"
+  _uberdev_goal_validate_id "$goal_id" || return 1
+  local tmpdir="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"
+  local tsv="$tmpdir/goal-$goal_id-batch-prs.tsv"
+  [ -r "$tsv" ] && [ -s "$tsv" ] || return 1
+  # 1) Collect HELD PRs.
+  local held=() _pr _issue _ts state
+  while IFS=$'\t' read -r _pr _issue _ts state; do
+    [ "$state" = "HELD" ] || continue
+    _uberdev_goal_validate_int "$_pr" || continue
+    held+=("$_pr")
+  done < "$tsv"
+  [ "${#held[@]}" -gt 0 ] || return 1
+  # Held-set membership probe (newline-delimited; grep -xF exact-line match).
+  local held_set; held_set="$(printf '%s\n' "${held[@]}")"
+  # 2) Build edges P<TAB>Q into a newline-delimited string set.
+  local edges="" p body line n q
+  for p in "${held[@]}"; do
+    body="$(_uberdev_goal_fetch_pr_body "$p")"
+    [ -n "$body" ] || continue
+    while IFS= read -r line; do
+      n="$(_uberdev_goal_parse_blocks_line "$line")"
+      [ -n "$n" ] || continue
+      q="$(uberdev_goal_find_pr_for_issue "$n" 2>/dev/null)"
+      [ -n "$q" ] || continue
+      _uberdev_goal_validate_int "$q" || continue
+      # Q must be a HELD PR in this batch for the edge to matter.
+      printf '%s\n' "$held_set" | grep -qxF "$q" || continue
+      edges="${edges}${p}	${q}
+"
+    done <<< "$body"
+  done
+  [ -n "$edges" ] || return 1
+  # 3) Reachability closure via fixpoint. `reach` holds "FROM<TAB>TO" pairs.
+  # Seed with the direct edges, then repeatedly compose reach∘edges until no
+  # new pair is added. A self-pair "X<TAB>X" anywhere means X lies on a cycle.
+  # #270 cross-shell: declare `pair` ONCE at function scope, never re-`local`
+  # inside the loop — under zsh, `local var` (= `typeset var`) on an
+  # already-declared var ECHOES `var=<value>` to stdout, which polluted the
+  # function's stdout (the cycle CSV) when run under the zsh Bash tool. Hoisting
+  # the declaration and assigning with a bare `printf -v` keeps stdout clean in
+  # both shells.
+  local reach="$edges" changed=1 a b c re_from re_to pair
+  while [ "$changed" = "1" ]; do
+    changed=0
+    # For each reachable pair (a,b) and each edge (b,c), try to add (a,c).
+    while IFS=$'\t' read -r a b; do
+      [ -n "$a" ] && [ -n "$b" ] || continue
+      while IFS=$'\t' read -r re_from re_to; do
+        [ "$re_from" = "$b" ] || continue
+        c="$re_to"
+        printf -v pair '%s\t%s' "$a" "$c"
+        if ! printf '%s' "$reach" | grep -qxF "$pair"; then
+          reach="${reach}${pair}
+"
+          changed=1
+        fi
+      done <<< "$edges"
+    done <<< "$reach"
+  done
+  # 4) Any self-pair X<TAB>X ⇒ X is on a cycle. Collect distinct such PRs.
+  local cycle_prs
+  cycle_prs="$(printf '%s' "$reach" \
+    | awk -F'\t' '$1!="" && $1==$2 && !seen[$1]++ {print $1}' \
+    | sort -n | paste -sd, -)"
+  [ -n "$cycle_prs" ] || return 1
+  printf '%s\n' "$cycle_prs"
+  return 0
+}
+
 # _uberdev_goal_set_batch_terminal_state GOAL_ID PR STATE
 # Rewrite the PR's row in goal-<id>-batch-prs.tsv with the new terminal_state.
 # Atomic-write via _uberdev_dispatch_prepare_tmp_target + mktemp + mv -f
@@ -1680,12 +2073,22 @@ _uberdev_goal_check_unblock() {
 # unknown PR — that would let a typo masquerade as a state change.
 # rc 0 on success; rc 1 validation / PR-not-in-registry; rc 3 atomic-write;
 # rc 4 missing dispatch lib.
+#
+# #289.2 — MERGING is a NON-terminal sentinel (NOT in uberdev_goal_batch_all_terminal's
+# terminal set, NOT in _uberdev_goal_batch_green_prs_ordered's GREEN filter). Phase 2c
+# sets it on the lowest green PR the instant /merge is dispatched, so (a) that PR drops
+# out of the green-ordered list and (b) batch_all_terminal goes rc 1 — which makes the
+# Phase-2c barrier gate FALSE and blocks any further /merge dispatch until Phase 2d
+# drives the in-flight PR to MERGED. That cross-pass interlock (paired with the in-pass
+# `break`) is what serializes version-bump merges: a second manifest-touching PR can
+# never be dispatched while the first is still landing, so two PRs can no longer both
+# land vN+1 and have git silently eat the second bump (project_uberdev_merge_version_collision).
 _uberdev_goal_set_batch_terminal_state() {
   local goal_id="$1" pr="$2" state="$3"
   _uberdev_goal_validate_id  "$goal_id" || return 1
   _uberdev_goal_validate_int "$pr"      || return 1
   case "$state" in
-    GREEN|HELD|MERGE_FAILED|MERGED|PENDING) : ;;
+    GREEN|HELD|MERGE_FAILED|MERGED|PENDING|MERGING) : ;;
     *) printf 'goal-state: invalid batch terminal state: %s\n' "$state" >&2; return 1 ;;
   esac
   if ! command -v _uberdev_dispatch_prepare_tmp_target >/dev/null 2>&1; then

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -672,6 +672,21 @@ while true; do
     fi
   done
 
+  # #290.3 — sustained-gh-outage breaker. find_pr_for_issue / pr_state_gh fail
+  # OPEN on a gh error (so a transient blip just re-polls), but each failure now
+  # ticks a consecutive-failure counter that any success resets. After
+  # _UBERDEV_GOAL_MAX_GH_FAILURES consecutive failures the breaker fires
+  # gh_api_failed — so a rate-limit / auth / network window that would otherwise
+  # ride the 150m solve-timeout to a FALSE `failed` (or churn a merged PR) halts
+  # the goal loudly instead. (gh_api_failed previously guarded only Phase 3's
+  # `gh issue list`.) print_summary + exit on fire, mirroring the wall-clock
+  # barrier breaker.
+  if uberdev_goal_gh_failure_breaker_check "$GOAL_ID"; then
+    _uberdev_goal_reap_zombies || true
+    print_summary "$cycle"
+    exit 1
+  fi
+
   # 2b. Read the leaf /review-pr verdict for PRs in pushed-reviewing (file-based
   # verdict locator + trust signal — the unchanged, version-independent contract).
   # TIME-GRACED (issue #180): the leaf solver runs its OWN /review-pr ~20m after
@@ -781,17 +796,23 @@ while true; do
     esac
   done
 
-  # 2c. Barrier-gated merge dispatch (issue #211).
+  # 2c. Barrier-gated merge dispatch (issue #211; barrier semantics #289).
   # The previous per-PR `if green; then /merge` body is replaced by a two-
   # predicate gate: ONLY dispatch /merge once (a) every PR in the batch is in
   # a terminal state (GREEN | HELD | MERGE_FAILED | MERGED — barrier-terminal,
-  # NOT to be confused with the convergence-terminal set) AND (b) the unblock
-  # wait is clear (every blocking issue closed AND every blocked PR carries a
-  # `review-pr:green` trust label). Until both predicates hold the per-cycle
-  # batch sits at the merge barrier — preventing the multi-PR version-bump
-  # collision (the user_workflow_todo_queue memory + project_uberdev_goal_
-  # version_bump_collision capture). Sequential, PR-asc merge plus a
-  # collision-chain rebase keeps the manifest-touching PRs serialized.
+  # NOT to be confused with the convergence-terminal set; MERGING is the
+  # NON-terminal in-flight sentinel from #289.2) AND (b) the unblock wait is
+  # clear. #289.1/#289.3: a HELD row gates the barrier ONLY while at least one
+  # of its `Blocks: #N` issues is still OPEN (the legitimate hold-and-unblock
+  # window); once ALL its blockers close it is PSEUDO-TERMINAL and no longer
+  # gates co-batched GREEN PRs — whether or not the re-review cleared it green
+  # (detected via the `uberdev-approved` label /review-pr actually writes, NOT
+  # the zero-producer `review-pr:green`). Until both predicates hold the
+  # per-cycle batch sits at the merge barrier — preventing the multi-PR
+  # version-bump collision (the user_workflow_todo_queue memory +
+  # project_uberdev_goal_version_bump_collision capture). #289.2: STRICT
+  # lowest-first single-dispatch + the MERGING interlock keep the
+  # manifest-touching PRs serialized (at most one merge in flight).
   #
   # B2 — only transition to `merging` on dispatch rc=0; a failed dispatch
   # (mktemp/prompt-write/session-refuse) leaves the PR in `green` for a
@@ -822,57 +843,91 @@ while true; do
 
   if uberdev_goal_batch_all_terminal "$GOAL_ID" && \
      uberdev_goal_batch_unblock_wait_clear "$GOAL_ID"; then
-    # Both predicates clear — dispatch /merge for GREEN PRs in PR-number-
-    # ascending order. The collision-chain rebase forces a fresh main pull
-    # after each successful merge so the next PR in the chain rebases onto
-    # the just-landed commit before its own merge attempt. This is what
-    # serializes manifest-touching PRs (CHANGELOG.md, plugin.json,
-    # marketplace.json, README.md) — without it, parallel version-bump PRs
-    # silently auto-merge to the SAME vN+1 and the second PR's bump is
-    # eaten by git's identical-change auto-resolution (the
-    # project_uberdev_merge_version_collision memory).
-    for pr in $(_uberdev_goal_batch_green_prs_ordered "$GOAL_ID"); do
+    # #289.2 (BLOCKER) — STRICTLY SERIALIZE version-bump merges. The prior loop
+    # dispatched /merge for ALL green PRs in one async pass (each
+    # _uberdev_goal_dispatch_merge → claude --bg returns immediately); the
+    # collision-chain ran between dispatches but only fetched main + audited —
+    # it never WAITED for the prior merge to land and never renumbered. So two
+    # version-bump PRs both landed vN+1 and git silently ate the second bump
+    # (project_uberdev_merge_version_collision).
+    #
+    # Fix: handle ONLY the lowest green PR per pass, then `break`. The instant
+    # we dispatch its /merge we flip its batch row to MERGING (a non-terminal
+    # sentinel — #289.2 in goal-state.sh). That makes uberdev_goal_batch_all_terminal
+    # rc 1 on every subsequent pass, so the Phase-2c gate above stays FALSE and
+    # NO further /merge can be dispatched until Phase 2d drives this PR to
+    # MERGED. Only then does batch_all_terminal clear again and the NEXT-lowest
+    # green PR — now rebased onto the just-landed vN+1 main, re-reviewed, and
+    # renumbered to vN+2 by its own /merge — become eligible. The in-pass
+    # `break` + the cross-pass MERGING interlock together guarantee at most one
+    # manifest-touching merge is ever in flight.
+    pr="$(_uberdev_goal_batch_green_prs_ordered "$GOAL_ID" | head -n 1)"
+    if [ -n "$pr" ]; then
       if uberdev_goal_pr_is_merged "$pr"; then
         # Resume / human-merged — finalize via step 2d without re-dispatching
-        # /merge against an already-landed PR.
+        # /merge against an already-landed PR. Flip the batch row to MERGING so
+        # the barrier stays closed until 2d records MERGED.
         uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" green merging
+        _uberdev_goal_set_batch_terminal_state "$GOAL_ID" "$pr" MERGING \
+          || printf 'goal: set_batch_terminal_state(MERGING) failed for PR=%s (rc=%s); barrier may not serialize\n' "$pr" "$?" >&2
         any_active=1
-        continue
-      fi
       # Phase 2c in-flight gate (issue #220, Component 3.3) — never dispatch
-      # /merge while the same PR has a /review-pr still in flight; defer one
-      # poll tick. Emits goal_merge_deferred so the audit reflects the back-off.
-      #
-      # B2 (post-impl-review): set any_active=1 BEFORE continue (mirrors the
-      # symmetric Phase 2b in-flight branch which sets it before emitting
-      # goal_review_pr_deferred). Without this, an entire batch deferred by
-      # in-flight /review-pr leaves any_active=0 and the watch loop terminates
-      # with a spurious queue_empty_not_converged breaker fire.
-      if uberdev_goal_review_pr_in_flight "$pr"; then
+      # /merge while the lowest green PR still has a /review-pr in flight. Defer
+      # the WHOLE merge step one poll tick (do NOT skip ahead to a higher PR —
+      # that would let a higher-numbered version bump land before the lower one,
+      # reintroducing the collision). Emits goal_merge_deferred for the audit.
+      elif uberdev_goal_review_pr_in_flight "$pr"; then
         any_active=1
         uberdev_goal_audit goal_merge_deferred \
           "{\"goal_id\":\"$GOAL_ID\",\"pr\":$pr,\"reason\":\"review_in_flight\",\"in_flight_count\":1}"
-        continue   # next poll tick re-checks
-      fi
-      if uberdev_goal_should_automerge "$GOAL_ID" "$pr"; then
+      elif uberdev_goal_should_automerge "$GOAL_ID" "$pr"; then
         if _uberdev_goal_dispatch_merge "$pr"; then
           uberdev_goal_pr_state_transition "$GOAL_ID" "$pr" green merging
-          # Force-refresh main + rebase any remaining batch PRs that share
-          # manifest paths so the next iteration's merge sees the just-landed
-          # commit (collision-chain serialization, R5).
-          # Helper contract is "rc 0 always" (see docstring at goal-state.sh:1238);
-          # no `||` fallback needed — best-effort collision detection never halts.
+          # Flip to the MERGING sentinel BEFORE the collision-chain so the very
+          # next batch_all_terminal read (this PR no longer GREEN/terminal)
+          # blocks re-entry — the cross-pass half of the serialization.
+          _uberdev_goal_set_batch_terminal_state "$GOAL_ID" "$pr" MERGING \
+            || printf 'goal: set_batch_terminal_state(MERGING) failed for PR=%s (rc=%s); barrier may not serialize\n' "$pr" "$?" >&2
+          # Force-refresh main + flag any remaining green batch PRs that share
+          # manifest paths so the NEXT pass's /merge dispatch rebases onto the
+          # just-landed commit and renumbers its bump (collision-chain, R5).
+          # Helper contract is "rc 0 always"; no `||` fallback needed.
           _uberdev_goal_rebase_collision_chain "$GOAL_ID" "$pr"
+          any_active=1
         else
           printf 'goal-pipeline: _uberdev_goal_dispatch_merge failed for PR %s; staying in green for next-cycle retry\n' \
             "$pr" >&2
           any_active=1
         fi
       fi
-    done
+      # No loop: exactly one green PR is acted on per pass (strict
+      # lowest-first serialization, #289.2). The rest wait behind the MERGING
+      # interlock until this one reaches MERGED in step 2d.
+    fi
   else
     # Barrier NOT clear yet — at least one PR is PENDING or the unblock-wait
-    # has unresolved blockers. Check the wall-clock circuit breaker against
+    # has unresolved blockers.
+    #
+    # #292.1 — mutual-Blocks DEADLOCK guard, checked BEFORE the wall-clock
+    # cap. _uberdev_goal_check_unblock only re-reviews a held PR when ALL its
+    # Blocks: issues close, with no cycle detection: A-blocks-B + B-blocks-A
+    # would otherwise spin both held PRs to the 4h stuck_loop with no
+    # diagnostic naming the cycle. uberdev_goal_detect_blocks_cycle finds an
+    # SCC over the Blocks: edges across the batch's held PRs; on a hit, halt
+    # NOW with a distinct stuck_loop/phase=blocks_cycle row + the cycle PR set
+    # (D5 keeps GOAL_CIRCUIT_BREAKER_REASONS closed — the phase subfield
+    # distinguishes this, mirroring phase=merge_barrier).
+    cycle_prs="$(uberdev_goal_detect_blocks_cycle "$GOAL_ID")"
+    if [ -n "$cycle_prs" ]; then
+      uberdev_goal_audit goal_circuit_breaker \
+        "$(printf '{"reason":"stuck_loop","phase":"blocks_cycle","cycle_prs":"%s"}' "$cycle_prs")"
+      printf 'goal-pipeline: HALT — mutual Blocks: dependency cycle among held PRs (%s); no PR in the cycle can ever unblock\n' \
+        "$cycle_prs" >&2
+      _uberdev_goal_reap_zombies || true
+      print_summary "$cycle"
+      exit 1
+    fi
+    # Check the wall-clock circuit breaker against
     # BARRIER_TIMEOUT_S (default 4h, configurable via --barrier-timeout=N /
     # UBERDEV_GOAL_BARRIER_TIMEOUT_S / goal.barrier_timeout_s). The reason
     # field reuses the existing stuck_loop enum — D5 keeps GOAL_CIRCUIT_
@@ -1012,6 +1067,17 @@ while true; do
       green)
         uberdev_goal_pr_state_transition "$GOAL_ID" "$held_pr" "$held_current" green
         uberdev_goal_record_held_audit "$GOAL_ID" "$held_pr" "$new_audit"
+        # #292.2 — reset the per-PR merge-attempt counter on this held→green
+        # recovery. The cap (uberdev_goal_should_automerge, default 3) is
+        # otherwise per-PR-LIFETIME and never reset, so a PR blocked for ≥2
+        # cycles can hit the cap from transient merge stalls accumulated across
+        # its hold and never auto-merge again (stalling into
+        # queue_empty_not_converged with a GREEN-but-unmergeable PR). Scoping
+        # the cap to the PR's CURRENT green lifetime fixes that. Best-effort:
+        # a counter-reset write failure must not block the recovery transition.
+        uberdev_goal_reset_merge_attempts "$GOAL_ID" "$held_pr" \
+          || printf 'goal: reset_merge_attempts failed for PR=%s (rc=%s); merge cap may not reset\n' \
+             "$held_pr" "$?" >&2
         # #211 — update the batch registry so the next pass's step 2c
         # barrier sees this PR as GREEN (terminal-for-barrier) instead of
         # PENDING/HELD. Without this, a held→green transition is invisible

--- a/tests/goal-batch-barrier.test.sh
+++ b/tests/goal-batch-barrier.test.sh
@@ -102,9 +102,16 @@ echo "== B1: batch registry CRUD =="
 # ---------------------------------------------------------------------------
 echo "== B2: unblock_wait predicate exists in lib =="
 assert_grep "$GOAL_LIB" "^uberdev_goal_batch_unblock_wait_clear\(\)" "B2.predicate-defined"
-# Verify lib references both gating conditions (issue CLOSED + trust label review-pr:green).
+# Verify lib references the gating condition (issue CLOSED) + the CORRECT trust
+# label. #289.1: the gate must read `uberdev-approved` (the label /review-pr
+# actually writes), NOT the zero-producer `review-pr:green`. Assert the active
+# jq label-select uses uberdev-approved; assert no LIVE gate reads review-pr:green.
 assert_grep "$GOAL_LIB" 'CLOSED'                                    "B2.closed-issue-check"
-assert_grep "$GOAL_LIB" 'review-pr:green'                           "B2.green-trust-label"
+assert_grep "$GOAL_LIB" 'select\(\. == "uberdev-approved"\)'        "B2.approved-trust-label"
+# Negative: no executable `gh pr view ... select(. == "review-pr:green")` gate
+# remains (the phantom-label bug). A comment mentioning the old name is fine;
+# a live jq select on it is the regression.
+assert_no_grep "$GOAL_LIB" 'select\(\. == "review-pr:green"\)'      "B2.no-phantom-green-label-gate"
 
 # ---------------------------------------------------------------------------
 # B3 — barrier_start_ts persist/rehydrate under fresh-shell-with-cleared-env.
@@ -359,6 +366,285 @@ EOF
 
   echo "B9 PASS"
 ) || { FAIL=$((FAIL + 1)); echo "  FAIL  B9 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B10 — #289.3 (MAJOR) — batch_unblock_wait_clear requires ALL Blocks: issues
+# CLOSED (the prior loop break-ed after the FIRST match). A held PR with two
+# Blocks lines, only one closed, MUST keep gating the barrier (rc 1).
+# ---------------------------------------------------------------------------
+echo "== B10: unblock-wait requires ALL Blocks closed (#289.3) =="
+(
+  set -u
+  SCRATCH="$(mktemp -d)"; trap 'rm -rf "$SCRATCH"' EXIT
+  export UBERDEV_TMPDIR="$SCRATCH"; export UBERDEV_GOAL_ID="b10"
+  GOAL_ID="$UBERDEV_GOAL_ID"
+  . "$DISPATCH_LIB"; . "$GOAL_LIB"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null
+  uberdev_goal_register_batch_pr "$GOAL_ID" 100 200 >/dev/null
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 100 HELD
+  # PR body carries TWO Blocks lines; issue 201 CLOSED, issue 202 OPEN.
+  gh() {
+    case "$1 $2" in
+      "pr view") case "$*" in *body*) printf 'Blocks: #201\nBlocks: #202';; *labels*) printf '0';; esac ;;
+      "issue view") case "$3" in 201) printf 'CLOSED';; 202) printf 'OPEN';; esac ;;
+    esac
+  }
+  if uberdev_goal_batch_unblock_wait_clear "$GOAL_ID"; then
+    echo "B10.one-of-two-open-must-gate FAIL (returned rc0/clear)"; exit 1
+  fi
+  # Now BOTH closed → pseudo-terminal, no longer gates (rc0).
+  gh() {
+    case "$1 $2" in
+      "pr view") case "$*" in *body*) printf 'Blocks: #201\nBlocks: #202';; *labels*) printf '0';; esac ;;
+      "issue view") printf 'CLOSED' ;;
+    esac
+  }
+  if ! uberdev_goal_batch_unblock_wait_clear "$GOAL_ID" 2>/dev/null; then
+    echo "B10.all-closed-must-clear FAIL (returned rc1/wait)"; exit 1
+  fi
+  echo "B10 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B10 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B11 — #289.1 (BLOCKER) — the rc-1-FOREVER phantom-label bug. A held PR whose
+# (single) Blocks issue is CLOSED but which stays held (no uberdev-approved
+# label) MUST be pseudo-terminal (rc 0 — does NOT gate co-batched GREEN PRs).
+# The OLD code gated on the zero-producer `review-pr:green` and returned rc 1
+# forever, blocking every co-batched GREEN PR until the 4h stuck_loop.
+# ---------------------------------------------------------------------------
+echo "== B11: held+blocker-closed+no-green-label is pseudo-terminal, not rc1-forever (#289.1) =="
+(
+  set -u
+  SCRATCH="$(mktemp -d)"; trap 'rm -rf "$SCRATCH"' EXIT
+  export UBERDEV_TMPDIR="$SCRATCH"; export UBERDEV_GOAL_ID="b11"
+  GOAL_ID="$UBERDEV_GOAL_ID"
+  . "$DISPATCH_LIB"; . "$GOAL_LIB"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null
+  uberdev_goal_register_batch_pr "$GOAL_ID" 100 200 >/dev/null
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 100 HELD
+  # Blocker CLOSED, but NO uberdev-approved label (length 0). Stays held.
+  gh() {
+    case "$1 $2" in
+      "pr view") case "$*" in *body*) printf 'Blocks: #201';; *labels*) printf '0';; esac ;;
+      "issue view") printf 'CLOSED' ;;
+    esac
+  }
+  if ! uberdev_goal_batch_unblock_wait_clear "$GOAL_ID" 2>/dev/null; then
+    echo "B11.pseudo-terminal-must-clear FAIL (rc1 — the phantom-label deadlock)"; exit 1
+  fi
+  # While the blocker is still OPEN, it MUST gate (legitimate hold-and-unblock).
+  gh() {
+    case "$1 $2" in
+      "pr view") case "$*" in *body*) printf 'Blocks: #201';; *labels*) printf '0';; esac ;;
+      "issue view") printf 'OPEN' ;;
+    esac
+  }
+  if uberdev_goal_batch_unblock_wait_clear "$GOAL_ID"; then
+    echo "B11.blocker-open-must-gate FAIL (rc0 while blocker open)"; exit 1
+  fi
+  echo "B11 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B11 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B12 — #292.1 (MAJOR) — mutual Blocks cycle detection. PR100 blocks on issue
+# 201 (closed by held PR101); PR101 blocks on issue 200 (closed by held PR100).
+# detect_blocks_cycle MUST return rc 0 + both PRs. An acyclic graph returns rc 1.
+# ---------------------------------------------------------------------------
+echo "== B12: mutual-Blocks cycle detection (#292.1) =="
+(
+  set -u
+  SCRATCH="$(mktemp -d)"; trap 'rm -rf "$SCRATCH"' EXIT
+  export UBERDEV_TMPDIR="$SCRATCH"; export UBERDEV_GOAL_ID="b12"
+  GOAL_ID="$UBERDEV_GOAL_ID"
+  . "$DISPATCH_LIB"; . "$GOAL_LIB"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null
+  uberdev_goal_register_batch_pr "$GOAL_ID" 100 200 >/dev/null
+  uberdev_goal_register_batch_pr "$GOAL_ID" 101 201 >/dev/null
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 100 HELD
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 101 HELD
+  # PR100 body Blocks #201; PR101 body Blocks #200. find_pr: issue 200->PR100, 201->PR101.
+  gh() {
+    case "$1 $2" in
+      "pr view") case "$*" in *body*) case "$3" in 100) printf 'Blocks: #201';; 101) printf 'Blocks: #200';; esac ;; esac ;;
+      "pr list")
+        local jqf='.'; while [ $# -gt 0 ]; do [ "$1" = "--jq" ] && jqf="$2"; shift; done
+        printf '%s' '[{"number":100,"closingIssuesReferences":[{"number":200}],"headRefName":"feat/200-a"},{"number":101,"closingIssuesReferences":[{"number":201}],"headRefName":"feat/201-b"}]' | jq -r "$jqf" ;;
+    esac
+  }
+  cyc="$(uberdev_goal_detect_blocks_cycle "$GOAL_ID")"; rc=$?
+  [ "$rc" = "0" ] || { echo "B12.cycle-must-fire FAIL (rc=$rc)"; exit 1; }
+  case "$cyc" in *100*) : ;; *) echo "B12.cycle-missing-100 FAIL got [$cyc]"; exit 1 ;; esac
+  case "$cyc" in *101*) : ;; *) echo "B12.cycle-missing-101 FAIL got [$cyc]"; exit 1 ;; esac
+  # Acyclic: PR100 held, blocks issue 999 which NO held PR closes.
+  uberdev_goal_state_init "$GOAL_ID-acyc" >/dev/null
+  export UBERDEV_GOAL_ID="$GOAL_ID-acyc"; GOAL_ID="$GOAL_ID-acyc"
+  uberdev_goal_register_batch_pr "$GOAL_ID" 100 200 >/dev/null
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 100 HELD
+  gh() {
+    case "$1 $2" in
+      "pr view") case "$*" in *body*) printf 'Blocks: #999';; esac ;;
+      "pr list") local jqf='.'; while [ $# -gt 0 ]; do [ "$1" = "--jq" ] && jqf="$2"; shift; done; printf '[]' | jq -r "$jqf" ;;
+    esac
+  }
+  if uberdev_goal_detect_blocks_cycle "$GOAL_ID" >/dev/null; then
+    echo "B12.acyclic-must-not-fire FAIL"; exit 1
+  fi
+  echo "B12 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B12 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B13 — #292.2 (MAJOR) — per-PR merge-attempt counter reset. After 3 cumulative
+# attempts should_automerge refuses; reset_merge_attempts re-allows it (held→
+# green recovery). The counter must read 0 after the reset (last-write-wins).
+# ---------------------------------------------------------------------------
+echo "== B13: merge-attempt counter reset on held→green recovery (#292.2) =="
+(
+  set -u
+  SCRATCH="$(mktemp -d)"; trap 'rm -rf "$SCRATCH"' EXIT
+  export UBERDEV_TMPDIR="$SCRATCH"; export UBERDEV_GOAL_ID="b13"
+  GOAL_ID="$UBERDEV_GOAL_ID"
+  . "$DISPATCH_LIB"; . "$GOAL_LIB"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null
+  # Simulate 3 accumulated merge attempts → at the cap.
+  printf '%s\t%s\n' 100 3 > "$SCRATCH/goal-$GOAL_ID-merge-attempts.tsv"
+  if uberdev_goal_should_automerge "$GOAL_ID" 100; then
+    echo "B13.at-cap-must-refuse FAIL (should_automerge allowed at cap)"; exit 1
+  fi
+  uberdev_goal_reset_merge_attempts "$GOAL_ID" 100 || { echo "B13.reset-rc FAIL"; exit 1; }
+  cnt="$(_uberdev_goal_count_merge_attempts "$GOAL_ID" 100)"
+  [ "$cnt" = "0" ] || { echo "B13.count-after-reset FAIL got '$cnt' want 0"; exit 1; }
+  if ! uberdev_goal_should_automerge "$GOAL_ID" 100; then
+    echo "B13.after-reset-must-allow FAIL (still refusing post-reset)"; exit 1
+  fi
+  echo "B13 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B13 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B14 — #290.3 (MAJOR) — consecutive-gh-failure breaker. record bumps, reset
+# clears, breaker fires only at/above threshold and emits gh_api_failed.
+# ---------------------------------------------------------------------------
+echo "== B14: consecutive gh-failure breaker (#290.3) =="
+(
+  set -u
+  SCRATCH="$(mktemp -d)"; trap 'rm -rf "$SCRATCH"' EXIT
+  export UBERDEV_TMPDIR="$SCRATCH"; export UBERDEV_GOAL_ID="b14"
+  GOAL_ID="$UBERDEV_GOAL_ID"
+  . "$DISPATCH_LIB"; . "$GOAL_LIB"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null
+  # No failures yet → breaker does not fire.
+  if uberdev_goal_gh_failure_breaker_check "$GOAL_ID" 3; then echo "B14.fresh-must-not-fire FAIL"; exit 1; fi
+  _uberdev_goal_record_gh_failure; _uberdev_goal_record_gh_failure
+  if uberdev_goal_gh_failure_breaker_check "$GOAL_ID" 3; then echo "B14.under-threshold-must-not-fire FAIL"; exit 1; fi
+  _uberdev_goal_record_gh_failure   # now 3
+  if ! uberdev_goal_gh_failure_breaker_check "$GOAL_ID" 3 >/dev/null; then echo "B14.at-threshold-must-fire FAIL"; exit 1; fi
+  # The fire emits a gh_api_failed circuit-breaker audit row.
+  audit="$SCRATCH/goal-$GOAL_ID.jsonl"
+  grep -q '"reason":"gh_api_failed"' "$audit" || { echo "B14.audit-reason FAIL"; exit 1; }
+  grep -q '"phase":"poll"'           "$audit" || { echo "B14.audit-phase FAIL"; exit 1; }
+  # A success resets the counter → breaker no longer fires.
+  _uberdev_goal_reset_gh_failure
+  if uberdev_goal_gh_failure_breaker_check "$GOAL_ID" 3; then echo "B14.after-reset-must-not-fire FAIL"; exit 1; fi
+  echo "B14 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B14 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B15 — #290.4 (MAJOR) — find_pr_for_issue prefers the closingIssuesReferences
+# match over the feat/N- head-ref heuristic, and scans --state open. The lib
+# must use `--state open` (not `--state all`).
+# ---------------------------------------------------------------------------
+echo "== B15: find_pr prefers closes-match + scans open (#290.4) =="
+assert_grep "$GOAL_LIB" 'gh pr list --state open'   "B15.scans-state-open"
+assert_no_grep "$GOAL_LIB" 'gh pr list --state all' "B15.no-state-all"
+(
+  set -u
+  SCRATCH="$(mktemp -d)"; trap 'rm -rf "$SCRATCH"' EXIT
+  export UBERDEV_TMPDIR="$SCRATCH"; export UBERDEV_GOAL_ID="b15"
+  . "$DISPATCH_LIB"; . "$GOAL_LIB"
+  # PR5 CLOSES issue 77; PR9 merely has a re-used feat/77- branch but closes 88.
+  # The closes-match (5) must win over the head-ref distractor (9).
+  gh() {
+    local jqf='.'; while [ $# -gt 0 ]; do [ "$1" = "--jq" ] && jqf="$2"; shift; done
+    printf '%s' '[{"number":5,"closingIssuesReferences":[{"number":77}],"headRefName":"feat/77-real"},{"number":9,"closingIssuesReferences":[{"number":88}],"headRefName":"feat/77-reused"}]' | jq -r "$jqf"
+  }
+  got="$(uberdev_goal_find_pr_for_issue 77)"
+  [ "$got" = "5" ] || { echo "B15.closes-preference FAIL got '$got' want 5"; exit 1; }
+  # Head-ref fallback only when NO closes-match exists.
+  gh() {
+    local jqf='.'; while [ $# -gt 0 ]; do [ "$1" = "--jq" ] && jqf="$2"; shift; done
+    printf '%s' '[{"number":12,"closingIssuesReferences":[],"headRefName":"feat/77-x"}]' | jq -r "$jqf"
+  }
+  got2="$(uberdev_goal_find_pr_for_issue 77)"
+  [ "$got2" = "12" ] || { echo "B15.head-ref-fallback FAIL got '$got2' want 12"; exit 1; }
+  echo "B15 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B15 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B16 — #290.2 (CRITICAL) — read_merge_result reads the merge agent WORKTREE
+# mirror (.claude/worktrees/*/.uberdev/audit.jsonl), not just the cwd-relative
+# file. A pr_parked row written only in the worktree mirror must classify
+# (conflict), where the OLD cwd-only read returned `missing`.
+# ---------------------------------------------------------------------------
+echo "== B16: read_merge_result anchors to merge worktree audit (#290.2) =="
+(
+  set -u
+  WT="$(mktemp -d)"; trap 'rm -rf "$WT"' EXIT
+  export UBERDEV_TMPDIR="$WT"   # (read_merge_result uses cwd-relative globs, not tmpdir)
+  . "$DISPATCH_LIB"; . "$GOAL_LIB"
+  mkdir -p "$WT/.claude/worktrees/merge-run/.uberdev"
+  printf '%s\n' '{"event":"pr_parked","data":{"pr":777,"reason":"refused"}}' \
+    > "$WT/.claude/worktrees/merge-run/.uberdev/audit.jsonl"
+  gh() { case "$1 $2" in "pr view") printf 'OPEN';; esac; }   # not merged
+  out="$(cd "$WT" && uberdev_goal_read_merge_result 777)"
+  [ "$out" = "conflict" ] || { echo "B16.worktree-audit FAIL got '$out' want conflict"; exit 1; }
+  # Cross-file: cwd has a stale parked row, worktree has the real merge_executed.
+  # The worktree row (slurped LAST in glob order) wins → success.
+  mkdir -p "$WT/.uberdev"
+  printf '%s\n' '{"event":"pr_parked","data":{"pr":888,"reason":"refused"}}' > "$WT/.uberdev/audit.jsonl"
+  printf '%s\n' '{"event":"merge_executed","data":{"pr":888}}' > "$WT/.claude/worktrees/merge-run/.uberdev/audit.jsonl"
+  out2="$(cd "$WT" && uberdev_goal_read_merge_result 888)"
+  [ "$out2" = "success" ] || { echo "B16.cross-file-worktree-wins FAIL got '$out2' want success"; exit 1; }
+  echo "B16 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B16 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B17 — #289.2 (BLOCKER) — MERGING is a valid NON-terminal batch sentinel that
+# excludes the PR from the green-ordered list and forces batch_all_terminal to
+# rc 1 (the cross-pass serialization interlock). SKILL.md Phase 2c must use it.
+# ---------------------------------------------------------------------------
+echo "== B17: MERGING sentinel serializes merge dispatch (#289.2) =="
+(
+  set -u
+  SCRATCH="$(mktemp -d)"; trap 'rm -rf "$SCRATCH"' EXIT
+  export UBERDEV_TMPDIR="$SCRATCH"; export UBERDEV_GOAL_ID="b17"
+  GOAL_ID="$UBERDEV_GOAL_ID"
+  . "$DISPATCH_LIB"; . "$GOAL_LIB"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null
+  uberdev_goal_register_batch_pr "$GOAL_ID" 100 200 >/dev/null
+  uberdev_goal_register_batch_pr "$GOAL_ID" 101 201 >/dev/null
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 100 GREEN
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 101 GREEN
+  uberdev_goal_batch_all_terminal "$GOAL_ID" || { echo "B17.precondition-all-green-terminal FAIL"; exit 1; }
+  # Dispatch lowest (100) → MERGING.
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 100 MERGING || { echo "B17.set-merging-rc FAIL"; exit 1; }
+  if uberdev_goal_batch_all_terminal "$GOAL_ID"; then
+    echo "B17.merging-must-block-all-terminal FAIL (barrier did not interlock)"; exit 1
+  fi
+  ordered="$(_uberdev_goal_batch_green_prs_ordered "$GOAL_ID" | tr '\n' ' ' | sed 's/  *$//')"
+  [ "$ordered" = "101" ] || { echo "B17.merging-dropped-from-green FAIL got '$ordered' want 101"; exit 1; }
+  echo "B17 PASS"
+) || { FAIL=$((FAIL + 1)); echo "  FAIL  B17 block exited non-zero"; }
+
+# ---------------------------------------------------------------------------
+# B18 — #289.2 SKILL.md Phase-2c structural: the green-PR merge loop must take
+# the LOWEST green PR (head -n 1) and flip it to the MERGING sentinel, NOT loop
+# over all green PRs dispatching /merge in one async pass.
+# ---------------------------------------------------------------------------
+echo "== B18: Phase 2c dispatches lowest green PR + MERGING sentinel (#289.2 structural) =="
+GOAL_SKILL="$REPO_ROOT/plugins/uberdev/skills/goal-pipeline/SKILL.md"
+assert_grep "$GOAL_SKILL" '_uberdev_goal_batch_green_prs_ordered "\$GOAL_ID" \| head -n 1' "B18.lowest-green-head1"
+assert_grep "$GOAL_SKILL" '_uberdev_goal_set_batch_terminal_state "\$GOAL_ID" "\$pr" MERGING' "B18.flips-to-merging"
+# The phantom-label gate must NOT appear as a live jq select in the lib.
+assert_no_grep "$GOAL_LIB"  'select\(\. == "review-pr:green"\)'                              "B18.no-phantom-green-gate-in-lib"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/goal-state-zsh.test.sh
+++ b/tests/goal-state-zsh.test.sh
@@ -233,6 +233,134 @@ else
   pass "Z5c: no \${BASH_REMATCH[1]} PR-number extraction remains in finish-branch"
 fi
 
+echo
+echo "== Z6: batch_unblock_wait_clear — ALL Blocks closed + uberdev-approved gate (#289.1/#289.3) =="
+# Runs the barrier unblock-wait predicate UNDER THE LIVE SHELL. The lib uses
+# indexed arrays + a per-blocker loop internally; this proves the #289 fix holds
+# in BOTH bash and zsh (the rc1-forever phantom-label deadlock + the
+# break-after-first-Blocks bug both surfaced from cross-shell-fragile code).
+Z6_TMP="$(mktemp -d)"
+Z6_OUT="$(
+  GOAL_ID="goal-z6abcd01"
+  export GOAL_ID UBERDEV_GOAL_ID="$GOAL_ID" UBERDEV_TMPDIR="$Z6_TMP"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null 2>&1
+  uberdev_goal_register_batch_pr "$GOAL_ID" 100 200 >/dev/null 2>&1
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 100 HELD >/dev/null 2>&1
+  # Two Blocks; only one closed → must GATE (rc1).
+  gh() {
+    case "$1 $2" in
+      "pr view") case "$*" in (*body*) printf 'Blocks: #201\nBlocks: #202';; (*labels*) printf '0';; esac ;;
+      "issue view") case "$3" in (201) printf 'CLOSED';; (202) printf 'OPEN';; esac ;;
+    esac
+  }
+  uberdev_goal_batch_unblock_wait_clear "$GOAL_ID" >/dev/null 2>&1 && r_partial=0 || r_partial=1
+  # Both closed, no uberdev-approved → pseudo-terminal, must CLEAR (rc0).
+  gh() {
+    case "$1 $2" in
+      "pr view") case "$*" in (*body*) printf 'Blocks: #201\nBlocks: #202';; (*labels*) printf '0';; esac ;;
+      "issue view") printf 'CLOSED' ;;
+    esac
+  }
+  uberdev_goal_batch_unblock_wait_clear "$GOAL_ID" >/dev/null 2>&1 && r_allclosed=0 || r_allclosed=1
+  printf 'partial=%s allclosed=%s\n' "$r_partial" "$r_allclosed"
+)"
+case "$Z6_OUT" in
+  *"partial=1 allclosed=0"*)
+    pass "Z6a: unblock-wait gates on one-of-two-open, clears (pseudo-terminal) on all-closed under $RUN_SHELL" ;;
+  *)
+    fail "Z6a: unblock-wait wrong (#289 — got: [$Z6_OUT]; expect partial=1 allclosed=0)" ;;
+esac
+# Structural: the live label gate reads uberdev-approved, NOT review-pr:green.
+if grep -qE 'select\(\. == "uberdev-approved"\)' "$GOAL_LIB"; then
+  pass "Z6b: unblock-wait label gate reads uberdev-approved (the producer label)"
+else
+  fail "Z6b: unblock-wait must read uberdev-approved (review-pr writes that, not review-pr:green)"
+fi
+if grep -qE 'select\(\. == "review-pr:green"\)' "$GOAL_LIB"; then
+  fail "Z6c: a LIVE jq gate on the phantom review-pr:green label still remains (rc1-forever bug)"
+else
+  pass "Z6c: no live jq gate on the phantom review-pr:green label remains"
+fi
+rm -rf "$Z6_TMP" 2>/dev/null || true
+
+echo
+echo "== Z7: read_trust_signal SHA-binding under the live shell (#290.1) =="
+Z7_TMP="$(mktemp -d)"
+Z7_OUT="$(
+  export UBERDEV_TMPDIR="$Z7_TMP"
+  vf="$Z7_TMP/verdict.json"
+  printf '%s\n' '{"pr":42,"sha":"abc123","phases":{"phase2_5":{"by_severity":{"blocker":0,"critical":0},"halted":false}}}' > "$vf"
+  gh() { case "$1 $2" in ("pr view") printf 'abc123';; esac; }
+  m="$(uberdev_goal_read_trust_signal "$vf" 2>/dev/null)"
+  gh() { case "$1 $2" in ("pr view") printf 'def456';; esac; }
+  s="$(uberdev_goal_read_trust_signal "$vf" 2>/dev/null)"
+  gh() { return 1; }
+  f="$(uberdev_goal_read_trust_signal "$vf" 2>/dev/null)"
+  printf 'match=%s mismatch=%s failsafe=%s\n' "$m" "$s" "$f"
+)"
+case "$Z7_OUT" in
+  *"match=green mismatch=stale failsafe=green"*)
+    pass "Z7a: SHA-binding green/stale/fail-safe correct under $RUN_SHELL" ;;
+  *)
+    fail "Z7a: SHA-binding wrong (#290.1 — got: [$Z7_OUT]; expect match=green mismatch=stale failsafe=green)" ;;
+esac
+rm -rf "$Z7_TMP" 2>/dev/null || true
+
+echo
+echo "== Z8: detect_blocks_cycle finds a mutual Blocks cycle under the live shell (#292.1) =="
+# The SCC detector uses indexed arrays + a reachability-closure fixpoint (NO
+# associative arrays — those diverge between bash and zsh). This proves it works
+# in both shells.
+Z8_TMP="$(mktemp -d)"
+Z8_OUT="$(
+  GOAL_ID="goal-z8abcd01"
+  export GOAL_ID UBERDEV_GOAL_ID="$GOAL_ID" UBERDEV_TMPDIR="$Z8_TMP"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null 2>&1
+  uberdev_goal_register_batch_pr "$GOAL_ID" 100 200 >/dev/null 2>&1
+  uberdev_goal_register_batch_pr "$GOAL_ID" 101 201 >/dev/null 2>&1
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 100 HELD >/dev/null 2>&1
+  _uberdev_goal_set_batch_terminal_state "$GOAL_ID" 101 HELD >/dev/null 2>&1
+  gh() {
+    case "$1 $2" in
+      "pr view") case "$*" in (*body*) case "$3" in (100) printf 'Blocks: #201';; (101) printf 'Blocks: #200';; esac ;; esac ;;
+      "pr list")
+        jqf='.'; while [ $# -gt 0 ]; do [ "$1" = "--jq" ] && jqf="$2"; shift; done
+        printf '%s' '[{"number":100,"closingIssuesReferences":[{"number":200}],"headRefName":"feat/200-a"},{"number":101,"closingIssuesReferences":[{"number":201}],"headRefName":"feat/201-b"}]' | jq -r "$jqf" ;;
+    esac
+  }
+  cyc="$(uberdev_goal_detect_blocks_cycle "$GOAL_ID" 2>/dev/null)" && rc=0 || rc=1
+  printf 'rc=%s cyc=[%s]\n' "$rc" "$cyc"
+)"
+case "$Z8_OUT" in
+  *"rc=0"*100*101*|*"rc=0"*101*100*)
+    pass "Z8a: detect_blocks_cycle fires on the mutual A↔B cycle under $RUN_SHELL (got: $Z8_OUT)" ;;
+  *)
+    fail "Z8a: detect_blocks_cycle missed the mutual cycle (#292.1 — got: [$Z8_OUT])" ;;
+esac
+rm -rf "$Z8_TMP" 2>/dev/null || true
+
+echo
+echo "== Z9: reset_merge_attempts re-allows should_automerge under the live shell (#292.2) =="
+Z9_TMP="$(mktemp -d)"
+Z9_OUT="$(
+  GOAL_ID="goal-z9abcd01"
+  export GOAL_ID UBERDEV_GOAL_ID="$GOAL_ID" UBERDEV_TMPDIR="$Z9_TMP"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null 2>&1
+  printf '%s\t%s\n' 100 3 > "$Z9_TMP/goal-$GOAL_ID-merge-attempts.tsv"
+  uberdev_goal_should_automerge "$GOAL_ID" 100 && pre=allow || pre=refuse
+  uberdev_goal_reset_merge_attempts "$GOAL_ID" 100 >/dev/null 2>&1
+  cnt="$(_uberdev_goal_count_merge_attempts "$GOAL_ID" 100)"
+  uberdev_goal_should_automerge "$GOAL_ID" 100 && post=allow || post=refuse
+  printf 'pre=%s cnt=%s post=%s\n' "$pre" "$cnt" "$post"
+)"
+case "$Z9_OUT" in
+  *"pre=refuse cnt=0 post=allow"*)
+    pass "Z9a: merge-attempt cap resets on recovery (refuse@cap → reset → allow) under $RUN_SHELL" ;;
+  *)
+    fail "Z9a: reset_merge_attempts wrong (#292.2 — got: [$Z9_OUT]; expect pre=refuse cnt=0 post=allow)" ;;
+esac
+rm -rf "$Z9_TMP" 2>/dev/null || true
+
 # Cleanup
 rm -rf "$Z2_TMP" "$Z3_TMP" "$Z4_TMP" 2>/dev/null || true
 

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -300,8 +300,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.17) =="
-assert_version_bump "$REPO_ROOT" "0.35.17"
+echo "== G20: version bump locked (0.35.18) =="
+assert_version_bump "$REPO_ROOT" "0.35.18"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -468,12 +468,19 @@ assert_grep "$GOAL_LIB" 'gh pr diff'                                      "G29.g
 assert_grep "$GOAL_LIB" 'sort -n'                                         "G29.sort-numeric-pr-ordering"
 
 echo
-echo "== G30: Unblock-wait dual condition (issue closed + review-pr:green label) (#211 AC5) =="
-# The unblock-wait predicate in lib/goal-state.sh must reference BOTH conditions.
+echo "== G30: Unblock-wait condition (issue closed + uberdev-approved label) (#211 AC5 / #289.1) =="
+# The unblock-wait predicate in lib/goal-state.sh must reference the closed-issue
+# condition and the CORRECT trust label. #289.1: the gate now reads the label
+# /review-pr actually writes (`uberdev-approved`) — the prior `review-pr:green`
+# had ZERO producers, so a held batch row whose blocker closed returned rc 1
+# forever and blocked every co-batched GREEN PR until the 4h stuck_loop.
 assert_grep "$GOAL_LIB" '^uberdev_goal_batch_unblock_wait_clear\(\)'      "G30.predicate-defined"
-assert_grep "$GOAL_LIB" 'review-pr:green'                                 "G30.green-trust-label"
-# Stale/missing label data treated as "still waiting" (rc 1) — defensive default arm.
-assert_grep "$GOAL_LIB" 'closed'                                          "G30.closed-issue-check"
+assert_grep "$GOAL_LIB" 'select\(\. == "uberdev-approved"\)'             "G30.approved-trust-label"
+# Negative regression guard: no LIVE jq gate on the phantom review-pr:green
+# label remains (a comment naming the old label is acceptable).
+assert_no_grep "$GOAL_LIB" 'select\(\. == "review-pr:green"\)'           "G30.no-phantom-green-label-gate"
+# Stale/missing issue data treated as "still waiting" (rc 1) — defensive default arm.
+assert_grep "$GOAL_LIB" 'CLOSED'                                          "G30.closed-issue-check"
 
 echo
 echo "== G31: Phase 2 step 2e updates batch registry on held → green transitions (#211 AC3/AC5 wiring) =="
@@ -1474,6 +1481,65 @@ cat > "$_bt23_audit_red_halted_critical" <<'EOF'
 EOF
 assert_eq "$(uberdev_goal_read_trust_signal "$_bt23_audit_red_halted_critical")" "red" \
   "BT23.halted-and-critical-emits-red"
+
+# ----- BT23a-BT23e — uberdev_goal_read_trust_signal SHA-binding (#290.1) -----
+# The verdict JSON carries `.pr` + `.sha` (the post-emission anchor headRefOid).
+# read_trust_signal must compare that `.sha` against the LIVE
+# `gh pr view <pr> --json headRefOid` and return `stale` on mismatch — a commit
+# pushed after a GREEN verdict must NOT drive pushed-reviewing→green on the
+# stale review. Each case overrides `gh` locally (the section-global gh() mock
+# is for state/body/list, not headRefOid).
+
+# BT23a — GREEN verdict, HEAD == verdict.sha → green (binding holds, no churn).
+_bt23a_v="$_b12_tmpdir/v-sha-match.json"
+cat > "$_bt23a_v" <<'EOF'
+{"pr":42,"sha":"abc123","phases":{"phase2_5":{"by_severity":{"blocker":0,"critical":0},"halted":false}}}
+EOF
+_bt23a_out="$(
+  gh() { case "$1 $2" in "pr view") printf 'abc123' ;; esac; }
+  uberdev_goal_read_trust_signal "$_bt23a_v" 2>/dev/null
+)"
+assert_eq "$_bt23a_out" "green" "BT23a.sha-match-green"
+
+# BT23b — GREEN verdict, HEAD advanced (!= verdict.sha) → stale (the #290.1 bug).
+_bt23b_out="$(
+  gh() { case "$1 $2" in "pr view") printf 'def456' ;; esac; }
+  uberdev_goal_read_trust_signal "$_bt23a_v" 2>/dev/null
+)"
+assert_eq "$_bt23b_out" "stale" "BT23b.sha-mismatch-stale"
+
+# BT23c — RED verdict + HEAD advanced → STILL stale (a new push invalidates the
+# whole review regardless of colour; re-review is the only safe action).
+_bt23c_v="$_b12_tmpdir/v-sha-red.json"
+cat > "$_bt23c_v" <<'EOF'
+{"pr":42,"sha":"abc123","phases":{"phase2_5":{"by_severity":{"blocker":1,"critical":0},"halted":false}}}
+EOF
+_bt23c_out="$(
+  gh() { case "$1 $2" in "pr view") printf 'def456' ;; esac; }
+  uberdev_goal_read_trust_signal "$_bt23c_v" 2>/dev/null
+)"
+assert_eq "$_bt23c_out" "stale" "BT23c.sha-mismatch-overrides-red-to-stale"
+
+# BT23d — gh outage reading headRefOid (rc!=0 / empty) → fail-SAFE: fall through
+# to the colour decision (green here), NOT a false stale (which would churn).
+_bt23d_out="$(
+  gh() { return 1; }
+  uberdev_goal_read_trust_signal "$_bt23a_v" 2>/dev/null
+)"
+assert_eq "$_bt23d_out" "green" "BT23d.gh-outage-failsafe-no-false-stale"
+
+# BT23e — legacy verdict WITHOUT a `.sha` field → no binding (backward compat);
+# the colour decision stands even if HEAD differs. Guards the audit-path-only
+# fixtures (BT12-BT23) that carry neither `.pr` nor `.sha`.
+_bt23e_v="$_b12_tmpdir/v-no-sha.json"
+cat > "$_bt23e_v" <<'EOF'
+{"pr":42,"phases":{"phase2_5":{"by_severity":{"blocker":0,"critical":0},"halted":false}}}
+EOF
+_bt23e_out="$(
+  gh() { case "$1 $2" in "pr view") printf 'zzz999' ;; esac; }
+  uberdev_goal_read_trust_signal "$_bt23e_v" 2>/dev/null
+)"
+assert_eq "$_bt23e_out" "green" "BT23e.legacy-no-sha-skips-binding"
 
 # Cleanup: remove the isolated tmpdir we created via mktemp -d above.
 # The single `rm -rf "$_b12_tmpdir"` subsumes any per-BT artifacts

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.16 -> 0.35.17 propagated =="
-assert_version_bump "$REPO_ROOT" "0.35.17"
+echo "== Version bump 0.35.17 -> 0.35.18 propagated =="
+assert_version_bump "$REPO_ROOT" "0.35.18"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
Found by the 7-agent `/ubergoal` audit (#288-294 drive). G2 of the parallel-fix wave: all of `lib/goal-state.sh` + ONLY Phase 2c (and the disjoint Phase 2a/2e wiring) of `goal-pipeline/SKILL.md`. Phases 0/1/3 are owned by a sibling PR — untouched here.

Closes #290
Closes #292
Closes #289

## #290 — external-read hardening (`lib/goal-state.sh`)
- **#290.1 (CRITICAL, verified) — trust signal now bound to HEAD SHA.** `uberdev_goal_read_trust_signal` reads `.pr`+`.sha` from the verdict JSON, fetches the live `gh pr view <pr> --json headRefOid`, and returns `stale` on mismatch (a commit pushed after a GREEN verdict no longer drives `pushed-reviewing→green→merging` on a stale review). Fail-SAFE on a gh outage (no false stale → no churn); backward-compatible (skips the binding when `.sha`/`.pr` are absent, e.g. legacy/audit-path-only fixtures).
- **#290.2 (CRITICAL, reported→verified) — merge-result audit anchored to the merge worktree.** `/merge` writes `merge_executed`/`pr_parked` to its own dispatched worktree's relative `.uberdev/audit.jsonl`; the watcher polls from the project root. `uberdev_goal_read_merge_result` now scans the `_UBERDEV_GOAL_WORKTREE_PREFIXES` mirror set (cwd first, worktree mirrors after; `last` line-order tiebreak preserved → BT46-safe), so the conflict/hook-failed path no longer returns `missing` forever.
- **#290.3 (MAJOR, verified) — consecutive-gh-failure breaker.** `find_pr_for_issue`/`pr_state_gh` still fail OPEN, but each failure now ticks a per-goal counter (any success resets it); a new `uberdev_goal_gh_failure_breaker_check` fires `gh_api_failed` after N consecutive failures (default 5) instead of riding the 150m solve / 60m merge timeout to a false `failed`. Wired into Phase 2a.
- **#290.4 (MAJOR, reported→verified) — `find_pr_for_issue` binds the right PR.** Scans `--state open` (was `--state all`, which let a stale CLOSED `feat/N-` branch win `max`) and prefers the `closingIssuesReferences` match over the `feat/N-` head-ref heuristic.

## #292 — held-PR liveness (`lib/goal-state.sh`)
- **#292.1 (MAJOR, reported→verified) — mutual `Blocks:` cycle detection.** New `uberdev_goal_detect_blocks_cycle` builds the Blocks graph over held PRs (edge P→Q when P blocks on an issue closed by held PR Q) and finds any SCC via a reachability-closure fixpoint (indexed arrays only — no assoc arrays, cross-shell-safe). Phase 2c halts a detected A↔B deadlock with a distinct `stuck_loop`/`phase=blocks_cycle` row instead of spinning to the 4h cap.
- **#292.2 (MAJOR, reported→verified) — per-cycle merge-attempt cap.** New `uberdev_goal_reset_merge_attempts` zeroes the per-PR counter; Phase 2e calls it on a held→green recovery so a PR blocked across cycles is not permanently capped by transient stalls.

## #289 — Phase-2c merge barrier (`SKILL.md` Phase 2c + lib `batch_*`)
- **#289.1 (BLOCKER, verified) — phantom-label deadlock.** `batch_unblock_wait_clear` gated on `review-pr:green`, which has ZERO producers (`/review-pr` emits `uberdev-approved`/`uberdev-approved-with-concerns`). A held row whose blocker closed but stayed held returned rc1 forever, blocking every co-batched GREEN PR until the 4h `stuck_loop`. Fix: gate on `uberdev-approved`, and make a held PR pseudo-terminal (stops gating others) the moment all its blockers close — gating only while a blocker is still OPEN.
- **#289.2 (BLOCKER, verified) — version-bump serialization.** The green-PR loop dispatched `/merge` for ALL green PRs in one async pass (no wait, no renumber) → two PRs both land vN+1, git eats the second bump. Fix: dispatch only the LOWEST green PR per pass, flip it to a new non-terminal `MERGING` batch sentinel (forces `batch_all_terminal` rc1 → blocks barrier re-entry until Phase 2d records `MERGED`), then `break`. At most one manifest-touching merge in flight; the next PR rebases onto the just-landed main.
- **#289.3 (MAJOR, verified) — multi-blocker.** `batch_unblock_wait_clear` collects and requires ALL `Blocks:` issues closed (mirrors `check_unblock`; was break-after-first).

## Cross-shell (#270 class — both bash AND zsh kept green)
The `_UBERDEV_GOAL_WORKTREE_PREFIXES` consumers (the merge-result read + the two existing locators) now route through a new `_uberdev_goal_glob_worktree` helper: a variable-derived `*` is NOT glob-expanded under the zsh Bash tool, so worktree-mirror verdict/audit/lock discovery was silently dead there. All loop-body `local` re-declarations were hoisted to function scope (zsh `typeset var` on an existing var echoes `var=value` to stdout).

## Tests (existing files extended — no new test files, no `test.yml` change)
- `goal-batch-barrier.test.sh` B10-B18, `goal.test.sh` BT23a-e + G30/B2 repoint to `uberdev-approved`, `goal-state-zsh.test.sh` Z6-Z9 (dual-shell).
- Each fix red-checked against a reverted-fix copy (the test FAILS on the old code, PASSES on the fix).
- Verified: `bash tests/goal.test.sh` (467/0), `bash tests/goal-batch-barrier.test.sh` (14/0), `zsh tests/goal-state-zsh.test.sh` + `bash tests/goal-state-zsh.test.sh` (19/0 each), `goal-dispatch-helpers` (23/0), `goal-state-sidecar` (31/0). Full `tests/*.test.sh` suite: 58 files green (zsh-run ones under zsh).

Release surfaces (version files, README badge, CHANGELOG, `test.yml`, the G20/solve-claim version-locks) are intentionally untouched — the orchestrator handles the version bump at sequential land to avoid collision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.35.18

* **Bug Fixes**
  * Fixed stale PR verdict handling to validate commit SHA bindings.
  * Improved merge outcome resolution across worktree mirror locations.
  * Added consecutive GitHub failure tracking with circuit-breaker halt.
  * Enhanced PR discovery to prefer explicit issue references over heuristics.
  * Implemented circular dependency detection in blocking issues.
  * Reset merge attempt counters when held PRs return to green status.
  * Corrected held PR gating logic requiring all blockers closed.

* **Documentation**
  * Updated `/merge` barrier behavior documentation.

* **Tests**
  * Expanded dual-shell test coverage for goal-state functions and regression scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->