### PR TITLE
fix(goal): driveable Phase-2 watch loop from the Claude Code Bash tool (#299)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.36.0",
+      "version": "0.36.1",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.1] — 2026-05-31
+
+### Fixed
+- **`/goal` Phase-2 watch loop is now driveable from the Claude Code Bash tool (#299).** Three fixes so `/ubergoal` → `/uberdev:goal` runs end-to-end as-presented:
+  - **Bounded / single-tick watch mode (finding 2).** New `--watch-passes=N` / `--watch-budget=SECS` flags (and the `GOAL_SINGLE_TICK=1` env shorthand for one pass) make the Phase-2 watch loop run a bounded number of poll passes (or a per-fence wall-clock budget) and then exit with a documented re-invocation contract instead of the unbounded `while true … sleep` loop that a single 600s-capped Bash-tool call cannot host. Exit codes: `0` = drained (proceed to Phase 3), `42` = still-active (re-invoke Phase 2), `1` = circuit-breaker halt. Each bounded tick persists run-state via `uberdev_goal_write_run_state` and prints current state; the reaper fires only on a breaker or a genuine INT/TERM — **never on a bounded pause**, so live bg solver agents survive between ticks. Default 0 = unbounded (legacy behaviour unchanged). The bound round-trips run-state (new `WATCH_PASSES` / `WATCH_BUDGET` sidecar fields, exported by `uberdev_goal_read_run_state`) so it survives the fresh-shell Phase-2 fences.
+  - **Doubled `goal-goal-<id>-` sidecar prefix dropped (finding 3).** `GOAL_ID` is now generated WITHOUT the leading `goal-` (`<epoch>-<rand>` instead of `goal-<epoch>-<rand>`), so the per-goal sidecars are single-`goal-`-prefixed on disk (`goal-<epoch>-<rand>-runstate`, …) instead of `goal-goal-…`. Fixes the debugging foot-gun where `"$TMPDIR"/goal-<id>-*` silently matched nothing. Read/write symmetry preserved (every site shares the `goal-$GOAL_ID-` format string); the id stays digits/dash/alnum so the path-traversal + mis-pathing guards are unaffected.
+  - **Cross-shell verdict-locator regression guard (finding 1).** Locks the (already-fixed at HEAD via `_uberdev_goal_glob_worktree`) behaviour that the watch loop's verdict locator + peer glob enumerators return cleanly on zero matches under zsh — a bare unmatched glob fatals `no matches found` under zsh, so a new `tests/goal-state-zsh.test.sh` case (Z10) asserts none of them ever fatal.
+
 ## [0.36.0] — 2026-05-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.36.0-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.36.1-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/commands/goal.md
+++ b/plugins/uberdev/commands/goal.md
@@ -20,6 +20,9 @@ Autonomous convergence orchestrator that drives one or more GitHub issues to mer
   reason; no new breaker enum is added. Resolved via the same precedence as `--max-cycles`.
 - `--only-mine` — only enqueue `review-pr-finding` issues authored by `$GH_USER`. **Requires a single `gh` identity (issue #291):** it filters on `.author.login`, so it assumes the detached bg `/review-pr` agent that files the findings runs under the same `gh` identity as the watcher. On a CI-token / multi-identity setup the bg-filed findings carry a different author and would be silently dropped (false convergence with open blockers) — OMIT `--only-mine` there. Opt-in, OFF by default.
 - `--dry-run` — print planned cycle 1 dispatch + watch-loop preview, exit 0. No `/uberdev:orchestrator`, no `/merge`, no `/review-pr` is invoked.
+- `--watch-passes=N` — run a bounded number of Phase-2 poll passes per fence invocation, then exit for re-invocation (0=unbounded default).
+- `--watch-budget=SECS` — bound each Phase-2 fence to a wall-clock budget, then exit for re-invocation (0=unbounded default).
+- `GOAL_SINGLE_TICK=1` (env) — shorthand for `--watch-passes=1`.
 - `--backend=<name>` — pin a dispatch backend (`claude-bg` | `wezterm` | `background`); otherwise auto-resolved once by Phase 0 preflight and frozen for the run.
 
 **Merge barrier (issue #211).** `/merge` no longer fires per-PR the instant a PR turns GREEN.
@@ -63,6 +66,8 @@ The Claude-Code Bash tool runs every SKILL.md fence under `/bin/zsh` (where `BAS
 - **Already under bash ≥ 4** (e.g. CI, or an explicit `bash`-invoked fence): proceed.
 - **Not bash ≥ 4, but a bash ≥ 4 binary is discoverable** (checked in order: `/opt/homebrew/bin/bash`, `/usr/local/bin/bash`, `command -v bash` — each version-verified ≥ 4): Phase 0 publishes it as the exported `UBERDEV_GOAL_BASH`. If the fence was invoked as a real shebang **script file** it `exec`s that script under `UBERDEV_GOAL_BASH`; for an **inline** `zsh -c` body (no script path to re-feed) it proceeds and prints the resolved path. **Run `/goal`'s subsequent SKILL.md fences under `$UBERDEV_GOAL_BASH`** — e.g. by invoking each fence as `"$UBERDEV_GOAL_BASH" -c '<fence body>'`, or by ensuring the Bash tool's shell is bash ≥ 4 for the duration of the run. The bash-requiring glob lives in the Phase 2 watch loop; Phase 0/1's own steps are bash-safe under zsh, but the watch loop is NOT.
 - **No bash ≥ 4 anywhere**: Phase 0 exits 2 with `brew install bash`. This is the only case where `/goal` genuinely cannot run.
+
+A driving harness that bounds the watch loop (via `--watch-passes` / `--watch-budget` / `GOAL_SINGLE_TICK=1`) must honor the Phase-2 fence's exit contract: exit `0` = drained, proceed to Phase 3; exit `42` = work still in flight, re-invoke the Phase-2 fence; exit `1` = halt (a circuit breaker, or a fail-loud run-state-flush failure).
 
 > **TL;DR for operators:** on stock macOS run `brew install bash` once (gives `/opt/homebrew/bin/bash` 5.x). `/goal` then auto-discovers it. The old behavior — a hard `exit 2` on the first fence even with bash 5 installed — is fixed.
 

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -120,8 +120,9 @@ _UBERDEV_GOAL_WORKTREE_PREFIXES=("" ".claude/worktrees/*/" ".worktrees/*/" "work
 : "${_UBERDEV_GOAL_STUCK_DIALOG_SECS:=60}"   # ge 60 (preserved threshold)
 
 # Mirrored from skills/goal-pipeline/SKILL.md Phase 0 Constants block (issue #245).
-# This is the runtime SSOT — fresh-shell rehydration fences (SKILL.md ~210, 382,
-# 909, 1003, 1040, 1109) source ONLY this lib, never re-execute the Phase 0
+# This is the runtime SSOT — the per-phase fresh-shell rehydration fences (grep
+# SKILL.md for the `uberdev_goal_read_run_state` rehydration call) source ONLY
+# this lib, never re-execute the Phase 0
 # block. Defaulted-assignment ( := ) is order-safe: if the Phase 0 block ran
 # first (cycle 1 happy path), these are no-ops; if the lib was sourced fresh
 # (every Phase 2 poll iteration), these set the canonical defaults so the

--- a/plugins/uberdev/lib/goal-state.sh
+++ b/plugins/uberdev/lib/goal-state.sh
@@ -2203,7 +2203,8 @@ _uberdev_goal_rebase_collision_chain() {
 # uberdev_goal_write_run_state
 #   Reads GOAL_ID, cycle, watch_start, overflow_count, overflow_detected,
 #   MAX_CYCLES, UBERDEV_RESOLVED_BACKEND, MAX_PARALLEL, BARRIER_TIMEOUT_S,
-#   barrier_start_ts, and the queue/active_issues arrays from the caller's
+#   barrier_start_ts, REVIEW_GRACE_SECS, WATCH_PASSES, WATCH_BUDGET (#299
+#   bounded-watch bound), and the queue/active_issues arrays from the caller's
 #   shell; persists them to predictable, GOAL_ID-keyed sidecars under
 #   $UBERDEV_TMPDIR, plus a fixed-path goal-active-id.txt pointer so a fresh
 #   shell (no GOAL_ID in env/scalar) can discover the active GOAL_ID.
@@ -2232,11 +2233,12 @@ uberdev_goal_write_run_state() {
   _uberdev_dispatch_prepare_tmp_target "$sc" 0 "goal" || return 3
   local tmp _filtered aid
   tmp="$(mktemp "${sc}.XXXXXXXX")" || return 3
-  printf 'GOAL_ID=%s\ncycle=%s\nwatch_start=%s\noverflow_count=%s\noverflow_detected=%s\nMAX_CYCLES=%s\nUBERDEV_RESOLVED_BACKEND=%s\nMAX_PARALLEL=%s\nBARRIER_TIMEOUT_S=%s\nbarrier_start_ts=%s\nREVIEW_GRACE_SECS=%s\nCIRCUIT_BREAKER_HALT=%s\n' \
+  printf 'GOAL_ID=%s\ncycle=%s\nwatch_start=%s\noverflow_count=%s\noverflow_detected=%s\nMAX_CYCLES=%s\nUBERDEV_RESOLVED_BACKEND=%s\nMAX_PARALLEL=%s\nBARRIER_TIMEOUT_S=%s\nbarrier_start_ts=%s\nREVIEW_GRACE_SECS=%s\nWATCH_PASSES=%s\nWATCH_BUDGET=%s\nCIRCUIT_BREAKER_HALT=%s\n' \
     "$GOAL_ID" "${cycle:-0}" "${watch_start:-0}" "${overflow_count:-0}" \
     "${overflow_detected:-0}" "${MAX_CYCLES:-0}" "${UBERDEV_RESOLVED_BACKEND:-}" \
     "${MAX_PARALLEL:-0}" "${BARRIER_TIMEOUT_S:-0}" "${barrier_start_ts:-0}" \
-    "${REVIEW_GRACE_SECS:-0}" "${CIRCUIT_BREAKER_HALT:-}" > "$tmp"
+    "${REVIEW_GRACE_SECS:-0}" "${WATCH_PASSES:-0}" "${WATCH_BUDGET:-0}" \
+    "${CIRCUIT_BREAKER_HALT:-}" > "$tmp"
   # Append per-PID dialog-stuck samples (issue #220, AC ❸).
   # R3 SSOT (issue #220 simplify pass): single iterator over both prefixes —
   # PRIOR_LAST_ACTIVITY_<pid> and FIRST_DIALOG_TS_<pid> share identical
@@ -2308,7 +2310,8 @@ uberdev_goal_write_run_state() {
 #   goal-active-id.txt pointer (content gated through _uberdev_goal_validate_id).
 #   On success: sets the GOAL_ID, cycle, watch_start, overflow_count,
 #   overflow_detected, MAX_CYCLES, UBERDEV_RESOLVED_BACKEND, MAX_PARALLEL,
-#   BARRIER_TIMEOUT_S, barrier_start_ts scalars, rehydrates the
+#   BARRIER_TIMEOUT_S, barrier_start_ts, REVIEW_GRACE_SECS, WATCH_PASSES,
+#   WATCH_BUDGET scalars, rehydrates the
 #   queue/active_issues arrays, and EXPORTS UBERDEV_GOAL_ID + UBERDEV_TMPDIR
 #   (the env vars the uberdev_goal_* helpers + bare $UBERDEV_TMPDIR/... paths in
 #   the pipeline body depend on — see the export block at the function's end).
@@ -2347,6 +2350,8 @@ uberdev_goal_read_run_state() {
       BARRIER_TIMEOUT_S) _uberdev_goal_validate_int "$v" && BARRIER_TIMEOUT_S="$v" ;;
       barrier_start_ts)  _uberdev_goal_validate_int "$v" && barrier_start_ts="$v" ;;
       REVIEW_GRACE_SECS)  _uberdev_goal_validate_int "$v" && REVIEW_GRACE_SECS="$v" ;;
+      WATCH_PASSES)       _uberdev_goal_validate_int "$v" && WATCH_PASSES="$v" ;;
+      WATCH_BUDGET)       _uberdev_goal_validate_int "$v" && WATCH_BUDGET="$v" ;;
       CIRCUIT_BREAKER_HALT)
         case "$v" in
           max_cycles|nonconvergence|stuck_loop|merge_failed|gh_api_failed|unknown_merge_result|queue_empty_not_converged|agent_stuck_on_dialog)
@@ -2413,6 +2418,11 @@ uberdev_goal_read_run_state() {
   export UBERDEV_GOAL_ID="$GOAL_ID"
   export UBERDEV_TMPDIR="$tmpdir"
   export REVIEW_GRACE_SECS
+  # #299 finding 2 — re-export the bounded-watch bound so a fresh-shell Phase-2
+  # fence (and the per-pass write-back) keeps the same bound across tick-by-tick
+  # re-invocations. Default 0 (unbounded) when the sidecar predates the field.
+  export WATCH_PASSES="${WATCH_PASSES:-0}"
+  export WATCH_BUDGET="${WATCH_BUDGET:-0}"
   export CIRCUIT_BREAKER_HALT
   return 0
 }

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -246,8 +246,8 @@ Notes on the enums:
    ```bash
    export UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"   # D7 — stable sidecar dir for the watcher
    # #299 finding 3 — GOAL_ID does NOT carry a leading `goal-`. Every per-goal
-   # sidecar path is formatted `goal-$GOAL_ID-<suffix>` (lib/goal-state.sh, ~49
-   # sites), so a `goal-`-prefixed GOAL_ID produced `goal-goal-…` on disk — a
+   # sidecar path is formatted `goal-$GOAL_ID-<suffix>` throughout
+   # lib/goal-state.sh, so a `goal-`-prefixed GOAL_ID produced `goal-goal-…` on disk — a
    # debugging foot-gun (the obvious `"$TMPDIR"/goal-<id>-*` search matched
    # nothing). Generating the id WITHOUT the prefix yields a single clean
    # `goal-<epoch>-<rand>-…` on disk and preserves read/write symmetry (the same
@@ -1222,6 +1222,13 @@ while true; do
     if [ "${WATCH_PASSES:-0}" -gt 0 ] && [ "$_tick_passes" -ge "$WATCH_PASSES" ]; then
       _bound_hit=1
     fi
+    # WATCH_BUDGET is a FLOOR-OF-ONE-PASS, not a hard ceiling: this gate is
+    # reached only AFTER a full poll pass has completed, so a budget smaller than
+    # one pass of gh-call latency still runs (and is billed for) exactly one pass.
+    # The check bounds the SLEEP we are about to enter (it pre-adds one poll
+    # interval so we never sleep PAST the budget), not the pass duration — size
+    # the budget to leave headroom for one pass of gh latency under the harness
+    # call cap.
     if [ "${WATCH_BUDGET:-0}" -gt 0 ] && \
        [ "$(( _tick_now - _tick_start + _UBERDEV_GOAL_POLL_SECS ))" -gt "$WATCH_BUDGET" ]; then
       _bound_hit=1

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -169,7 +169,14 @@ Notes on the enums:
      agents are LEFT ALIVE (the reaper does NOT fire on a bounded-tick pause —
      only on a circuit-breaker halt or a genuine INT/TERM).
    - **`1`** — a circuit breaker fired (the reaper DOES fire here, exactly as in
-     the unbounded loop) → halt.
+     the unbounded loop) → halt. Exit `1` ALSO covers a fail-loud
+     run-state-flush failure at a bounded exit boundary (drain or pass/budget
+     bound): if `uberdev_goal_write_run_state` fails there, the fence halts with
+     a `goal: ERROR: run-state flush FAILED` diagnostic and exit 1 rather than
+     proceeding to Phase 3 on unpersisted state / re-inviting Phase 2 on a lost
+     bound that would silently revert to unbounded. The bg solver agents are
+     PRESERVED on this fail-loud path — distinct from a circuit-breaker exit 1,
+     which reaps first.
 
    When NEITHER `--watch-passes` / `--watch-budget` / `GOAL_SINGLE_TICK` is set,
    the watch loop runs unbounded (the legacy behaviour: one continuous fence
@@ -630,6 +637,9 @@ trap '_uberdev_goal_reap_zombies; exit 143' TERM
 # BOUNDED number of poll passes (or until a per-fence wall-clock budget) and
 # then exits 42 ("still-active, re-invoke") so an orchestrating harness can drive
 # the loop tick-by-tick within its own call cap (e.g. the 600s Bash-tool cap).
+# Exit 0 = drained -> proceed to Phase 3. Exit 1 = halt: a circuit breaker (reaps
+# first) OR a fail-loud run-state-flush failure at a bounded exit boundary (#300
+# Fix B — bg solver agents PRESERVED, no reap, distinct from a breaker exit 1).
 # _tick_start is the PER-FENCE wall-clock anchor (fresh every invocation — NOT
 # persisted, distinct from the goal-level watch_start that drives the 4h cap);
 # _tick_passes counts poll passes completed in THIS fence invocation.
@@ -1201,7 +1211,17 @@ while true; do
   if [ "$any_active" = "0" ] && \
      [ -z "$(uberdev_goal_list_prs_in_state "$GOAL_ID" merging)" ]; then
     if [ "$_watch_bounded" = "1" ]; then
-      uberdev_goal_write_run_state || echo "goal: warning: run-state flush failed at bounded-watch drain" >&2
+      # #300 Fix B (silent-failure-hunter CRITICAL) — fail LOUD on a run-state
+      # flush failure at this bounded-exit boundary. write_run_state persists the
+      # SOURCE-OF-TRUTH run-state (cycle/queue/active_issues + the WATCH_* bound);
+      # degrading a failed flush to a warning and still `exit 0` would proceed to
+      # Phase 3 on UNPERSISTED state. Halt with exit 1 instead. Do NOT reap here:
+      # this is a fail-loud halt distinct from a circuit-breaker exit 1 (which
+      # reaps first) — the bg solver agents must survive a transient persist blip.
+      if ! uberdev_goal_write_run_state; then
+        echo "goal: ERROR: run-state flush FAILED at drain boundary — halting (exit 1) rather than proceeding to Phase 3 on unpersisted state; bg solver agents left intact" >&2
+        exit 1
+      fi
       echo "goal: watch drained (no active agents, no merging PRs) -> proceed to Phase 3 [bounded-tick exit 0]" >&2
       exit 0
     fi
@@ -1213,8 +1233,7 @@ while true; do
   # run-state and exit 42 ("still-active, re-invoke") WITHOUT reaping — the bg
   # solver agents must survive the paused tick (the reaper fires ONLY on a
   # circuit-breaker halt or a genuine INT/TERM, never on a bounded pause). The
-  # budget check adds one POLL interval so we never overshoot the harness's call
-  # cap by sleeping into it. The UNBOUNDED path falls straight through to sleep.
+  # UNBOUNDED path falls straight through to sleep.
   if [ "$_watch_bounded" = "1" ]; then
     _tick_passes=$(( _tick_passes + 1 ))
     _tick_now="$(date +%s)"
@@ -1234,7 +1253,19 @@ while true; do
       _bound_hit=1
     fi
     if [ "$_bound_hit" = "1" ]; then
-      uberdev_goal_write_run_state || echo "goal: warning: run-state flush failed at bounded-watch tick boundary" >&2
+      # #300 Fix B (silent-failure-hunter CRITICAL) — fail LOUD on a run-state
+      # flush failure at this bounded-exit boundary. write_run_state persists the
+      # WATCH_PASSES/WATCH_BUDGET bound (+ cycle/queue/active_issues); if it fails
+      # and we still `exit 42`, the harness re-invokes a fresh Phase-2 fence that
+      # rehydrates from the UNWRITTEN sidecar -> WATCH_* default to 0 -> the loop
+      # SILENTLY reverts to UNBOUNDED (then the 600s harness cap SIGTERMs it ->
+      # reaper). Halt with exit 1 instead. Do NOT reap here: this is a fail-loud
+      # halt distinct from a circuit-breaker exit 1 (which reaps first) — the bg
+      # solver agents must survive a transient persist blip.
+      if ! uberdev_goal_write_run_state; then
+        echo "goal: ERROR: run-state flush FAILED at tick boundary — halting (exit 1) rather than re-inviting Phase 2 on a lost bound that would silently revert to unbounded; bg solver agents left intact" >&2
+        exit 1
+      fi
       echo "goal: watch bound reached (passes=$_tick_passes/${WATCH_PASSES:-0} budget=$(( _tick_now - _tick_start ))/${WATCH_BUDGET:-0}s); work still in flight -> re-invoke Phase 2 [bounded-tick exit 42]" >&2
       exit 42
     fi

--- a/plugins/uberdev/skills/goal-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/goal-pipeline/SKILL.md
@@ -130,6 +130,8 @@ Notes on the enums:
    max_parallel_cli=""
    barrier_timeout_cli=""
    review_grace_cli=""
+   watch_passes_cli=""
+   watch_budget_cli=""
    only_mine=0
    dry_run=0
    backend_cli=""
@@ -139,6 +141,8 @@ Notes on the enums:
        --max-parallel=*)       max_parallel_cli="${tok#--max-parallel=}" ;;
        --barrier-timeout=*)    barrier_timeout_cli="${tok#--barrier-timeout=}" ;;
        --review-grace-secs=*)  review_grace_cli="${tok#--review-grace-secs=}" ;;
+       --watch-passes=*)       watch_passes_cli="${tok#--watch-passes=}" ;;
+       --watch-budget=*)       watch_budget_cli="${tok#--watch-budget=}" ;;
        --only-mine)            only_mine=1 ;;
        --dry-run)              dry_run=1 ;;
        --backend=*)            backend_cli="${tok#--backend=}" ;;
