### PR TITLE
fix(testers): fail-loud dispatch guard + zsh-safe rate-limit wrapper + persona timestamps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.36.8",
+      "version": "0.36.9",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.9] — 2026-06-12
+
+- _Release notes pending — replace this stub before committing (inserted by bump-version.sh)._
+
 ## [0.36.8] — 2026-06-12
 
 - _Release notes pending — replace this stub before committing (inserted by bump-version.sh)._

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.36.8-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.36.9-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.36.8",
+  "version": "0.36.9",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/agents/testers-a11y-critic.md
+++ b/plugins/uberdev/agents/testers-a11y-critic.md
@@ -4,7 +4,7 @@ description: Accessibility-critic persona for /uberdev:testers. Audits keyboard-
 # WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: cyan
-allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_press_key", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_evaluate", "Write(.uberdev/research/*)"]
+allowed-tools: ["Bash(curl*)", "Bash(*/lib/rl-curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_press_key", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_evaluate", "Write(.uberdev/research/*)"]
 ---
 
 You are the **a11y-critic** persona in a `/uberdev:testers` squad audit.
@@ -29,9 +29,12 @@ You are the **a11y-critic** persona in a `/uberdev:testers` squad audit.
 
 - `max_actions: 200`
 - `max_clock_seconds: 300`
-- **Polite-rate (enforcement):** source `plugins/uberdev/lib/rate-limit-curl.sh`
-  and call `uberdev_rate_limit_curl <URL> <args>` for every `curl` invocation.
-  The wrapper hard-caps per-host RPS at the run's `--rps-cap` (default 10).
+- **Polite-rate (enforcement):** for every `curl` request, invoke the executable
+  shim `lib/rl-curl` as a SINGLE command word, with the per-call values from your
+  dispatch prompt — never a compound export/source form, and never ambient env:
+  `"<plugin-root>/lib/rl-curl" --rate-state-dir=<abs-dir> --rps-cap=<cap> <URL> <curl-args>`.
+  The shim wraps `uberdev_rate_limit_curl` from `plugins/uberdev/lib/rate-limit-curl.sh`,
+  hard-capping per-host RPS at the run's `--rps-cap` (default 10).
   Playwright / `browser_*` MCP calls cannot be HTTP-wrapped; the audit phase
   reads `evidence.network_request.timestamp` and fails the run if your per-host
   rolling 1-second RPS exceeds the cap. Populate `timestamp` on every
@@ -51,6 +54,11 @@ findings:
     evidence:
       screenshot: <path or null>
       dom_hash: <sha256 of a11y-tree subtree or null>
+      network_request:
+        method: <verb or null>
+        url: <url or null>
+        status: <code or null>
+        timestamp: <ISO 8601 with milliseconds, epoch-ms, or null>  # required for the rate-cap audit; rows without url+timestamp are skipped
       repro_steps: [<step>, ...]
       observed: <what happened>
       expected: <what should have happened per invariant>

--- a/plugins/uberdev/agents/testers-adversarial-security.md
+++ b/plugins/uberdev/agents/testers-adversarial-security.md
@@ -4,7 +4,7 @@ description: Adversarial-security persona for /uberdev:testers. Probes XSS/SQLi/
 # WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: red
-allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(node*)", "Bash(date*)", "Bash(jq*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_fill_form", "mcp__plugin_playwright_playwright__browser_evaluate", "mcp__plugin_playwright_playwright__browser_run_code_unsafe", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_network_requests", "mcp__plugin_playwright_playwright__browser_network_request", "mcp__plugin_playwright_playwright__browser_console_messages", "Write(.uberdev/research/*)"]
+allowed-tools: ["Bash(curl*)", "Bash(*/lib/rl-curl*)", "Bash(echo*)", "Bash(node*)", "Bash(date*)", "Bash(jq*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_fill_form", "mcp__plugin_playwright_playwright__browser_evaluate", "mcp__plugin_playwright_playwright__browser_run_code_unsafe", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_network_requests", "mcp__plugin_playwright_playwright__browser_network_request", "mcp__plugin_playwright_playwright__browser_console_messages", "Write(.uberdev/research/*)"]
 ---
 
 You are the **adversarial-security** persona in a `/uberdev:testers` squad audit.
@@ -32,9 +32,12 @@ Audit the target for security-adjacent invariant violations:
 
 - `max_actions: 200`
 - `max_clock_seconds: 300`
-- **Polite-rate (enforcement):** source `plugins/uberdev/lib/rate-limit-curl.sh`
-  and call `uberdev_rate_limit_curl <URL> <args>` for every `curl` invocation.
-  The wrapper hard-caps per-host RPS at the run's `--rps-cap` (default 10).
+- **Polite-rate (enforcement):** for every `curl` request, invoke the executable
+  shim `lib/rl-curl` as a SINGLE command word, with the per-call values from your
+  dispatch prompt — never a compound export/source form, and never ambient env:
+  `"<plugin-root>/lib/rl-curl" --rate-state-dir=<abs-dir> --rps-cap=<cap> <URL> <curl-args>`.
+  The shim wraps `uberdev_rate_limit_curl` from `plugins/uberdev/lib/rate-limit-curl.sh`,
+  hard-capping per-host RPS at the run's `--rps-cap` (default 10).
   Playwright / `browser_*` MCP calls cannot be HTTP-wrapped; the audit phase
   reads `evidence.network_request.timestamp` and fails the run if your per-host
   rolling 1-second RPS exceeds the cap. Populate `timestamp` on every
@@ -58,6 +61,7 @@ findings:
         method: <verb or null>
         url: <url or null>
         status: <code or null>
+        timestamp: <ISO 8601 with milliseconds, epoch-ms, or null>  # required for the rate-cap audit; rows without url+timestamp are skipped
       repro_steps: [<step>, ...]
       observed: <what happened>
       expected: <what should have happened per invariant>
@@ -65,7 +69,7 @@ findings:
 confidence: low | medium | high
 ```
 
-`evidence.network_request` (method/url/status) is mandatory for any API-tier finding; `evidence.screenshot` mandatory for any UI-tier finding. The aggregator drops unanchored findings.
+`evidence.network_request` (method/url/status/timestamp) is mandatory for any API-tier finding; `evidence.screenshot` mandatory for any UI-tier finding. The aggregator drops unanchored findings.
 
 ## Rules
 

--- a/plugins/uberdev/agents/testers-chaos-engineer.md
+++ b/plugins/uberdev/agents/testers-chaos-engineer.md
@@ -4,7 +4,7 @@ description: Chaos-engineering persona for /uberdev:testers. Runs flows under Sl
 # WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: purple
-allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_network_requests", "mcp__plugin_playwright_playwright__browser_console_messages", "Write(.uberdev/research/*)"]
+allowed-tools: ["Bash(curl*)", "Bash(*/lib/rl-curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_network_requests", "mcp__plugin_playwright_playwright__browser_console_messages", "Write(.uberdev/research/*)"]
 ---
 
 You are the **chaos-engineer** persona in a `/uberdev:testers` squad audit.
@@ -30,9 +30,12 @@ You are the **chaos-engineer** persona in a `/uberdev:testers` squad audit.
 - `max_actions: 200`
 - `max_clock_seconds: 300`
 - Throttle profiles to cycle: Slow 3G, Offline, CPU 4x, baseline.
-- **Polite-rate (enforcement):** source `plugins/uberdev/lib/rate-limit-curl.sh`
-  and call `uberdev_rate_limit_curl <URL> <args>` for every `curl` invocation.
-  The wrapper hard-caps per-host RPS at the run's `--rps-cap` (default 10).
+- **Polite-rate (enforcement):** for every `curl` request, invoke the executable
+  shim `lib/rl-curl` as a SINGLE command word, with the per-call values from your
+  dispatch prompt — never a compound export/source form, and never ambient env:
+  `"<plugin-root>/lib/rl-curl" --rate-state-dir=<abs-dir> --rps-cap=<cap> <URL> <curl-args>`.
+  The shim wraps `uberdev_rate_limit_curl` from `plugins/uberdev/lib/rate-limit-curl.sh`,
+  hard-capping per-host RPS at the run's `--rps-cap` (default 10).
   Playwright / `browser_*` MCP calls cannot be HTTP-wrapped; the audit phase
   reads `evidence.network_request.timestamp` and fails the run if your per-host
   rolling 1-second RPS exceeds the cap. Populate `timestamp` on every
@@ -56,6 +59,7 @@ findings:
         method: <verb or null>
         url: <url or null>
         status: <code or null>
+        timestamp: <ISO 8601 with milliseconds, epoch-ms, or null>  # required for the rate-cap audit; rows without url+timestamp are skipped
       repro_steps:
         - "throttle profile: Slow 3G | Offline | CPU 4x | baseline"
         - "<concrete steps>"

--- a/plugins/uberdev/agents/testers-mobile-thumb.md
+++ b/plugins/uberdev/agents/testers-mobile-thumb.md
@@ -4,7 +4,7 @@ description: Mobile-thumb persona for /uberdev:testers. 375px viewport, touch-on
 # WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: green
-allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_resize", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "Write(.uberdev/research/*)"]
+allowed-tools: ["Bash(curl*)", "Bash(*/lib/rl-curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_resize", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "Write(.uberdev/research/*)"]
 ---
 
 You are the **mobile-thumb** persona in a `/uberdev:testers` squad audit.
@@ -29,9 +29,12 @@ You are the **mobile-thumb** persona in a `/uberdev:testers` squad audit.
 
 - `max_actions: 200`
 - `max_clock_seconds: 300`
-- **Polite-rate (enforcement):** source `plugins/uberdev/lib/rate-limit-curl.sh`
-  and call `uberdev_rate_limit_curl <URL> <args>` for every `curl` invocation.
-  The wrapper hard-caps per-host RPS at the run's `--rps-cap` (default 10).
+- **Polite-rate (enforcement):** for every `curl` request, invoke the executable
+  shim `lib/rl-curl` as a SINGLE command word, with the per-call values from your
+  dispatch prompt — never a compound export/source form, and never ambient env:
+  `"<plugin-root>/lib/rl-curl" --rate-state-dir=<abs-dir> --rps-cap=<cap> <URL> <curl-args>`.
+  The shim wraps `uberdev_rate_limit_curl` from `plugins/uberdev/lib/rate-limit-curl.sh`,
+  hard-capping per-host RPS at the run's `--rps-cap` (default 10).
   Playwright / `browser_*` MCP calls cannot be HTTP-wrapped; the audit phase
   reads `evidence.network_request.timestamp` and fails the run if your per-host
   rolling 1-second RPS exceeds the cap. Populate `timestamp` on every
@@ -51,6 +54,11 @@ findings:
     evidence:
       screenshot: <path or null>
       dom_hash: <sha256 or null>
+      network_request:
+        method: <verb or null>
+        url: <url or null>
+        status: <code or null>
+        timestamp: <ISO 8601 with milliseconds, epoch-ms, or null>  # required for the rate-cap audit; rows without url+timestamp are skipped
       repro_steps:
         - "viewport: 375x667 | 414x896 | 768x1024"
         - "orientation: portrait | landscape"

--- a/plugins/uberdev/agents/testers-panicked-grandma.md
+++ b/plugins/uberdev/agents/testers-panicked-grandma.md
@@ -4,7 +4,7 @@ description: Slow-reader, easily-confused persona for /uberdev:testers. Mis-clic
 # WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: yellow
-allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_console_messages", "mcp__plugin_playwright_playwright__browser_navigate_back", "Write(.uberdev/research/*)"]
+allowed-tools: ["Bash(curl*)", "Bash(*/lib/rl-curl*)", "Bash(echo*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_console_messages", "mcp__plugin_playwright_playwright__browser_navigate_back", "Write(.uberdev/research/*)"]
 ---
 
 You are the **panicked-grandma** persona in a `/uberdev:testers` squad audit.
@@ -32,9 +32,12 @@ Audit the target for usability failures a non-technical user would hit. Specific
 - `max_actions: 200`
 - `max_clock_seconds: 300`
 - Stop and emit findings when either is hit.
-- **Polite-rate (enforcement):** source `plugins/uberdev/lib/rate-limit-curl.sh`
-  and call `uberdev_rate_limit_curl <URL> <args>` for every `curl` invocation.
-  The wrapper hard-caps per-host RPS at the run's `--rps-cap` (default 10).
+- **Polite-rate (enforcement):** for every `curl` request, invoke the executable
+  shim `lib/rl-curl` as a SINGLE command word, with the per-call values from your
+  dispatch prompt — never a compound export/source form, and never ambient env:
+  `"<plugin-root>/lib/rl-curl" --rate-state-dir=<abs-dir> --rps-cap=<cap> <URL> <curl-args>`.
+  The shim wraps `uberdev_rate_limit_curl` from `plugins/uberdev/lib/rate-limit-curl.sh`,
+  hard-capping per-host RPS at the run's `--rps-cap` (default 10).
   Playwright / `browser_*` MCP calls cannot be HTTP-wrapped; the audit phase
   reads `evidence.network_request.timestamp` and fails the run if your per-host
   rolling 1-second RPS exceeds the cap. Populate `timestamp` on every
@@ -54,6 +57,11 @@ findings:
     evidence:
       screenshot: <path or null>
       dom_hash: <sha256 or null>
+      network_request:
+        method: <verb or null>
+        url: <url or null>
+        status: <code or null>
+        timestamp: <ISO 8601 with milliseconds, epoch-ms, or null>  # required for the rate-cap audit; rows without url+timestamp are skipped
       repro_steps: [<step>, ...]
       observed: <what happened>
       expected: <what should have happened per invariant>

--- a/plugins/uberdev/agents/testers-power-user.md
+++ b/plugins/uberdev/agents/testers-power-user.md
@@ -4,7 +4,7 @@ description: Power-user persona for /uberdev:testers. Pastes 10k-char inputs, op
 # WAIT 4.8 sonnet: was sonnet; using inherit (= session Opus 4.8 1M) until Sonnet 4.8 ships
 model: inherit
 color: orange
-allowed-tools: ["Bash(curl*)", "Bash(echo*)", "Bash(node*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_fill_form", "mcp__plugin_playwright_playwright__browser_press_key", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_console_messages", "mcp__plugin_playwright_playwright__browser_tabs", "mcp__plugin_playwright_playwright__browser_network_requests", "Write(.uberdev/research/*)"]
+allowed-tools: ["Bash(curl*)", "Bash(*/lib/rl-curl*)", "Bash(echo*)", "Bash(node*)", "Bash(date*)", "Read", "mcp__plugin_playwright_playwright__browser_navigate", "mcp__plugin_playwright_playwright__browser_click", "mcp__plugin_playwright_playwright__browser_type", "mcp__plugin_playwright_playwright__browser_fill_form", "mcp__plugin_playwright_playwright__browser_press_key", "mcp__plugin_playwright_playwright__browser_take_screenshot", "mcp__plugin_playwright_playwright__browser_snapshot", "mcp__plugin_playwright_playwright__browser_console_messages", "mcp__plugin_playwright_playwright__browser_tabs", "mcp__plugin_playwright_playwright__browser_network_requests", "Write(.uberdev/research/*)"]
 ---
 
 You are the **power-user** persona in a `/uberdev:testers` squad audit.
@@ -32,9 +32,12 @@ Audit the target for failures under high-input-velocity conditions. Specifically
 
 - `max_actions: 200`
 - `max_clock_seconds: 300`
-- **Polite-rate (enforcement):** source `plugins/uberdev/lib/rate-limit-curl.sh`
-  and call `uberdev_rate_limit_curl <URL> <args>` for every `curl` invocation.
-  The wrapper hard-caps per-host RPS at the run's `--rps-cap` (default 10).
+- **Polite-rate (enforcement):** for every `curl` request, invoke the executable
+  shim `lib/rl-curl` as a SINGLE command word, with the per-call values from your
+  dispatch prompt — never a compound export/source form, and never ambient env:
+  `"<plugin-root>/lib/rl-curl" --rate-state-dir=<abs-dir> --rps-cap=<cap> <URL> <curl-args>`.
+  The shim wraps `uberdev_rate_limit_curl` from `plugins/uberdev/lib/rate-limit-curl.sh`,
+  hard-capping per-host RPS at the run's `--rps-cap` (default 10).
   Playwright / `browser_*` MCP calls cannot be HTTP-wrapped; the audit phase
   reads `evidence.network_request.timestamp` and fails the run if your per-host
   rolling 1-second RPS exceeds the cap. Populate `timestamp` on every
@@ -58,6 +61,7 @@ findings:
         method: <verb or null>
         url: <url or null>
         status: <code or null>
+        timestamp: <ISO 8601 with milliseconds, epoch-ms, or null>  # required for the rate-cap audit; rows without url+timestamp are skipped
       repro_steps: [<step>, ...]
       observed: <what happened>
       expected: <what should have happened per invariant>

--- a/plugins/uberdev/lib/rate-limit-curl.sh
+++ b/plugins/uberdev/lib/rate-limit-curl.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 # SOURCED, never executed. Source-time idempotent (mirrors dispatch.sh:20-23).
+# DUAL-SHELL: persona agents (and the lib/rl-curl shim) source this under bash
+# OR zsh — the Claude Code Bash tool runs /bin/zsh on macOS. Two zsh traps are
+# handled explicitly below (#306 / RFC 0012 §3.10 testers-R2):
+#   - BASH_SOURCE is unset in zsh -> ${(%):-%x} prompt-escape fallback;
+#   - `trap ... RETURN` is an "undefined signal" error in zsh (the trap never
+#     installs) -> the mkdir-mutex is released EXPLICITLY on every return path.
 if [ "${_UBERDEV_RATE_LIMIT_LOADED:-0}" = "1" ]; then return 0 2>/dev/null || true; fi
 _UBERDEV_RATE_LIMIT_LOADED=1
 
 # Absolute dir of this lib so the wrapper can find its sibling normalize_host.py — the
 # SINGLE SOURCE OF TRUTH for per-host bucket keys, shared with lib/rate-cap-audit.sh.
-_UBERDEV_RATE_LIMIT_LIBDIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# ${BASH_SOURCE[0]:-${(%):-%x}} resolves the sourced-file path in BOTH shells:
+# bash leaves the default unevaluated (BASH_SOURCE[0] is set when sourced, and
+# bash 3.2/5.x only expand `:-` defaults lazily); zsh has no BASH_SOURCE and
+# falls through to the %x prompt escape (file containing the executing code).
+_UBERDEV_RATE_LIMIT_SELF="${BASH_SOURCE[0]:-${(%):-%x}}"
+_UBERDEV_RATE_LIMIT_LIBDIR="$(CDPATH= cd -- "$(dirname -- "$_UBERDEV_RATE_LIMIT_SELF")" 2>/dev/null && pwd)"
 
 # uberdev_rate_limit_curl URL [curl-args...]
 #
@@ -18,7 +29,8 @@ _UBERDEV_RATE_LIMIT_LIBDIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 
 #   1. Normalizes <host> from URL via the shared normalize_host.py (lowercases; strips
 #      userinfo + :port; drops a trailing dot) so a@host / Host / host:443 / host. all
 #      share ONE bucket — the per-host cap can't be bypassed by varying the authority.
-#   2. Acquires mkdir-mutex on $RATE_STATE_DIR/<host>/.lock (trap on RETURN releases).
+#   2. Acquires mkdir-mutex on $RATE_STATE_DIR/<host>/.lock (bounded retry; released
+#      explicitly on every return path — never via `trap RETURN`, which zsh rejects).
 #   3. Reads $RATE_STATE_DIR/<host>/last_release (epoch-ms, default 0).
 #   4. Computes inter-call delay (FLOAT) = max(0, (1000 / $RPS_CAP) - (now_ms - last_ms)).
 #   5. If delay > 0, sleeps (`sleep "$delay_s"` where delay_s is delay/1000 via awk).
@@ -31,8 +43,10 @@ _UBERDEV_RATE_LIMIT_LIBDIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 
 #   - $RPS_CAP unset, non-integer, or out of [1, 1000] -> defensive re-validation;
 #     wrapper does NOT trust the env var since it could be re-injected mid-session.
 #     On bad value, exit 2.
-#   - mkdir-mutex contention -> retry every 10ms with no upper bound (per-host buckets
-#     mean contention is bounded by the number of agents hitting the same host, max 6).
+#   - mkdir-mutex contention -> retry every 10ms, BOUNDED at UBERDEV_RATE_MUTEX_MAX_TRIES
+#     (default 6000 ~= 60s). Legit contention is small (max 6 agents per host, each
+#     holding the lock for at most one ~1s pacing sleep); a leaked/stale .lock from a
+#     killed caller therefore fails LOUD with exit 2 instead of spinning forever.
 #   - URL parse fails (no host, or scope-escape host) -> exit 2 with stderr.
 #   - state-file write fails (full disk / RO fs) -> exit 2 with stderr (never silent).
 
@@ -66,9 +80,25 @@ uberdev_rate_limit_curl() {
   local LOCK="$HOST_DIR/.lock"
   local STATE="$HOST_DIR/last_release"
 
-  # mkdir-as-mutex (atomic across POSIX FS; no flock dependency).
-  until mkdir "$LOCK" 2>/dev/null; do sleep 0.01; done
-  trap 'rmdir "$LOCK" 2>/dev/null || true' RETURN
+  # mkdir-as-mutex (atomic across POSIX FS; no flock dependency). BOUNDED retry:
+  # a stale .lock left by a killed holder must fail loud, not spin forever. The
+  # default 6000 tries x 10ms ~= 60s sits far above worst-case legit contention
+  # (<=6 personas serialised behind a <=1s pacing sleep each); tests lower it
+  # via UBERDEV_RATE_MUTEX_MAX_TRIES (positive integer; malformed -> default).
+  local MUTEX_TRIES=0 MUTEX_MAX="${UBERDEV_RATE_MUTEX_MAX_TRIES:-6000}"
+  [[ "$MUTEX_MAX" =~ ^[1-9][0-9]*$ ]] || MUTEX_MAX=6000
+  until mkdir "$LOCK" 2>/dev/null; do
+    MUTEX_TRIES=$((MUTEX_TRIES + 1))
+    if [ "$MUTEX_TRIES" -ge "$MUTEX_MAX" ]; then
+      echo "rate-limit-curl: could not acquire mutex $LOCK after $MUTEX_MAX attempts — stale lock from a killed caller? rmdir it to recover" >&2
+      return 2
+    fi
+    sleep 0.01
+  done
+  # NO `trap ... RETURN` here: zsh rejects RETURN as an undefined signal, so the
+  # trap never installs and the mutex would leak on any early return — making
+  # the next caller's mutex loop spin until its retry bound. Every return path
+  # past this point MUST `rmdir "$LOCK"` explicitly first.
 
   local NOW_MS LAST_MS DELAY_S RELEASE_MS SLEPT
   # GNU date supports %3N (ms); BSD date (macOS) silently emits literal "3N".
@@ -105,12 +135,12 @@ EOF
   # re-paces from, silently corrupting the rate gate while the caller keeps requesting (#188).
   if ! { printf '%s' "$NOW_MS" > "$STATE.tmp" && mv -f "$STATE.tmp" "$STATE"; }; then
     rm -f "$STATE.tmp" 2>/dev/null || true
+    rmdir "$LOCK" 2>/dev/null || true  # explicit release — no RETURN trap (dead in zsh)
     echo "rate-limit-curl: failed to persist rate state to $STATE (refusing to proceed with stale pacing)" >&2
-    return 2  # RETURN trap releases the mutex
+    return 2
   fi
 
   rmdir "$LOCK" 2>/dev/null || true
-  trap - RETURN
 
   # `--` before URL neutralises -fOJ / -X-prefixed URL smuggling (security IMPORTANT-1).
   command curl --fail-with-body --silent --show-error "$@" -- "$URL"

--- a/plugins/uberdev/lib/rl-curl
+++ b/plugins/uberdev/lib/rl-curl
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# plugins/uberdev/lib/rl-curl — executable single-word shim over rate-limit-curl.sh.
+#
+# WHY THIS EXISTS (#306 / RFC 0012 §3.10): the testers persona agents run with
+# pattern-scoped allowed-tools (Bash(curl*), Bash(date*), ...). The previously
+# documented compound invocation `export RATE_STATE_DIR=...; source ...;
+# uberdev_rate_limit_curl ...` matches NONE of those patterns, and the testers
+# Phase-0 fence exports never reach a persona agent's environment anyway (each
+# Task agent is a fresh process) — so the rate-limit wrapper was unreachable at
+# every layer. This shim makes the wrapped call a SINGLE command word that the
+# persona allowlists can carry (`Bash(*/lib/rl-curl*)`), with RATE_STATE_DIR /
+# RPS_CAP injected PER CALL via argv (env remains the fallback).
+#
+# Usage:
+#   rl-curl [--rate-state-dir=DIR] [--rps-cap=N] URL [curl-args...]
+#
+# Options must precede the URL; the first non-option argument starts the
+# passthrough (a real URL can never begin with `--rate-state-dir=`, and URL
+# flag-smuggling is already neutralised inside the wrapper via `--`).
+# All validation (URL host parse, cap range/format, state-dir existence) lives
+# in uberdev_rate_limit_curl — the single source of truth; this shim stays thin.
+# Exit codes pass through: 2 on wrapper validation failure, else curl's rc.
+#
+# EXECUTED (never sourced) under its own bash shebang, so it is immune to the
+# zsh sourcing traps the lib itself handles; macOS bash-3.2-safe (no arrays,
+# no declare -A, no trap RETURN).
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --rate-state-dir=*) RATE_STATE_DIR="${1#--rate-state-dir=}"; export RATE_STATE_DIR; shift ;;
+    --rps-cap=*)        RPS_CAP="${1#--rps-cap=}";               export RPS_CAP;        shift ;;
+    *) break ;;
+  esac
+done
+
+_RL_CURL_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [ -z "$_RL_CURL_DIR" ] || [ ! -r "$_RL_CURL_DIR/rate-limit-curl.sh" ]; then
+  echo "rl-curl: cannot locate sibling rate-limit-curl.sh (lib dir: ${_RL_CURL_DIR:-unset})" >&2
+  exit 2
+fi
+. "$_RL_CURL_DIR/rate-limit-curl.sh"
+uberdev_rate_limit_curl "$@"

