### PR TITLE
test(goal): runtime coverage for goal-pipeline SKILL.md orchestration fences

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.35.18",
+      "version": "0.35.19",
       "category": "workflow",
       "tags": [
         "github",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
           bash tests/solve-effort-flag.test.sh && \
           zsh tests/solve-pipeline-zsh.test.sh && \
           zsh tests/goal-state-zsh.test.sh && \
+          zsh tests/goal-pipeline-zsh.test.sh && \
           bash tests/lib-assert-count.test.sh && \
           bash tests/crossplatform-shell-wrappers.test.sh && \
           bash tests/docs-accuracy.test.sh && \
@@ -172,6 +173,7 @@ jobs:
         # block below in lockstep; a new Unix-only fixture needs an entry
         # here AND its `bash tests/...` line in the ubuntu job above.
         #   - cluster-pipeline.test.sh
+        #   - goal-pipeline-zsh.test.sh
         #   - goal-state-zsh.test.sh
         #   - solve-pipeline-zsh.test.sh
         #   - testers-pipeline.test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.19] — 2026-05-29
+
+### Tests
+- **`/goal` orchestration layer gains runtime coverage (#293)** — the `lib/goal-state.sh` layer was densely unit-tested, but **no test executed the `skills/goal-pipeline/SKILL.md` bash fences** (CI only sourced the lib and grepped the markdown), so every orchestration-wiring regression — including the defects fixed in #288/#289/#290/#291/#292/#294 — could ship green. Adds CI-wired `tests/goal-pipeline-zsh.test.sh`, which extracts the SKILL.md `bash` fences and runs the key ones under the real **zsh** Bash-tool shell with `gh` / `claude` / `uberdev_dispatch_one` mocked: Phase-0 arg-parse + the bash≥4 resolver (asserts no spurious `exit 2` under zsh when bash≥4 is present, and `exit 2` when none — the #294 regression guard), the Phase-3 queue-empty convergence calc (#288), and one watch-loop iteration. Replaces the single-line negative-grep `--dry-run` assertion (G17) with a behavioural mocked-dispatch run asserting zero dispatch calls + `exit 0` + no `goal_dispatched` audit row. Wired into `.github/workflows/test.yml` per the `ci-wiring.test.sh` invariant.
+
 ## [0.35.18] — 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.35.18-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.35.19-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.35.18",
+  "version": "0.35.19",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/tests/goal-pipeline-zsh.test.sh
+++ b/tests/goal-pipeline-zsh.test.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+# tests/goal-pipeline-zsh.test.sh — RUNTIME coverage for the /uberdev:goal
+# ORCHESTRATION layer (issue #293).
+#
+# lib/goal-state.sh is densely unit-tested (goal.test.sh + goal-state-zsh.test.sh
+# + goal-dispatch-helpers.test.sh + goal-state-sidecar.test.sh), but until this
+# fixture NO test ever EXECUTED the bash-fenced blocks in
+# skills/goal-pipeline/SKILL.md — CI only sources the lib and greps the markdown
+# (G6-G10/G17/G22/G33/G37 are all `assert_grep`). The whole orchestration loop
+# (Phase-0 arg-parse + the bash>=4 resolver, the per-phase rehydration fences,
+# the watch loop, the circuit-breaker firing sites, the merge barrier, the
+# Phase-3 convergence calc) shipped with zero runtime coverage, so every wiring
+# regression — including the sibling /ubergoal-audit defects — shipped green.
+#
+# THIS fixture EXTRACTS the load-bearing `bash`-fenced blocks from SKILL.md and
+# RUNS them under the REAL shell with `gh` / `claude` / `uberdev_dispatch_one`
+# (and the heavy lib helpers) MOCKED. The repo's empirically-confirmed execution
+# model: the Claude-Code Bash tool runs every SKILL.md fence under /bin/zsh
+# (BASH_VERSINFO unset), and a bash>=4 binary exists at /opt/homebrew/bin/bash.
+# So the extracted fences are run under a dedicated `zsh` subprocess — that is
+# the real runtime the #294 / #270 / #290.2 cross-shell fixes were written for,
+# and the failure mode grep-only coverage can never catch.
+#
+# Launcher: CI runs this exactly like its sibling tests/goal-state-zsh.test.sh:
+#
+#   zsh tests/goal-pipeline-zsh.test.sh   # CI launcher (matches test.yml)
+#   bash tests/goal-pipeline-zsh.test.sh  # also works — the HARNESS is dual-
+#                                         # launchable; the extracted FENCES are
+#                                         # ALWAYS run under `zsh -f` regardless
+#                                         # of which shell launched the harness.
+#
+# Coverage (issue #293 acceptance set):
+#   P0  Phase-0 arg-parse + bash>=4 resolver (#294) — under zsh, a present
+#       bash>=4 resolves UBERDEV_GOAL_BASH and does NOT spuriously `exit 2`;
+#       with NO bash>=4 reachable it DOES `exit 2` (the brew-install dead-end).
+#   P3  Phase-3 terminal/convergence calc (#288) — does NOT converge while the
+#       rollover `queue` is non-empty; DOES converge when queue empty + all
+#       terminal; halts queue_empty_not_converged when a PR is stuck.
+#   W   One watch-loop iteration (step 2b) — the verdict-locator glob
+#       (_uberdev_goal_glob_worktree, #270/#290.2) finds a WORKTREE-MIRROR
+#       verdict under zsh and the loop transitions pushed-reviewing -> green
+#       WITHOUT fataling.
+#
+# Mutation guards (each behavioural assertion catches a real regression — revert
+# the named production fix in your worktree and re-run; the assertion goes RED):
+#   - P0a: resolver `for _cand … ; if major>=4 then UBERDEV_GOAL_BASH=…` arm ->
+#          old `[ -z BASH_VERSINFO ] && exit 2` guard  => P0a RED (spurious exit 2).
+#   - P3a: terminal-gate `&& [ "${#queue[@]}" -eq 0 ]` clause (issue #288 #1)
+#          removed => P3a RED (converges with a non-empty rollover queue).
+#   - W:   _uberdev_goal_glob_worktree `${~pat}` (zsh arm) -> bare `$pat`
+#          (#270/#290.2) => W RED (worktree-mirror verdict never found -> never
+#          transitions to green).
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/uberdev"
+export CLAUDE_PLUGIN_ROOT
+GOAL_SKILL="$CLAUDE_PLUGIN_ROOT/skills/goal-pipeline/SKILL.md"
+GOAL_LIB="$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh"
+DISPATCH_LIB="$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh"
+
+for f in "$GOAL_SKILL" "$GOAL_LIB" "$DISPATCH_LIB"; do
+  if [ ! -r "$f" ]; then
+    printf 'FATAL: required file missing or unreadable: %s\n' "$f" >&2
+    exit 2
+  fi
+done
+
+# The fences MUST run under a real zsh — that is the SKILL.md execution model
+# this fixture exists to cover. Refuse to run if no zsh is reachable rather than
+# silently degrading to a bash-only (false-confidence) run.
+ZSH_BIN="$(command -v zsh 2>/dev/null || true)"
+if [ -z "$ZSH_BIN" ]; then
+  echo "FATAL: zsh not found on PATH — this fixture runs the goal-pipeline SKILL.md" >&2
+  echo "       fences under zsh (their real Claude-Code Bash-tool runtime)." >&2
+  exit 2
+fi
+
+# Report which shell launched the HARNESS (the fences run under $ZSH_BIN either
+# way). Mirrors goal-state-zsh.test.sh's banner.
+if [ -n "${ZSH_VERSION:-}" ]; then
+  LAUNCH_SHELL="zsh"
+else
+  LAUNCH_SHELL="bash"
+fi
+echo "== goal-pipeline-zsh.test.sh — harness launched under: $LAUNCH_SHELL; fences run under: $ZSH_BIN =="
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL  $1"; FAIL=$((FAIL + 1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --------------------------------------------------------------------------
+# Fence extractors. SKILL.md fences are Skill-RENDERED markdown; the bash
+# blocks (some 3-space-indented inside the Phase-0 numbered steps) execute
+# under /bin/zsh. These awk helpers pull a fence (or a precise slice of one)
+# by CONTENT ANCHOR — robust to line-number drift, which matters for the
+# mutation tests in #293's discipline section (reverting a fix shifts lines).
+#
+# extract_fence ANCHOR  — print the body of the ```bash fence containing ANCHOR.
+# slice_fence S E       — print the lines from the (in-fence) line containing S
+#                         through the line containing E (inclusive); used to
+#                         pull one loop out of the 587-line Phase-2 watch fence.
+# Both exit 3 (-> caller fails the test) when the anchor is not found, so a
+# SKILL.md edit that removes/renames an anchored block fails LOUD here.
+# --------------------------------------------------------------------------
+EXTRACT_AWK="$WORK/extract.awk"
+cat > "$EXTRACT_AWK" <<'AWK'
+BEGIN { infence=0; curbash=0; found=0; buf="" }
+{
+  line=$0
+  if (line ~ /^[[:space:]]*```/) {
+    if (infence==0) {
+      stripped=line; sub(/^[[:space:]]*```/, "", stripped)
+      curbash = (stripped ~ /^bash[[:space:]]*$/) ? 1 : 0
+      infence=1; buf=""; hasanchor=0; next
+    } else {
+      if (curbash==1 && hasanchor==1) { printf "%s", buf; found=1; exit }
+      infence=0; curbash=0; next
+    }
+  }
+  if (infence==1 && curbash==1) {
+    buf = buf line "\n"
+    if (index(line, ANCHOR) > 0) hasanchor=1
+  }
+}
+END { if (found==0) exit 3 }
+AWK
+
+SLICE_AWK="$WORK/slice.awk"
+cat > "$SLICE_AWK" <<'AWK'
+BEGIN { infence=0; curbash=0; emitting=0; found=0 }
+{
+  line=$0
+  if (line ~ /^[[:space:]]*```/) {
+    if (infence==0) {
+      stripped=line; sub(/^[[:space:]]*```/, "", stripped)
+      curbash = (stripped ~ /^bash[[:space:]]*$/) ? 1 : 0
+      infence=1; next
+    } else { infence=0; curbash=0; next }
+  }
+  if (infence==1 && curbash==1) {
+    if (emitting==0 && index(line, SANCHOR) > 0) emitting=1
+    if (emitting==1) { print line; if (index(line, EANCHOR) > 0) { found=1; exit } }
+  }
+}
+END { if (found==0) exit 3 }
+AWK
+
+extract_fence() { awk -v ANCHOR="$1" -f "$EXTRACT_AWK" "$GOAL_SKILL"; }
+slice_fence()   { awk -v SANCHOR="$1" -v EANCHOR="$2" -f "$SLICE_AWK" "$GOAL_SKILL"; }
+
+# ==========================================================================
+# P0 — Phase-0 arg-parse + bash>=4 execution-contract resolver (#294).
+#
+# The pre-#294 guard hard-`exit 2`ed whenever BASH_VERSINFO was unset, which is
+# ALWAYS the case under the zsh-backed Bash tool — so /goal was unrunnable
+# out-of-box even with bash 5.x installed. The fix: discover a bash>=4, publish
+# UBERDEV_GOAL_BASH, and proceed; hard-exit 2 ONLY when no bash>=4 is reachable.
+# A pure grep cannot tell the two states apart — only running the resolver under
+# zsh can. We run the EXTRACTED resolver fence verbatim, swapping ONLY the
+# hard-coded candidate-path list (via sed) so the test controls which bash
+# binaries are probed (the version-gate + exit/publish logic stays verbatim).
+# ==========================================================================
+echo
+echo "== P0: Phase-0 bash>=4 resolver (#294) under zsh =="
+
+RESOLVER_FENCE="$WORK/resolver.fence.sh"
+if extract_fence 'Execution-contract resolver' > "$RESOLVER_FENCE" && [ -s "$RESOLVER_FENCE" ]; then
+  pass "P0.extract: located the #294 execution-contract resolver fence in SKILL.md"
+else
+  fail "P0.extract: could NOT extract the resolver fence (anchor 'Execution-contract resolver' moved/removed?)"
+fi
+
+# Fake bash binaries: one reporting MAJOR 5 (usable) and one reporting MAJOR 3
+# (the stock-macOS /bin/bash that must be REJECTED). The fence probes each
+# candidate with `"$cand" -c 'echo "${BASH_VERSINFO[0]:-0}"'`.
+mk_fake_bash() {  # $1=path $2=major
+  cat > "$1" <<FAKE
+#!/bin/sh
+[ "\$1" = "-c" ] && { echo $2; exit 0; }
+exit 0
+FAKE
+  chmod +x "$1"
+}
+mk_fake_bash "$WORK/bash5" 5
+mk_fake_bash "$WORK/bash3" 3
+
+# Candidate-list rewrite: the fence iterates
+#   for _cand in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash …)"
+# Replace the two hard-coded paths with test-controlled ones, and stub
+# `command -v bash` to return nothing, so ONLY our fake binaries are probed.
+make_resolver_variant() {  # $1=outfile  $2=first-cand  $3=second-cand
+  sed "s#/opt/homebrew/bin/bash /usr/local/bin/bash#$2 $3#" "$RESOLVER_FENCE" > "$1"
+}
+
+# --- P0a POSITIVE: a usable bash>=4 is present -> resolve + proceed (NOT exit 2).
+RES_POS="$WORK/resolver.pos.sh"
+make_resolver_variant "$RES_POS" "$WORK/bash5" "$WORK/none"
+DRV_POS="$WORK/drv_pos.zsh"
+{
+  echo 'set -u'
+  echo 'command() { if [ "$1" = "-v" ] && [ "$2" = "bash" ]; then return 1; fi; builtin command "$@"; }'
+  echo "source '$RES_POS'"
+  echo 'echo "PROCEEDED rc=$? bash=${UBERDEV_GOAL_BASH:-UNSET}"'
+} > "$DRV_POS"
+POS_OUT="$("$ZSH_BIN" -f "$DRV_POS" 2>&1)"
+POS_RC=$?
+if [ "$POS_RC" -eq 0 ] \
+   && printf '%s' "$POS_OUT" | grep -q "PROCEEDED rc=0" \
+   && printf '%s' "$POS_OUT" | grep -q "bash=$WORK/bash5"; then
+  pass "P0a: under zsh with a bash>=4 present, the resolver PROCEEDS (rc 0) and publishes UBERDEV_GOAL_BASH (no spurious exit 2 — the #294 fix)"
+else
+  fail "P0a: resolver did NOT proceed/publish under zsh (got rc=$POS_RC, out=[$POS_OUT]) — #294 regression?"
+fi
+
+# --- P0b NEGATIVE: no bash>=4 anywhere (only a bash3) -> exit 2 + brew directive.
+RES_NEG="$WORK/resolver.neg.sh"
+make_resolver_variant "$RES_NEG" "$WORK/bash3" "$WORK/none"
+DRV_NEG="$WORK/drv_neg.zsh"
+{
+  echo 'set -u'
+  echo 'command() { if [ "$1" = "-v" ] && [ "$2" = "bash" ]; then return 1; fi; builtin command "$@"; }'
+  echo "source '$RES_NEG'"
+  echo 'echo "DID-NOT-EXIT rc=$?"'
+} > "$DRV_NEG"
+NEG_OUT="$("$ZSH_BIN" -f "$DRV_NEG" 2>&1)"
+NEG_RC=$?
+if [ "$NEG_RC" -eq 2 ] && ! printf '%s' "$NEG_OUT" | grep -q 'DID-NOT-EXIT'; then
+  pass "P0b: under zsh with NO bash>=4 reachable, the resolver hard-exits 2 (the genuine-dead-end case)"
+else
+  fail "P0b: resolver should exit 2 when no bash>=4 exists (got rc=$NEG_RC, out=[$NEG_OUT])"
+fi
+if printf '%s' "$NEG_OUT" | grep -q 'brew install bash'; then
+  pass "P0c: the no-bash>=4 dead-end prints the brew-install remediation directive"
+else
+  fail "P0c: the exit-2 dead-end must print the 'brew install bash' directive (got: [$NEG_OUT])"
+fi
+
+# --- P0d: the bash>=4 ARM (already running bash>=4) is a no-op, not exit 2.
+# Run the resolver fence under bash>=4 itself (HBASH) — arm (a) must short-
+# circuit and the fence must NOT exit 2. This guards the `BASH_VERSINFO[0]>=4`
+# short-circuit branch the zsh runs never take.
+HBASH=""
+for c in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null)"; do
+  [ -n "$c" ] && [ -x "$c" ] || continue
+  m="$("$c" -c 'echo "${BASH_VERSINFO[0]:-0}"' 2>/dev/null)"
+  case "$m" in ''|*[!0-9]*) continue ;; esac
+  if [ "$m" -ge 4 ]; then HBASH="$c"; break; fi
+done
+if [ -n "$HBASH" ]; then
+  DRV_A="$WORK/drv_arma.sh"
+  { echo 'set -u'; echo "source '$RESOLVER_FENCE'"; echo 'echo "ARMA-OK rc=$?"'; } > "$DRV_A"
+  ARMA_OUT="$("$HBASH" "$DRV_A" 2>&1)"
+  ARMA_RC=$?
+  if [ "$ARMA_RC" -eq 0 ] && printf '%s' "$ARMA_OUT" | grep -q 'ARMA-OK rc=0'; then
+    pass "P0d: when already running bash>=4, the resolver short-circuits arm (a) — no exit 2 (got: [$ARMA_OUT])"
+  else
+    fail "P0d: resolver arm (a) (already bash>=4) should be a clean no-op (rc=$ARMA_RC, out=[$ARMA_OUT])"
+  fi
+else
+  fail "P0d: no bash>=4 found on this host to exercise resolver arm (a) — install bash (brew install bash)"
+fi
+
+# --- P0e: arg-parse fence collects positional issue numbers + flags under the
+# RESOLVED bash>=4 (the documented post-resolver execution contract).
+# The parser's `for tok in $ARGUMENTS` relies on word-splitting — which bash
+# does but zsh (SH_WORD_SPLIT=off) does NOT — so $ARGUMENTS arrives as ONE token
+# under raw zsh. That is EXACTLY why Phase 0's #294 resolver publishes
+# UBERDEV_GOAL_BASH and commands/goal.md directs the remaining fences to run
+# under it: the arg-parse + watch fences are bash>=4 fences. So this assertion
+# runs the EXTRACTED arg-parse fence under $HBASH (the resolved interpreter
+# P0d discovered) and asserts numeric tokens land in `queue` + flags set their
+# scalars — the parser the dry-run / dispatch paths depend on. (Running it under
+# raw zsh would only re-prove the word-split gap, not the parser's correctness.)
+ARGPARSE_FENCE="$WORK/argparse.fence.sh"
+if extract_fence 'for tok in $ARGUMENTS' > "$ARGPARSE_FENCE" && [ -s "$ARGPARSE_FENCE" ]; then
+  pass "P0e.extract: located the Phase-0 arg-parse fence in SKILL.md"
+  if [ -n "$HBASH" ]; then
+    DRV_AP="$WORK/drv_argparse.sh"
+    {
+      echo 'set -u'
+      echo 'ARGUMENTS="101 --max-cycles=7 202 --only-mine --dry-run --backend=claude-bg 303"'
+      echo "source '$ARGPARSE_FENCE'"
+      echo 'echo "queue=[${queue[*]}] mc=[$max_cycles_cli] om=[$only_mine] dr=[$dry_run] be=[$backend_cli]"'
+    } > "$DRV_AP"
+    AP_OUT="$("$HBASH" "$DRV_AP" 2>&1)"
+    AP_RC=$?
+    if [ "$AP_RC" -eq 0 ] \
+       && printf '%s' "$AP_OUT" | grep -q 'queue=\[101 202 303\]' \
+       && printf '%s' "$AP_OUT" | grep -q 'mc=\[7\]' \
+       && printf '%s' "$AP_OUT" | grep -q 'om=\[1\] dr=\[1\] be=\[claude-bg\]'; then
+      pass "P0e: arg-parse fence under the resolved bash collects positional issues (101/202/303) + flags (got: $AP_OUT)"
+    else
+      fail "P0e: arg-parse fence mis-parsed under the resolved bash (rc=$AP_RC, out=[$AP_OUT])"
+    fi
+  else
+    fail "P0e: no resolved bash>=4 available to run the arg-parse fence (see P0d)"
+  fi
+else
+  fail "P0e.extract: could not extract the Phase-0 arg-parse fence (anchor 'for tok in \$ARGUMENTS' moved?)"
+fi
+
+# ==========================================================================
+# P3 — Phase-3 terminal / convergence calc (#288).
+#
+# The convergence + queue-empty-not-converged gates are ALSO guarded on the
+# rollover `queue` being EMPTY (issue #288 #1). With more issues than
+# --max-parallel, Phase 1 defers the overflow into `queue`; those issues have
+# no PR yet, so a clean cycle has new_candidates empty AND terminal_count ==
+# all_pr_count even though work remains — without the `${#queue[@]} -eq 0`
+# clause the goal FALSELY converges (or false-halts queue_empty_not_converged)
+# while the overflow stays OPEN and never dispatched. We run the EXTRACTED
+# terminal-check fence under zsh against a seeded pr-states.tsv, stubbing the
+# rehydration + exit-side helpers (we set the loop scalars directly).
+# ==========================================================================
+echo
+echo "== P3: Phase-3 terminal/convergence calc (#288) under zsh =="
+
+TERMINAL_FENCE="$WORK/terminal.fence.sh"
+if extract_fence 'Terminal set for convergence' > "$TERMINAL_FENCE" && [ -s "$TERMINAL_FENCE" ]; then
+  pass "P3.extract: located the Phase-3 terminal/convergence fence in SKILL.md"
+else
+  fail "P3.extract: could NOT extract the terminal fence (anchor 'Terminal set for convergence' moved?)"
+fi
+
+# Driver template emitter: $1=goal-id $2=case(conv|queue|stuck).
+# Seeds the pr-states.tsv per case, then runs the extracted terminal fence.
+write_term_driver() {  # $1=outfile $2=gid $3=case
+  local out="$1" gid="$2" cs="$3"
+  {
+    echo 'set -u'
+    echo "export UBERDEV_TMPDIR='$WORK/state'"
+    echo "export GOAL_ID='$gid'"
+    echo "export UBERDEV_GOAL_ID='$gid'"
+    echo "PIPELINE_GOAL_CASE='$cs'"
+    echo ". \"\$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh\""
+    # Stub the fence's rehydration + terminal-exit side effects (the loop
+    # scalars are set directly below; reaper/print/cleanup/write are not under
+    # test here and would otherwise touch live state / fork agents).
+    echo 'uberdev_goal_read_run_state() { return 0; }'
+    echo 'uberdev_dispatch_resolve_env() { return 0; }'
+    echo '_uberdev_goal_reap_zombies() { return 0; }'
+    echo 'print_summary() { :; }'
+    echo 'uberdev_goal_cleanup_run_state() { return 0; }'
+    echo 'uberdev_goal_write_run_state() { return 0; }'
+    echo 'cycle=1'
+    echo 'MAX_CYCLES=5'
+    echo 'new_candidates=()'
+    echo 'watch_start="$(date +%s)"'
+    case "$cs" in
+      conv)  echo 'queue=()' ;;
+      queue) echo 'queue=(777)' ;;   # #288 #1: a non-empty rollover must BLOCK convergence
+      stuck) echo 'queue=()' ;;
+    esac
+    echo "source '$TERMINAL_FENCE'"
+    echo 'echo "FELL-THROUGH rc=$?"'
+  } > "$out"
+}
+
+mkdir -p "$WORK/state"
+audit_for() { printf '%s' "$WORK/state/goal-$1.jsonl"; }
+
+# --- P3a: rollover queue NON-EMPTY -> must NOT converge (issue #288 #1).
+G_Q="pipequeue01"
+printf '100\tmerged\t10\n200\tyellow-held\t20\n' > "$WORK/state/goal-$G_Q-pr-states.tsv"
+: > "$(audit_for "$G_Q")"; : > "$WORK/state/goal-$G_Q-issue-states.tsv"
+DRV_Q="$WORK/drv_term_queue.zsh"; write_term_driver "$DRV_Q" "$G_Q" queue
+Q_OUT="$("$ZSH_BIN" -f "$DRV_Q" 2>&1)"
+Q_RC=$?
+if printf '%s' "$Q_OUT" | grep -q 'FELL-THROUGH rc=0' \
+   && ! grep -q 'goal_converged' "$(audit_for "$G_Q")" 2>/dev/null \
+   && grep -q 'goal_cycle_completed' "$(audit_for "$G_Q")" 2>/dev/null; then
+  pass "P3a: with all PRs terminal BUT a non-empty rollover queue, the gate does NOT converge — it loops back (goal_cycle_completed). #288 #1"
+else
+  fail "P3a: non-empty rollover queue wrongly converged/halted (rc=$Q_RC, out=[$Q_OUT], audit=[$(tr -d '\n' < "$(audit_for "$G_Q")" 2>/dev/null)])"
+fi
+
+# --- P3b: queue EMPTY + all PRs terminal -> CONVERGE (goal_converged, exit 0).
+G_C="pipeconv01"
+printf '100\tmerged\t10\n200\tyellow-held\t20\n' > "$WORK/state/goal-$G_C-pr-states.tsv"
+: > "$(audit_for "$G_C")"; : > "$WORK/state/goal-$G_C-issue-states.tsv"
+DRV_C="$WORK/drv_term_conv.zsh"; write_term_driver "$DRV_C" "$G_C" conv
+C_OUT="$("$ZSH_BIN" -f "$DRV_C" 2>&1)"
+C_RC=$?
+# The fence `exit 0`s on convergence, so the driver's FELL-THROUGH line is NOT
+# printed and the zsh rc is 0.
+if [ "$C_RC" -eq 0 ] \
+   && ! printf '%s' "$C_OUT" | grep -q 'FELL-THROUGH' \
+   && grep -q 'goal_converged' "$(audit_for "$G_C")" 2>/dev/null; then
+  pass "P3b: queue empty + all PRs terminal (merged + held) -> goal_converged, exit 0"
+else
+  fail "P3b: convergence path wrong (rc=$C_RC, out=[$C_OUT], audit=[$(tr -d '\n' < "$(audit_for "$G_C")" 2>/dev/null)])"
+fi
+
+# --- P3c: queue empty + a NON-terminal PR -> queue_empty_not_converged, exit 1.
+G_S="pipestuck01"
+printf '100\tpushed-reviewing\t10\n' > "$WORK/state/goal-$G_S-pr-states.tsv"
+: > "$(audit_for "$G_S")"; : > "$WORK/state/goal-$G_S-issue-states.tsv"
+DRV_S="$WORK/drv_term_stuck.zsh"; write_term_driver "$DRV_S" "$G_S" stuck
+S_OUT="$("$ZSH_BIN" -f "$DRV_S" 2>&1)"
+S_RC=$?
+if [ "$S_RC" -eq 1 ] \
+   && grep -q 'queue_empty_not_converged' "$(audit_for "$G_S")" 2>/dev/null \
+   && ! grep -q 'goal_converged' "$(audit_for "$G_S")" 2>/dev/null; then
+  pass "P3c: queue empty + a PR still pushed-reviewing -> queue_empty_not_converged, exit 1 (deterministic pre-empt of the 4h stuck_loop)"
+else
+  fail "P3c: stuck-but-drained path wrong (rc=$S_RC, out=[$S_OUT], audit=[$(tr -d '\n' < "$(audit_for "$G_S")" 2>/dev/null)])"
+fi
+
+# ==========================================================================
+# W — One watch-loop iteration: the step-2b verdict read (#270 / #290.2).
+#
+# The watch loop's verdict locator (uberdev_goal_locate_review_pr_audit_by_pr ->
+# _uberdev_goal_glob_worktree) iterates worktree-prefix globs that carry a `*`.
+# bash glob-expands a var-derived `*`; zsh does NOT unless flagged `${~pat}`
+# (GLOB_SUBST). Since the watch fence runs under /bin/zsh, the pre-fix bare
+# `${prefix}` form silently matched NOTHING for the worktree-mirror prefixes —
+# so a /review-pr verdict written into a worktree mirror (the normal /goal
+# layout: each solver runs in its own .claude/worktrees/<wt>/ checkout) was
+# NEVER discovered, and the held/green transition never fired. We seed a GREEN
+# verdict in a WORKTREE-MIRROR path and run the EXTRACTED step-2b loop verbatim
+# under zsh; the PR must transition pushed-reviewing -> green. Reverting
+# _uberdev_goal_glob_worktree to the bare `$pat` form makes this RED (the
+# verdict is invisible -> signal stays missing -> no transition).
+# ==========================================================================
+echo
+echo "== W: watch-loop step-2b verdict read — verdict-locator glob under zsh (#270/#290.2) =="
+
+STEP2B_SLICE="$WORK/step2b.slice.sh"
+if slice_fence 'for pr_num in $(uberdev_goal_list_prs_in_state "$GOAL_ID" pushed-reviewing)' \
+               '2c. Barrier-gated merge dispatch' > "$STEP2B_SLICE" \
+   && [ -s "$STEP2B_SLICE" ] && grep -q 'uberdev_goal_locate_review_pr_audit_by_pr' "$STEP2B_SLICE"; then
+  pass "W.extract: sliced the step-2b verdict-read loop (incl. the verdict locator call) from the watch fence"
+else
+  fail "W.extract: could NOT slice the step-2b loop (loop head / step-2c marker moved?)"
+fi
+
+# Build a worktree-rooted sandbox: state dir under it, and a GREEN verdict in a
+# .claude/worktrees/<wt>/.uberdev/runs/<run-id>/ mirror (NOT the cwd-root path —
+# the cwd-root prefix is the one bare-`$pat` would still find, so seeding the
+# verdict ONLY in a mirror is what makes this discriminate the fix from the bug).
+WT_ROOT="$WORK/wt-root"
+WT_STATE="$WT_ROOT/state"
+WT_VERDICT_DIR="$WT_ROOT/.claude/worktrees/wt-A/.uberdev/runs/20260529-140000-cafe01"
+mkdir -p "$WT_STATE" "$WT_VERDICT_DIR"
+printf '%s\n' '{"pr":200,"sha":"cafe01","phases":{"phase2_5":{"by_severity":{"blocker":0,"critical":0},"halted":false}}}' \
+  > "$WT_VERDICT_DIR/review-pr-verdict.json"
+
+W_GID="pipewatch01"
+DRV_W="$WORK/drv_watch.zsh"
+{
+  echo 'set -u'
+  echo "cd '$WT_ROOT' || exit 9"
+  echo "export UBERDEV_TMPDIR='$WT_STATE'"
+  echo "export GOAL_ID='$W_GID'"
+  echo "export UBERDEV_GOAL_ID='$W_GID'"
+  echo ". \"\$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh\""
+  # gh stub: headRefOid (read by read_trust_signal's #290.1 SHA-binding) matches
+  # the seeded verdict sha, so the verdict binds and the colour is honoured.
+  echo 'gh() { case "$1 $2" in "pr view") printf "cafe01\n" ;; *) return 0 ;; esac }'
+  echo "uberdev_goal_state_init '$W_GID' >/dev/null 2>&1"
+  echo "uberdev_goal_pr_state_transition '$W_GID' 200 dispatched pushed-reviewing >/dev/null 2>&1"
+  # Scalars the loop body references on its NON-green arms (harmless on the green
+  # path we exercise, but keep the loop set -u-clean if a future SKILL.md edit
+  # reorders the case arms).
+  echo 'now="$(date +%s)"'
+  echo 'any_active=0'
+  echo 'REVIEW_GRACE_SECS=3600'
+  echo 'overflow_detected=0'
+  echo 'overflow_count=0'
+  echo 'echo "pre=[$(uberdev_goal_get_pr_state '"$W_GID"' 200)]"'
+  echo "source '$STEP2B_SLICE'"
+  echo 'echo "post=[$(uberdev_goal_get_pr_state '"$W_GID"' 200)]"'
+} > "$DRV_W"
+
+W_OUT="$("$ZSH_BIN" -f "$DRV_W" 2>"$WORK/watch.err")"
+W_RC=$?
+W_ERR="$(cat "$WORK/watch.err" 2>/dev/null)"
+if [ "$W_RC" -eq 0 ] \
+   && printf '%s' "$W_OUT" | grep -q 'pre=\[pushed-reviewing\]' \
+   && printf '%s' "$W_OUT" | grep -q 'post=\[green\]'; then
+  pass "W: the step-2b loop runs under zsh; the verdict locator finds the WORKTREE-MIRROR verdict and transitions pushed-reviewing -> green (no fatal). #270/#290.2"
+else
+  fail "W: step-2b loop did NOT reach green under zsh (rc=$W_RC, out=[$W_OUT], err=[$W_ERR]) — verdict-locator glob regression?"
+fi
+# The unmatched worktree-prefix globs must NOT have fataled the loop under zsh
+# (the `no matches found` NOMATCH failure mode the lib's `nonomatch`/`${~pat}`
+# guard prevents). Assert no such fatal leaked to stderr.
+if printf '%s' "$W_ERR" | grep -qi 'no matches found'; then
+  fail "W.nomatch: a zsh 'no matches found' fatal leaked from the verdict-locator glob (the #270/#290.2 nonomatch guard regressed)"
+else
+  pass "W.nomatch: no zsh 'no matches found' fatal from the verdict-locator glob"
+fi
+
+echo
+echo "== Summary =="
+echo "  harness shell: $LAUNCH_SHELL"
+echo "  fence shell:   $ZSH_BIN"
+echo "  $PASS passed, $FAIL failed"
+
+[ "$FAIL" -eq 0 ]