@@ -146,6 +150,32 @@ Notes on the enums:
      esac
    done
    ```
+
+   **Bounded watch mode (issue #299, finding 2).** `--watch-passes=N` and
+   `--watch-budget=SECS` (and the `GOAL_SINGLE_TICK=1` env shorthand for
+   `--watch-passes=1`) make the Phase-2 watch loop run a BOUNDED number of poll
+   passes (or until a wall-clock budget) and then exit with a documented
+   re-invocation contract, instead of the default `while true … sleep` loop that
+   runs up to the 4h goal-level cap. This is what lets an orchestrating harness
+   (e.g. the Claude-Code Bash tool, whose single call is capped at 600s) drive
+   the watch loop tick-by-tick: each tick persists run-state (via
+   `uberdev_goal_write_run_state`), prints the current state to stderr, and
+   exits with one of three DOCUMENTED codes:
+
+   - **`0`** — the watch loop DRAINED this cycle (Phase-2 step 2f intra-cycle
+     termination: no active agents AND no merging PRs) → proceed to Phase 3.
+   - **`42`** — the bound (pass count or budget) was reached while work is still
+     in flight → re-invoke the Phase-2 fence to continue polling. The bg solver
+     agents are LEFT ALIVE (the reaper does NOT fire on a bounded-tick pause —
+     only on a circuit-breaker halt or a genuine INT/TERM).
+   - **`1`** — a circuit breaker fired (the reaper DOES fire here, exactly as in
+     the unbounded loop) → halt.
+
+   When NEITHER `--watch-passes` / `--watch-budget` / `GOAL_SINGLE_TICK` is set,
+   the watch loop runs unbounded (the legacy behaviour: one continuous fence
+   that flows into Phase 3 inline on drain, bounded only by the 4h goal-level
+   `stuck_loop`). The bound is read in step 3 alongside the other range-checked
+   tunables.
 
 2. **Numeric-validate every positional argument** (T3 mitigation). For each token in `queue`, call `_uberdev_goal_validate_int` (from `lib/goal-state.sh`); any failure aborts before any `gh` call sees the value. This is the first defence against `gh` argument injection via PR/issue numbers (R3).
 
@@ -175,6 +205,23 @@ Notes on the enums:
    REVIEW_GRACE_SECS="$(UBERDEV_GOAL_REVIEW_GRACE_SECS="${review_grace_cli:-${UBERDEV_GOAL_REVIEW_GRACE_SECS:-}}" \
      uberdev_read_int_in_range goal.review_grace_secs UBERDEV_GOAL_REVIEW_GRACE_SECS 60 86400 \
      "$_UBERDEV_GOAL_DEFAULT_REVIEW_GRACE_SECS")"
+
+   # Bounded watch mode (issue #299 finding 2). WATCH_PASSES / WATCH_BUDGET use
+   # range [0, N] with default 0 — 0 is the UNBOUNDED sentinel (legacy
+   # `while true … sleep` behaviour). A positive value bounds the Phase-2 watch
+   # loop to N poll passes / SECS wall-clock per fence invocation; on the bound
+   # the loop persists run-state and exits 42 ("still-active, re-invoke"). Both
+   # default to 0 so the unbounded loop is unchanged unless explicitly opted in.
+   # GOAL_SINGLE_TICK=1 is the env shorthand for --watch-passes=1 (applied only
+   # when neither a pass nor a budget bound was given).
+   WATCH_PASSES="$(UBERDEV_GOAL_WATCH_PASSES="${watch_passes_cli:-${UBERDEV_GOAL_WATCH_PASSES:-}}" \
+     uberdev_read_int_in_range goal.watch_passes UBERDEV_GOAL_WATCH_PASSES 0 100000 0)"
+   WATCH_BUDGET="$(UBERDEV_GOAL_WATCH_BUDGET="${watch_budget_cli:-${UBERDEV_GOAL_WATCH_BUDGET:-}}" \
+     uberdev_read_int_in_range goal.watch_budget UBERDEV_GOAL_WATCH_BUDGET 0 86400 0)"
+   if [ "${GOAL_SINGLE_TICK:-0}" = "1" ] && [ "${WATCH_PASSES:-0}" -eq 0 ] && [ "${WATCH_BUDGET:-0}" -eq 0 ]; then
+     WATCH_PASSES=1
+   fi
+   export WATCH_PASSES WATCH_BUDGET
    ```
 
 4. **Source `lib/dispatch.sh`; call `uberdev_dispatch_preflight`** → sets `UBERDEV_RESOLVED_BACKEND` once for the whole run (D15). The resolved backend is forwarded to every `/uberdev:orchestrator` (Phase 1), `/merge`, and `/review-pr` (Phase 2) child dispatch in this run; it is NEVER re-resolved per cycle.