--- a/plugins/uberdev/skills/testers-pipeline/SKILL.md
+++ b/plugins/uberdev/skills/testers-pipeline/SKILL.md
@@ -118,8 +118,14 @@ for arg in $ARGUMENTS; do
   esac
 done
 
+# Per-host rate-gate state for this run. ABSOLUTE path: the values are injected
+# into every persona Bash call via lib/rl-curl long options (see the Polite-rate
+# directive in Phase 2-4) — persona agents are fresh processes that never inherit
+# this fence's exports, and may run with a different cwd. The exports below serve
+# only same-fence consumers.
 mkdir -p "$RUN_DIR/.rate-state"
-export RATE_STATE_DIR="$RUN_DIR/.rate-state"
+RATE_STATE_DIR="$(pwd)/$RUN_DIR/.rate-state"
+export RATE_STATE_DIR
 export RPS_CAP
 
 # Auto-detect surface if needed
@@ -157,6 +163,16 @@ else
   MASTER_PROMPT="/uberdev:testers $ARGUMENTS --watch"
   # #171 — canonical CLAUDE_PLUGIN_ROOT-relative source (robust across cwd changes)
   [ -r "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh" ] && . "${CLAUDE_PLUGIN_ROOT}/lib/dispatch.sh"
+  # #306 fail-loud guard: lib/dispatch.sh has NEVER provided dispatch_master (its
+  # public surface is uberdev_dispatch_preflight/_resolve_env/_one). Without this
+  # guard the rc=127 of the missing function was swallowed by the success echo +
+  # exit 0 below — the documented mode printed "dispatched master" with nothing
+  # running. `command -v` (not `type -t`, which misfires under zsh) hard-refuses
+  # instead, steering to the inline path.
+  command -v dispatch_master >/dev/null 2>&1 || {
+    echo "error: master dispatch unavailable (#306) — dispatch_master is not provided by lib/dispatch.sh; re-run /uberdev:testers with --watch to execute the audit inline" >&2
+    exit 127
+  }
   dispatch_master "$MASTER_PROMPT" "$RUN_DIR/master.log"
   echo "[testers] dispatched master. Watch progress: $RUN_DIR/master.log"
   echo "[testers] run_id=$RUN_ID surface=$SURFACE target=$TARGET"