--- a/tests/goal-pipeline-zsh.test.sh
+++ b/tests/goal-pipeline-zsh.test.sh
@@ -185,7 +185,7 @@ mk_fake_bash() {  # $1=path $2=major
 [ "\$1" = "-c" ] && { echo $2; exit 0; }
 exit 0
 FAKE
-  chmod +x "$1"
+  chmod +x "$1" || { echo "FATAL: chmod +x $1 failed (fake bash would be non-executable -> P0 false result)" >&2; exit 3; }
 }
 mk_fake_bash "$WORK/bash5" 5
 mk_fake_bash "$WORK/bash3" 3
@@ -195,7 +195,14 @@ mk_fake_bash "$WORK/bash3" 3
 # Replace the two hard-coded paths with test-controlled ones, and stub
 # `command -v bash` to return nothing, so ONLY our fake binaries are probed.
 make_resolver_variant() {  # $1=outfile  $2=first-cand  $3=second-cand
-  sed "s#/opt/homebrew/bin/bash /usr/local/bin/bash#$2 $3#" "$RESOLVER_FENCE" > "$1"
+  sed "s#/opt/homebrew/bin/bash /usr/local/bin/bash#$2 $3#" "$RESOLVER_FENCE" > "$1" \
+    || { echo "FATAL: make_resolver_variant sed failed writing $1" >&2; exit 3; }
+  # Fail LOUD if the substitution did not apply. A drifted SKILL.md candidate-list
+  # anchor would make sed a no-op passthrough, leaving the REAL bash paths in the
+  # variant -> P0a/P0b would then probe the host's real bash and FALSE-PASS,
+  # defeating the regression guard. Assert the test-controlled path landed.
+  grep -q "$2" "$1" \
+    || { echo "FATAL: resolver candidate-list substitution did not apply (SKILL.md anchor '/opt/homebrew/bin/bash /usr/local/bin/bash' drifted?)" >&2; exit 3; }
 }
 
 # --- P0a POSITIVE: a usable bash>=4 is present -> resolve + proceed (NOT exit 2).