@@ -198,7 +245,17 @@ Notes on the enums:
 
    ```bash
    export UBERDEV_TMPDIR="${UBERDEV_TMPDIR:-${TMPDIR:-/tmp}}"   # D7 — stable sidecar dir for the watcher
-   GOAL_ID="goal-$(date +%s)-$(mktemp -u XXXXXXXX | tr -d '/' | head -c 8)"
+   # #299 finding 3 — GOAL_ID does NOT carry a leading `goal-`. Every per-goal
+   # sidecar path is formatted `goal-$GOAL_ID-<suffix>` (lib/goal-state.sh, ~49
+   # sites), so a `goal-`-prefixed GOAL_ID produced `goal-goal-…` on disk — a
+   # debugging foot-gun (the obvious `"$TMPDIR"/goal-<id>-*` search matched
+   # nothing). Generating the id WITHOUT the prefix yields a single clean
+   # `goal-<epoch>-<rand>-…` on disk and preserves read/write symmetry (the same
+   # `goal-$GOAL_ID-` format string drives both writers and readers). The id is
+   # still digits/dash/alnum only, so _uberdev_goal_validate_id accepts it, and
+   # it never begins with `goal-` so the sidecar mis-pathing guard
+   # (`case "$GOAL_ID" in goal--*`) cannot trip.
+   GOAL_ID="$(date +%s)-$(mktemp -u XXXXXXXX | tr -d '/' | head -c 8)"
    export UBERDEV_GOAL_ID="$GOAL_ID"
    ```
 