@@ -233,14 +249,25 @@ EOF
   #   - scratch dir scoped to .uberdev/research/$RUN_ID/testers/scratch/<agent>/
   # Each Task returns the canonical reviewer YAML on stdout.
   #
-  # Per-persona prompts MUST embed the following Polite-rate directive verbatim
-  # so every dispatched persona enforces and audits the per-host RPS ceiling:
+  # Per-persona prompts MUST embed the following Polite-rate directive verbatim —
+  # with $RPS_CAP, $RATE_STATE_DIR and ${CLAUDE_PLUGIN_ROOT} expanded to their
+  # CONCRETE values — so every dispatched persona enforces and audits the
+  # per-host RPS ceiling:
   #
   # ## Polite-rate (enforcement)
   #
-  # Source plugins/uberdev/lib/rate-limit-curl.sh in your bash environment.
-  # Call `uberdev_rate_limit_curl <URL> <curl-args>` for EVERY HTTP request you
-  # make via curl. The wrapper hard-caps per-host RPS at $RPS_CAP (default 10).
+  # For EVERY HTTP request you make via curl, invoke the executable shim as a
+  # SINGLE command word (your allowed-tools carry Bash(*/lib/rl-curl*); a
+  # compound `export ...; source ...; uberdev_rate_limit_curl ...` form matches
+  # no allowlist pattern, and exports from the orchestrating session never
+  # reach your environment):
+  #
+  #   "${CLAUDE_PLUGIN_ROOT}/lib/rl-curl" --rate-state-dir="$RATE_STATE_DIR" --rps-cap=$RPS_CAP <URL> [curl-args...]
+  #
+  # The shim sources plugins/uberdev/lib/rate-limit-curl.sh and calls
+  # uberdev_rate_limit_curl, which hard-caps per-host RPS at $RPS_CAP
+  # (default 10). RATE_STATE_DIR / RPS_CAP are injected PER CALL via the long
+  # options — never rely on ambient env.
   #
   # Playwright / browser_* MCP calls cannot be HTTP-wrapped. The audit phase
   # reads your findings[].evidence.network_request.timestamp and fails the run

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -420,8 +420,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.36.8) =="
-assert_version_bump "$REPO_ROOT" "0.36.8"
+echo "== G20: version bump locked (0.36.9) =="
+assert_version_bump "$REPO_ROOT" "0.36.9"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -273,8 +273,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.36.7 -> 0.36.8 propagated =="
-assert_version_bump "$REPO_ROOT" "0.36.8"
+echo "== Version bump 0.36.8 -> 0.36.9 propagated =="
+assert_version_bump "$REPO_ROOT" "0.36.9"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/testers-agent-contract.test.sh
+++ b/tests/testers-agent-contract.test.sh
@@ -127,4 +127,72 @@ for a in "${EXPECTED_AGENTS[@]}"; do
 done
 pass "C7: all agents declare verdict / findings / confidence in their output contract"
 