@@ -362,7 +369,7 @@ write_term_driver() {  # $1=outfile $2=gid $3=case
   } > "$out"
 }
 
-mkdir -p "$WORK/state"
+mkdir -p "$WORK/state" || { echo "FATAL: mkdir -p $WORK/state failed" >&2; exit 3; }
 audit_for() { printf '%s' "$WORK/state/goal-$1.jsonl"; }
 
 # --- P3a: rollover queue NON-EMPTY -> must NOT converge (issue #288 #1).
@@ -434,8 +441,9 @@ echo "== W: watch-loop step-2b verdict read — verdict-locator glob under zsh (
 STEP2B_SLICE="$WORK/step2b.slice.sh"
 if slice_fence 'for pr_num in $(uberdev_goal_list_prs_in_state "$GOAL_ID" pushed-reviewing)' \
                '2c. Barrier-gated merge dispatch' > "$STEP2B_SLICE" \
-   && [ -s "$STEP2B_SLICE" ] && grep -q 'uberdev_goal_locate_review_pr_audit_by_pr' "$STEP2B_SLICE"; then
-  pass "W.extract: sliced the step-2b verdict-read loop (incl. the verdict locator call) from the watch fence"
+   && [ -s "$STEP2B_SLICE" ] && grep -q 'uberdev_goal_locate_review_pr_audit_by_pr' "$STEP2B_SLICE" \
+   && grep -qE '^[[:space:]]*done' "$STEP2B_SLICE"; then
+  pass "W.extract: sliced the step-2b verdict-read loop (incl. the verdict locator call + a loop-closing 'done' — guards a head-only partial slice) from the watch fence"
 else
   fail "W.extract: could NOT slice the step-2b loop (loop head / step-2c marker moved?)"
 fi