@@ -232,6 +289,8 @@ Notes on the enums:
      printf '  MAX_CYCLES=%s\n' "$MAX_CYCLES"
      printf '  MAX_PARALLEL=%s\n' "$MAX_PARALLEL"
      printf '  BARRIER_TIMEOUT_S=%s\n' "$BARRIER_TIMEOUT_S"
+     printf '  WATCH_PASSES=%s WATCH_BUDGET=%s (0=unbounded watch loop)\n' \
+       "${WATCH_PASSES:-0}" "${WATCH_BUDGET:-0}"
      printf '  backend=%s\n' "$UBERDEV_RESOLVED_BACKEND"
      printf '  issues=%s\n' "${queue[*]}"
      printf '  would emit goal_dispatched\n'
@@ -564,6 +623,22 @@ trap 'rm -f "$gh_err" "$findings_err"' EXIT
 # would force the reaper on graceful convergence (slow, wasteful).
 trap '_uberdev_goal_reap_zombies; exit 130' INT
 trap '_uberdev_goal_reap_zombies; exit 143' TERM
+
+# #299 finding 2 — bounded watch mode. WATCH_PASSES / WATCH_BUDGET are
+# rehydrated by uberdev_goal_read_run_state above (default 0 = UNBOUNDED, the
+# legacy `while true … sleep` loop). When EITHER is positive, this fence runs a
+# BOUNDED number of poll passes (or until a per-fence wall-clock budget) and
+# then exits 42 ("still-active, re-invoke") so an orchestrating harness can drive
+# the loop tick-by-tick within its own call cap (e.g. the 600s Bash-tool cap).
+# _tick_start is the PER-FENCE wall-clock anchor (fresh every invocation — NOT
+# persisted, distinct from the goal-level watch_start that drives the 4h cap);
+# _tick_passes counts poll passes completed in THIS fence invocation.
+_tick_start="$(date +%s)"
+_tick_passes=0
+_watch_bounded=0
+if [ "${WATCH_PASSES:-0}" -gt 0 ] || [ "${WATCH_BUDGET:-0}" -gt 0 ]; then
+  _watch_bounded=1
+fi
 
 while true; do
   now="$(date +%s)"
@@ -1118,10 +1193,44 @@ while true; do
     esac
   done
 
-  # 2f. Termination check (intra-cycle)
+  # 2f. Termination check (intra-cycle). DRAINED = no active agents AND no
+  # merging PR. In the UNBOUNDED loop this `break`s out of `while true` and the
+  # fence flows inline into Phase 3. In BOUNDED mode there is no inline Phase 3
+  # (the harness re-invokes a separate Phase-3 fence), so persist run-state and
+  # exit 0 — the documented "drained -> proceed to Phase 3" code (#299 finding 2).
   if [ "$any_active" = "0" ] && \
      [ -z "$(uberdev_goal_list_prs_in_state "$GOAL_ID" merging)" ]; then
+    if [ "$_watch_bounded" = "1" ]; then
+      uberdev_goal_write_run_state || echo "goal: warning: run-state flush failed at bounded-watch drain" >&2
+      echo "goal: watch drained (no active agents, no merging PRs) -> proceed to Phase 3 [bounded-tick exit 0]" >&2
+      exit 0
+    fi
     break
+  fi
+
+  # #299 finding 2 — bounded-watch pass/budget gate. A pass just completed; count
+  # it, then decide whether THIS fence's bound is reached. If so, persist
+  # run-state and exit 42 ("still-active, re-invoke") WITHOUT reaping — the bg
+  # solver agents must survive the paused tick (the reaper fires ONLY on a
+  # circuit-breaker halt or a genuine INT/TERM, never on a bounded pause). The
+  # budget check adds one POLL interval so we never overshoot the harness's call
+  # cap by sleeping into it. The UNBOUNDED path falls straight through to sleep.
+  if [ "$_watch_bounded" = "1" ]; then
+    _tick_passes=$(( _tick_passes + 1 ))
+    _tick_now="$(date +%s)"
+    _bound_hit=0
+    if [ "${WATCH_PASSES:-0}" -gt 0 ] && [ "$_tick_passes" -ge "$WATCH_PASSES" ]; then
+      _bound_hit=1
+    fi
+    if [ "${WATCH_BUDGET:-0}" -gt 0 ] && \
+       [ "$(( _tick_now - _tick_start + _UBERDEV_GOAL_POLL_SECS ))" -gt "$WATCH_BUDGET" ]; then
+      _bound_hit=1
+    fi
+    if [ "$_bound_hit" = "1" ]; then
+      uberdev_goal_write_run_state || echo "goal: warning: run-state flush failed at bounded-watch tick boundary" >&2
+      echo "goal: watch bound reached (passes=$_tick_passes/${WATCH_PASSES:-0} budget=$(( _tick_now - _tick_start ))/${WATCH_BUDGET:-0}s); work still in flight -> re-invoke Phase 2 [bounded-tick exit 42]" >&2
+      exit 42
+    fi
   fi
 
   sleep "$_UBERDEV_GOAL_POLL_SECS"

--- a/tests/goal-pipeline-zsh.test.sh
+++ b/tests/goal-pipeline-zsh.test.sh
@@ -705,6 +705,82 @@ else
   fail "W2e: reaper sentinel stub failed to write even when called directly (out=[$W2E_OUT]) — W2c would be a vacuous pass"
 fi
 
+# --- W2f: #300 Fix B (silent-failure-hunter CRITICAL) — a run-state FLUSH
+# FAILURE at a bounded exit boundary must FAIL LOUD (exit 1 + 'run-state flush
+# FAILED' breadcrumb), NOT degrade to a warning and still exit 42/0. write_run_state
+# persists the SOURCE-OF-TRUTH run-state (cycle/queue/active_issues + the WATCH_*
+# bound); if a failed flush still exit-42'd, the harness would re-invoke a fresh
+# Phase-2 fence that rehydrates WATCH_*=0 -> the loop SILENTLY reverts to unbounded
+# (then the 600s harness cap SIGTERMs it). So the boundary halts (exit 1) instead.
+#
+# Harness: bespoke driver mirroring write_w2_driver's slice assembly (cat $W2_SETUP
+# + the closing `fi` it omits + an any_active line + cat $W2_GATE), but with two
+# mutations: (1) uberdev_goal_write_run_state is stubbed to RETURN 1 (the flush
+# failure under test); (2) a reaper sentinel stub proves the exit-1 fail-loud path
+# does NOT reap (bg solver agents must survive a transient persist blip — the
+# fail-loud halt is DISTINCT from a circuit-breaker exit 1 which reaps first).
+# sleep is stubbed to exit 77 so a regression that falls through to the sleep is
+# caught (the bounded arm must exit BEFORE sleep). list_prs_in_state is stubbed
+# empty so the drain predicate is driven purely by $5 (any_active).
+#
+# MUTATION GUARD: revert EITHER bounded boundary's `if ! uberdev_goal_write_run_state;
+# then ... exit 1; fi` back to the old `uberdev_goal_write_run_state || echo warning`
+# form and W2f flips RED — the tick variant trips W2f.tick (rc 42 instead of 1), the
+# drain variant trips W2f.drain (rc 0 instead of 1). This is the exact silent-revert-
+# to-unbounded / proceed-on-unpersisted-state regression #300 Fix B closes.
+echo "== W2f: bounded-watch run-state FLUSH FAILURE fails loud (exit 1, no reap) under zsh (#300 Fix B) =="
+
+write_w2f_driver() {  # $1=out $2=tag $3=passes $4=budget $5=any_active
+  local out="$1" tag="$2" wp="$3" wb="$4" act="$5"
+  {
+    echo '#!/usr/bin/env zsh'
+    echo 'set -u'
+    echo "UBERDEV_TMPDIR='$WORK'"
+    echo 'GOAL_ID=w2f'
+    echo '_UBERDEV_GOAL_POLL_SECS=60'
+    # (1) the flush failure under test: write_run_state returns rc 1.
+    echo 'uberdev_goal_write_run_state() { return 1; }'
+    # (2) reaper sentinel — assert it does NOT fire on the fail-loud exit-1 path.
+    echo "W2F_REAPER_SENTINEL='$WORK/w2f-reaper-$tag'"
+    echo '_uberdev_goal_reap_zombies() { echo fired > "$W2F_REAPER_SENTINEL"; }'
+    # drain predicate is driven purely by $act; merging set is always empty.
+    echo 'uberdev_goal_list_prs_in_state() { :; }'
+    # sleep must never be reached (bounded arm exits first).
+    echo 'sleep() { echo "W2F-REACHED-SLEEP"; exit 77; }'
+    echo "WATCH_PASSES=$wp"
+    echo "WATCH_BUDGET=$wb"
+    cat "$W2_SETUP"; echo 'fi'        # Slice A + the closing fi it omits.
+    echo "any_active=$act"
+    cat "$W2_GATE"                    # Slice B (step-2f drain + pass/budget gate).
+    echo 'echo "W2F-FELL-THROUGH rc=$?"'
+  } > "$out"
+}
+
+# W2f.tick: bounded (WATCH_PASSES=1) + work in flight -> pass-count bound hit ->
+# flush fails -> EXIT 1 (NOT 42), 'run-state flush FAILED' breadcrumb, NO reaper.
+DRV_W2FT="$WORK/drv_w2f_tick.zsh"; write_w2f_driver "$DRV_W2FT" tick 1 0 1
+W2FT_OUT="$("$ZSH_BIN" -f "$DRV_W2FT" 2>&1)"; W2FT_RC=$?
+if [ "$W2FT_RC" -eq 1 ] && printf '%s' "$W2FT_OUT" | grep -q 'run-state flush FAILED'; then
+  pass "W2f.tick: bounded + work in flight + flush FAILS at the pass/budget bound -> the fence EXITS 1 (not 42) and prints the 'run-state flush FAILED' ERROR breadcrumb (#300 Fix B)"
+else
+  fail "W2f.tick: expected exit 1 + 'run-state flush FAILED' (got rc=$W2FT_RC, out=[$W2FT_OUT]) — a failed flush must NOT silently revert to unbounded via exit 42"
+fi
+if [ ! -f "$WORK/w2f-reaper-tick" ]; then
+  pass "W2f.tick.noreap: the fail-loud exit-1 flush-halt did NOT reap (bg solver agents survive a transient persist blip — distinct from a circuit-breaker exit 1)"
+else
+  fail "W2f.tick.noreap: reaper FIRED on the fail-loud flush-halt (sentinel PRESENT) — Fix B must NOT reap on this path"
+fi
+
+# W2f.drain: bounded + DRAINED (any_active=0, merging empty) + flush FAILS at the
+# step-2f drain boundary -> EXIT 1 (NOT 0), same breadcrumb. Cheap second arm.
+DRV_W2FD="$WORK/drv_w2f_drain.zsh"; write_w2f_driver "$DRV_W2FD" drain 1 0 0
+W2FD_OUT="$("$ZSH_BIN" -f "$DRV_W2FD" 2>&1)"; W2FD_RC=$?
+if [ "$W2FD_RC" -eq 1 ] && printf '%s' "$W2FD_OUT" | grep -q 'run-state flush FAILED'; then
+  pass "W2f.drain: bounded + drained + flush FAILS at the drain boundary -> the fence EXITS 1 (not 0); never proceeds to Phase 3 on unpersisted state (#300 Fix B)"
+else
+  fail "W2f.drain: expected exit 1 + 'run-state flush FAILED' (got rc=$W2FD_RC, out=[$W2FD_OUT]) — a failed drain flush must NOT proceed via exit 0"
+fi
+
 echo
 echo "== Summary =="
 echo "  harness shell: $LAUNCH_SHELL"