+# C8 (#306 / RFC 0012 §3.10): the Phase-1 dispatch_master call site is guarded.
+# lib/dispatch.sh has NEVER defined dispatch_master (public surface:
+# uberdev_dispatch_preflight/_resolve_env/_one) — pre-guard, the rc=127 of the
+# missing function was swallowed by the success echo + exit 0, so the documented
+# default mode printed "dispatched master" with nothing running. Call/definition
+# pairing: if dispatch_master is ever actually implemented in lib/dispatch.sh the
+# first arm goes green (guard becomes optional); until then the SKILL must refuse
+# loud (exit 127) and steer to --watch BEFORE the call.
+SKILL_FILE="$SKILL_DIR/SKILL.md"
+DISPATCH_LIB="plugins/uberdev/lib/dispatch.sh"
+grep -q 'dispatch_master "$MASTER_PROMPT"' "$SKILL_FILE" \
+  || fail "C8: dispatch_master call site missing from SKILL.md (dispatch form changed? re-point this test)"
+if grep -qE '^[[:space:]]*(function[[:space:]]+dispatch_master|dispatch_master[[:space:]]*\(\))' "$DISPATCH_LIB"; then
+  pass "C8: dispatch_master is now defined in lib/dispatch.sh (fail-loud guard no longer load-bearing)"
+else
+  grep -q 'command -v dispatch_master' "$SKILL_FILE" \
+    || fail "C8: missing 'command -v dispatch_master' fail-loud guard (#306)"
+  grep -q 'master dispatch unavailable (#306)' "$SKILL_FILE" \
+    || fail "C8: guard lacks the 'master dispatch unavailable (#306)' error literal"
+  grep -q 'exit 127' "$SKILL_FILE" || fail "C8: guard must exit 127"
+  GUARD_LINE="$(grep -n 'command -v dispatch_master' "$SKILL_FILE" | head -1 | cut -d: -f1)"
+  CALL_LINE="$(grep -n 'dispatch_master "$MASTER_PROMPT"' "$SKILL_FILE" | head -1 | cut -d: -f1)"
+  [ "$GUARD_LINE" -lt "$CALL_LINE" ] \
+    || fail "C8: guard must PRECEDE the dispatch_master call (guard line $GUARD_LINE, call line $CALL_LINE)"
+  awk -v a="$GUARD_LINE" -v b="$CALL_LINE" 'NR>=a && NR<=b' "$SKILL_FILE" | grep -q -- '--watch' \
+    || fail "C8: the guard's refusal must steer users to --watch"
+  pass "C8: dispatch_master fail-loud guard precedes the call, exits 127, steers to --watch"
+fi
+
+# C9 (#306 / RFC 0012 testers-R3a): every persona's network_request evidence schema
+# carries url + timestamp. lib/rate-cap-audit.sh silently skips rows lacking EITHER
+# field (`if not url or not ts: continue`) — without these schema keys the personas
+# never emit them and the polite-rate breach gate audits ~nothing.
+for a in "${PERSONA_AGENTS[@]}"; do
+  F="$AGENT_DIR/$a.md"
+  grep -q 'network_request:' "$F" || fail "C9 $a: missing network_request evidence block"
+  grep -A5 'network_request:' "$F" | grep -q 'url:' \
+    || fail "C9 $a: network_request block lacks url: (rate-cap audit skips the row)"
+  grep -A5 'network_request:' "$F" | grep -q 'timestamp:' \
+    || fail "C9 $a: network_request block lacks timestamp: (rate-cap audit skips the row)"
+done
+pass "C9: all 6 persona network_request schema blocks carry url + timestamp"
+
+# C10 (#306 / RFC 0012 §3.10): the executable lib/rl-curl shim exists and the
+# rate-limit invocation chain is allowlist-reachable end to end:
+#   - shim is executable, bash-shebanged, sources the SSOT wrapper, and accepts
+#     per-call --rate-state-dir= / --rps-cap= argv injection;
+#   - every persona allowlist carries the Bash(*/lib/rl-curl*) pattern (the compound
+#     export+source+uberdev_rate_limit_curl form matches no Bash() pattern);
+#   - persona polite-rate blocks and the SKILL dispatch directive document the
+#     per-call long-option form (Phase-0 fence exports never reach persona agents).
+RLC="plugins/uberdev/lib/rl-curl"
+[ -f "$RLC" ] || fail "C10: $RLC missing"
+[ -x "$RLC" ] || fail "C10: $RLC is not executable (x-bit lost on checkout?)"
+head -1 "$RLC" | grep -q 'bash' || fail "C10: $RLC must run under a bash shebang"
+grep -q 'rate-limit-curl.sh' "$RLC" || fail "C10: shim does not source the SSOT wrapper rate-limit-curl.sh"
+grep -q 'uberdev_rate_limit_curl' "$RLC" || fail "C10: shim does not call uberdev_rate_limit_curl"
+grep -q -- '--rate-state-dir=' "$RLC" || fail "C10: shim lacks --rate-state-dir= argv injection"
+grep -q -- '--rps-cap=' "$RLC" || fail "C10: shim lacks --rps-cap= argv injection"
+for a in "${PERSONA_AGENTS[@]}"; do
+  F="$AGENT_DIR/$a.md"
+  grep -qF 'Bash(*/lib/rl-curl*)' "$F" || fail "C10 $a: allowed-tools lacks the Bash(*/lib/rl-curl*) pattern"
+  grep -q -- '--rate-state-dir=' "$F" || fail "C10 $a: polite-rate block lacks the per-call --rate-state-dir= injection form"
+done
+grep -q 'lib/rl-curl' "$SKILL_FILE" || fail "C10: SKILL dispatch directive does not reference lib/rl-curl"
+grep -q -- '--rate-state-dir=' "$SKILL_FILE" || fail "C10: SKILL dispatch directive lacks the per-call --rate-state-dir= injection form"
+pass "C10: rl-curl shim, persona allowlists and per-call injection are consistent"
+
 echo "ALL TESTS PASS"