@@ -447,7 +455,7 @@ fi
 WT_ROOT="$WORK/wt-root"
 WT_STATE="$WT_ROOT/state"
 WT_VERDICT_DIR="$WT_ROOT/.claude/worktrees/wt-A/.uberdev/runs/20260529-140000-cafe01"
-mkdir -p "$WT_STATE" "$WT_VERDICT_DIR"
+mkdir -p "$WT_STATE" "$WT_VERDICT_DIR" || { echo "FATAL: mkdir -p worktree-mirror sandbox ($WT_VERDICT_DIR) failed" >&2; exit 3; }
 printf '%s\n' '{"pr":200,"sha":"cafe01","phases":{"phase2_5":{"by_severity":{"blocker":0,"critical":0},"halted":false}}}' \
   > "$WT_VERDICT_DIR/review-pr-verdict.json"
 

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -85,6 +85,48 @@ assert_no_grep() {
 # guard per #209: a missing/unreadable helper aborts rc=2, not vacuous-green.
 source "$REPO_ROOT/tests/_lib_assert_structural.sh" || { echo "FATAL: _lib_assert_structural.sh missing/unreadable" >&2; exit 2; }
 
+# assert_eq GOT WANT LABEL — scalar equality (used by the behavioural G17 run).
+assert_eq() {
+  local got="$1" want="$2" label="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS + 1)); printf '  PASS  %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n' "$label" >&2
+    printf '        got:  [%s]\n' "$got" >&2
+    printf '        want: [%s]\n' "$want" >&2
+  fi
+}
+
+# extract_fence ANCHOR FILE — print the body of the ```bash fence containing
+# ANCHOR (handles the 3-space-indented Phase-0 fences). Content-anchored so it
+# survives line drift. Exit 3 (caller fails loud) when the anchor is not found.
+# Lets G17 RUN the real dry-run fences instead of grepping the markdown.
+_GOAL_EXTRACT_AWK="$(mktemp)"
+cat > "$_GOAL_EXTRACT_AWK" <<'AWK'
+BEGIN { infence=0; curbash=0; found=0; buf="" }
+{
+  line=$0
+  if (line ~ /^[[:space:]]*```/) {
+    if (infence==0) {
+      stripped=line; sub(/^[[:space:]]*```/, "", stripped)
+      curbash = (stripped ~ /^bash[[:space:]]*$/) ? 1 : 0
+      infence=1; buf=""; hasanchor=0; next
+    } else {
+      if (curbash==1 && hasanchor==1) { printf "%s", buf; found=1; exit }
+      infence=0; curbash=0; next
+    }
+  }
+  if (infence==1 && curbash==1) {
+    buf = buf line "\n"
+    if (index(line, ANCHOR) > 0) hasanchor=1
+  }
+}
+END { if (found==0) exit 3 }
+AWK
+extract_fence() { awk -v ANCHOR="$1" -f "$_GOAL_EXTRACT_AWK" "$2"; }
+trap 'rm -f "$_GOAL_EXTRACT_AWK"' EXIT
+
 echo "== G1: frontmatter (skill + command) =="
 assert_grep "$GOAL_SKILL" '^name: goal-pipeline$'        "G1.skill-name"
 assert_grep "$GOAL_CMD"   '^description: '               "G1.cmd-description"