--- a/tests/goal-pipeline-zsh.test.sh
+++ b/tests/goal-pipeline-zsh.test.sh
@@ -505,6 +505,206 @@ else
   pass "W.nomatch: no zsh 'no matches found' fatal from the verdict-locator glob"
 fi
 
+# ==========================================================================
+# W2 — Phase-2 bounded-watch EXIT-CODE CONTRACT, executed (#299 finding 2).
+#
+# Finding-2's load-bearing behaviour is the exit code the watch loop returns so
+# an orchestrating harness (the 600s-capped Bash tool) can drive it tick-by-tick:
+#   exit 42 = bound (passes/budget) hit while work is STILL in flight -> re-invoke
+#   exit  0 = step-2f DRAINED (no active agents AND no merging PR)    -> Phase 3
+#   break   = the UNBOUNDED loop drains -> flow inline into Phase 3 (no exit)
+# and a hard guarantee: the reaper does NOT fire on a bounded-tick pause (only on
+# a circuit-breaker halt or a real INT/TERM), so the bg solver agents survive the
+# paused tick. Until now this was asserted ONLY by STRUCTURAL grep of SKILL.md
+# (goal-state-zsh.test.sh Z11b/Z11c grep for the `bounded-tick exit 42/0`
+# breadcrumb STRINGS) — a regression that flipped the exit-0/exit-42 ARMS keeps
+# both breadcrumb strings present (they live on separate lines from the `exit N`)
+# and ships GREEN. This test EXECUTES the real arms under zsh and asserts the
+# ACTUAL exit codes + the reaper-skip, so an arm-flip goes RED.
+#
+# Slicing discipline (mirrors the `W` step-2b slice above): the watch fence is a
+# ~595-line `while true; do … done`; running it whole would mean mocking ~30
+# step-2a..2e helpers (brittle, off-target). Instead slice the TWO load-bearing
+# fragments verbatim from SKILL.md —
+#   (A) the per-fence bound SETUP block (`_tick_start`/`_tick_passes`/the
+#       `_watch_bounded` derivation from WATCH_PASSES/WATCH_BUDGET), and
+#   (B) the step-2f drain check + the pass/budget gate + the trailing `sleep`
+#       (the EXACT exit-42 / exit-0 / break arms — the mutation target) —
+# then stitch them into a controllable single-iteration `while true` whose ONLY
+# free inputs are `any_active` (which steps 2a-2e set in production; we set it
+# directly) and the merging-PR list (seeded empty via state_init). This runs the
+# production exit-code logic byte-for-byte; nothing about the arms is re-typed.
+#
+# Mocking choices (each isolates the exit-code contract, none fakes it):
+#   - any_active is the loop's drain signal; set per scenario (the real 2a-2e
+#     walk would compute it from gh/agent state we are deliberately not exercising
+#     here — 2a-2e correctness is the `W` test's job, not W2's).
+#   - uberdev_goal_write_run_state is stubbed to rc 0 so a tmpdir/write hiccup
+#     cannot muddy the exit-code assertion (the bound's run-state ROUND-TRIP is
+#     already proven by goal-state-zsh.test.sh Z11a).
+#   - _uberdev_goal_reap_zombies is stubbed to TOUCH a sentinel so we can assert
+#     it is NOT called on the exit-42/exit-0 pause (W2c) — and a positive control
+#     (W2e) calls the stub directly to prove the sentinel mechanism works.
+#   - sleep is stubbed to exit 77: the bounded arms exit (42/0) BEFORE the sleep,
+#     so reaching sleep means the bound gate FAILED to fire (caught as rc 77, not
+#     a 60s hang); the unbounded drain `break`s before sleep too.
+#
+# Mutation guards (revert in your worktree, re-run -> the named assertion goes RED):
+#   - SWAP the two arms in SKILL.md's step 2f / budget gate (`exit 42`<->`exit 0`)
+#     => W2a flips to rc 0 and W2b flips to rc 42 (both RED). This is the exact
+#     regression Z11b/Z11c (grep-only) cannot see.
+#   - Move `_uberdev_goal_reap_zombies` INTO the bounded exit-42 path (reap-on-
+#     pause regression) => W2c RED (sentinel PRESENT after the 42 path).
+#   - Drop the `[ "$_watch_bounded" = "1" ]` guard on the 2f bounded arm, or the
+#     WATCH_PASSES/WATCH_BUDGET `-gt 0` derivation in the setup block
+#     => W2d RED (the unbounded loop would exit 0/42 mid-fence instead of break).
+# ==========================================================================
+echo
+echo "== W2: Phase-2 bounded-watch exit-code contract (42/0/break + reaper-skip) under zsh (#299 finding 2) =="
+
+# (A) the bound SETUP fragment: `_tick_start` .. the `_watch_bounded=1` line. The
+# slice deliberately STOPS before the closing `fi` (its own line carries no
+# unique anchor); the driver appends `fi` so the `if` closes in the SAME parse
+# unit (production runs setup + loop in one fence — inlining matches that).
+W2_SETUP="$WORK/w2_setup.frag.sh"
+# (B) the step-2f drain + pass/budget gate + trailing `sleep` — the real arms.
+W2_GATE="$WORK/w2_gate.frag.sh"
+if slice_fence '_tick_start="$(date' '_watch_bounded=1' > "$W2_SETUP" \
+   && [ -s "$W2_SETUP" ] && grep -q 'WATCH_PASSES' "$W2_SETUP" && grep -q 'WATCH_BUDGET' "$W2_SETUP"; then
+  pass "W2.extractA: sliced the per-fence bounded-watch SETUP block (_tick_start + _watch_bounded derivation) from the watch fence"
+else
+  fail "W2.extractA: could NOT slice the bounded-watch setup block (anchor '_tick_start=' / '_watch_bounded=1' moved?)"
+fi
+if slice_fence '2f. Termination check' 'sleep "$_UBERDEV_GOAL_POLL_SECS"' > "$W2_GATE" \
+   && [ -s "$W2_GATE" ] \
+   && grep -q 'bounded-tick exit 42' "$W2_GATE" \
+   && grep -q 'bounded-tick exit 0'  "$W2_GATE" \
+   && grep -qE '^[[:space:]]*exit 42[[:space:]]*$' "$W2_GATE" \
+   && grep -qE '^[[:space:]]*exit 0[[:space:]]*$'  "$W2_GATE"; then
+  pass "W2.extractB: sliced the step-2f drain check + pass/budget gate (both real 'exit 42' and 'exit 0' arms present — guards a head-only partial slice) from the watch fence"
+else
+  fail "W2.extractB: could NOT slice the step-2f/budget gate with BOTH exit arms (step-2f marker / sleep tail / an 'exit N' arm moved?)"
+fi
+
+# Emit one bounded-watch driver. $1=outfile $2=tag $3=WATCH_PASSES $4=WATCH_BUDGET
+# $5=any_active. Stitches: lib source + state_init (so the 2f `merging` probe is
+# set -u-clean and empty) + the stubs above + Slice A (+`fi`) + a single-iteration
+# `while true` carrying the controlled any_active + Slice B verbatim. A reaper
+# sentinel path is exported per driver so W2c can assert non-firing.
+write_w2_driver() {  # $1=out $2=tag $3=passes $4=budget $5=any_active
+  local out="$1" tag="$2" wp="$3" wb="$4" aa="$5"
+  {
+    echo 'set -u'
+    echo "export UBERDEV_TMPDIR='$WORK/w2-state-$tag'"
+    echo "export GOAL_ID='pipew2$tag'"
+    echo "export UBERDEV_GOAL_ID='pipew2$tag'"
+    echo ". \"\$CLAUDE_PLUGIN_ROOT/lib/dispatch.sh\""
+    echo ". \"\$CLAUDE_PLUGIN_ROOT/lib/goal-state.sh\""
+    echo "uberdev_goal_state_init 'pipew2$tag' >/dev/null 2>&1"
+    # Reaper sentinel: the stub TOUCHES it; the exit-42/exit-0 pause must NOT.
+    echo "W2_REAPER_SENTINEL='$WORK/w2-reaper-$tag'"
+    echo '_uberdev_goal_reap_zombies() { echo fired > "$W2_REAPER_SENTINEL"; }'
+    # Isolate the exit-code contract from run-state I/O (Z11a proves the bound's
+    # run-state round-trip; here a write hiccup must not muddy the rc assertion).
+    echo 'uberdev_goal_write_run_state() { return 0; }'
+    # If the loop reaches `sleep`, the bound gate FAILED to exit — surface it as
+    # rc 77 (not a 60s hang). Bounded arms exit 42/0 BEFORE sleep; unbounded drain
+    # `break`s before it.
+    echo 'sleep() { echo "W2-REACHED-SLEEP arg=$1"; exit 77; }'
+    echo "WATCH_PASSES=$wp"
+    echo "WATCH_BUDGET=$wb"
+    # --- Slice A (bounded-watch setup) verbatim, then the closing fi it omits.
+    cat "$W2_SETUP"
+    echo 'fi'
+    # --- One controlled iteration carrying the real Slice B arms verbatim.
+    echo 'while true; do'
+    echo "  any_active=$aa"
+    cat "$W2_GATE"
+    echo 'done'
+    # Reached ONLY if Slice B `break`s out (the unbounded-drain path).
+    echo 'echo "W2-FELL-THROUGH rc=$?"'
+  } > "$out"
+}
+
+w2_sentinel_state() {  # $1=tag -> PRESENT|ABSENT
+  [ -f "$WORK/w2-reaper-$1" ] && printf 'PRESENT' || printf 'ABSENT'
+}
+
+# --- W2a: BOUND HIT, work in flight -> exit 42 (+ no reaper). WATCH_PASSES=1,
+# any_active=1 (a solver still working) so step 2f does NOT drain; one pass
+# completes, _tick_passes(1) >= WATCH_PASSES(1) -> _bound_hit -> exit 42.
+DRV_W2A="$WORK/drv_w2a.zsh"; write_w2_driver "$DRV_W2A" a 1 0 1
+W2A_OUT="$("$ZSH_BIN" -f "$DRV_W2A" 2>&1)"; W2A_RC=$?
+if [ "$W2A_RC" -eq 42 ] && printf '%s' "$W2A_OUT" | grep -q 'bounded-tick exit 42'; then
+  pass "W2a: bounded (WATCH_PASSES=1) + work in flight -> the watch fence EXITS 42 and prints the 'bounded-tick exit 42' breadcrumb (#299 finding 2)"
+else
+  fail "W2a: expected exit 42 + 'bounded-tick exit 42' breadcrumb (got rc=$W2A_RC, out=[$W2A_OUT]) — exit-code-arm regression?"
+fi
+# W2c (part 1): the reaper must NOT have fired on the exit-42 pause.
+if [ "$(w2_sentinel_state a)" = "ABSENT" ]; then
+  pass "W2c: reaper did NOT fire on the bounded exit-42 pause (bg solver agents survive the tick) — #299 finding 2 guarantee"
+else
+  fail "W2c: reaper FIRED on the bounded exit-42 pause (sentinel PRESENT) — reap-on-pause regression"
+fi
+
+# --- W2b: DRAINED -> exit 0. WATCH_PASSES=1 (bounded) but any_active=0 AND no
+# merging PR (state_init left the pr-states TSV empty), so step 2f's bounded arm
+# persists + exits 0 BEFORE the pass/budget gate is reached.
+DRV_W2B="$WORK/drv_w2b.zsh"; write_w2_driver "$DRV_W2B" b 1 0 0
+W2B_OUT="$("$ZSH_BIN" -f "$DRV_W2B" 2>&1)"; W2B_RC=$?
+if [ "$W2B_RC" -eq 0 ] && printf '%s' "$W2B_OUT" | grep -q 'bounded-tick exit 0'; then
+  pass "W2b: bounded + DRAINED (no active agents, no merging PR) -> the watch fence EXITS 0 and prints the 'bounded-tick exit 0' breadcrumb (#299 finding 2)"
+else
+  fail "W2b: expected exit 0 + 'bounded-tick exit 0' breadcrumb (got rc=$W2B_RC, out=[$W2B_OUT]) — exit-code-arm regression?"
+fi
+# W2c (part 2): reaper must NOT fire on the clean exit-0 drain either.
+if [ "$(w2_sentinel_state b)" = "ABSENT" ]; then
+  pass "W2c.drain: reaper did NOT fire on the bounded exit-0 drain (clean proceed-to-Phase-3 path)"
+else
+  fail "W2c.drain: reaper FIRED on the bounded exit-0 drain (sentinel PRESENT) — reap-on-drain regression"
+fi
+
+# --- W2d: UNBOUNDED -> no early exit. WATCH_PASSES=0 WATCH_BUDGET=0 so
+# _watch_bounded=0; drained step 2f takes the legacy `break` (NOT exit 0/42) and
+# control flows past the loop to the FELL-THROUGH breadcrumb (= inline Phase 3).
+DRV_W2D="$WORK/drv_w2d.zsh"; write_w2_driver "$DRV_W2D" d 0 0 0
+W2D_OUT="$("$ZSH_BIN" -f "$DRV_W2D" 2>&1)"; W2D_RC=$?
+if [ "$W2D_RC" -eq 0 ] \
+   && printf '%s' "$W2D_OUT" | grep -q 'W2-FELL-THROUGH' \
+   && ! printf '%s' "$W2D_OUT" | grep -q 'bounded-tick exit' \
+   && ! printf '%s' "$W2D_OUT" | grep -q 'W2-REACHED-SLEEP'; then
+  pass "W2d: unbounded (WATCH_PASSES=0 WATCH_BUDGET=0) + drained -> step 2f BREAKS into inline Phase 3 (no mid-fence exit 0/42, no sleep) (#299 finding 2)"
+else
+  fail "W2d: unbounded drain should break (FELL-THROUGH, no 'bounded-tick exit', no sleep); got rc=$W2D_RC, out=[$W2D_OUT]"
+fi
+
+# --- W2.budget: the BUDGET bound (not pass count) also fires exit 42. POLL=60s is
+# always added to the elapsed budget check, so WATCH_BUDGET=1 trips on pass 1 even
+# with WATCH_PASSES=0 — proving the wall-clock arm of the bound, independent of
+# the pass-count arm exercised by W2a.
+DRV_W2BU="$WORK/drv_w2bu.zsh"; write_w2_driver "$DRV_W2BU" bu 0 1 1
+W2BU_OUT="$("$ZSH_BIN" -f "$DRV_W2BU" 2>&1)"; W2BU_RC=$?
+if [ "$W2BU_RC" -eq 42 ] && printf '%s' "$W2BU_OUT" | grep -q 'bounded-tick exit 42'; then
+  pass "W2.budget: bounded by WATCH_BUDGET (wall-clock arm, WATCH_PASSES=0) + work in flight -> exit 42 (the budget gate fires, not just the pass-count gate)"
+else
+  fail "W2.budget: expected exit 42 from the budget arm (got rc=$W2BU_RC, out=[$W2BU_OUT]) — budget-gate regression?"
+fi
+
+# --- W2e: positive control — the reaper STUB itself writes the sentinel when
+# CALLED. Without this, an always-broken stub would make W2c pass vacuously
+# (sentinel never written for ANY reason). This proves W2c's ABSENT assertions
+# mean "not called", not "stub is a no-op".
+W2E_OUT="$("$ZSH_BIN" -f -c "
+  W2_REAPER_SENTINEL='$WORK/w2-reaper-e'
+  _uberdev_goal_reap_zombies() { echo fired > \"\$W2_REAPER_SENTINEL\"; }
+  _uberdev_goal_reap_zombies
+" 2>&1)"
+if [ -f "$WORK/w2-reaper-e" ]; then
+  pass "W2e: positive control — the reaper sentinel stub DOES write when invoked (so W2c's ABSENT means 'reaper not called', not 'stub is inert')"
+else
+  fail "W2e: reaper sentinel stub failed to write even when called directly (out=[$W2E_OUT]) — W2c would be a vacuous pass"
+fi
+
 echo
 echo "== Summary =="
 echo "  harness shell: $LAUNCH_SHELL"

--- a/tests/goal-state-zsh.test.sh
+++ b/tests/goal-state-zsh.test.sh
@@ -377,6 +377,11 @@ echo "== Z10: verdict-locator + peer enumerators do NOT fatal on ZERO matches un
 # localoptions nonomatch` removed, or `${~pat}` -> bare `$pat` with the loop
 # expanding the literal directly) => Z10 goes RED with a leaked `no matches
 # found` fatal.
+# Coverage note: Z10 exercises the ZERO-match path (the locator must not fatal).
+# The complementary POSITIVE-match path — the locator FINDING a worktree-mirror
+# verdict under zsh and the watch loop transitioning pushed-reviewing -> green —
+# is covered by goal-pipeline-zsh.test.sh `W` (it seeds a verdict in a worktree
+# mirror and runs the sliced step-2b loop). Together they lock both glob arms.
 Z10_TMP="$(mktemp -d)"
 Z10_OUT="$(
   GOAL_ID="goal-z10abc01"

--- a/tests/goal-state-zsh.test.sh
+++ b/tests/goal-state-zsh.test.sh
@@ -361,6 +361,159 @@ case "$Z9_OUT" in
 esac
 rm -rf "$Z9_TMP" 2>/dev/null || true
 
+echo
+echo "== Z10: verdict-locator + peer enumerators do NOT fatal on ZERO matches under zsh (#299 finding 1) =="
+# #299 finding 1: the Phase-2 watch loop's verdict locator
+# (uberdev_goal_locate_review_pr_audit_by_pr) and peer enumerators iterate the
+# worktree-prefix globs via _uberdev_goal_glob_worktree. Under zsh a BARE
+# unmatched glob FATALS (`no matches found`) — proven below — so any enumerator
+# that expanded an unmatched glob WITHOUT the helper's `setopt localoptions
+# nonomatch` + `${~pat}` guard would abort the whole watch fence. The issue
+# reporter hit exactly this at uberdev 0.35.19. This locks the fix: every
+# glob-iterating enumerator must return cleanly (rc 0, empty) on zero matches —
+# NEVER fatal — even when run from a directory where NO .uberdev/runs/* exists.
+#
+# Mutation guard: revert _uberdev_goal_glob_worktree's zsh arm (`setopt
+# localoptions nonomatch` removed, or `${~pat}` -> bare `$pat` with the loop
+# expanding the literal directly) => Z10 goes RED with a leaked `no matches
+# found` fatal.
+Z10_TMP="$(mktemp -d)"
+Z10_OUT="$(
+  GOAL_ID="goal-z10abc01"
+  export GOAL_ID UBERDEV_GOAL_ID="$GOAL_ID" UBERDEV_TMPDIR="$Z10_TMP"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null 2>&1
+  # cd to an EMPTY checkout: every worktree-mirror glob is UNMATCHED here, which
+  # is the exact zero-verdict state at the start of a /goal watch pass. A bare
+  # unmatched glob would FATAL here under zsh (`no matches found`); the
+  # helper-routed enumerators below must NOT.
+  cd "$Z10_TMP" || exit 9
+  # Stub gh so uberdev_goal_locate_review_pr_audit (issue->PR path) and the
+  # read_merge_result tier-1 gh probe never hit the network; both still drive the
+  # unmatched-glob enumeration internally.
+  gh() { return 1; }
+  errfile="$Z10_TMP/err.txt"
+  : > "$errfile"
+  for spec in \
+    "uberdev_goal_locate_review_pr_audit_by_pr 200" \
+    "uberdev_goal_list_prs_in_state $GOAL_ID pushed-reviewing" \
+    "uberdev_goal_read_merge_result 200" \
+    "_uberdev_goal_locked_marker_for_pr_fresh 200 3600" \
+    "uberdev_goal_locate_review_pr_audit 200"; do
+    out="$(eval "$spec" 2>>"$errfile")"
+    # A non-zero rc here is acceptable for the locked-marker probe (rc 1 = "no
+    # fresh marker") and the locators (empty = no verdict); the FATAL we guard
+    # against is the zsh `no matches found` abort, asserted on stderr below. A
+    # non-empty stdout would mean a stray match leaked from the empty checkout.
+    [ -n "$out" ] && printf 'UNEXPECTED-OUTPUT[%s]=%s\n' "$spec" "$out"
+  done
+  if grep -qi 'no matches found' "$errfile"; then
+    printf 'NOMATCH-FATAL=[%s]\n' "$(tr -d '\n' < "$errfile")"
+  else
+    printf 'CLEAN\n'
+  fi
+)"
+if printf '%s' "$Z10_OUT" | grep -q 'CLEAN' \
+   && ! printf '%s' "$Z10_OUT" | grep -qi 'no matches found'; then
+  pass "Z10a: all glob-iterating enumerators return cleanly on zero matches under $RUN_SHELL — no 'no matches found' fatal (#299 finding 1)"
+else
+  fail "Z10a: an enumerator FATALED on zero matches under $RUN_SHELL (got: [$Z10_OUT]) — verdict-locator glob regression (#299 finding 1)"
+fi
+rm -rf "$Z10_TMP" 2>/dev/null || true
+
+echo
+echo "== Z11: bounded-watch bound (WATCH_PASSES/WATCH_BUDGET) round-trips run-state under zsh (#299 finding 2) =="
+# #299 finding 2: the Phase-2 watch loop honours a BOUNDED bound so an
+# orchestrating harness can drive it tick-by-tick. WATCH_PASSES / WATCH_BUDGET
+# are persisted by uberdev_goal_write_run_state and rehydrated + EXPORTed by
+# uberdev_goal_read_run_state across the fresh-shell Phase-2 fences (exactly like
+# REVIEW_GRACE_SECS / MAX_PARALLEL). This proves the persistence SSOT carries the
+# bound in BOTH shells — if it did not, a bounded tick that re-invokes a fresh
+# Phase-2 fence would silently lose the bound and revert to the unbounded loop.
+Z11_TMP="$(mktemp -d)"
+Z11_OUT="$(
+  GOAL_ID="goal-z11abc01"
+  export GOAL_ID UBERDEV_GOAL_ID="$GOAL_ID" UBERDEV_TMPDIR="$Z11_TMP"
+  cycle=1; watch_start=1729000000; MAX_CYCLES=5
+  WATCH_PASSES=3; WATCH_BUDGET=540
+  queue=(); active_issues=()
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null 2>&1
+  uberdev_goal_write_run_state >/dev/null 2>&1
+  # Fresh shell #2: clear the bound scalars, then rehydrate from the sidecar
+  # (the active-id pointer bootstraps GOAL_ID, mirroring a fresh Phase-2 fence).
+  unset WATCH_PASSES WATCH_BUDGET GOAL_ID UBERDEV_GOAL_ID
+  uberdev_goal_read_run_state >/dev/null 2>&1
+  printf 'passes=%s budget=%s exported_passes=%s\n' \
+    "${WATCH_PASSES:-UNSET}" "${WATCH_BUDGET:-UNSET}" \
+    "$(env | grep -c '^WATCH_PASSES=3$')"
+)"
+case "$Z11_OUT" in
+  *"passes=3 budget=540 exported_passes=1"*)
+    pass "Z11a: WATCH_PASSES/WATCH_BUDGET persist + rehydrate + export across a fresh shell under $RUN_SHELL (#299 finding 2)" ;;
+  *)
+    fail "Z11a: bounded-watch bound did NOT round-trip run-state (got: [$Z11_OUT]; expect passes=3 budget=540 exported_passes=1)" ;;
+esac
+rm -rf "$Z11_TMP" 2>/dev/null || true
+# Structural: the Phase-2 watch loop in SKILL.md must carry the bounded-tick
+# contract (exit 42 still-active + exit 0 drained + the no-reaper-on-pause
+# guarantee). These are the load-bearing exit codes the harness drives on.
+if grep -q 'bounded-tick exit 42' "$GOAL_SKILL"; then
+  pass "Z11b: Phase-2 watch loop emits the documented 'still-active, re-invoke' exit 42 (#299 finding 2)"
+else
+  fail "Z11b: Phase-2 watch loop must exit 42 on a bounded tick with work in flight (#299 finding 2)"
+fi
+if grep -q 'bounded-tick exit 0' "$GOAL_SKILL"; then
+  pass "Z11c: Phase-2 watch loop emits the documented 'drained -> Phase 3' exit 0 in bounded mode (#299 finding 2)"
+else
+  fail "Z11c: Phase-2 watch loop must exit 0 on a bounded-mode drain (#299 finding 2)"
+fi
+
+echo
+echo "== Z12: GOAL_ID generation yields a SINGLE goal- sidecar prefix (#299 finding 3) =="
+# #299 finding 3: every per-goal sidecar path is formatted `goal-$GOAL_ID-…` in
+# lib/goal-state.sh (~49 sites). A GOAL_ID that itself began with `goal-`
+# produced `goal-goal-…` files on disk — a debugging foot-gun (the obvious
+# `"$TMPDIR"/goal-<id>-*` search matched nothing). The fix generates the id
+# WITHOUT the leading `goal-`, so files are single-`goal-`-prefixed. This runs
+# the EXACT production generator from SKILL.md Phase-0 step 5 under the live
+# shell, inits state, and asserts: (1) no `goal-goal-` file exists, (2) the
+# `goal-<id>-*` glob now MATCHES (foot-gun resolved), (3) the id passes
+# _uberdev_goal_validate_id, (4) the sidecar mis-pathing guard cannot trip.
+# Mutation guard: revert the SKILL.md generator to `GOAL_ID="goal-$(date …)…"`
+# => Z12 RED (a goal-goal- file appears + the structural assert below fails).
+Z12_TMP="$(mktemp -d)"
+Z12_OUT="$(
+  export UBERDEV_TMPDIR="$Z12_TMP"
+  # Verbatim production generator (SKILL.md Phase-0 step 5, post-#299-finding-3).
+  GOAL_ID="$(date +%s)-$(mktemp -u XXXXXXXX | tr -d '/' | head -c 8)"
+  export GOAL_ID UBERDEV_GOAL_ID="$GOAL_ID"
+  uberdev_goal_state_init "$GOAL_ID" >/dev/null 2>&1
+  cycle=1; watch_start="$(date +%s)"; MAX_CYCLES=5; queue=(); active_issues=()
+  uberdev_goal_write_run_state >/dev/null 2>&1
+  dbl="$(ls "$Z12_TMP" 2>/dev/null | grep -c 'goal-goal-')"
+  single="$(ls "$Z12_TMP"/goal-"$GOAL_ID"-runstate 2>/dev/null | grep -c .)"
+  vid=0; _uberdev_goal_validate_id "$GOAL_ID" && vid=1
+  guard=safe; case "$GOAL_ID" in goal--*) guard=trips ;; esac
+  printf 'doubled=%s single=%s vid=%s guard=%s\n' "$dbl" "$single" "$vid" "$guard"
+)"
+case "$Z12_OUT" in
+  *"doubled=0 single=1 vid=1 guard=safe"*)
+    pass "Z12a: production GOAL_ID gen yields single-goal--prefixed sidecars (no goal-goal-), id valid, guard safe under $RUN_SHELL (#299 finding 3)" ;;
+  *)
+    fail "Z12a: GOAL_ID prefix wrong (#299 finding 3 — got: [$Z12_OUT]; expect doubled=0 single=1 vid=1 guard=safe)" ;;
+esac
+rm -rf "$Z12_TMP" 2>/dev/null || true
+# Structural: the SKILL.md generator must NOT emit a `goal-`-prefixed id.
+if grep -qE 'GOAL_ID="goal-\$\(date' "$GOAL_SKILL"; then
+  fail "Z12b: SKILL.md still generates a goal--prefixed GOAL_ID (produces goal-goal-… sidecars) — #299 finding 3 regression"
+else
+  pass "Z12b: SKILL.md GOAL_ID generator no longer carries a leading goal- prefix (#299 finding 3)"
+fi
+if grep -qE 'GOAL_ID="\$\(date \+%s\)-\$\(mktemp' "$GOAL_SKILL"; then
+  pass "Z12c: SKILL.md GOAL_ID generator uses the prefix-free \$(date)-\$(mktemp) form (#299 finding 3)"
+else
+  fail "Z12c: SKILL.md GOAL_ID generator must be the prefix-free \$(date +%s)-\$(mktemp …) form (#299 finding 3)"
+fi
+
 # Cleanup
 rm -rf "$Z2_TMP" "$Z3_TMP" "$Z4_TMP" 2>/dev/null || true
 

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -420,8 +420,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.36.0) =="
-assert_version_bump "$REPO_ROOT" "0.36.0"
+echo "== G20: version bump locked (0.36.1) =="
+assert_version_bump "$REPO_ROOT" "0.36.1"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.35.19 -> 0.36.0 propagated =="
-assert_version_bump "$REPO_ROOT" "0.36.0"
+echo "== Version bump 0.36.0 -> 0.36.1 propagated =="
+assert_version_bump "$REPO_ROOT" "0.36.1"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary

