### PR TITLE
ci: concurrency group + push branch filter + ref-conditional cancel

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.36.3",
+      "version": "0.36.4",
       "category": "workflow",
       "tags": [
         "github",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,27 @@ name: Tests
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+# One CI set per change (#309, RFC 0012 §7.7 infra-R2). The unfiltered
+# push+pull_request pair used to fire TWO full runs for every push to a PR
+# branch, and a concurrency group ALONE cannot dedupe that pair: the group
+# keys differ per event (a push run keys on refs/heads/<branch>, the
+# pull_request run on refs/pull/<N>/merge), so the push branch filter above
+# is the load-bearing half — PR branches now get exactly one run, via the
+# authoritative pull_request event. The group below then cancels a
+# superseded PR run when a newer push lands on the same ref. Tag pushes
+# (releases) no longer trigger a run; the tagged SHA was already tested by
+# its push-to-main run.
+#
+# cancel-in-progress is ref-conditional: post-merge runs on main are NEVER
+# cancelled — sequential-release drives land PRs minutes apart, and the
+# per-commit main CI signal must survive every landing (a cancelled main
+# run would leave a release commit with no green check).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Least-privilege default. PR runs from forks otherwise inherit a write token
 # and would gate on enabling `Send write tokens to workflows from fork pull
@@ -14,7 +34,10 @@ jobs:
   shape-checks:
     name: shape-checks
     runs-on: ubuntu-latest
-    # 5 minutes is generous for the ~330 grep-and-assert checks (44 test files).
+    # 5 minutes is generous for the wired suite — 59 test files, ~2,700
+    # grep-and-assert checks, measured at #309 (ci-wiring.test.sh keeps the
+    # run list below complete against tests/*.test.sh on disk; these counts
+    # are a point-in-time snapshot, refresh when they age).
     # Caps the default 360-min budget so a hung test from a fork PR can't burn
     # the public-repo Actions allowance. Bump if the suite legitimately grows.
     timeout-minutes: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.4] — 2026-06-12
+
+- _Release notes pending — replace this stub before committing (inserted by bump-version.sh)._
+
 ## [0.36.3] — 2026-06-12
 
 - _Release notes pending — replace this stub before committing (inserted by bump-version.sh)._

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.36.3-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.36.4-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -420,8 +420,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.36.3) =="
-assert_version_bump "$REPO_ROOT" "0.36.3"
+echo "== G20: version bump locked (0.36.4) =="
+assert_version_bump "$REPO_ROOT" "0.36.4"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -268,8 +268,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.36.2 -> 0.36.3 propagated =="
-assert_version_bump "$REPO_ROOT" "0.36.3"
+echo "== Version bump 0.36.3 -> 0.36.4 propagated =="
+assert_version_bump "$REPO_ROOT" "0.36.4"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary

Kills the per-PR-push double CI run and makes superseded PR runs cancel themselves, while guaranteeing post-merge `main` runs are never cancelled. One PR-sized bundle of the #309 series: `push: branches:[main]` and the workflow-level concurrency group land TOGETHER because the group keys differ per event (a push run keys on `refs/heads/<branch>`, the pull_request run on `refs/pull/<N>/merge`) — the branch filter is the load-bearing half of the dedupe; the group alone cannot do it.

Part of #309 (per RFC 0012 §7.7, second arrow: infra-R2, including the ref-conditional-cancel fold; §9 Phase 0 internal ordering).

## Changes

- `.github/workflows/test.yml` (workflow-level top region + the shape-checks sizing comment only):
  - `on.push` filtered to `branches: [main]` — PR branches now get exactly one CI set, via the authoritative `pull_request` event.
  - New workflow-level `concurrency` group `${{ github.workflow }}-${{ github.ref }}`.
  - `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` — superseded PR runs cancel; post-merge `main` runs never do, so sequential-release drives that land PRs minutes apart keep a per-commit `main` CI signal.
  - Fixed the stale sizing comment: it claimed ~330 checks across 44 test files; the wired suite is 59 test files / ~2,700 grep-and-assert checks (measured this PR; `ci-wiring.test.sh` keeps the run list complete against `tests/*.test.sh` on disk).
- Intentionally NOT done here (explicit follow-up arrow per RFC §7.7): windows job shard + ci-wiring W2/W4 awk-range rework. The run-list blocks, job keys, and windows skip-list marker block are byte-untouched.
- Side effect to be aware of: tag pushes (releases) no longer trigger the workflow — the tagged SHA is already covered by its push-to-main run.

## Tests run

- `actionlint` on the workflow: clean.
- PyYAML structural parse: `on`/`concurrency`/`jobs` shapes as intended.
- Full ubuntu run list extracted from `test.yml` and executed from the worktree root: **59/59 green** (including `tests/ci-wiring.test.sh` — W1/W1b/W2/W3/W4 all PASS; its awk ranges anchor on the untouched job keys).
- Grep sweep: the removed tokens (`~330`, `44 test files`) existed only in `test.yml`; no test greps the workflow top region.

## Landing notes

- **No version bump — sequential landing per RFC 0012 §9.**
- **HARD GATE: land only AFTER `fix/302-review-pr-trust-criticals`** — its benign-cancel dedupe must precede cancellation, or superseded pushes manufacture red `cancel` rows that review-pr Phase 3 misreads (RFC §7.7 ordering: "#302-R1 before infra-R2's cancel-in-progress").
- `test.yml` is also touched by `feat/309-bump-version-script` and the carrier PR (run-list lines) — disjoint regions, but rebase-check on landing order.
- Known bounded edge (documented GitHub semantics, not a regression): with `cancel-in-progress: false` on `main`, GitHub keeps at most one pending run per group — if 3+ PRs land within a single run's ~3-minute window, the middle commit's pending run is replaced ("Canceled by higher priority waiting request"). At the proven minutes-apart sequential-release cadence this does not bite; #302's benign-cancel dedupe covers the row shape if it ever does.
- Adjacent doc rot spotted, NOT fixed here (outside owned files): `CONTRIBUTING.md:90` and `plugins/uberdev/docs/testing.md:56` say CI runs "on every push" — now main-only pushes + every PR. Neither phrase is pinned by `docs-accuracy.test.sh`. Suggest folding the one-phrase fixes into the infra-R1+R8 hook-diet/drift series, which already edits CONTRIBUTING claims.