@@ -216,23 +258,101 @@ assert_grep "$GOAL_SKILL" 'uberdev_goal_should_automerge'                "G16.au
 assert_grep "$GOAL_SKILL" 'automerge_attempt|merge.*attempt|MERGE_ATTEMPTS'  "G16.attempt-counter"
 
 echo
-echo "== G17: --dry-run semantics =="
+echo "== G17: --dry-run semantics (BEHAVIOURAL — #293) =="
 assert_grep "$GOAL_SKILL" '--dry-run|dry_run'                            "G17.dry-run-flag"
 assert_grep "$GOAL_SKILL" 'exit 0'                                       "G17.dry-run-exit"
-# Negative — must NOT actually dispatch /uberdev:orchestrator inside the
-# dry-run code path. The prose ("would dispatch /uberdev:orchestrator") is
-# descriptive narration, not real dispatch. Anchor on the imperative
-# call-site shape rather than the prose: a real dispatch invokes
-# uberdev_dispatch_one (or a slash-command inside a child-process prompt
-# heredoc) — both forbidden inside the dry-run branch.
-# Plan-literal `dry.run.*dispatch.*turbo` false-positives on Step 8's
-# explanatory bullet (around SKILL.md ~line 169 — "planned cycle-1 dispatch
-# list … would dispatch /uberdev:orchestrator for issues …"); the contract
-# this assertion locks is "no actual gh/dispatch call in the dry-run branch",
-# which is shape-checked by requiring the dry-run branch to exit before
-# reaching uberdev_dispatch_one.
+# #293 — the old G17 was a single-line negative grep
+# (`dry_run=1.*uberdev_dispatch_one`) that CANNOT catch a real dispatch leak:
+# the guard is an early `exit 0` hundreds of lines away from any dispatch call,
+# so the two literals never share a line regardless of whether the gate works.
+# Replace it with a BEHAVIOURAL run: extract the real Phase-0 fences (arg-parse
+# -> dry-run gate -> the step-9 `goal_dispatched` emit) from SKILL.md, run them
+# under bash with `uberdev_dispatch_one` + `uberdev_goal_audit` MOCKED as
+# call-recorders, and assert the dry-run contract (S9 + D16):
+#   (1) exit 0, (2) ZERO dispatch calls, (3) NO goal_dispatched audit row.
+# A negative control (same fences, NO --dry-run) proves the assertion is not
+# vacuous: it MUST reach the emit and record goal_dispatched.
+g17_dir="$(mktemp -d)"
+g17_argparse="$g17_dir/argparse.sh"
+g17_dryrun="$g17_dir/dryrun.sh"
+g17_emit="$g17_dir/emit.sh"
+# CI runs goal.test.sh under bash (ubuntu bash 5.x / windows Git Bash 4.x+) —
+# both are bash>=4, so the dry-run fences (which use bash arrays) run under the
+# launching interpreter. $BASH is the absolute path to the running bash.
+g17_bash="${BASH:-bash}"
+if extract_fence 'for tok in $ARGUMENTS' "$GOAL_SKILL" > "$g17_argparse" && [ -s "$g17_argparse" ] \
+   && extract_fence 'dry-run preview (no agent spawn' "$GOAL_SKILL" > "$g17_dryrun" && [ -s "$g17_dryrun" ] \
+   && extract_fence 'issues_json=' "$GOAL_SKILL" > "$g17_emit" && [ -s "$g17_emit" ]; then
+  PASS=$((PASS + 1)); printf '  PASS  %s\n' "G17.extract: arg-parse + dry-run gate + goal_dispatched emit fences located in SKILL.md"
+
+  # Build the dry-run driver. Mocks record into files; we pre-seed the resolved
+  # Phase-0 scalars the dry-run gate prints, then run the three fences in order.
+  cat > "$g17_dir/dry_driver.sh" <<DRV
+set -u
+export UBERDEV_TMPDIR="$g17_dir/state"; mkdir -p "\$UBERDEV_TMPDIR"
+. "$GOAL_LIB"
+uberdev_dispatch_one() { printf 'DISPATCH %s\n' "\$*" >> "$g17_dir/dispatch.log"; return 0; }
+uberdev_goal_audit()  { printf 'AUDIT %s\n'    "\$1" >> "$g17_dir/audit.log"; return 0; }
+MAX_CYCLES=5; MAX_PARALLEL=3; BARRIER_TIMEOUT_S=14400
+UBERDEV_RESOLVED_BACKEND=claude-bg
+GOAL_ID="goal-g17dryrun01"
+ARGUMENTS="101 202 --dry-run"
+source "$g17_argparse"
+source "$g17_dryrun"
+source "$g17_emit"
+printf 'REACHED-EMIT rc=%s\n' "\$?"
+DRV
+  g17_out="$("$g17_bash" "$g17_dir/dry_driver.sh" 2>&1)"
+  g17_rc=$?
+  assert_eq "$g17_rc" "0" "G17.behavioral.exit0: --dry-run run exits 0"
+  g17_dispatched="$([ -s "$g17_dir/dispatch.log" ] && echo LEAKED || echo none)"
+  assert_eq "$g17_dispatched" "none" "G17.behavioral.no-dispatch: --dry-run made ZERO uberdev_dispatch_one calls"
+  if [ -s "$g17_dir/audit.log" ] && grep -q 'goal_dispatched' "$g17_dir/audit.log"; then
+    assert_eq "goal_dispatched-emitted" "absent" "G17.behavioral.no-audit: --dry-run emitted NO goal_dispatched row (S9)"
+  else
+    assert_eq "absent" "absent" "G17.behavioral.no-audit: --dry-run emitted NO goal_dispatched row (S9)"
+  fi
+  # The dry-run `exit 0` must short-circuit BEFORE the step-9 emit fence runs.
+  if printf '%s' "$g17_out" | grep -q 'REACHED-EMIT'; then
+    assert_eq "reached-emit" "short-circuited" "G17.behavioral.short-circuit: dry-run exits before the goal_dispatched emit fence"
+  else
+    assert_eq "short-circuited" "short-circuited" "G17.behavioral.short-circuit: dry-run exits before the goal_dispatched emit fence"
+  fi
+
+  # Negative control — WITHOUT --dry-run the SAME fences MUST reach the emit and
+  # record goal_dispatched. Proves the dry-run assertions above are non-vacuous
+  # (a broken/removed dry-run gate would let the dry-run run fall through to the
+  # emit, flipping G17.behavioral.no-audit RED).
+  cat > "$g17_dir/real_driver.sh" <<DRV
+set -u
+export UBERDEV_TMPDIR="$g17_dir/state2"; mkdir -p "\$UBERDEV_TMPDIR"
+. "$GOAL_LIB"
+uberdev_dispatch_one() { printf 'DISPATCH %s\n' "\$*" >> "$g17_dir/dispatch2.log"; return 0; }
+uberdev_goal_audit()  { printf 'AUDIT %s\n'    "\$1" >> "$g17_dir/audit2.log"; return 0; }
+MAX_CYCLES=5; MAX_PARALLEL=3; BARRIER_TIMEOUT_S=14400
+UBERDEV_RESOLVED_BACKEND=claude-bg
+GOAL_ID="goal-g17real01"
+ARGUMENTS="101 202"
+source "$g17_argparse"
+source "$g17_dryrun"
+source "$g17_emit"
+printf 'REACHED-EMIT rc=%s\n' "\$?"
+DRV
+  "$g17_bash" "$g17_dir/real_driver.sh" >/dev/null 2>&1
+  if [ -s "$g17_dir/audit2.log" ] && grep -q 'goal_dispatched' "$g17_dir/audit2.log"; then
+    assert_eq "emitted" "emitted" "G17.behavioral.control: WITHOUT --dry-run the emit fence IS reached + records goal_dispatched (non-vacuous proof)"
+  else
+    assert_eq "absent" "emitted" "G17.behavioral.control: WITHOUT --dry-run the emit fence IS reached + records goal_dispatched (non-vacuous proof)"
+  fi
+else
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "G17.extract: could NOT extract the Phase-0 dry-run fences from SKILL.md (anchors moved?)" >&2
+fi
+# Structural backstop (kept from the original G17): no literal dispatch call on
+# a `dry_run=1` line. Cheap and complementary to the behavioural run above.
 assert_no_grep "$GOAL_SKILL" 'dry_run=1.*uberdev_dispatch_one|uberdev_dispatch_one.*dry_run=1' \
                                                                          "G17.dry-run-no-dispatch"