Makes `/ubergoal` → `/uberdev:goal` (the `goal-pipeline` skill) runnable **end-to-end from inside the Claude Code Bash tool** as-presented. Fixes all three findings in #299. Dispatch (Phase 0/1) already worked; this repairs the **Phase-2 watch loop**.

`Closes #299`

## Two corrections to the issue's diagnosis (surfaced by research)

Worth flagging for the issue author — two of the findings were partly resolved or mislocated since the report was written against rendered **v0.35.19**:

1. **Finding 1's named helpers are already zsh-safe at HEAD.** `uberdev_goal_locate_review_pr_audit_by_pr` and `uberdev_goal_list_prs_in_state` no longer iterate bare unmatched globs — they route through `_uberdev_goal_glob_worktree` (`setopt localoptions nonomatch` + `${~pat}`), landed in #270/#290.2. So the verdict locator does **not** fatal under zsh at HEAD. The reporter hit the pre-fix 0.35.19 behaviour. This PR adds a **regression guard** rather than re-fixing already-correct code, and (via the Finding-2 work) verifies the *whole* Phase-2 fence runs under zsh without `no matches found`.
2. **Finding 3's doubling is mint-side, not `state_init`-side.** The lib uses a single `goal-$goal_id-` template; the second `goal-` comes from the `GOAL_ID="goal-$(date +%s)-…"` mint at SKILL.md Phase-0 step 5. Fixing it at the mint (the issue's sanctioned option) is a one-line change with zero lib-reader churn and no read/write-symmetry risk.