--- a/tests/testers-rate-limit-wrapper.test.sh
+++ b/tests/testers-rate-limit-wrapper.test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Tests: lib/rate-limit-curl.sh + parse-site --rps-cap validation in SKILL.md.
-# Cases: 1-7 (parse + wrapper pacing + mkdir-mutex), 11-12 (security: flag-smuggling + defensive re-validation).
+# Tests: lib/rate-limit-curl.sh + lib/rl-curl shim + parse-site --rps-cap validation in SKILL.md.
+# Cases: 1-7 (parse + wrapper pacing + mkdir-mutex), 11-12 (security: flag-smuggling +
+# defensive re-validation), 13-20 (separator, mutex release, normalizer, float delay,
+# fail-loud), 21-25 (#306: explicit mutex release on error paths, bounded mutex retry,
+# zsh runtime fixture, rl-curl shim argv/env injection + fail-closed).
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_TMPDIR="$(mktemp -d)"
@@ -220,9 +223,10 @@ EOF
 }
 test_curl_dash_dash_separator
 
-# Case 14: trap RETURN releases mutex even on curl failure
+# Case 14: mutex released even on curl failure (explicit release — trap RETURN is
+# dead under zsh, so the wrapper must never rely on it; see Cases 21-23)
 test_trap_release_on_curl_failure() {
-  # Verifies trap RETURN releases the mutex even when curl exits non-zero.
+  # Verifies the mutex is released even when curl exits non-zero.
   export RATE_STATE_DIR="$TEST_TMPDIR/trap-$RANDOM"
   mkdir -p "$RATE_STATE_DIR"
   export RPS_CAP=10
@@ -402,5 +406,138 @@ EOF
   pass "$FUNCNAME"
 }
 test_normalizer_tool_failure_surfaces