+rm -rf "$g17_dir"
 
 echo
 echo "== G18: ReDoS-safe Blocks: parser =="

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -420,8 +420,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.35.18) =="
-assert_version_bump "$REPO_ROOT" "0.35.18"
+echo "== G20: version bump locked (0.35.19) =="
+assert_version_bump "$REPO_ROOT" "0.35.19"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.17 -> 0.35.18 propagated =="
-assert_version_bump "$REPO_ROOT" "0.35.18"
+echo "== Version bump 0.35.18 -> 0.35.19 propagated =="
+assert_version_bump "$REPO_ROOT" "0.35.19"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary

The `/uberdev:goal` **orchestration layer** (`skills/goal-pipeline/SKILL.md` bash fences) had **zero runtime coverage** — CI only sourced `lib/goal-state.sh` and grepped the markdown (G6–G10/G17/G22/G33/G37 are all `assert_grep`). The entire loop (Phase-0 arg-parse + the bash≥4 resolver, the per-phase rehydration fences, the watch loop, the circuit-breaker firing sites, the merge barrier, Phase-3 convergence) shipped with no runtime test, so every wiring regression — including the sibling `/ubergoal`-audit defects — shipped green.

This PR **adds runtime coverage** by extracting the load-bearing bash fences from `SKILL.md` and **running them under the real shell** with `gh` / `claude` / `uberdev_dispatch_one` mocked. No production code is refactored.