## Changes

### Finding 2 (primary) — bounded / single-tick watch mode
The Phase-2 fence was `while true; do … sleep N; done`, bounded only by the 4h goal-level `stuck_loop` — unrunnable inside a single 600s-capped Bash-tool call (the SIGTERM at the cap also tripped the INT/TERM reaper).

New opt-in bound:
- **`--watch-passes=N`** / **`--watch-budget=SECS`** flags + **`GOAL_SINGLE_TICK=1`** env shorthand (one pass).
- Documented exit contract: **`0`** = drained → proceed to Phase 3; **`42`** = still-active → re-invoke Phase 2; **`1`** = circuit-breaker halt.
- Each bounded tick persists run-state (`uberdev_goal_write_run_state`) and prints current state to stderr.
- **The reaper fires only on a breaker or a genuine INT/TERM — never on a bounded pause**, so live bg solver agents survive between ticks.
- **Default `0` = unbounded** → the legacy continuous loop is byte-for-byte unchanged unless explicitly opted in.
- `WATCH_PASSES` / `WATCH_BUDGET` round-trip run-state (new sidecar fields, exported by `uberdev_goal_read_run_state`) so the bound survives the fresh-shell Phase-2 fences.

### Finding 3 — doubled `goal-goal-<id>-` prefix
`GOAL_ID` is now minted **without** the leading `goal-` (`<epoch>-<rand>`), so per-goal sidecars are single-`goal-`-prefixed on disk (`goal-<epoch>-<rand>-runstate`, …) instead of `goal-goal-…`. Fixes the debugging foot-gun where `"$TMPDIR"/goal-<id>-*` matched nothing. Read/write symmetry preserved; the id stays `validate_id`-safe and never begins with `goal-` (the mis-pathing guard cannot trip).