+
+# Case 21 (#306, testers-R2): the mutex is released on the state-write-failure RETURN
+# path. Pre-fix this relied on `trap RETURN` (dead under zsh: "undefined signal"); the
+# wrapper now rmdirs explicitly on EVERY return path, which must hold in bash too.
+test_mutex_release_on_state_write_failure() {
+  export RATE_STATE_DIR="$TEST_TMPDIR/relfail-$RANDOM"
+  mkdir -p "$RATE_STATE_DIR/relfail.test"
+  mkdir "$RATE_STATE_DIR/relfail.test/last_release.tmp"  # forces the write-failure return 2
+  export RPS_CAP=1000
+  SHIM="$TEST_TMPDIR/relfail-shim"; mkdir -p "$SHIM"
+  cat > "$SHIM/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$SHIM/curl"
+  OLD_PATH="$PATH"; export PATH="$SHIM:$PATH"
+  . "$REPO_ROOT/plugins/uberdev/lib/rate-limit-curl.sh"
+  uberdev_rate_limit_curl "http://relfail.test/x" >/dev/null 2>&1 || true
+  export PATH="$OLD_PATH"
+  if [ -d "$RATE_STATE_DIR/relfail.test/.lock" ]; then
+    fail "$FUNCNAME" "mutex leaked on the state-write-failure return path"; return
+  fi
+  pass "$FUNCNAME"
+}
+test_mutex_release_on_state_write_failure
+
+# Case 22 (#306, testers-R2): BOUNDED mutex retry — a stale .lock (holder killed
+# mid-call) fails LOUD with exit 2 + a recovery hint instead of spinning forever
+# (pre-fix: unbounded `until mkdir`). Bound lowered via UBERDEV_RATE_MUTEX_MAX_TRIES
+# so the case runs in ~30ms.
+test_bounded_mutex_retry_fails_loud_on_stale_lock() {
+  export RATE_STATE_DIR="$TEST_TMPDIR/stale-$RANDOM"
+  mkdir -p "$RATE_STATE_DIR/stale.test/.lock"  # pre-leaked lock with no live holder
+  export RPS_CAP=10
+  . "$REPO_ROOT/plugins/uberdev/lib/rate-limit-curl.sh"
+  export UBERDEV_RATE_MUTEX_MAX_TRIES=3
+  rc=0; out=$(uberdev_rate_limit_curl "http://stale.test/x" 2>&1) || rc=$?
+  unset UBERDEV_RATE_MUTEX_MAX_TRIES
+  [ "$rc" -eq 2 ] || { fail "$FUNCNAME" "expected exit 2 on stale lock, got $rc"; return; }
+  echo "$out" | grep -q "could not acquire mutex" || { fail "$FUNCNAME" "stderr lacks the bounded-retry error: $out"; return; }
+  pass "$FUNCNAME"
+}
+test_bounded_mutex_retry_fails_loud_on_stale_lock
+
+# Case 23 (#306, testers-R2): zsh runtime fixture — persona agents source the wrapper
+# under /bin/zsh (the Claude Code Bash tool shell on macOS), where BASH_SOURCE is unset
+# and `trap ... RETURN` never installs. Asserts under REAL zsh: (1) the dual-shell
+# ${BASH_SOURCE[0]:-${(%):-%x}} libdir fallback resolves (normalize_host.py found);
+# (2) a happy-path call paces + buckets; (3) the state-write-failure return releases
+# the mutex (the pre-fix leak); (4) a follow-up call does not spin on a leaked lock.
+# zsh is a hard dep of this case: CI installs it on ubuntu for the *-zsh fixtures and
+# macOS ships it — fail loud, never skip silently.
+test_wrapper_under_zsh() {
+  command -v zsh >/dev/null 2>&1 || { fail "$FUNCNAME" "zsh not on PATH (CI installs it; macOS ships it)"; return; }
+  ZSTATE="$TEST_TMPDIR/zsh-state-$RANDOM"
+  mkdir -p "$ZSTATE"
+  SHIM="$TEST_TMPDIR/zsh-shim"; mkdir -p "$SHIM"
+  cat > "$SHIM/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$SHIM/curl"
+  ZFIXTURE="$TEST_TMPDIR/zsh-fixture-$RANDOM.zsh"
+  cat > "$ZFIXTURE" <<'EOF'
+set -u
+. "$REPO_ROOT/plugins/uberdev/lib/rate-limit-curl.sh"
+[ -f "$_UBERDEV_RATE_LIMIT_LIBDIR/normalize_host.py" ] || { echo "ZFAIL libdir unresolved under zsh: ${_UBERDEV_RATE_LIMIT_LIBDIR:-unset}"; exit 1; }
+uberdev_rate_limit_curl "http://zwrap.test/a" >/dev/null || { echo "ZFAIL happy-path rc=$?"; exit 1; }
+[ -d "$RATE_STATE_DIR/zwrap.test" ] || { echo "ZFAIL host bucket missing"; exit 1; }
+mkdir -p "$RATE_STATE_DIR/zwrap.test/last_release.tmp"
+uberdev_rate_limit_curl "http://zwrap.test/b" >/dev/null 2>&1
+rc=$?
+[ "$rc" -eq 2 ] || { echo "ZFAIL write-failure rc=$rc (want 2)"; exit 1; }
+[ ! -d "$RATE_STATE_DIR/zwrap.test/.lock" ] || { echo "ZFAIL mutex leaked under zsh (trap RETURN regression)"; exit 1; }
+rmdir "$RATE_STATE_DIR/zwrap.test/last_release.tmp"
+UBERDEV_RATE_MUTEX_MAX_TRIES=5 uberdev_rate_limit_curl "http://zwrap.test/c" >/dev/null || { echo "ZFAIL follow-up call rc=$? (leaked-lock spin?)"; exit 1; }
+echo ZOK
+EOF
+  out="$(RATE_STATE_DIR="$ZSTATE" RPS_CAP=1000 PATH="$SHIM:$PATH" REPO_ROOT="$REPO_ROOT" zsh "$ZFIXTURE" 2>&1)" || { fail "$FUNCNAME" "zsh fixture failed: $out"; return; }
+  echo "$out" | grep -q "ZOK" || { fail "$FUNCNAME" "zsh fixture did not reach ZOK: $out"; return; }
+  pass "$FUNCNAME"
+}
+test_wrapper_under_zsh
+
+# Case 24 (#306, RFC 0012 §3.10): lib/rl-curl shim — SINGLE-word invocation with
+# per-call argv injection (the form persona allowed-tools carry via
+# Bash(*/lib/rl-curl*)). Ambient env deliberately UNSET: argv must be sufficient,
+# because Phase-0 fence exports never reach persona agents.
+test_rl_curl_shim_argv_injection() {
+  STATE_DIR="$TEST_TMPDIR/shim-argv-$RANDOM"
+  mkdir -p "$STATE_DIR"
+  SHIM="$TEST_TMPDIR/shimexe-shim"; mkdir -p "$SHIM"
+  cat > "$SHIM/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$SHIM/curl"
+  if ! env -u RATE_STATE_DIR -u RPS_CAP PATH="$SHIM:$PATH" \
+      "$REPO_ROOT/plugins/uberdev/lib/rl-curl" \
+      --rate-state-dir="$STATE_DIR" --rps-cap=10 "http://shimargv.test/x" >/dev/null 2>&1; then
+    fail "$FUNCNAME" "argv-injected shim call failed"; return
+  fi
+  [ -d "$STATE_DIR/shimargv.test" ] || { fail "$FUNCNAME" "no host bucket created via shim"; return; }
+  pass "$FUNCNAME"
+}
+test_rl_curl_shim_argv_injection
+
+# Case 25 (#306): shim env fallback works, and with NEITHER argv NOR env it fails
+# CLOSED (exit 2, no curl performed) — never a silent unwrapped request.
+test_rl_curl_shim_env_fallback_and_fail_closed() {
+  STATE_DIR="$TEST_TMPDIR/shim-env-$RANDOM"
+  mkdir -p "$STATE_DIR"
+  SHIM="$TEST_TMPDIR/shimenv-shim"; mkdir -p "$SHIM"
+  CURL_HITS="$TEST_TMPDIR/shimenv-hits-$RANDOM"
+  cat > "$SHIM/curl" <<EOF
+#!/usr/bin/env bash
+echo hit >> "$CURL_HITS"
+exit 0
+EOF
+  chmod +x "$SHIM/curl"
+  env RATE_STATE_DIR="$STATE_DIR" RPS_CAP=10 PATH="$SHIM:$PATH" \
+    "$REPO_ROOT/plugins/uberdev/lib/rl-curl" "http://shimenv.test/x" >/dev/null 2>&1 \
+    || { fail "$FUNCNAME" "env-fallback shim call failed"; return; }
+  rc=0
+  env -u RATE_STATE_DIR -u RPS_CAP PATH="$SHIM:$PATH" \
+    "$REPO_ROOT/plugins/uberdev/lib/rl-curl" "http://shimenv.test/y" >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 2 ] || { fail "$FUNCNAME" "expected fail-closed exit 2 without env/argv, got $rc"; return; }
+  # exactly one curl execution: the env-fallback call; the fail-closed call must not curl
+  hits="$(wc -l < "$CURL_HITS" | tr -d ' ')"
+  [ "$hits" = "1" ] || { fail "$FUNCNAME" "expected exactly 1 curl execution, got $hits (fail-closed path leaked a request?)"; return; }
+  pass "$FUNCNAME"
+}
+test_rl_curl_shim_env_fallback_and_fail_closed
 
 exit "$FAILS"