## What changed

### New `tests/goal-pipeline-zsh.test.sh`
CI-launched under **zsh** (the SKILL.md fences' real Claude-Code Bash-tool runtime, where `BASH_VERSINFO` is unset); dual-launchable under bash too — the harness is launcher-agnostic and the extracted **fences always run under `zsh -f`**. A content-anchored `awk` extractor pulls each fence (robust to line drift, which matters for the mutation tests). Coverage:

- **P0 — Phase-0 bash≥4 resolver (#294):** under zsh a present bash≥4 resolves `UBERDEV_GOAL_BASH` and does **not** spuriously `exit 2`; with no bash≥4 reachable it **does** `exit 2` with the brew-install directive; arm-(a) is a clean no-op under bash≥4; the arg-parse fence parses issues+flags under the resolved bash (it relies on `$ARGUMENTS` word-splitting — which is exactly why the resolver publishes a bash≥4 interpreter).
- **P3 — Phase-3 terminal/convergence calc (#288):** does **not** converge while the rollover `queue` is non-empty (the #288 #1 queue-empty clause); **does** converge when queue empty + all PRs terminal; halts `queue_empty_not_converged` on a stuck PR.
- **W — one watch-loop iteration (step 2b):** the verdict-locator glob (`_uberdev_goal_glob_worktree`, #270/#290.2) finds a **worktree-mirror** verdict under zsh and transitions `pushed-reviewing → green` with **no `no matches found` fatal**.

### Replaced `goal.test.sh` G17 with a behavioural `--dry-run` run
The old G17 was a single-line negative grep (`dry_run=1.*uberdev_dispatch_one`) that **cannot** catch a real dispatch leak — the guard is an early `exit 0` hundreds of lines from any dispatch. The new G17 runs the real arg-parse + dry-run gate + `goal_dispatched`-emit fences with dispatch/audit mocked and asserts **exit 0 + zero dispatch calls + no `goal_dispatched` audit row**, plus a non-vacuous negative control (without `--dry-run` the emit IS reached). The G20 version-lock block is untouched.

### Wired into `.github/workflows/test.yml`
Wired exactly like the sibling `-zsh` fixtures: `zsh tests/goal-pipeline-zsh.test.sh` in the ubuntu `run:` block + an entry in the `ci-wiring windows-skip-list` marker block (it needs zsh, so the Windows job excludes it). `ci-wiring.test.sh` W1/W4 pass.

## Mutation verification (smoking-gun)
Each behavioural assertion was proven to catch its regression (revert fix → test RED → restore → GREEN):

| Mutation | Assertion that went RED |
|---|---|
| #294 resolver reverted to pre-fix `exit 2` dead-end | `P0a` |
| #288 `&& [ "${#queue[@]}" -eq 0 ]` clause removed | `P3a` (audit shows a false `goal_converged`) |
| #270/#290.2 `${~pat}` → bare `$pat` in glob_worktree | `W` (worktree-mirror verdict invisible → no green) |
| dry-run `exit 0` neutered | `G17.behavioral.no-audit` + `G17.behavioral.short-circuit` |

## Test results
- `bash tests/goal.test.sh` → **499 passed, 0 failed**
- `bash tests/ci-wiring.test.sh` → **5 passed, 0 failed**
- `zsh tests/goal-pipeline-zsh.test.sh` → **14 passed, 0 failed**
- `bash tests/goal-pipeline-zsh.test.sh` (dual-launch) → **14 passed, 0 failed**
- `bash tests/goal-dispatch-helpers.test.sh` → **23 passed, 0 failed**

Version bump deferred to the sequential land (no version surfaces touched).

Closes #293


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 0.35.19

* **Chores**
  * Bumped version to 0.35.19 across all manifests and documentation.

* **Tests**
  * Added comprehensive runtime test coverage for orchestration functionality.
  * Enhanced CI workflow with additional validation checks.
  * Strengthened test assertions with improved behavioral verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->