### Finding 1 — cross-shell regression guard
New `Z10` case in `tests/goal-state-zsh.test.sh` runs every glob-iterating enumerator from an empty checkout under the live shell and asserts none leak `no matches found`. Mutation-guarded: reverting `_uberdev_goal_glob_worktree`'s zsh arm turns Z10 red.

## Tests
- New `Z10` / `Z11` / `Z12` in `tests/goal-state-zsh.test.sh` (run under **bash AND zsh**) covering all three findings, each with a documented mutation guard.
- **Full `tests/` suite green** under bash, plus the zsh fixtures + `goal.test.sh` under zsh (independently re-run: 0 failing files). Includes `merge.test.sh`, all model-lock tests, `review-pr`, `finish-branch`, `solve-claim`, `ci-wiring`, `skill-renderer-awk-collision`.

## Version
`0.36.0` → `0.36.1` (patch) across all four manifest/badge/changelog locations + the two release-ratchet lock tests (`goal.test.sh` G20, `solve-claim.test.sh`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.36.1

* **New Features**
  * Introduced bounded watch mode with new `--watch-passes=N` and `--watch-budget=SECS` CLI flags to control loop execution
  * Added `GOAL_SINGLE_TICK=1` environment variable support

* **Bug Fixes**
  * Resolved sidecar naming inconsistencies
  * Fixed cross-shell glob enumeration issues in zsh environments
  * Corrected watch loop exit codes and re-invocation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheFJK/UberDev/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->