### PR DESCRIPTION
## Summary

Do-first safety bundle for `/uberdev:testers`: converts the fail-open never-worked `dispatch_master` default mode into a hard refusal, makes the polite-rate curl wrapper actually executable by persona agents (zsh-safe lib + a single-word `rl-curl` shim with per-call injection), and adds `timestamp:` to the persona evidence schemas so the rate-cap breach gate audits real rows instead of ~nothing.

Part of #306 (per RFC 0012 §7.1, §7.9 (testers-R2/R3a), §3.10 do-first block).

## Changes

- **`skills/testers-pipeline/SKILL.md`** — `command -v dispatch_master` fail-loud guard (error literal `master dispatch unavailable (#306)`, `exit 127`, steers to `--watch`) BEFORE the call site; `lib/dispatch.sh` has never defined `dispatch_master` (public surface: `uberdev_dispatch_preflight/_resolve_env/_one`), and the rc=127 was previously swallowed by the success echo + `exit 0`. Phase-0 `RATE_STATE_DIR` made absolute; the Phase 2–4 Polite-rate dispatch directive now mandates the per-call `rl-curl` long-option form with concrete values (fence exports never reach persona processes).
- **`lib/rate-limit-curl.sh`** (testers-R2) — dual-shell libdir `${BASH_SOURCE[0]:-${(%):-%x}}`, empirically verified under macOS `/bin/bash` 3.2 AND zsh; explicit `rmdir` on EVERY return path past mutex acquisition (`trap ... RETURN` is an `undefined signal` under zsh — empirically reproduced — so the old trap never installed and leaked the mutex, making the previously-unbounded `until mkdir` spin forever); bounded mutex retry (`UBERDEV_RATE_MUTEX_MAX_TRIES`, default 6000×10 ms ≈ 60 s) failing loud with a recovery hint.
- **NEW `lib/rl-curl`** (executable, bash shebang, bash-3.2-safe) — single-word shim over the SSOT wrapper; reads `RATE_STATE_DIR`/`RPS_CAP` from `--rate-state-dir=`/`--rps-cap=` argv (env fallback); fail-closed (exit 2, no request) when neither is supplied; passes wrapper/curl exit codes through.
- **6 persona agents** — `allowed-tools` += `Bash(*/lib/rl-curl*)` (the documented compound `export …; source …; uberdev_rate_limit_curl …` form matched NO existing `Bash()` pattern); Polite-rate prose rewritten to the per-call shim form; `timestamp:` added to every `network_request` schema block (testers-R3a — `lib/rate-cap-audit.sh` `if not url or not ts: continue` silently skips rows lacking either, so the breach gate audited ~nothing). Monitor agents untouched (migration scope).
- **`lib/rate-cap-audit.sh`** — read, NOT edited: its parser already accepts ISO 8601 / epoch-ms / epoch-s, matching the schema comment added to the personas.
- **Tests** — `testers-agent-contract.test.sh`: C8 call/definition grep-anchor for the guard (greps the SKILL call site AND probes `lib/dispatch.sh` for a real definition; asserts guard-precedes-call, exit 127, `--watch` steer), C9 url+timestamp schema assert ×6, C10 shim/allowlist/per-call-form end-to-end consistency (incl. x-bit). `testers-rate-limit-wrapper.test.sh`: Case 21 mutex release on the write-failure return path, Case 22 bounded-retry fail-loud on a stale lock, Case 23 real-zsh runtime fixture (libdir fallback + pacing + mutex release + no leaked-lock spin; ubuntu CI installs zsh), Cases 24–25 shim argv injection, env fallback, and fail-closed-without-config (asserts zero curl executions on the refused path).

## Empirical note — agent allowed-tools enforcement (RFC 0012 §3.10 open question)

Cheap probe run on Claude Code 2.1.174 (2026-06-12), disposable project with an agent declaring `allowed-tools: ["Bash(echo *)"]` (exact-format relay proved the agent file loaded):

- Under `--dangerously-skip-permissions` (the standard operating policy here): `pwd` — matching no allowed pattern — **RAN**. Allowed-tools `Bash()` pattern scoping is NOT a hard tool-availability boundary under bypass.
- Default headless mode: `pwd` also ran (consistent with safe-command auto-approval — not discriminating); a `touch` was blocked by the working-directory sandbox boundary, not attributably by the allowlist pattern.
- Unresolved nuance: agents may canonically use the `tools:` frontmatter key; `allowed-tools` (what the testers fleet declares) may not be parsed for agents at all. Either way the operative conclusion holds: **the squad's read-only guarantee currently rests on prompts + workspace sandbox boundaries, not on allowed-tools patterns, under skip-permissions.** The `Bash(*/lib/rl-curl*)` pattern ships anyway — harmless if decorative, necessary wherever enforcement is real (e.g. stricter interactive tiers), and it keeps the documented contract coherent.

## Tests run

- Full ubuntu `test.yml` run list (59 invocations incl. the 3 zsh-driven fixtures) executed from the worktree root: **59/59 pass**.
- New/modified: `tests/testers-agent-contract.test.sh` (C1–C10), `tests/testers-rate-limit-wrapper.test.sh` (Cases 1–25 incl. the zsh fixture); `tests/testers-rate-limit-audit.test.sh` + `tests/testers-pipeline.test.sh` re-run green (P9 phrasing + `schema_version: 1` locks intact).

## Landing notes

- Independent; no gates.
- No version bump — sequential landing per RFC 0012 §9.
