### PR TITLE
feat(carrier): workflow-script test architecture (T1-T4) + config→args envelope + fallback convention + enum-lock extension

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.36.12",
+      "version": "0.37.0",
       "category": "workflow",
       "tags": [
         "github",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,9 @@ jobs:
           bash tests/skill-renderer-awk-collision.test.sh && \
           bash tests/dispatch-prompt-no-bare-slash.test.sh && \
           bash tests/bump-version.test.sh && \
-          bash tests/test-harness-source-guards.test.sh
+          bash tests/test-harness-source-guards.test.sh && \
+          bash tests/workflow-scripts.test.sh && \
+          bash tests/workflow-args.test.sh (feat(carrier): workflow-script test architecture (T1-T4) + config→args envelope + fallback convention + enum-lock extension)
 
   shape-checks-windows:
     name: shape-checks-windows
@@ -259,4 +261,6 @@ jobs:
           bash tests/skill-renderer-awk-collision.test.sh && \
           bash tests/dispatch-prompt-no-bare-slash.test.sh && \
           bash tests/bump-version.test.sh && \
-          bash tests/test-harness-source-guards.test.sh
+          bash tests/test-harness-source-guards.test.sh && \
+          bash tests/workflow-scripts.test.sh && \
+          bash tests/workflow-args.test.sh (feat(carrier): workflow-script test architecture (T1-T4) + config→args envelope + fallback convention + enum-lock extension)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
           bash tests/bump-version.test.sh && \
           bash tests/test-harness-source-guards.test.sh && \
           bash tests/workflow-scripts.test.sh && \
-          bash tests/workflow-args.test.sh (feat(carrier): workflow-script test architecture (T1-T4) + config→args envelope + fallback convention + enum-lock extension)
+          bash tests/workflow-args.test.sh
 
   shape-checks-windows:
     name: shape-checks-windows
@@ -263,4 +263,4 @@ jobs:
           bash tests/bump-version.test.sh && \
           bash tests/test-harness-source-guards.test.sh && \
           bash tests/workflow-scripts.test.sh && \
-          bash tests/workflow-args.test.sh (feat(carrier): workflow-script test architecture (T1-T4) + config→args envelope + fallback convention + enum-lock extension)
+          bash tests/workflow-args.test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.0] — 2026-06-12
+
+- _Release notes pending — replace this stub before committing (inserted by bump-version.sh)._
+
 ## [0.36.12] — 2026-06-12
 
 - _Release notes pending — replace this stub before committing (inserted by bump-version.sh)._

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.36.12-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.37.0-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.36.12",
+  "version": "0.37.0",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/docs/testing.md
+++ b/plugins/uberdev/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing UberDev
 
-UberDev's product is **markdown prompt files, shell libraries, and a little Python** — there is no application server and no build step. The test suite reflects that: it is a set of **shape-check scripts** (`tests/*.test.sh`) that grep the shipped command / agent / skill / lib files for the exact tokens, contracts, and invariants each change is supposed to preserve. A few fixtures additionally *execute* a sourced `lib/` helper to lock a runtime behaviour, but the suite is grep-and-assert throughout — it never spins up a real Claude Code session.
+UberDev's product is **markdown prompt files, shell libraries, a little Python, and (per RFC 0012) on-disk Workflow orchestration scripts in JavaScript** — there is no application server and no build step. The test suite reflects that: it is a set of **shape-check scripts** (`tests/*.test.sh`) that grep the shipped command / agent / skill / lib files for the exact tokens, contracts, and invariants each change is supposed to preserve. A few fixtures additionally *execute* a sourced `lib/` helper (or, for workflow scripts, a sandboxed dry-run — see the T1–T4 tier below) to lock a runtime behaviour, but the suite is grep-and-assert throughout — it never spins up a real Claude Code session.
 
 ## The harness at a glance
 
@@ -8,6 +8,7 @@ UberDev's product is **markdown prompt files, shell libraries, and a little Pyth
 - **Runner:** there is no separate runner binary — each file is self-contained and run directly with `bash tests/<name>.test.sh` (one fixture, `solve-pipeline-zsh.test.sh`, runs under `zsh` — see below).
 - **What CI runs:** `.github/workflows/test.yml` is the **single source of truth** for the active test set. Do not maintain a second hand-curated list anywhere — read `test.yml`.
 - **Shared assertion library:** `tests/_lib_assert_structural.sh` provides the section-scoped `assert_in_section` / structural helpers that many tests `source`.
+- **Workflow-script harness:** `tests/_workflow_harness.js` is a node-run helper (not a test file itself) that `tests/workflow-scripts.test.sh` drives for the T1–T4 workflow-script tiers below.
 
 ## Running tests locally
 
@@ -40,6 +41,19 @@ Each test prints a `PASS` / `FAIL` line per assertion and a `== Summary ==` bloc
 
 `tests/solve-pipeline-zsh.test.sh` is run with **`zsh`**, not `bash`. SKILL.md `bash` fences execute under Claude Code's Bash tool, which is `/bin/zsh` at runtime, so this fixture locks behaviour that only manifests under zsh's word-splitting and array semantics (e.g. the v0.22.2 regression where a scalar `EFFORT_FLAG="--effort max"` broke under `SH_WORD_SPLIT=off`). `ubuntu-latest` does not ship `zsh` by default, so the CI job installs it before running the suite. Run it locally with `zsh tests/solve-pipeline-zsh.test.sh`.
 
+### The workflow-script tier (T1–T4)
+
+RFC 0012 migrates the heavy pipelines onto on-disk Workflow orchestration scripts (`plugins/uberdev/skills/<name>/workflow.js`, children under `skills/<name>/workflows/`). Those scripts get their own four-tier check, driven by `tests/workflow-scripts.test.sh` (a normal `.test.sh`, wired into **both** CI jobs — node is preinstalled on the ubuntu and windows images) with `tests/_workflow_harness.js` as its engine:
+
+| Tier | What it locks | Where |
+| --- | --- | --- |
+| **T1 — lint** | every glob-discovered workflow script parses as ESM via the **pinned** stdin form `node --check --input-type=module < "$f"` (bare/unpinned `node --check` flips between Node versions on the `export const meta` + top-level-await shape); forbidden-token greps (`import`/`require`/`process.`/`fs.`/`Date.now`/`Math.random`/`new Date(` outside `SHARED` marker blocks); 512 KB runtime size cap | `workflow-scripts.test.sh` (shell) |
+| **T2 — meta validation** | the `meta` export is a **pure-JSON literal** between `/* META-BEGIN */` and `/* META-END */` markers; `{name, description, phases[]}` shape; every `phase()` / `opts.phase` string literal is declared in `meta.phases` | `_workflow_harness.js validate` |
+| **T3 — behavioral dry-run** | the harness strips the meta export, wraps the body in an async IIFE and executes it via `vm.runInNewContext` under **faithful runtime stubs** (`agent()` canned returns keyed by label/agentType; `parallel` = barrier + thunk-throws-to-null; `pipeline` = no inter-stage barrier + item drop; budget with falsy `total` by default; `Date.now`/`Math.random`/argless `new Date()` shadows that THROW). Dead-circuit-breaker bugs become executed, deterministic tests | `_workflow_harness.js validate` + per-pipeline fixtures |
+| **T4 — shared-snippet drift** | `// === SHARED:<name> v<N> ===` … `// === END SHARED ===` blocks with the same name+version must be **byte-identical** across scripts (scripts are self-contained; shared code is copy-paste) | `_workflow_harness.js shared-drift` |
+
+The harness ships **self-tests** (`node tests/_workflow_harness.js self-test`) locking every stub semantic and the preprocessing step, so the tier is non-vacuous even while zero `workflow.js` files exist on disk. `workflow-scripts.test.sh` also enforces the RFC 0012 §4.2 shape guard: every on-disk `skills/*/workflow.js` must have a sibling `SKILL.md` carrying both the Workflow invocation block and a `## No-Workflow fallback` section. Authoring conventions live in `plugins/uberdev/skills/writing-skills/SKILL.md`; the args-envelope contract (`uberdev_emit_workflow_args`, RFC 0012 §4.3) is locked by `tests/workflow-args.test.sh`.
+
 ## What the tests check (and what they don't)
 
 These are **structural / contract** checks, not end-to-end behavioural tests of a running agent:
@@ -49,7 +63,7 @@ These are **structural / contract** checks, not end-to-end behavioural tests of 
 - **Release-ratchet version locks** — `goal.test.sh` (the `G20: version bump locked` block) and `solve-claim.test.sh` (the `Version bump A.B.C -> X.Y.Z propagated` block) hardcode the current version and **turn CI red on a missed bump**. They are part of the mandatory bump-everywhere ritual (see the project `CLAUDE.md`). A contributor who skips the full suite skips exactly the tests that catch a forgotten version bump.
 - **CI-wiring invariant** — `tests/ci-wiring.test.sh` asserts that *every* `tests/*.test.sh` on disk is wired into the workflow, so a new test that is forgotten in `test.yml` fails CI rather than silently never running.
 
-They deliberately do **not** launch real `claude` sessions, parse session transcripts, or measure token usage. UberDev ships no headless-integration runner and no token-analysis script — the suite is the `tests/*.test.sh` shape-checks and nothing else.
+They deliberately do **not** launch real `claude` sessions, parse session transcripts, or measure token usage. UberDev ships no headless-integration runner and no token-analysis script — the suite is the `tests/*.test.sh` shape-checks (plus the helper files they drive: `tests/_lib_assert_structural.sh`, `tests/_workflow_harness.js`) and nothing else.
 
 ## The two-job CI matrix
 
@@ -111,4 +125,6 @@ Conventions worth honouring:
 - `.github/workflows/test.yml` — the authoritative test set and the two-job matrix.
 - `tests/ci-wiring.test.sh` — the wiring invariant that keeps the workflow and the on-disk test set in sync.
 - `tests/_lib_assert_structural.sh` — shared section-scoped assertion helpers.
+- `tests/_workflow_harness.js` — the T1–T4 workflow-script harness (self-tests: `node tests/_workflow_harness.js self-test`).
+- RFC 0012 (ultracode workflow migration, `docs/rfc/`) — defines the workflow-script conventions the T1–T4 tier enforces.
 - The project `CLAUDE.md` — the bump-version-everywhere ritual the version-lock tests enforce.

--- a/plugins/uberdev/lib/config-read.sh
+++ b/plugins/uberdev/lib/config-read.sh
@@ -11,10 +11,15 @@
 #   uberdev_tier_rank          TIER_NAME            -> 0|1|2|3|""
 #   uberdev_tier_name          RANK                 -> trivial|small|medium|large
 #   uberdev_clamp_tier         TIER FLOOR CEILING   -> clamped tier name
+#   uberdev_emit_workflow_args PIPELINE [KEY=VALUE ...]
+#                              -> v1 Workflow args envelope between
+#                                 WORKFLOW_ARGS_BEGIN/END markers (RFC 0012 §4.3)
 #
 # Sourced by:
 #   - launcher script written by skills/solve-pipeline/SKILL.md (/tmp/solve-$N.sh)
 #   - tests/config-override.test.sh
+#   - tests/workflow-args.test.sh
+#   - migrated-pipeline thin preflights (RFC 0012 DR-2)
 #
 # All variable expansions are double-quoted (security mitigation 1, mirrors
 # aliases-sync.sh:36 discipline).
@@ -276,4 +281,165 @@ uberdev_clamp_tier() {
     return 0
   fi
   printf '%s' "$tier"
+}
+
+# uberdev_emit_workflow_args PIPELINE [KEY=VALUE ...]
+# RFC 0012 §4.3 (infra-R7): assemble and print the VERSIONED Workflow args
+# envelope between WORKFLOW_ARGS_BEGIN / WORKFLOW_ARGS_END marker lines, for
+# verbatim relay into the skill-mandated Workflow({scriptPath: ...}, args)
+# call (DR-2: the model relays the JSON between the markers verbatim — no
+# LLM-composed handoffs).
+#
+# Envelope (v1), one compact-JSON line:
+#   { "v": 1, "run_id": "...", "now_epoch": <int>, "now_iso": "...",
+#     "plugin_root": "<abs>", "repo_root": "<abs>", "cwd": "<abs>",
+#     "pipeline": "<name>", "config": { ... } }
+#
+# KEY=VALUE handling:
+#   - overridable top-level keys: run_id, plugin_root, repo_root, cwd
+#     (defaults: minted run_id / $CLAUDE_PLUGIN_ROOT / git toplevel / $PWD);
+#   - locked keys (v, now_epoch, now_iso, pipeline, config) are REJECTED —
+#     fail loud, never silently shadow the envelope skeleton;
+#   - every other KEY lands under .config — KEY may be dotted (e.g.
+#     fanout_concurrency.solve_bg), stored as a literal JSON key;
+#   - VALUES are expected to be ALREADY RESOLVED by the caller via the
+#     uberdev_read_int_in_range/enum/string helpers above. The env >
+#     uberdev.local.md > default precedence, the warn-once sentinels and
+#     the audit rows all live in THOSE helpers and are untouched here;
+#   - integer-shaped values (no leading zeros) and bare true/false are
+#     emitted as JSON numbers/booleans; everything else is a JSON string.
+#
+# FROZEN-TIME CONTRACT (RFC 0012 DR-7): now_epoch / now_iso freeze HERE, at
+# preflight emission, and never advance for the life of the workflow run —
+# the Workflow runtime forbids Date.now() / Math.random() / argless
+# new Date() inside scripts (resume determinism), so scripts read time ONLY
+# from these args. Any wall-clock gate evaluated MID-run (CI settle windows,
+# grace timers, stuck detection) must take live time from agent-side `date`,
+# NEVER from these frozen values. They are deliberately not overridable.
+#
+# SECURITY — constant-name discipline preserved: the read helpers above
+# expand only CONSTANT env NAMES chosen by repo code (the four printf-based
+# indirect-expansion sites in _uberdev_is_validated / uberdev_read_*).
+# This emitter extends that property by never expanding anything as code:
+# caller-supplied KEYs and VALUEs travel exclusively through `jq --arg` /
+# `--argjson` (data, not code), and KEYs are allow-list validated before
+# use. Values are never interpolated into shell words or jq programs.
+#
+# Requires jq (hard dependency for migrated preflights per RFC 0012 §4.3;
+# the session-start hook already warns loudly when jq is missing, and the
+# §4.2 No-Workflow fallback covers jq-less hosts).
+# Returns 0 + envelope on stdout; 2 + one stderr line on any usage error.
+uberdev_emit_workflow_args() {
+  if [ "$#" -lt 1 ] || [ -z "$1" ]; then
+    echo "uberdev_emit_workflow_args: missing PIPELINE argument" >&2
+    return 2
+  fi
+  local pipeline="$1"
+  shift
+  case "$pipeline" in
+    *[!A-Za-z0-9._-]*)
+      echo "uberdev_emit_workflow_args: invalid PIPELINE '$pipeline' (allowed: A-Za-z0-9._-)" >&2
+      return 2
+      ;;
+  esac
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "uberdev_emit_workflow_args: jq is required (RFC 0012 §4.3) but not on PATH" >&2
+    return 2
+  fi
+
+  local now_epoch now_iso
+  now_epoch="$(date -u +%s)"
+  now_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  case "$now_epoch" in
+    ''|*[!0-9]*)
+      echo "uberdev_emit_workflow_args: date -u +%s returned non-integer '$now_epoch'" >&2
+      return 2
+      ;;
+  esac
+
+  # Defaults for the overridable top-level keys. run_id shape matches the
+  # established RUN_ID convention (^[0-9]{8}-[0-9]{6}-[a-f0-9]+$); callers
+  # with their own minted RUN_ID pass run_id=... to override.
+  local run_id plugin_root repo_root cwd
+  run_id="$(date -u +%Y%m%d-%H%M%S)-$(printf '%04x%04x' "$$" "$RANDOM")"
+  plugin_root="${CLAUDE_PLUGIN_ROOT:-}"
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || repo_root=""
+  [ -n "$repo_root" ] || repo_root="$PWD"
+  cwd="$PWD"
+
+  # First pass: pull out top-level overrides, validate every KEY, and
+  # hard-reject locked keys. Second pass below folds the rest into .config.
+  local kv k v
+  for kv in "$@"; do
+    case "$kv" in
+      *=*) ;;
+      *)
+        echo "uberdev_emit_workflow_args: argument '$kv' is not KEY=VALUE" >&2
+        return 2
+        ;;
+    esac
+    k="${kv%%=*}"
+    v="${kv#*=}"
+    if [ -z "$k" ]; then
+      echo "uberdev_emit_workflow_args: empty KEY in '$kv'" >&2
+      return 2
+    fi
+    case "$k" in
+      *[!A-Za-z0-9._-]*)
+        echo "uberdev_emit_workflow_args: invalid KEY '$k' (allowed: A-Za-z0-9._-)" >&2
+        return 2
+        ;;
+    esac
+    case "$k" in
+      v|now_epoch|now_iso|pipeline|config)
+        echo "uberdev_emit_workflow_args: KEY '$k' is locked (envelope skeleton; now_* are frozen per DR-7)" >&2
+        return 2
+        ;;
+      run_id)      run_id="$v" ;;
+      plugin_root) plugin_root="$v" ;;
+      repo_root)   repo_root="$v" ;;
+      cwd)         cwd="$v" ;;
+    esac
+  done
+
+  local envelope
+  envelope="$(jq -nc \
+    --arg pipeline "$pipeline" \
+    --argjson now_epoch "$now_epoch" \
+    --arg now_iso "$now_iso" \
+    --arg run_id "$run_id" \
+    --arg plugin_root "$plugin_root" \
+    --arg repo_root "$repo_root" \
+    --arg cwd "$cwd" \
+    '{v: 1, run_id: $run_id, now_epoch: $now_epoch, now_iso: $now_iso,
+      plugin_root: $plugin_root, repo_root: $repo_root, cwd: $cwd,
+      pipeline: $pipeline, config: {}}')" || {
+    echo "uberdev_emit_workflow_args: jq failed to assemble the envelope skeleton" >&2
+    return 2
+  }
+
+  # Fold config entries in. Auto-typing keeps resolved ints/bools usable as
+  # JSON numbers/booleans inside scripts; the regex rejects leading zeros so
+  # values like "007" stay strings instead of shifting magnitude.
+  local int_re='^(0|-?[1-9][0-9]*)$'
+  for kv in "$@"; do
+    k="${kv%%=*}"
+    v="${kv#*=}"
+    case "$k" in
+      run_id|plugin_root|repo_root|cwd) continue ;;
+    esac
+    if [[ "$v" =~ $int_re ]]; then
+      envelope="$(printf '%s' "$envelope" | jq -c --arg k "$k" --argjson tv "$v" '.config[$k] = $tv')"
+    elif [ "$v" = "true" ] || [ "$v" = "false" ]; then
+      envelope="$(printf '%s' "$envelope" | jq -c --arg k "$k" --argjson tv "$v" '.config[$k] = $tv')"
+    else
+      envelope="$(printf '%s' "$envelope" | jq -c --arg k "$k" --arg tv "$v" '.config[$k] = $tv')"
+    fi
+    if [ -z "$envelope" ]; then
+      echo "uberdev_emit_workflow_args: jq failed while adding config key '$k'" >&2
+      return 2
+    fi
+  done
+
+  printf 'WORKFLOW_ARGS_BEGIN\n%s\nWORKFLOW_ARGS_END\n' "$envelope"
 }

--- a/plugins/uberdev/skills/using-uberdev/references/codex-tools.md
+++ b/plugins/uberdev/skills/using-uberdev/references/codex-tools.md
@@ -12,6 +12,7 @@ Skills use Claude Code tool names. When you encounter these in a skill, use your
 | `Skill` tool (invoke a skill) | Skills load natively — just follow the instructions |
 | `Read`, `Write`, `Edit` (files) | Use your native file tools |
 | `Bash` (run commands) | Use your native shell tools |
+| `Workflow` tool (background orchestration script) | No equivalent — use the skill's `## No-Workflow fallback` section |
 
 ## Subagent dispatch requires multi-agent support
 

--- a/plugins/uberdev/skills/using-uberdev/references/copilot-tools.md
+++ b/plugins/uberdev/skills/using-uberdev/references/copilot-tools.md
@@ -18,6 +18,7 @@ Skills use Claude Code tool names. When you encounter these in a skill, use your
 | `TodoWrite` (task tracking) | `sql` with built-in `todos` table |
 | `WebSearch` | No equivalent — use `web_fetch` with a search engine URL |
 | `EnterPlanMode` / `ExitPlanMode` | No equivalent — stay in the main session |
+| `Workflow` tool (background orchestration script) | No equivalent — use the skill's `## No-Workflow fallback` section |
 
 ## Agent types
 

--- a/plugins/uberdev/skills/using-uberdev/references/gemini-tools.md
+++ b/plugins/uberdev/skills/using-uberdev/references/gemini-tools.md
@@ -15,6 +15,7 @@ Skills use Claude Code tool names. When you encounter these in a skill, use your
 | `WebSearch` | `google_web_search` |
 | `WebFetch` | `web_fetch` |
 | `Task` tool (dispatch subagent) | No equivalent — Gemini CLI does not support subagents |
+| `Workflow` tool (background orchestration script) | No equivalent — use the skill's `## No-Workflow fallback` section |
 
 ## No subagent support
 

--- a/plugins/uberdev/skills/writing-skills/SKILL.md
+++ b/plugins/uberdev/skills/writing-skills/SKILL.md
@@ -372,6 +372,94 @@ pptx/
 ```
 When: Reference material too large for inline
 
+### Skill with a Workflow Orchestration Script (RFC 0012)
+```
+review-pr/
+  SKILL.md       # Thin preflight + Workflow invocation + No-Workflow fallback
+  workflow.js    # The orchestration script (never enters context; scriptPath only)
+  workflows/     # Optional child workflow scripts
+```
+When: The skill's heavy orchestration (multi-wave agent fanout, loops with
+circuit breakers, cross-wave state) migrates onto the Workflow tool. See the
+authoring conventions below.
+
+## Workflow-Script Authoring Conventions (RFC 0012)
+
+Binding conventions for any `skills/<name>/workflow.js` (children under
+`skills/<name>/workflows/`). They are enforced by the T1–T4 tiers in
+`tests/workflow-scripts.test.sh` + `tests/_workflow_harness.js` (see
+`plugins/uberdev/docs/testing.md`) — a script that breaks them reds CI.
+
+### META markers (T2)
+
+The `meta` export is a **pure-JSON literal** — no identifiers, comments,
+trailing commas, or computed values — between exactly one pair of markers:
+
+```js
+/* META-BEGIN */
+export const meta = { "name": "review-pr", "description": "...", "phases": ["Phase 1 — Review fanout", "Verdict"] };
+/* META-END */
+```
+
+Every `phase("...")` call and `opts.phase` string in the script body must be
+declared in `meta.phases` (exact match). Nothing else in the file may use
+`export`.
+
+### Script constraints (T1)
+
+- Plain self-contained JS: **no `import`/`require`**, no `process.`/`fs.`
+  (agents do all filesystem/git/gh work — the script only orchestrates).
+- **No `Date.now()` / `Math.random()` / argless `new Date()`** — the runtime
+  THROWS on them (resume determinism). Timestamps arrive frozen in `args`
+  (`now_epoch` / `now_iso`); mid-run wall-clock gates use agent-side `date`.
+- ≤ 512 KB; must parse under `node --check --input-type=module`.
+
+### Versioned SHARED blocks (T4)
+
+Scripts cannot import, so shared code is copy-paste — guarded by markers:
+
+```js
+// === SHARED:envelope v1 ===
+...copy-paste-identical code...
+// === END SHARED ===
+```
+
+Blocks with the same name+version must be **byte-identical** across all
+scripts (CI diffs them). Diverging legitimately? Bump `v<N>`. SHARED blocks
+are also the audited escape hatch for coarse forbidden-token greps (e.g. a
+reviewed `new Date(epochValue)` formatter) — the T3 runtime shadows still
+apply inside them.
+
+### Thin preflight + args envelope
+
+The SKILL.md keeps only what the script cannot do: `$ARGUMENTS` parsing,
+config reads, RUN_ID/timestamp mint, gh identity/repo resolution, feature
+probes. It then emits the canonical args JSON via
+`uberdev_emit_workflow_args <pipeline> KEY=VALUE...` (lib/config-read.sh,
+RFC 0012 §4.3) between `WORKFLOW_ARGS_BEGIN`/`WORKFLOW_ARGS_END` markers,
+and mandates the Workflow call with the JSON relayed **verbatim**:
+
+```
+Workflow({scriptPath: "$CLAUDE_PLUGIN_ROOT/skills/<name>/workflow.js"}, <the JSON between the markers>)
+```
+
+Always `scriptPath` (resolved from `${CLAUDE_PLUGIN_ROOT}`) — never the
+saved-workflow name form (unverified for plugin dirs). The preflight
+validates `[ -f "$CLAUDE_PLUGIN_ROOT/skills/<name>/workflow.js" ]` before
+mandating the call.
+
+### No-Workflow fallback section (mandatory)
+
+Every SKILL.md that mandates a Workflow call also carries a
+`## No-Workflow fallback` section: a SHORT degraded recipe (sequential
+inline execution or the retained legacy path), gated on the model
+self-checking its tool list ("if Workflow is not among your tools…").
+Platforms without the tool (see `references/{gemini,copilot,codex}-tools.md`)
+degrade instead of breaking. The shape guard in
+`tests/workflow-scripts.test.sh` fails any `skills/*/workflow.js` whose
+sibling SKILL.md lacks the invocation block or the fallback marker. Keep
+fallback recipes thin — or the token win evaporates.
+
 ## The Iron Law (Same as TDD)
 
 ```

--- a/tests/_workflow_harness.js
+++ b/tests/_workflow_harness.js
@@ -1,0 +1,1063 @@
+#!/usr/bin/env node
+'use strict';
+/*
+ * tests/_workflow_harness.js — RFC 0012 §4.4 test harness for workflow scripts
+ * (T2 meta validation, T3 behavioral dry-run, T4 shared-snippet drift guard).
+ *
+ * Driven by tests/workflow-scripts.test.sh (the suite entry — T1 lint and the
+ * forbidden-token greps live THERE, in shell). This file is a TEST TOOL, not a
+ * workflow script: it may use Node APIs (fs, vm) freely. The no-fs/no-Date.now
+ * constraints apply to the workflow scripts it validates, never to itself.
+ *
+ * CLI:
+ *   node tests/_workflow_harness.js self-test
+ *       Run the embedded harness self-tests. These lock EVERY stub semantic
+ *       and the preprocessing step (RFC 0012 §4.4 T3: "non-vacuous before the
+ *       first workflow lands") so stub drift and wrapper bugs are caught by
+ *       the suite itself even while zero workflow.js files exist on disk.
+ *   node tests/_workflow_harness.js validate <file...>
+ *       T2 + generic T3 per file: parse/validate the META block, preprocess,
+ *       execute under the stub sandbox with a minimal args envelope, fail on
+ *       meta-shape errors, phase-discipline violations, forbidden-global
+ *       throws, escaped budget throws, or a hung script (timeout).
+ *   node tests/_workflow_harness.js shared-drift <file...>
+ *       T4: `// === SHARED:<name> v<N> ===` ... `// === END SHARED ===`
+ *       blocks with the same name+version must be byte-identical across (and
+ *       within) the given scripts.
+ *   node tests/_workflow_harness.js meta <file>
+ *       Print the parsed meta JSON (utility for other tests / debugging).
+ *
+ * Exit codes: 0 = all green; 1 = assertion failures; 2 = usage / IO error.
+ *
+ * T3 EXECUTION PATH (encoded choice per RFC 0012 §4.4): strip the
+ * `export const meta` statement (T2 already parses it from the markers), wrap
+ * the remaining body in an async IIFE, and evaluate via vm.runInNewContext.
+ * The vm.SourceTextModule alternative is NOT used — it sits behind
+ * --experimental-vm-modules, and an experimental runner flag is exactly the
+ * unpinned-guard class T1 exists to kill.
+ *
+ * STUB SEMANTICS (faithful to the documented runtime, RFC 0012 §2.1; every
+ * bullet below is locked by a self-test):
+ *   - agent(prompt, opts) -> Promise. Canned returns keyed by opts.label,
+ *     then opts.agentType, then the fixture default ({}). A canned `null`
+ *     models user-skip / terminal API error (the runtime returns null, it
+ *     does not reject). With opts.schema the canned return is handed back
+ *     parsed (the runtime retries until schema-valid; fixtures supply valid
+ *     shapes) and the call is recorded with hasSchema for fixture asserts.
+ *   - budget = { total, spent(), remaining() } with total = null (falsy) by
+ *     default. When total is set, an agent() call whose cost would go PAST
+ *     the ceiling throws (and is NOT recorded as a dispatched call).
+ *   - parallel(thunks): barrier (resolves only after every thunk settles),
+ *     never rejects, a throwing thunk resolves to null in its slot, order
+ *     preserved. NOTE: per the never-rejects contract this swallows budget
+ *     throws inside thunks to null too — loop guards must check
+ *     budget.total && budget.remaining() (DR-8), not rely on a rejection.
+ *   - pipeline(items, ...stages): each item flows through stages
+ *     independently — NO inter-stage barrier; stage callbacks receive
+ *     (prevResult, originalItem, index); the FIRST stage receives the item
+ *     itself as prevResult (harness encoding of the spec); a throwing stage
+ *     drops that item to null and skips its remaining stages; the resolved
+ *     array stays index-aligned with items.
+ *   - phase(title) / log(message): recorders. phase()/opts.phase titles are
+ *     matched EXACTLY against meta.phases at run time (mirroring the runtime)
+ *     — an undeclared title is a violation that fails validate.
+ *   - Date.now() / Math.random() / argless new Date(): sandbox shadows that
+ *     THROW exactly like the runtime (resume determinism). new Date(value)
+ *     WITH arguments stays usable.
+ *   - args: the fixture's JSON, verbatim (deep-cloned per run).
+ *   - workflow(nameOr{scriptPath}, args): recorder with canned returns keyed
+ *     by scriptPath/name. One-level-nesting enforcement is the live runtime's
+ *     job; the harness only records.
+ *   - No timers in the sandbox (setTimeout/setInterval absent — constraint 3:
+ *     no script-level sleeps). A script that references them fails at call
+ *     time with a ReferenceError, which fails validate.
+ *
+ * FIXTURE DISCIPLINE (RFC 0012 §4.4): any secret-shaped fixture token must be
+ * assembled at runtime by string concatenation, never contiguous source
+ * bytes — the finish-branch pre-push scanner hard-aborts on them.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const META_BEGIN = '/* META-BEGIN */';
+const META_END = '/* META-END */';
+const SHARED_BEGIN_RE = /^[ \t]*\/\/ === SHARED:([A-Za-z0-9._-]+) v([0-9]+) ===[ \t]*$/;
+const SHARED_END_RE = /^[ \t]*\/\/ === END SHARED ===[ \t]*$/;
+const DEFAULT_RUN_TIMEOUT_MS = 10000;
+
+function hasOwn(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function clone(value) {
+  if (value === null || value === undefined) return value;
+  if (typeof value !== 'object') return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+/* ------------------------------------------------------------------ *
+ * T2 — meta extraction + validation
+ * ------------------------------------------------------------------ */
+
+// Returns { meta, metaText, error }. error is a human-readable string with a
+// clear remediation (RFC 0012 §4.4 T2: "enforced via clear T2 error messages").
+function extractMeta(source) {
+  const beginIdx = source.indexOf(META_BEGIN);
+  if (beginIdx === -1) {
+    return { error: `missing ${META_BEGIN} marker — the meta export must sit between ${META_BEGIN} and ${META_END}` };
+  }
+  if (source.indexOf(META_BEGIN, beginIdx + META_BEGIN.length) !== -1) {
+    return { error: `more than one ${META_BEGIN} marker — exactly one meta block is allowed` };
+  }
+  const endIdx = source.indexOf(META_END);
+  if (endIdx === -1) {
+    return { error: `missing ${META_END} marker` };
+  }
+  if (source.indexOf(META_END, endIdx + META_END.length) !== -1) {
+    return { error: `more than one ${META_END} marker — exactly one meta block is allowed` };
+  }
+  if (endIdx < beginIdx) {
+    return { error: `${META_END} appears before ${META_BEGIN}` };
+  }
+  const region = source.slice(beginIdx + META_BEGIN.length, endIdx);
+  const m = region.match(/^\s*export\s+const\s+meta\s*=\s*([\s\S]*?);?\s*$/);
+  if (!m) {
+    return { error: `the META region must contain exactly one statement of the form: export const meta = <pure JSON literal>;` };
+  }
+  let meta;
+  try {
+    meta = JSON.parse(m[1]);
+  } catch (e) {
+    return { error: `meta is not a PURE JSON literal (JSON.parse: ${e.message}) — no identifiers, comments, trailing commas, or computed values are allowed between the META markers` };
+  }
+  return { meta, metaText: m[1] };
+}
+
+// Returns [] when valid, else a list of error strings.
+function validateMetaShape(meta) {
+  const errors = [];
+  if (meta === null || typeof meta !== 'object' || Array.isArray(meta)) {
+    return ['meta must be a JSON object literal'];
+  }
+  if (typeof meta.name !== 'string' || meta.name.length === 0) {
+    errors.push('meta.name must be a non-empty string');
+  }
+  if (typeof meta.description !== 'string' || meta.description.length === 0) {
+    errors.push('meta.description must be a non-empty string');
+  }
+  if (!Array.isArray(meta.phases)) {
+    errors.push('meta.phases must be an array of phase-title strings');
+  } else {
+    meta.phases.forEach((p, i) => {
+      if (typeof p !== 'string' || p.length === 0) {
+        errors.push(`meta.phases[${i}] must be a non-empty string`);
+      }
+    });
+  }
+  if (hasOwn(meta, 'whenToUse') && typeof meta.whenToUse !== 'string') {
+    errors.push('meta.whenToUse, when present, must be a string');
+  }
+  const allowed = ['name', 'description', 'phases', 'whenToUse'];
+  for (const key of Object.keys(meta)) {
+    if (!allowed.includes(key)) {
+      errors.push(`meta has unknown key "${key}" — allowed keys: ${allowed.join(', ')}`);
+    }
+  }
+  return errors;
+}
+
+// Static scan: every phase("...") / phase: "..." STRING LITERAL in the body
+// (meta region excluded) must be declared in meta.phases. Dynamic titles
+// (template interpolation, variables) are invisible to this scan; the T3
+// runtime recorder catches those when the script actually runs.
+function scanPhaseLiterals(body) {
+  const found = [];
+  const callRe = /(^|[^.\w$])phase\s*\(\s*(['"`])((?:\\.|(?!\2)[^\\])*)\2\s*[,)]/g;
+  const propRe = /(^|[^.\w$])phase\s*:\s*(['"`])((?:\\.|(?!\2)[^\\])*)\2/g;
+  let m;
+  while ((m = callRe.exec(body)) !== null) {
+    if (!m[3].includes('${')) found.push(m[3]);
+  }
+  while ((m = propRe.exec(body)) !== null) {
+    if (!m[3].includes('${')) found.push(m[3]);
+  }
+  return found;
+}
+
+/* ------------------------------------------------------------------ *
+ * T3 — preprocessing + sandbox + execution
+ * ------------------------------------------------------------------ */
+
+// Strip the meta block (markers inclusive), refuse leftover export
+// statements, wrap the body in an async IIFE. Returns { wrapped, error }.
+function preprocess(source) {
+  const beginIdx = source.indexOf(META_BEGIN);
+  const endIdx = source.indexOf(META_END);
+  if (beginIdx === -1 || endIdx === -1 || endIdx < beginIdx) {
+    return { error: 'cannot preprocess: META markers missing or out of order (run the T2 checks first)' };
+  }
+  const body = source.slice(0, beginIdx) + source.slice(endIdx + META_END.length);
+  if (/^[ \t]*export\s/m.test(body)) {
+    return { error: 'leftover export statement after stripping the meta block — workflow scripts export ONLY the meta literal between the META markers' };
+  }
+  // NOTE: the wrapper adds exactly one line above the body — stack-trace line
+  // numbers from the vm are offset by 1 relative to the original file.
+  const wrapped = '(async () => { "use strict";\n' + body + '\n})()';
+  return { wrapped };
+}
+
+function makeThrowingDate() {
+  return new Proxy(Date, {
+    construct(target, argList, newTarget) {
+      if (argList.length === 0) {
+        throw new Error('new Date() without arguments is forbidden in workflow scripts — wall-clock time arrives via args (now_epoch / now_iso); mid-run wall-clock gates use agent-side `date` (RFC 0012 DR-7)');
+      }
+      return Reflect.construct(target, argList, newTarget);
+    },
+    get(target, prop, receiver) {
+      if (prop === 'now') {
+        return () => {
+          throw new Error('Date.now() is forbidden in workflow scripts — wall-clock time arrives via args (now_epoch / now_iso); mid-run wall-clock gates use agent-side `date` (RFC 0012 DR-7)');
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+function makeThrowingMath() {
+  return new Proxy(Math, {
+    get(target, prop, receiver) {
+      if (prop === 'random') {
+        return () => {
+          throw new Error('Math.random() is forbidden in workflow scripts (resume determinism) — derive run-scoped uniqueness from args.run_id');
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+function makeRecord() {
+  return {
+    agentCalls: [],
+    budgetThrows: 0,
+    parallelCalls: [],
+    pipelineCalls: [],
+    pipelineDrops: [],
+    phases: [],
+    currentPhase: null,
+    logs: [],
+    consoleLines: [],
+    workflowCalls: [],
+    violations: [],
+  };
+}
+
+// fixture = {
+//   args?: object,                  // verbatim workflow args
+//   budgetTotal?: number|null,      // default null (falsy) per §4.4
+//   agentCost?: number,             // default 1 budget unit per agent() call
+//   agentReturns?: { [labelOrAgentType]: any | (entry) => any },
+//   defaultAgentReturn?: any,       // default {}
+//   agentGate?: (entry) => Promise|null,   // self-test interleaving control
+//   workflowReturns?: { [scriptPathOrName]: any },
+// }
+function makeSandbox(fixture, meta, record) {
+  const budgetState = {
+    total: hasOwn(fixture, 'budgetTotal') ? fixture.budgetTotal : null,
+    spent: 0,
+  };
+
+  async function agentStub(prompt, opts) {
+    opts = opts || {};
+    const entry = {
+      prompt,
+      label: typeof opts.label === 'string' ? opts.label : null,
+      agentType: typeof opts.agentType === 'string' ? opts.agentType : null,
+      phase: typeof opts.phase === 'string' ? opts.phase : record.currentPhase,
+      hasSchema: opts.schema !== undefined && opts.schema !== null,
+      model: typeof opts.model === 'string' ? opts.model : null,
+    };
+    if (typeof prompt !== 'string' || prompt.length === 0) {
+      record.violations.push('agent() called with a non-string or empty prompt');
+    }
+    if (meta && typeof opts.phase === 'string' && !meta.phases.includes(opts.phase)) {
+      record.violations.push(`agent() opts.phase "${opts.phase}" is not declared in meta.phases`);
+    }
+    const cost = hasOwn(fixture, 'agentCost') ? fixture.agentCost : 1;
+    if (budgetState.total && budgetState.spent + cost > budgetState.total) {
+      record.budgetThrows += 1;
+      const err = new Error(`workflow budget exceeded: spent ${budgetState.spent} + cost ${cost} > total ${budgetState.total}`);
+      err.workflowBudgetExceeded = true;
+      throw err;
+    }
+    budgetState.spent += cost;
+    record.agentCalls.push(entry);
+    // Real async hop so barrier / no-barrier semantics are exercised on a
+    // genuine tick, not resolved synchronously.
+    await new Promise((resolve) => setImmediate(resolve));
+    if (typeof fixture.agentGate === 'function') {
+      const gate = fixture.agentGate(entry);
+      if (gate) await gate;
+    }
+    let ret;
+    if (entry.label !== null && fixture.agentReturns && hasOwn(fixture.agentReturns, entry.label)) {
+      ret = fixture.agentReturns[entry.label];
+    } else if (entry.agentType !== null && fixture.agentReturns && hasOwn(fixture.agentReturns, entry.agentType)) {
+      ret = fixture.agentReturns[entry.agentType];
+    } else if (hasOwn(fixture, 'defaultAgentReturn')) {
+      ret = fixture.defaultAgentReturn;
+    } else {
+      ret = {};
+    }
+    if (typeof ret === 'function') ret = ret(entry);
+    return clone(ret);
+  }
+
+  async function parallelStub(thunks) {
+    if (!Array.isArray(thunks)) {
+      record.violations.push('parallel() called with a non-array');
+      return [];
+    }
+    record.parallelCalls.push(thunks.length);
+    // Promise.all over throw-swallowing wrappers = barrier + never rejects +
+    // throwing thunk -> null in its slot, order preserved.
+    return Promise.all(
+      thunks.map(async (thunk) => {
+        if (typeof thunk !== 'function') {
+          record.violations.push('parallel() received a non-thunk element');
+          return null;
+        }
+        try {
+          return await thunk();
+        } catch (e) {
+          return null;
+        }
+      })
+    );
+  }
+
+  async function pipelineStub(items, ...stages) {
+    if (!Array.isArray(items)) {
+      record.violations.push('pipeline() called with a non-array items argument');
+      return [];
+    }
+    record.pipelineCalls.push({ items: items.length, stages: stages.length });
+    // Each item maps to its OWN stage chain — no inter-stage barrier.
+    return Promise.all(
+      items.map(async (item, index) => {
+        let prev = item; // first stage receives the item itself as prevResult
+        for (const stage of stages) {
+          try {
+            prev = await stage(prev, item, index);
+          } catch (e) {
+            record.pipelineDrops.push({ index });
+            return null; // item drops to null; remaining stages skipped
+          }
+        }
+        return prev;
+      })
+    );
+  }
+
+  function phaseStub(title) {
+    record.phases.push(title);
+    if (typeof title !== 'string' || title.length === 0) {
+      record.violations.push('phase() called with a non-string or empty title');
+      record.currentPhase = null;
+      return;
+    }
+    record.currentPhase = title;
+    if (meta && !meta.phases.includes(title)) {
+      record.violations.push(`phase("${title}") is not declared in meta.phases`);
+    }
+  }
+
+  function logStub(message) {
+    record.logs.push(String(message));
+  }
+
+  const budget = {
+    total: budgetState.total,
+    spent: () => budgetState.spent,
+    remaining: () => (budgetState.total == null ? Infinity : Math.max(0, budgetState.total - budgetState.spent)),
+  };
+
+  async function workflowStub(nameOrObj, args) {
+    record.workflowCalls.push({ ref: clone(nameOrObj), args: clone(args) });
+    const key = nameOrObj && typeof nameOrObj === 'object' ? nameOrObj.scriptPath : nameOrObj;
+    if (key != null && fixture.workflowReturns && hasOwn(fixture.workflowReturns, key)) {
+      return clone(fixture.workflowReturns[key]);
+    }
+    return {};
+  }
+
+  const consoleStub = {
+    log: (...a) => record.consoleLines.push(a.join(' ')),
+    warn: (...a) => record.consoleLines.push(a.join(' ')),
+    error: (...a) => record.consoleLines.push(a.join(' ')),
+    info: (...a) => record.consoleLines.push(a.join(' ')),
+  };
+
+  const sandbox = {
+    args: clone(hasOwn(fixture, 'args') ? fixture.args : {}),
+    agent: agentStub,
+    parallel: parallelStub,
+    pipeline: pipelineStub,
+    phase: phaseStub,
+    log: logStub,
+    budget,
+    workflow: workflowStub,
+    Date: makeThrowingDate(),
+    Math: makeThrowingMath(),
+    console: consoleStub,
+    // Deliberately ABSENT: setTimeout/setInterval/setImmediate/queueMicrotask
+    // (no script-level sleeps/timers — RFC 0012 §2.2 constraint 3), fs,
+    // process, require, fetch (no Node/network API in the script itself).
+  };
+  return { sandbox, budgetState };
+}
+
+// Execute preprocessed source. Returns { result } or { error }.
+async function executeWrapped(wrapped, sandbox, filename, timeoutMs) {
+  let pending;
+  try {
+    // vm.runInNewContext is THE encoded execution path (RFC 0012 §4.4 T3);
+    // it contextifies the stub sandbox, compiles and runs in one step. A
+    // compile (Syntax) error surfaces here too — same catch. The timeout
+    // option only bounds SYNCHRONOUS execution; the Promise.race below
+    // bounds the async run.
+    pending = vm.runInNewContext(wrapped, sandbox, { filename, timeout: timeoutMs });
+  } catch (e) {
+    return { error: `threw synchronously: ${e.message}` };
+  }
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`dry-run timed out after ${timeoutMs}ms (hung await? scripts must not poll/sleep)`)), timeoutMs);
+  });
+  try {
+    const result = await Promise.race([Promise.resolve(pending), timeout]);
+    return { result };
+  } catch (e) {
+    return { error: e && e.message ? e.message : String(e) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Full T2+T3 pass over one script source. Returns { errors, record, meta }.
+async function runScript(source, fixture, label, timeoutMs) {
+  const errors = [];
+  const extracted = extractMeta(source);
+  if (extracted.error) {
+    return { errors: [`[T2] ${extracted.error}`], record: makeRecord(), meta: null };
+  }
+  const meta = extracted.meta;
+  for (const e of validateMetaShape(meta)) errors.push(`[T2] ${e}`);
+  if (errors.length > 0) {
+    return { errors, record: makeRecord(), meta };
+  }
+
+  const pre = preprocess(source);
+  if (pre.error) {
+    errors.push(`[T3] ${pre.error}`);
+    return { errors, record: makeRecord(), meta };
+  }
+
+  // Static phase-literal discipline (meta region excluded from the scan).
+  const beginIdx = source.indexOf(META_BEGIN);
+  const endIdx = source.indexOf(META_END);
+  const body = source.slice(0, beginIdx) + source.slice(endIdx + META_END.length);
+  for (const lit of scanPhaseLiterals(body)) {
+    if (!meta.phases.includes(lit)) {
+      errors.push(`[T2] phase literal "${lit}" used in the script is not declared in meta.phases`);
+    }
+  }
+  if (errors.length > 0) {
+    return { errors, record: makeRecord(), meta };
+  }
+
+  const record = makeRecord();
+  const { sandbox } = makeSandbox(fixture, meta, record);
+  const run = await executeWrapped(pre.wrapped, sandbox, label, timeoutMs || DEFAULT_RUN_TIMEOUT_MS);
+  if (run.error) {
+    errors.push(`[T3] dry-run failed: ${run.error}`);
+  }
+  for (const v of record.violations) {
+    errors.push(`[T3] violation: ${v}`);
+  }
+  return { errors, record, meta };
+}
+
+// Fixture-assert helper for current and future per-pipeline fixtures.
+function countAgentsByPhase(record) {
+  const counts = {};
+  for (const call of record.agentCalls) {
+    const key = call.phase == null ? '(none)' : call.phase;
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return counts;
+}
+
+/* ------------------------------------------------------------------ *
+ * T4 — shared-snippet drift guard
+ * ------------------------------------------------------------------ */
+
+// Returns { blocks: [{name, version, body, file, line}], errors: [] }.
+function extractSharedBlocks(source, file) {
+  const blocks = [];
+  const errors = [];
+  const lines = source.split('\n');
+  let open = null;
+  let bodyLines = [];
+  for (let i = 0; i < lines.length; i++) {
+    const begin = lines[i].match(SHARED_BEGIN_RE);
+    if (begin) {
+      if (open) {
+        errors.push(`${file}:${i + 1}: SHARED block "${begin[1]}" opens inside unterminated SHARED block "${open.name}" (line ${open.line})`);
+        continue;
+      }
+      open = { name: begin[1], version: begin[2], line: i + 1 };
+      bodyLines = [];
+      continue;
+    }
+    if (SHARED_END_RE.test(lines[i])) {
+      if (!open) {
+        errors.push(`${file}:${i + 1}: END SHARED marker without a matching SHARED begin marker`);
+        continue;
+      }
+      blocks.push({ name: open.name, version: open.version, body: bodyLines.join('\n'), file, line: open.line });
+      open = null;
+      continue;
+    }
+    if (open) bodyLines.push(lines[i]);
+  }
+  if (open) {
+    errors.push(`${file}:${open.line}: SHARED block "${open.name}" is never closed with // === END SHARED ===`);
+  }
+  return { blocks, errors };
+}
+
+// fileSources: [{file, source}]. Returns error strings ([] = no drift).
+function checkSharedDrift(fileSources) {
+  const errors = [];
+  const byKey = new Map();
+  for (const { file, source } of fileSources) {
+    const { blocks, errors: extractErrors } = extractSharedBlocks(source, file);
+    errors.push(...extractErrors);
+    for (const block of blocks) {
+      const key = `${block.name} v${block.version}`;
+      if (!byKey.has(key)) byKey.set(key, []);
+      byKey.get(key).push(block);
+    }
+  }
+  for (const [key, instances] of byKey) {
+    const reference = instances[0];
+    for (const other of instances.slice(1)) {
+      if (other.body !== reference.body) {
+        errors.push(
+          `SHARED block ${key} drifted: ${other.file}:${other.line} is not byte-identical to ${reference.file}:${reference.line} — same name+version blocks must be copy-paste identical (bump v<N> if they legitimately diverge)`
+        );
+      }
+    }
+  }
+  return errors;
+}
+
+/* ------------------------------------------------------------------ *
+ * Self-tests (RFC 0012 §4.4: lock every stub semantic + preprocessing)
+ * ------------------------------------------------------------------ */
+
+// Build fixture sources from line arrays — avoids nested template-literal
+// escaping pain and keeps `${` out of the harness's own source where the
+// fixtures don't need it.
+function src(lines) {
+  return lines.join('\n');
+}
+
+const VALID_META = [
+  '/* META-BEGIN */',
+  'export const meta = { "name": "fixture-flow", "description": "harness self-test fixture", "phases": ["Alpha", "Beta"] };',
+  '/* META-END */',
+];
+
+async function selfTest() {
+  let pass = 0;
+  let fail = 0;
+  const ok = (cond, desc) => {
+    if (cond) {
+      console.log(`  PASS  ${desc}`);
+      pass += 1;
+    } else {
+      console.log(`  FAIL  ${desc}`);
+      fail += 1;
+    }
+  };
+
+  /* H1 — meta extraction happy path */
+  {
+    const { meta, error } = extractMeta(src(VALID_META));
+    ok(!error && meta && meta.name === 'fixture-flow', 'H1.1 meta JSON parses from between the META markers');
+    ok(!error && Array.isArray(meta.phases) && meta.phases.length === 2, 'H1.2 meta.phases array extracted');
+    ok(!error && validateMetaShape(meta).length === 0, 'H1.3 valid meta shape produces zero errors');
+  }
+
+  /* H2 — meta negatives */
+  {
+    ok(!!extractMeta('export const meta = {"name":"x"};').error, 'H2.1 missing META markers is an error');
+    ok(!!extractMeta(src(['/* META-BEGIN */', 'const meta = {"name":"x"};', '/* META-END */'])).error,
+      'H2.2 META region without the export-const-meta statement is an error');
+    ok(!!extractMeta(src(['/* META-BEGIN */', 'export const meta = { name: "x" };', '/* META-END */'])).error,
+      'H2.3 non-pure-JSON meta (unquoted key) is an error');
+    ok(!!extractMeta(src(['/* META-BEGIN */', 'export const meta = buildMeta();', '/* META-END */'])).error,
+      'H2.4 computed meta (function call) is an error');
+    const dupe = src(VALID_META) + '\n' + src(VALID_META);
+    ok(!!extractMeta(dupe).error, 'H2.5 duplicate META blocks are an error');
+    const noPhases = extractMeta(src(['/* META-BEGIN */', 'export const meta = { "name": "x", "description": "y" };', '/* META-END */']));
+    ok(!noPhases.error && validateMetaShape(noPhases.meta).some((e) => e.includes('phases')),
+      'H2.6 missing meta.phases fails shape validation');
+    const unknownKey = extractMeta(src(['/* META-BEGIN */', 'export const meta = { "name": "x", "description": "y", "phases": [], "extra": 1 };', '/* META-END */']));
+    ok(!unknownKey.error && validateMetaShape(unknownKey.meta).some((e) => e.includes('unknown key')),
+      'H2.7 unknown meta key fails shape validation');
+    const badPhase = extractMeta(src(['/* META-BEGIN */', 'export const meta = { "name": "x", "description": "y", "phases": [1] };', '/* META-END */']));
+    ok(!badPhase.error && validateMetaShape(badPhase.meta).length > 0,
+      'H2.8 non-string phases element fails shape validation');
+  }
+
+  /* H3 — static phase-literal discipline */
+  {
+    const good = src([...VALID_META, 'phase("Alpha");', 'await agent("p", { phase: "Beta" });']);
+    const { errors } = await runScript(good, {}, 'h3-good', 2000);
+    ok(errors.length === 0, `H3.1 declared phase()/opts.phase literals pass (${errors.join('; ') || 'no errors'})`);
+    const bad = src([...VALID_META, 'phase("Gamma");']);
+    const res = await runScript(bad, {}, 'h3-bad', 2000);
+    ok(res.errors.some((e) => e.includes('"Gamma"')), 'H3.2 undeclared phase() literal fails T2');
+    const badProp = src([...VALID_META, 'await agent("p", { phase: "Delta" });']);
+    const resProp = await runScript(badProp, {}, 'h3-badprop', 2000);
+    ok(resProp.errors.some((e) => e.includes('"Delta"')), 'H3.3 undeclared opts.phase literal fails T2');
+  }
+
+  /* H4 — preprocessing */
+  {
+    const pre = preprocess(src([...VALID_META, 'log("alive");']));
+    ok(!pre.error && !pre.wrapped.includes('META-BEGIN') && !pre.wrapped.includes('export const meta'),
+      'H4.1 preprocessing strips the meta block (markers + export statement)');
+    ok(!pre.error && pre.wrapped.startsWith('(async () => {') && pre.wrapped.endsWith('})()'),
+      'H4.2 preprocessing wraps the body in an async IIFE');
+    const leftover = preprocess(src([...VALID_META, 'export const other = 1;']));
+    ok(!!leftover.error && leftover.error.includes('leftover export'),
+      'H4.3 leftover export statement after meta strip is a preprocessing error');
+    const { errors, record } = await runScript(src([...VALID_META, 'log("alive");', 'await Promise.resolve(1);']), {}, 'h4-run', 2000);
+    ok(errors.length === 0 && record.logs.length === 1 && record.logs[0] === 'alive',
+      'H4.4 preprocessed body executes in the sandbox (top-level await works inside the IIFE)');
+  }
+
+  /* H5 — agent() canned returns */
+  {
+    const fixture = {
+      agentReturns: {
+        'review-1': { verdict: 'GREEN' },
+        'uberdev:code-reviewer': { findings: 2 },
+        'skip-me': null,
+      },
+      defaultAgentReturn: { fallback: true },
+    };
+    const script = src([
+      ...VALID_META,
+      'const byLabel = await agent("p1", { label: "review-1" });',
+      'const byType = await agent("p2", { agentType: "uberdev:code-reviewer" });',
+      'const skipped = await agent("p3", { label: "skip-me" });',
+      'const dflt = await agent("p4", { label: "unknown-label" });',
+      'const withSchema = await agent("p5", { label: "review-1", schema: { "type": "object" } });',
+      'log(JSON.stringify([byLabel, byType, skipped, dflt]));',
+    ]);
+    const { errors, record } = await runScript(script, fixture, 'h5', 2000);
+    const got = errors.length === 0 ? JSON.parse(record.logs[0]) : null;
+    ok(errors.length === 0 && got && got[0].verdict === 'GREEN', 'H5.1 canned return keyed by opts.label');
+    ok(got && got[1].findings === 2, 'H5.2 canned return keyed by opts.agentType');
+    ok(got && got[2] === null, 'H5.3 canned null models user-skip / terminal API error (resolves null, never rejects)');
+    ok(got && got[3].fallback === true, 'H5.4 unmatched label falls through to the fixture default');
+    ok(record.agentCalls.filter((c) => c.hasSchema).length === 1, 'H5.5 schema presence recorded per call');
+  }
+
+  /* H6 — budget semantics */
+  {
+    const noCeiling = src([
+      ...VALID_META,
+      'log("total:" + String(budget.total));',
+      'for (let i = 0; i < 5; i++) { await agent("p" + i, { label: "any" }); }',
+      'log("spent:" + String(budget.spent()));',
+    ]);
+    const r1 = await runScript(noCeiling, {}, 'h6-null', 2000);
+    ok(r1.errors.length === 0 && r1.record.logs[0] === 'total:null',
+      'H6.1 budget.total is null (falsy) by default — loop guards can check budget.total && budget.remaining()');
+    ok(r1.errors.length === 0 && r1.record.agentCalls.length === 5 && r1.record.logs[1] === 'spent:5',
+      'H6.2 no ceiling: agent() never throws, spent() counts costs');
+
+    const ceiling = src([
+      ...VALID_META,
+      'try {',
+      '  for (let i = 0; i < 5; i++) { await agent("p" + i, { label: "any" }); }',
+      '  log("never-reached");',
+      '} catch (e) { log("caught:" + e.message); }',
+      'log("remaining:" + String(budget.remaining()));',
+    ]);
+    const r2 = await runScript(ceiling, { budgetTotal: 2 }, 'h6-cap', 2000);
+    ok(r2.errors.length === 0 && r2.record.agentCalls.length === 2 && r2.record.budgetThrows === 1,
+      'H6.3 with total=2 the third agent() call throws past the ceiling (and is not recorded as dispatched)');
+    ok(r2.errors.length === 0 && r2.record.logs.some((l) => l.startsWith('caught:workflow budget exceeded')),
+      'H6.4 the budget throw is catchable inside the script (DR-8 finalize pattern)');
+    ok(r2.errors.length === 0 && r2.record.logs.includes('remaining:0'),
+      'H6.5 budget.remaining() reaches 0 at the ceiling');
+
+    const escaped = src([...VALID_META, 'await agent("a", {}); await agent("b", {});']);
+    const r3 = await runScript(escaped, { budgetTotal: 1 }, 'h6-escape', 2000);
+    ok(r3.errors.some((e) => e.includes('budget exceeded')),
+      'H6.6 an uncaught budget throw fails the dry-run (the DR-8 violation surfaces)');
+  }
+
+  /* H7 — parallel(): barrier + thunk-throws-to-null + order */
+  {
+    let release;
+    const gatePromise = new Promise((resolve) => { release = resolve; });
+    const fixture = {
+      agentReturns: { fast: { id: 'fast' }, slow: { id: 'slow' }, boom: { id: 'boom' } },
+      agentGate: (entry) => (entry.label === 'slow' ? gatePromise : null),
+    };
+    const script = src([
+      ...VALID_META,
+      'const results = await parallel([',
+      '  () => agent("slow prompt", { label: "slow" }),',
+      '  () => agent("fast prompt", { label: "fast" }),',
+      '  () => { throw new Error("thunk exploded"); },',
+      ']);',
+      'log("barrier-released");',
+      'log(JSON.stringify(results));',
+    ]);
+    const runPromise = runScript(script, fixture, 'h7', 4000);
+    // Give the fast thunk time to finish while the slow gate is still held.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const fixtureRecordProbe = 'barrier holds: run not settled while one thunk is gated';
+    let settledEarly = false;
+    const probe = runPromise.then(() => { settledEarly = true; });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    ok(!settledEarly, `H7.1 ${fixtureRecordProbe}`);
+    release();
+    const { errors, record } = await runPromise;
+    await probe;
+    const results = errors.length === 0 ? JSON.parse(record.logs[1]) : null;
+    ok(errors.length === 0 && record.logs[0] === 'barrier-released',
+      'H7.2 parallel() resolves only after ALL thunks settle (barrier)');
+    ok(results && results[0].id === 'slow' && results[1].id === 'fast',
+      'H7.3 parallel() preserves thunk order in the results array');
+    ok(results && results[2] === null,
+      'H7.4 a throwing thunk resolves to null in its slot (parallel never rejects)');
+  }
+
+  /* H8 — pipeline(): callback args + drop-to-null + NO inter-stage barrier */
+  {
+    const argShapes = [];
+    let releaseA;
+    const gateA = new Promise((resolve) => { releaseA = resolve; });
+    const events = [];
+    const fixture = {
+      agentReturns: {
+        'stage1-a': () => { events.push('s1-a'); return { item: 'a', stage: 1 }; },
+        'stage1-b': () => { events.push('s1-b'); return { item: 'b', stage: 1 }; },
+        'stage2-a': () => { events.push('s2-a'); return { item: 'a', stage: 2 }; },
+        'stage2-b': () => { events.push('s2-b'); return { item: 'b', stage: 2 }; },
+      },
+      agentGate: (entry) => (entry.label === 'stage1-a' ? gateA : null),
+    };
+    const script = src([
+      ...VALID_META,
+      'const out = await pipeline(["a", "b"],',
+      '  (prev, item, index) => { log("argshape:" + JSON.stringify([prev, item, index])); return agent("s1 " + item, { label: "stage1-" + item }); },',
+      '  (prev, item, index) => agent("s2 " + item + " prev " + prev.stage, { label: "stage2-" + item })',
+      ');',
+      'log("out:" + JSON.stringify(out));',
+    ]);
+    const runPromise = runScript(script, fixture, 'h8', 4000);
+    // Item b should clear BOTH stages while item a is still gated in stage 1.
+    // Poll (instead of a fixed sleep) so a slow CI runner can't false-FAIL:
+    // the gate on stage1-a is held, so 's2-a' CANNOT appear until releaseA().
+    {
+      const deadline = Date.now() + 2000;
+      while (!events.includes('s2-b') && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    }
+    const bFinishedFirst = events.includes('s2-b') && !events.includes('s2-a');
+    releaseA();
+    const { errors, record } = await runPromise;
+    ok(errors.length === 0, `H8.0 pipeline fixture runs clean (${errors.join('; ') || 'no errors'})`);
+    const shapeLog = record.logs.find((l) => l.startsWith('argshape:'));
+    ok(!!shapeLog && shapeLog.includes('["a","a",0]'),
+      'H8.1 stage callbacks receive (prevResult, originalItem, index); the first stage sees the item as prevResult');
+    ok(bFinishedFirst,
+      'H8.2 NO inter-stage barrier: item b reached stage 2 while item a was still in stage 1');
+    const outLog = record.logs.find((l) => l.startsWith('out:'));
+    ok(!!outLog && JSON.parse(outLog.slice(4)).length === 2,
+      'H8.3 pipeline() returns an array index-aligned with items');
+
+    const dropScript = src([
+      ...VALID_META,
+      'const out = await pipeline([1, 2, 3],',
+      '  (prev, item) => { if (item === 2) throw new Error("stage boom"); return item * 10; },',
+      '  (prev) => prev + 1',
+      ');',
+      'log(JSON.stringify(out));',
+    ]);
+    const dropRun = await runScript(dropScript, {}, 'h8-drop', 2000);
+    const dropOut = dropRun.errors.length === 0 ? JSON.parse(dropRun.record.logs[0]) : null;
+    ok(dropOut && dropOut[0] === 11 && dropOut[1] === null && dropOut[2] === 31,
+      'H8.4 a throwing stage drops that item to null and skips its remaining stages (others unaffected)');
+    ok(dropRun.record.pipelineDrops.length === 1 && dropRun.record.pipelineDrops[0].index === 1,
+      'H8.5 the drop is recorded with the item index');
+  }
+
+  /* H9 — forbidden-global shadows THROW */
+  {
+    const cases = [
+      ['Date.now()', 'const t = Date.now();'],
+      ['Math.random()', 'const r = Math.random();'],
+      ['argless new Date()', 'const d = new Date();'],
+    ];
+    for (const [name, line] of cases) {
+      const { errors } = await runScript(src([...VALID_META, line]), {}, 'h9', 2000);
+      ok(errors.some((e) => e.includes('forbidden')), `H9 ${name} throws inside the sandbox`);
+    }
+    const allowed = src([
+      ...VALID_META,
+      'const d = new Date(1700000000000);',
+      'const f = Math.floor(2.7);',
+      'log("ok:" + d.getUTCFullYear() + ":" + f);',
+    ]);
+    const r = await runScript(allowed, {}, 'h9-allowed', 2000);
+    ok(r.errors.length === 0 && r.record.logs[0] === 'ok:2023:2',
+      'H9.4 new Date(value) with arguments and non-random Math statics stay usable');
+  }
+
+  /* H10 — args verbatim */
+  {
+    const fixture = { args: { v: 1, run_id: 'r-1', config: { areas: 8, nested: { deep: true } } } };
+    const script = src([...VALID_META, 'log(JSON.stringify(args));']);
+    const { errors, record } = await runScript(script, fixture, 'h10', 2000);
+    ok(errors.length === 0 && record.logs[0] === JSON.stringify(fixture.args),
+      'H10.1 args arrive verbatim (deep-equal round-trip)');
+  }
+
+  /* H11 — phase/log recorders + per-phase agent counts */
+  {
+    const script = src([
+      ...VALID_META,
+      'phase("Alpha");',
+      'log("in alpha");',
+      'await agent("a1", {});',
+      'await agent("a2", {});',
+      'phase("Beta");',
+      'await agent("b1", {});',
+      'await agent("b2", { phase: "Alpha" });',
+    ]);
+    const { errors, record } = await runScript(script, {}, 'h11', 2000);
+    ok(errors.length === 0 && record.phases.join(',') === 'Alpha,Beta',
+      'H11.1 phase() recorder captures titles in order');
+    ok(errors.length === 0 && record.logs.join(',') === 'in alpha',
+      'H11.2 log() recorder captures messages');
+    const counts = countAgentsByPhase(record);
+    ok(errors.length === 0 && counts.Alpha === 3 && counts.Beta === 1,
+      'H11.3 agent-call counts per phase (opts.phase overrides the current phase() group)');
+  }
+
+  /* H12 — runtime phase discipline catches dynamic titles */
+  {
+    const script = src([
+      ...VALID_META,
+      'const dynamic = ["Gam", "ma"].join("");',
+      'phase(dynamic);',
+    ]);
+    const { errors } = await runScript(script, {}, 'h12', 2000);
+    ok(errors.some((e) => e.includes('not declared in meta.phases')),
+      'H12.1 a dynamic phase title not in meta.phases is caught at run time (static scan cannot see it)');
+  }
+
+  /* H13 — T4 shared-block drift guard */
+  {
+    const blockA = ['// === SHARED:retry v1 ===', 'const RETRIES = 3;', '// === END SHARED ==='].join('\n');
+    const blockADrift = ['// === SHARED:retry v1 ===', 'const RETRIES = 4;', '// === END SHARED ==='].join('\n');
+    const blockAv2 = ['// === SHARED:retry v2 ===', 'const RETRIES = 4;', '// === END SHARED ==='].join('\n');
+    ok(checkSharedDrift([
+      { file: 'one.js', source: blockA },
+      { file: 'two.js', source: blockA },
+    ]).length === 0, 'H13.1 byte-identical SHARED blocks across scripts pass');
+    ok(checkSharedDrift([
+      { file: 'one.js', source: blockA },
+      { file: 'two.js', source: blockADrift },
+    ]).some((e) => e.includes('drifted')), 'H13.2 a one-byte drift in a same-name+version SHARED block fails');
+    ok(checkSharedDrift([
+      { file: 'one.js', source: blockA },
+      { file: 'two.js', source: blockAv2 },
+    ]).length === 0, 'H13.3 same name with a DIFFERENT version is allowed to differ (bump-the-version escape hatch)');
+    ok(checkSharedDrift([
+      { file: 'one.js', source: '// === SHARED:retry v1 ===\nconst X = 1;' },
+    ]).some((e) => e.includes('never closed')), 'H13.4 an unterminated SHARED block is an error');
+    ok(checkSharedDrift([
+      { file: 'one.js', source: blockA + '\n' + blockADrift },
+    ]).some((e) => e.includes('drifted')), 'H13.5 drift between two instances INSIDE one file is also caught');
+  }
+
+  /* H14 — workflow() recorder */
+  {
+    const fixture = { workflowReturns: { 'skills/x/workflows/child.js': { child: 'ran' } } };
+    const script = src([
+      ...VALID_META,
+      'const a = await workflow({ scriptPath: "skills/x/workflows/child.js" }, { v: 1 });',
+      'const b = await workflow("saved-name", {});',
+      'log(JSON.stringify([a, b]));',
+    ]);
+    const { errors, record } = await runScript(script, fixture, 'h14', 2000);
+    const got = errors.length === 0 ? JSON.parse(record.logs[0]) : null;
+    ok(errors.length === 0 && got && got[0].child === 'ran',
+      'H14.1 workflow() canned return keyed by scriptPath');
+    ok(errors.length === 0 && record.workflowCalls.length === 2,
+      'H14.2 workflow() calls are recorded');
+  }
+
+  /* H15 — hung script hits the timeout */
+  {
+    const script = src([...VALID_META, 'await new Promise(() => {});']);
+    const { errors } = await runScript(script, {}, 'h15', 300);
+    ok(errors.some((e) => e.includes('timed out')),
+      'H15.1 a hung await fails the dry-run with a timeout (scripts must not poll/sleep)');
+  }
+
+  /* H16 — sandbox has no timers / Node APIs */
+  {
+    const script = src([...VALID_META, 'setTimeout(() => {}, 10);']);
+    const { errors } = await runScript(script, {}, 'h16', 2000);
+    ok(errors.some((e) => e.includes('setTimeout')),
+      'H16.1 setTimeout is absent from the sandbox (constraint 3: no script-level timers)');
+    const script2 = src([...VALID_META, 'const data = fs.readFileSync("/etc/hosts");']);
+    const r2 = await runScript(script2, {}, 'h16-fs', 2000);
+    ok(r2.errors.some((e) => e.includes('fs')),
+      'H16.2 fs is absent from the sandbox (constraint 6: the script cannot touch the filesystem)');
+  }
+
+  console.log('');
+  console.log('== _workflow_harness self-test summary ==');
+  console.log(`  passed: ${pass}`);
+  console.log(`  failed: ${fail}`);
+  return fail === 0 ? 0 : 1;
+}
+
+/* ------------------------------------------------------------------ *
+ * CLI
+ * ------------------------------------------------------------------ */
+
+// Minimal args envelope for generic `validate` runs (per-pipeline T3 fixtures
+// with real canned returns land WITH each migrated-pipeline PR per RFC 0012
+// §9; the carrier ships the generic dry-run + the self-tests above).
+const GENERIC_ARGS = {
+  v: 1,
+  run_id: 'workflow-harness-dry-run',
+  now_epoch: 0,
+  now_iso: '1970-01-01T00:00:00Z',
+  plugin_root: '/workflow-harness/plugin_root',
+  repo_root: '/workflow-harness/repo_root',
+  cwd: '/workflow-harness/cwd',
+  config: {},
+};
+
+function readFileOrExit(file) {
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    console.error(`FATAL: cannot read ${file}: ${e.message}`);
+    process.exit(2);
+  }
+}
+
+async function main() {
+  const [, , command, ...rest] = process.argv;
+  if (command === 'self-test') {
+    process.exit(await selfTest());
+  }
+  if (command === 'validate') {
+    if (rest.length === 0) {
+      console.error('usage: node tests/_workflow_harness.js validate <file...>');
+      process.exit(2);
+    }
+    let failures = 0;
+    for (const file of rest) {
+      const source = readFileOrExit(file);
+      const { errors } = await runScript(source, { args: GENERIC_ARGS }, path.basename(file), DEFAULT_RUN_TIMEOUT_MS);
+      if (errors.length === 0) {
+        console.log(`  PASS  validate ${file}`);
+      } else {
+        failures += 1;
+        console.log(`  FAIL  validate ${file}`);
+        for (const e of errors) console.log(`        ${e}`);
+      }
+    }
+    process.exit(failures === 0 ? 0 : 1);
+  }
+  if (command === 'shared-drift') {
+    if (rest.length === 0) {
+      console.error('usage: node tests/_workflow_harness.js shared-drift <file...>');
+      process.exit(2);
+    }
+    const fileSources = rest.map((file) => ({ file, source: readFileOrExit(file) }));
+    const errors = checkSharedDrift(fileSources);
+    if (errors.length === 0) {
+      console.log(`  PASS  shared-drift across ${rest.length} file(s): no drift`);
+      process.exit(0);
+    }
+    console.log('  FAIL  shared-drift:');
+    for (const e of errors) console.log(`        ${e}`);
+    process.exit(1);
+  }
+  if (command === 'meta') {
+    if (rest.length !== 1) {
+      console.error('usage: node tests/_workflow_harness.js meta <file>');
+      process.exit(2);
+    }
+    const source = readFileOrExit(rest[0]);
+    const { meta, error } = extractMeta(source);
+    if (error) {
+      console.error(`FAIL: ${error}`);
+      process.exit(1);
+    }
+    const shapeErrors = validateMetaShape(meta);
+    if (shapeErrors.length > 0) {
+      for (const e of shapeErrors) console.error(`FAIL: ${e}`);
+      process.exit(1);
+    }
+    console.log(JSON.stringify(meta, null, 2));
+    process.exit(0);
+  }
+  console.error('usage: node tests/_workflow_harness.js <self-test|validate|shared-drift|meta> [args]');
+  process.exit(2);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(`FATAL: harness crashed: ${e && e.stack ? e.stack : e}`);
+    process.exit(2);
+  });
+}
+
+module.exports = {
+  extractMeta,
+  validateMetaShape,
+  scanPhaseLiterals,
+  preprocess,
+  makeSandbox,
+  makeRecord,
+  runScript,
+  countAgentsByPhase,
+  extractSharedBlocks,
+  checkSharedDrift,
+};

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -420,8 +420,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.36.12) =="
-assert_version_bump "$REPO_ROOT" "0.36.12"
+echo "== G20: version bump locked (0.37.0) =="
+assert_version_bump "$REPO_ROOT" "0.37.0"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -273,8 +273,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.36.11 -> 0.36.12 propagated =="
-assert_version_bump "$REPO_ROOT" "0.36.12"
+echo "== Version bump 0.36.12 -> 0.37.0 propagated =="
+assert_version_bump "$REPO_ROOT" "0.37.0"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input

--- a/tests/uberthink.test.sh
+++ b/tests/uberthink.test.sh
@@ -76,8 +76,10 @@ for a in "${AGENTS[@]}"; do
   f="$AGENTS_DIR/uberthink-$a.md"
   ck "agent file exists: uberthink-$a.md" "[ -r '$f' ]"
   ck "agent frontmatter name is uberthink-$a" "grep -qE '^name: uberthink-$a\$' '$f'"
-  # model is one of opus|sonnet|haiku|inherit
-  ck "agent model in {opus,sonnet,haiku,inherit}: uberthink-$a" "grep -qE '^model: (opus|sonnet|haiku|inherit)\$' '$f'"
+  # model is one of opus|sonnet|haiku|fable|inherit (fable added per RFC 0012
+  # §5 — enum extension only; the per-agent WANT_MODEL lock below stays
+  # all-inherit, and no agent pins fable until open question Q5 resolves)
+  ck "agent model in {opus,sonnet,haiku,fable,inherit}: uberthink-$a" "grep -qE '^model: (opus|sonnet|haiku|fable|inherit)\$' '$f'"
   # spec §2.5 specific assignment
   want="${WANT_MODEL[$a]}"
   ck "agent model matches all-inherit policy: uberthink-$a == $want" "grep -qE '^model: $want\$' '$f'"

--- a/tests/workflow-args.test.sh
+++ b/tests/workflow-args.test.sh
@@ -49,6 +49,19 @@ command -v jq >/dev/null 2>&1 || {
   exit 2
 }
 
+# MSYS2/Git-for-Windows arg mangling: on the windows runner, bash rewrites
+# absolute-POSIX-looking argv values (e.g. /pr) into Windows paths
+# (C:/Program Files/Git/pr) at the exec boundary when invoking NATIVE
+# binaries (jq.exe) — BEFORE jq ever sees them. That breaks byte-exact
+# envelope asserts (W4.1) while proving nothing about the emitter, whose
+# data-not-code contract is what this file tests. Disable the conversion for
+# this test process via the documented Git-for-Windows controls; inert on
+# POSIX hosts. (Production note: conversion of REAL host paths to C:/-style
+# in live Windows preflights is desirable for node-side consumption — the
+# emitter correctly leaves that to the platform.)
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
+
 PASS=0
 FAIL=0
 pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }

--- a/tests/workflow-args.test.sh
+++ b/tests/workflow-args.test.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# tests/workflow-args.test.sh — contract tests for uberdev_emit_workflow_args
+# (RFC 0012 §4.3, infra-R7): the config → Workflow-args plumbing every
+# migrated thin preflight relies on (DR-2 verbatim relay).
+#
+# Contract under test:
+#   W1  — envelope emitted between exact WORKFLOW_ARGS_BEGIN/END marker lines;
+#         the payload between them is one valid compact-JSON object.
+#   W2  — versioned envelope keys: v==1, run_id, now_epoch (int), now_iso,
+#         plugin_root, repo_root, cwd, pipeline, config{}.
+#   W3  — KEY=VALUE config folding with auto-typing (int → number,
+#         true/false → boolean, everything else → string; leading-zero
+#         values stay strings) and dotted keys as literal JSON keys.
+#   W4  — reserved top-level overrides (run_id / plugin_root / repo_root /
+#         cwd) land top-level, never under .config; locked keys
+#         (v / now_epoch / now_iso / pipeline / config) are REJECTED rc=2.
+#   W5  — composition with the existing read helpers: values resolved via
+#         uberdev_read_* (env > uberdev.local.md > default) flow into the
+#         envelope; the emitter itself NEVER warns, never touches the
+#         warn-once sentinels, never writes audit rows.
+#   W6  — injection discipline: caller-supplied VALUEs travel as data
+#         (jq --arg), never expanded as code — `$(...)`, backticks and
+#         quotes survive as literal JSON string bytes and execute nothing.
+#   W7  — never-eval-a-caller-supplied-NAME discipline (structural): the
+#         emitter's function body contains zero `eval`; the four legacy
+#         constant-name `eval "printf` sites in the read helpers are intact.
+#   W8  — error paths exit 2 with a one-line stderr diagnostic (missing
+#         pipeline, bad pipeline charset, non-KEY=VALUE arg, bad KEY).
+#   W9  — the frozen-time contract (RFC 0012 DR-7) is documented in the
+#         helper and now_epoch/now_iso are emitter-minted (not overridable).
+#
+# Runs under bash on ubuntu AND windows Git Bash (jq + git ship on both CI
+# images). Mirrors the _isolate sandbox convention of config-override.test.sh
+# (same lib, fresh PWD + empty config per snippet, sentinels reset by
+# sub-shelling) without touching that file — it is owned by the
+# solve-launcher PR series.
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$REPO_ROOT/plugins/uberdev/lib/config-read.sh"
+
+for f in "$HELPER"; do
+  [ -r "$f" ] || { echo "FATAL: required file missing or unreadable: $f" >&2; exit 2; }
+done
+command -v jq >/dev/null 2>&1 || {
+  echo "FATAL: jq is required for the workflow-args contract tests (preinstalled on both CI images)" >&2
+  exit 2
+}
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL  $1"; FAIL=$((FAIL + 1)); }
+
+# _isolate BODY — run a snippet in a throwaway PWD with an empty config file,
+# sourcing the helper fresh in a sub-shell (sentinel exports die with it).
+# Captures stdout in _LAST_STDOUT, stderr in _LAST_STDERR, rc in _LAST_RC.
+_LAST_STDOUT=""
+_LAST_STDERR=""
+_LAST_RC=0
+_isolate() {
+  local body="$1"
+  local sandbox out err
+  sandbox="$(mktemp -d)"
+  out="$(mktemp)"
+  err="$(mktemp)"
+  mkdir -p "$sandbox/.claude"
+  : > "$sandbox/.claude/uberdev.local.md"
+  (
+    cd "$sandbox"
+    # shellcheck source=/dev/null
+    . "$HELPER"
+    eval "$body"
+  ) >"$out" 2>"$err"
+  _LAST_RC=$?
+  _LAST_STDOUT="$(cat "$out")"
+  _LAST_STDERR="$(cat "$err")"
+  rm -rf "$sandbox" "$out" "$err"
+}
+
+# Extract the JSON payload between the markers from _LAST_STDOUT.
+_payload() {
+  printf '%s\n' "$_LAST_STDOUT" | sed -n '/^WORKFLOW_ARGS_BEGIN$/,/^WORKFLOW_ARGS_END$/p' | sed '1d;$d'
+}
+
+echo "## workflow-args contract (RFC 0012 §4.3 — uberdev_emit_workflow_args)"
+
+# ---------------------------------------------------------------------------
+echo "== W1: marker framing + valid JSON =="
+_isolate 'uberdev_emit_workflow_args review-pr'
+if [ "$_LAST_RC" -eq 0 ]; then
+  pass "W1.1 bare invocation exits 0"
+else
+  fail "W1.1 bare invocation exits 0 (got rc=$_LAST_RC, stderr: $_LAST_STDERR)"
+fi
+first_line="$(printf '%s\n' "$_LAST_STDOUT" | sed -n '1p')"
+last_line="$(printf '%s\n' "$_LAST_STDOUT" | sed -n '$p')"
+[ "$first_line" = "WORKFLOW_ARGS_BEGIN" ] \
+  && pass "W1.2 first output line is the literal WORKFLOW_ARGS_BEGIN marker" \
+  || fail "W1.2 first output line is the literal WORKFLOW_ARGS_BEGIN marker (got: $first_line)"
+[ "$last_line" = "WORKFLOW_ARGS_END" ] \
+  && pass "W1.3 last output line is the literal WORKFLOW_ARGS_END marker" \
+  || fail "W1.3 last output line is the literal WORKFLOW_ARGS_END marker (got: $last_line)"
+payload="$(_payload)"
+if printf '%s' "$payload" | jq -e 'type == "object"' >/dev/null 2>&1; then
+  pass "W1.4 payload between the markers parses as one JSON object"
+else
+  fail "W1.4 payload between the markers parses as one JSON object (got: $payload)"
+fi
+[ "$(printf '%s\n' "$payload" | wc -l | tr -d '[:space:]')" = "1" ] \
+  && pass "W1.5 payload is compact single-line JSON (verbatim-relay friendly)" \
+  || fail "W1.5 payload is compact single-line JSON"
+
+# ---------------------------------------------------------------------------
+echo "== W2: versioned envelope keys =="
+if printf '%s' "$payload" | jq -e '
+    .v == 1
+    and (.run_id | type == "string")
+    and (.now_epoch | type == "number")
+    and (.now_iso | type == "string")
+    and (.plugin_root | type == "string")
+    and (.repo_root | type == "string")
+    and (.cwd | type == "string")
+    and .pipeline == "review-pr"
+    and (.config | type == "object")
+  ' >/dev/null 2>&1; then
+  pass "W2.1 envelope carries v=1, run_id, now_epoch:int, now_iso, plugin_root, repo_root, cwd, pipeline, config{}"
+else
+  fail "W2.1 envelope keys/types drifted from the §4.3 v1 contract (got: $payload)"
+fi
+if printf '%s' "$payload" | jq -r '.run_id' | grep -qE '^[0-9]{8}-[0-9]{6}-[a-f0-9]+$'; then
+  pass "W2.2 minted run_id matches the established RUN_ID shape ^[0-9]{8}-[0-9]{6}-[a-f0-9]+\$"
+else
+  fail "W2.2 minted run_id matches the established RUN_ID shape (got: $(printf '%s' "$payload" | jq -r '.run_id'))"
+fi
+if printf '%s' "$payload" | jq -r '.now_iso' | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'; then
+  pass "W2.3 now_iso is UTC ISO-8601 (YYYY-MM-DDTHH:MM:SSZ)"
+else
+  fail "W2.3 now_iso is UTC ISO-8601 (got: $(printf '%s' "$payload" | jq -r '.now_iso'))"
+fi
+# now_epoch sanity: a real recent epoch (> 2020-01-01), not 0 / garbage.
+if printf '%s' "$payload" | jq -e '.now_epoch > 1577836800' >/dev/null 2>&1; then
+  pass "W2.4 now_epoch is a live epoch (frozen at emission, not a placeholder)"
+else
+  fail "W2.4 now_epoch is a live epoch (got: $(printf '%s' "$payload" | jq -r '.now_epoch'))"
+fi
+[ -z "$_LAST_STDERR" ] \
+  && pass "W2.5 happy path emits nothing on stderr" \
+  || fail "W2.5 happy path emits nothing on stderr (got: $_LAST_STDERR)"
+
+# ---------------------------------------------------------------------------
+echo "== W3: config folding + auto-typing =="
+_isolate 'uberdev_emit_workflow_args uberscan areas=8 deep=true neg=-3 zerolead=007 label="hello world" fanout_concurrency.solve_bg=6'
+payload="$(_payload)"
+if printf '%s' "$payload" | jq -e '
+    .config.areas == 8 and (.config.areas | type == "number")
+    and .config.deep == true
+    and .config.neg == -3
+    and .config.zerolead == "007"
+    and .config.label == "hello world"
+    and .config["fanout_concurrency.solve_bg"] == 6
+  ' >/dev/null 2>&1; then
+  pass "W3.1 int → number, true → boolean, -3 → number, 007 → string, free text → string, dotted KEY is a literal JSON key"
+else
+  fail "W3.1 config auto-typing/folding drifted (got: $payload)"
+fi
+if printf '%s' "$payload" | jq -e '.config | keys | length == 6' >/dev/null 2>&1; then
+  pass "W3.2 exactly the six supplied keys land under .config"
+else
+  fail "W3.2 exactly the six supplied keys land under .config (got: $payload)"
+fi
+
+# ---------------------------------------------------------------------------
+echo "== W4: reserved overrides + locked keys =="
+_isolate 'uberdev_emit_workflow_args goal run_id=20260612-010203-abc123 plugin_root=/pr repo_root=/rr cwd=/cw extra=1'
+payload="$(_payload)"
+if printf '%s' "$payload" | jq -e '
+    .run_id == "20260612-010203-abc123"
+    and .plugin_root == "/pr" and .repo_root == "/rr" and .cwd == "/cw"
+    and .config == {extra: 1}
+  ' >/dev/null 2>&1; then
+  pass "W4.1 run_id/plugin_root/repo_root/cwd override top-level and stay OUT of .config"
+else
+  fail "W4.1 reserved-override routing drifted (got: $payload)"
+fi
+for locked in v now_epoch now_iso pipeline config; do
+  _isolate "uberdev_emit_workflow_args goal $locked=x"
+  if [ "$_LAST_RC" -eq 2 ] && printf '%s' "$_LAST_STDERR" | grep -q "locked"; then
+    pass "W4.2 locked key '$locked' is rejected rc=2"
+  else
+    fail "W4.2 locked key '$locked' is rejected rc=2 (rc=$_LAST_RC, stderr: $_LAST_STDERR)"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+echo "== W5: composition with uberdev_read_* (precedence + sentinel silence) =="
+_isolate '
+  export UBERDEV_TEST_FANOUT=7
+  resolved="$(uberdev_read_int_in_range fanout_concurrency.research UBERDEV_TEST_FANOUT 1 50 6)"
+  uberdev_emit_workflow_args scan fanout="$resolved"
+'
+payload="$(_payload)"
+if printf '%s' "$payload" | jq -e '.config.fanout == 7' >/dev/null 2>&1; then
+  pass "W5.1 env-resolved value (env tier beats default) flows into .config as a number"
+else
+  fail "W5.1 env-resolved value flows into .config (got: $payload)"
+fi
+_isolate '
+  printf "fanout_concurrency:\n  research: 9\n" > .claude/uberdev.local.md
+  resolved="$(uberdev_read_int_in_range fanout_concurrency.research UBERDEV_TEST_UNSET_VAR 1 50 6)"
+  uberdev_emit_workflow_args scan fanout="$resolved"
+'
+payload="$(_payload)"
+if printf '%s' "$payload" | jq -e '.config.fanout == 9' >/dev/null 2>&1; then
+  pass "W5.2 uberdev.local.md-resolved value (file tier) flows into .config"
+else
+  fail "W5.2 uberdev.local.md-resolved value flows into .config (got: $payload)"
+fi
+_isolate '
+  export UBERDEV_TEST_FANOUT=999
+  resolved="$(uberdev_read_int_in_range fanout_concurrency.research UBERDEV_TEST_FANOUT 1 50 6)"
+  uberdev_emit_workflow_args scan fanout="$resolved"
+  uberdev_emit_workflow_args scan fanout="$resolved" >/dev/null
+'
+payload="$(_payload)"
+warn_count="$(printf '%s\n' "$_LAST_STDERR" | grep -cE "fanout_concurrency.research = .999. is invalid" || true)"
+if printf '%s' "$payload" | jq -e '.config.fanout == 6' >/dev/null 2>&1 && [ "$warn_count" = "1" ]; then
+  pass "W5.3 invalid value falls back via the READ helper (one D7 warn) and the emitter adds no warning of its own"
+else
+  fail "W5.3 read-helper warn-once + emitter silence (payload: $payload; warn_count=$warn_count)"
+fi
+if printf '%s\n' "$_LAST_STDERR" | grep -q 'uberdev_emit_workflow_args'; then
+  fail "W5.4 emitter stays silent on stderr when inputs are valid (got: $_LAST_STDERR)"
+else
+  pass "W5.4 emitter stays silent on stderr when inputs are valid"
+fi
+
+# ---------------------------------------------------------------------------
+echo "== W6: injection discipline (values are data, never code) =="
+CANARY="$(mktemp -d)/canary"
+_isolate "uberdev_emit_workflow_args scan sneaky='\$(touch $CANARY)' tick='\`touch $CANARY\`' quotes='\";]} bad'"
+payload="$(_payload)"
+if [ ! -e "$CANARY" ]; then
+  pass "W6.1 command-substitution/backtick payloads in VALUEs execute nothing"
+else
+  fail "W6.1 command-substitution/backtick payloads in VALUEs execute nothing (canary file appeared)"
+fi
+if printf '%s' "$payload" | jq -e '.config.sneaky | startswith("$(touch ")' >/dev/null 2>&1 \
+   && printf '%s' "$payload" | jq -e '.config.quotes == "\";]} bad"' >/dev/null 2>&1; then
+  pass "W6.2 hostile bytes survive as literal JSON string content (jq --arg quoting)"
+else
+  fail "W6.2 hostile bytes survive as literal JSON string content (got: $payload)"
+fi
+if printf '%s' "$payload" | jq -e 'type == "object"' >/dev/null 2>&1; then
+  pass "W6.3 envelope stays valid JSON under hostile values"
+else
+  fail "W6.3 envelope stays valid JSON under hostile values"
+fi
+rm -rf "$(dirname "$CANARY")"
+
+# ---------------------------------------------------------------------------
+echo "== W7: never-eval discipline (structural) =="
+# Function body scoped: from the function's opening line to its closing `}`.
+emit_body="$(awk '/^uberdev_emit_workflow_args\(\)/{inb=1} inb{print} inb&&/^\}/{exit}' "$HELPER")"
+if [ -n "$emit_body" ]; then
+  pass "W7.1 uberdev_emit_workflow_args function body found in lib/config-read.sh"
+else
+  fail "W7.1 uberdev_emit_workflow_args function body found in lib/config-read.sh"
+fi
+if printf '%s\n' "$emit_body" | grep -qwE 'eval'; then
+  fail "W7.2 emitter body must contain ZERO eval — caller-supplied KEY/VALUE may never be expanded as code"
+else
+  pass "W7.2 emitter body contains zero eval (KEY/VALUE travel via jq --arg only)"
+fi
+legacy_eval_count="$(grep -c 'eval "printf' "$HELPER" || true)"
+if [ "$legacy_eval_count" = "4" ]; then
+  pass "W7.3 the four legacy constant-name 'eval \"printf' sites in the read helpers are intact (no more, no fewer)"
+else
+  fail "W7.3 expected exactly 4 constant-name 'eval \"printf' sites in config-read.sh, found $legacy_eval_count"
+fi
+
+# ---------------------------------------------------------------------------
+echo "== W8: error paths =="
+_isolate 'uberdev_emit_workflow_args'
+[ "$_LAST_RC" -eq 2 ] && printf '%s' "$_LAST_STDERR" | grep -q 'missing PIPELINE' \
+  && pass "W8.1 missing PIPELINE → rc=2 + diagnostic" \
+  || fail "W8.1 missing PIPELINE → rc=2 + diagnostic (rc=$_LAST_RC, stderr: $_LAST_STDERR)"
+_isolate 'uberdev_emit_workflow_args "bad name"'
+[ "$_LAST_RC" -eq 2 ] && printf '%s' "$_LAST_STDERR" | grep -q 'invalid PIPELINE' \
+  && pass "W8.2 PIPELINE with disallowed chars → rc=2" \
+  || fail "W8.2 PIPELINE with disallowed chars → rc=2 (rc=$_LAST_RC)"
+_isolate 'uberdev_emit_workflow_args scan notakeyvalue'
+[ "$_LAST_RC" -eq 2 ] && printf '%s' "$_LAST_STDERR" | grep -q 'not KEY=VALUE' \
+  && pass "W8.3 non-KEY=VALUE argument → rc=2" \
+  || fail "W8.3 non-KEY=VALUE argument → rc=2 (rc=$_LAST_RC)"
+_isolate 'uberdev_emit_workflow_args scan "ba d=1"'
+[ "$_LAST_RC" -eq 2 ] && printf '%s' "$_LAST_STDERR" | grep -q 'invalid KEY' \
+  && pass "W8.4 KEY with disallowed chars → rc=2" \
+  || fail "W8.4 KEY with disallowed chars → rc=2 (rc=$_LAST_RC)"
+_isolate 'uberdev_emit_workflow_args scan =1'
+[ "$_LAST_RC" -eq 2 ] && printf '%s' "$_LAST_STDERR" | grep -q 'empty KEY' \
+  && pass "W8.5 empty KEY → rc=2" \
+  || fail "W8.5 empty KEY → rc=2 (rc=$_LAST_RC)"
+_isolate 'uberdev_emit_workflow_args scan 2>/dev/null || echo "MARKER_ABSENT_RC=$?"'
+if printf '%s' "$_LAST_STDOUT" | grep -q 'WORKFLOW_ARGS_BEGIN'; then
+  pass "W8.6 happy path still frames with markers after the error-path battery (no sticky state)"
+else
+  fail "W8.6 happy path still frames with markers after the error-path battery"
+fi
+
+# ---------------------------------------------------------------------------
+echo "== W9: frozen-time contract is documented + enforced =="
+if grep -qE 'FROZEN-TIME CONTRACT \(RFC 0012 DR-7\)' "$HELPER"; then
+  pass "W9.1 helper documents the frozen-time contract (DR-7) in a comment"
+else
+  fail "W9.1 helper documents the frozen-time contract (DR-7) in a comment"
+fi
+if grep -qE 'agent-side .date.' "$HELPER"; then
+  pass "W9.2 helper names agent-side date as the ONLY mid-run wall-clock source"
+else
+  fail "W9.2 helper names agent-side date as the ONLY mid-run wall-clock source"
+fi
+_isolate 'uberdev_emit_workflow_args scan now_epoch=12345'
+[ "$_LAST_RC" -eq 2 ] \
+  && pass "W9.3 now_epoch cannot be overridden (frozen at emission)" \
+  || fail "W9.3 now_epoch cannot be overridden (rc=$_LAST_RC)"
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/workflow-scripts.test.sh
+++ b/tests/workflow-scripts.test.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+# tests/workflow-scripts.test.sh — RFC 0012 §4.4 test architecture for
+# on-disk Workflow orchestration scripts (the ultracode migration carrier).
+#
+# Tiers (suite entry for all four; T2/T3/T4 delegate to the node harness):
+#   T1 — lint: `node --check --input-type=module < "$f"` over every
+#        glob-discovered workflow script under plugins/, plus forbidden-token
+#        greps (import/require/process./fs./Date.now/Math.random/new Date(
+#        outside SHARED marker blocks) and the 512 KB runtime size cap.
+#   T2 — meta validation: pure-JSON `export const meta` literal between
+#        /* META-BEGIN */ and /* META-END */ markers; {name, description,
+#        phases[]} shape; every phase()/opts.phase string literal declared
+#        in meta.phases.            (via tests/_workflow_harness.js validate)
+#   T3 — behavioral dry-run: preprocess (strip meta export, wrap in an async
+#        IIFE) + vm.runInNewContext under faithful runtime stubs.
+#                                   (via tests/_workflow_harness.js validate)
+#   T4 — shared-snippet drift guard: `// === SHARED:<name> v<N> ===` blocks
+#        with the same name+version must be byte-identical across scripts.
+#                               (via tests/_workflow_harness.js shared-drift)
+#   §4.2 shape guard — every on-disk skills/*/workflow.js must have a sibling
+#        SKILL.md carrying BOTH the Workflow invocation block and a
+#        `## No-Workflow fallback` section (a migrated pipeline cannot ship
+#        workflow-only).
+#
+# NON-VACUOUS BY DESIGN: with ZERO workflow scripts on disk (the carrier
+# lands before any workflow.js ships — RFC 0012 §9 Phase-1 gate) the
+# per-script checks pass with a notice, while the harness SELF-TESTS (every
+# stub semantic + the preprocessing step) and the T1/T2/T4 control fixtures
+# below always execute, so stub drift and wrapper bugs red CI even today.
+#
+# T1 INVOCATION FORM IS LOAD-BEARING (asserted in this test, not left to
+# runner defaults): workflow scripts are ESM-shaped (`export const meta` +
+# top-level await) plain .js files with no package.json scoping. Verified
+# live on Node v20.19.2: `node --check < "$f"` (stdin WITHOUT
+# --input-type=module) REDS on that shape (stdin defaults to CommonJS),
+# while runners with default module detection (>=22.7, backported into late
+# 20.x for the file form) pass it — an unpinned guard flips on runner-image
+# updates. The pinned stdin form `node --check --input-type=module < "$f"`
+# is deterministic on every Node the CI images ship, with no .mjs renames
+# and no package.json `type:module` side effects on the plugin.
+#
+# Runs on BOTH CI jobs (ubuntu + windows Git Bash): node ships on both
+# GitHub images; harness paths are passed as plain argv (MSYS2 converts
+# them), and stdin redirection is done by bash itself.
+#
+# FIXTURE DISCIPLINE (RFC 0012 §4.4): any secret-shaped fixture token must
+# be assembled at runtime by concatenation, never contiguous source bytes —
+# the finish-branch pre-push scanner hard-aborts on them. The fixtures below
+# contain none.
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+THIS_FILE="$REPO_ROOT/tests/workflow-scripts.test.sh"
+HARNESS="$REPO_ROOT/tests/_workflow_harness.js"
+PLUGINS_DIR="$REPO_ROOT/plugins"
+SIZE_CAP_BYTES=524288   # 512 KB — the documented Workflow runtime script cap
+
+# Hard-fail (exit 2) on missing inputs — a moved/renamed file must be an
+# explicit failure, never silently-zero-assertions PASS.
+for f in "$THIS_FILE" "$HARNESS"; do
+  [ -r "$f" ] || { echo "FATAL: required file missing or unreadable: $f" >&2; exit 2; }
+done
+[ -d "$PLUGINS_DIR" ] || { echo "FATAL: plugins/ directory missing: $PLUGINS_DIR" >&2; exit 2; }
+command -v node >/dev/null 2>&1 || {
+  echo "FATAL: node is required for the workflow-script tiers (preinstalled on both CI images)" >&2
+  exit 2
+}
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL  $1"; FAIL=$((FAIL + 1)); }
+
+TMPDIR_FIXTURES="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_FIXTURES"' EXIT
+
+# ---------------------------------------------------------------------------
+# Discovery: workflow scripts live at plugins/*/skills/<name>/workflow.js
+# (children under skills/<name>/workflows/) per RFC 0012 DR-1. The glob also
+# accepts workflow-*.js siblings so a renamed variant cannot dodge the lint.
+# Newline-delimited; repo paths may contain spaces, so consume ONLY via
+# `while IFS= read -r`.
+# ---------------------------------------------------------------------------
+discover_workflow_scripts() {
+  find "$PLUGINS_DIR" -type f \( -name 'workflow*.js' -o -path '*/workflows/*.js' \) 2>/dev/null | sort
+}
+
+SCRIPTS_FILE="$TMPDIR_FIXTURES/discovered.txt"
+discover_workflow_scripts > "$SCRIPTS_FILE"
+SCRIPT_COUNT=0
+while IFS= read -r _line; do
+  [ -n "$_line" ] && SCRIPT_COUNT=$((SCRIPT_COUNT + 1))
+done < "$SCRIPTS_FILE"
+
+echo "## workflow-scripts tiers T1-T4 (RFC 0012 §4.4) — discovered scripts: $SCRIPT_COUNT"
+
+# ---------------------------------------------------------------------------
+# T1 control fixtures — assert the pinned invocation form itself, every run.
+# ---------------------------------------------------------------------------
+echo "== T1: lint invocation-form controls =="
+
+GOOD_ESM="$TMPDIR_FIXTURES/good-esm.js"
+{
+  echo '/* META-BEGIN */'
+  echo 'export const meta = { "name": "control", "description": "T1 control fixture", "phases": ["Only"] };'
+  echo '/* META-END */'
+  echo 'phase("Only");'
+  echo 'await Promise.resolve(1);'
+} > "$GOOD_ESM"
+
+if node --check --input-type=module < "$GOOD_ESM" >/dev/null 2>&1; then
+  pass "T1.c1 pinned form accepts the spec-mandated ESM shape (export const meta + top-level await)"
+else
+  fail "T1.c1 pinned form rejected the spec-mandated ESM shape — Node on this runner broke the invocation contract"
+fi
+
+BAD_SYNTAX="$TMPDIR_FIXTURES/bad-syntax.js"
+printf 'export const meta = {;\n' > "$BAD_SYNTAX"
+if node --check --input-type=module < "$BAD_SYNTAX" >/dev/null 2>&1; then
+  fail "T1.c2 pinned form must red on a syntax error (it passed a broken fixture)"
+else
+  pass "T1.c2 pinned form reds on a syntax error"
+fi
+
+# Self-anchor: the lint below must keep using the PINNED stdin form. A future
+# edit that drops --input-type=module (reverting to runner-default module
+# detection) reds here before it can flip on a runner-image update.
+if grep -qF -- 'node --check --input-type=module <' "$THIS_FILE"; then
+  pass "T1.c3 this test pins the stdin --input-type=module invocation form"
+else
+  fail "T1.c3 the pinned invocation form literal vanished from this test"
+fi
+
+# ---------------------------------------------------------------------------
+# T1 per-script: lint + size cap + forbidden-token greps.
+#
+# Forbidden tokens are checked OUTSIDE `// === SHARED:<name> v<N> ===` blocks
+# (RFC 0012 §4.4): a SHARED block is the audited escape hatch for coarse-grep
+# false positives (e.g. a reviewed `new Date(epochValue)` formatter — the
+# grep cannot see arguments). T4 keeps every such block byte-identical across
+# scripts, and the T3 sandbox shadows still THROW on argless new Date() /
+# Date.now() / Math.random() at run time, so the escape hatch never weakens
+# the runtime contract.
+# ---------------------------------------------------------------------------
+echo "== T1: per-script lint + forbidden tokens + size cap =="
+
+# Strip SHARED-marked regions; prefix surviving lines with their original
+# line number (NN:) for actionable FAIL output. The boundary classes in the
+# patterns below treat ':' as a non-identifier char, so the prefix never
+# masks a real start-of-line hit.
+strip_shared_blocks() {
+  awk '
+    /^[ \t]*\/\/ === SHARED:[A-Za-z0-9._-]+ v[0-9]+ ===[ \t]*$/ { inshared=1; next }
+    /^[ \t]*\/\/ === END SHARED ===[ \t]*$/                     { inshared=0; next }
+    !inshared { printf "%d:%s\n", NR, $0 }
+  ' "$1"
+}
+
+# Each entry: <ERE pattern>|<human label>. Patterns run with grep -E over the
+# SHARED-stripped, line-number-prefixed content. import/require additionally
+# use -w (word match) so e.g. "important" cannot false-positive.
+check_forbidden_tokens() {
+  local file="$1" base="$2" stripped hits
+  stripped="$(strip_shared_blocks "$file")"
+
+  hits="$(printf '%s\n' "$stripped" | grep -wE 'import|require' || true)"
+  if [ -n "$hits" ]; then
+    fail "T1 $base: forbidden token import/require (scripts are self-contained — copy-paste via SHARED blocks)"
+    printf '%s\n' "$hits" | head -5 | sed 's/^/        /'
+  else
+    pass "T1 $base: no import/require"
+  fi
+
+  hits="$(printf '%s\n' "$stripped" | grep -E '(^|[^[:alnum:]_$.])process\.|(^|[^[:alnum:]_$.])fs\.' || true)"
+  if [ -n "$hits" ]; then
+    fail "T1 $base: forbidden token process./fs. (the script cannot touch Node APIs or the filesystem — agents do)"
+    printf '%s\n' "$hits" | head -5 | sed 's/^/        /'
+  else
+    pass "T1 $base: no process./fs."
+  fi
+
+  hits="$(printf '%s\n' "$stripped" | grep -E '(^|[^[:alnum:]_$])Date\.now|(^|[^[:alnum:]_$])Math\.random|new[[:space:]]+Date[[:space:]]*\(' || true)"
+  if [ -n "$hits" ]; then
+    fail "T1 $base: forbidden token Date.now/Math.random/new Date( — timestamps arrive via args (DR-7)"
+    printf '%s\n' "$hits" | head -5 | sed 's/^/        /'
+  else
+    pass "T1 $base: no Date.now/Math.random/new Date("
+  fi
+}
+
+if [ "$SCRIPT_COUNT" -eq 0 ]; then
+  pass "T1 notice: no workflow scripts on disk yet — per-script lint vacuously green (carrier lands before Phase 2 ships the first script)"
+else
+  while IFS= read -r script; do
+    [ -n "$script" ] || continue
+    base="${script#"$REPO_ROOT"/}"
+
+    if node --check --input-type=module < "$script" >/dev/null 2>&1; then
+      pass "T1 $base: node --check --input-type=module < file"
+    else
+      fail "T1 $base: failed ESM lint (node --check --input-type=module)"
+      node --check --input-type=module < "$script" 2>&1 | head -5 | sed 's/^/        /'
+    fi
+
+    size="$(wc -c < "$script" | tr -d '[:space:]')"
+    if [ "$size" -le "$SIZE_CAP_BYTES" ] 2>/dev/null; then
+      pass "T1 $base: size $size <= $SIZE_CAP_BYTES bytes (512 KB runtime cap)"
+    else
+      fail "T1 $base: size $size exceeds the 512 KB Workflow runtime cap"
+    fi
+
+    check_forbidden_tokens "$script" "$base"
+  done < "$SCRIPTS_FILE"
+fi
+
+# Forbidden-token grep controls: the strip+grep machinery must (a) hit a
+# violation outside SHARED markers, (b) honour the SHARED escape hatch.
+FORBIDDEN_FIXTURE="$TMPDIR_FIXTURES/forbidden.js"
+{
+  echo 'const t = Date.now();'
+  echo '// === SHARED:date-fmt v1 ==='
+  echo 'const d = new Date(1700000000000).toISOString();'
+  echo '// === END SHARED ==='
+} > "$FORBIDDEN_FIXTURE"
+if strip_shared_blocks "$FORBIDDEN_FIXTURE" | grep -qE '(^|[^[:alnum:]_$])Date\.now'; then
+  pass "T1.c4 forbidden-token grep catches Date.now outside SHARED markers"
+else
+  fail "T1.c4 forbidden-token grep MISSED Date.now outside SHARED markers"
+fi
+if strip_shared_blocks "$FORBIDDEN_FIXTURE" | grep -qE 'new[[:space:]]+Date[[:space:]]*\('; then
+  fail "T1.c5 SHARED-block escape hatch broken: new Date( INSIDE markers leaked into the grep surface"
+else
+  pass "T1.c5 SHARED-block contents are exempt from the static grep (T3 runtime shadows still apply)"
+fi
+if printf '%s\n' '1:// important: requires careful reading' | grep -qwE 'import|require'; then
+  fail "T1.c6 word-boundary control: 'important'/'requires' must not trip the import/require grep"
+else
+  pass "T1.c6 import/require grep is word-bounded (no 'important'/'requires' false positives)"
+fi
+
+# ---------------------------------------------------------------------------
+# Harness self-tests — lock every stub semantic + the preprocessing step.
+# This is what keeps the suite non-vacuous while zero scripts exist.
+# ---------------------------------------------------------------------------
+echo "== T2/T3: harness self-tests (stub semantics + preprocessing) =="
+if node "$HARNESS" self-test >"$TMPDIR_FIXTURES/selftest.out" 2>&1; then
+  pass "harness self-test green ($(grep -c '^  PASS' "$TMPDIR_FIXTURES/selftest.out" || echo '?') stub-semantic asserts)"
+else
+  fail "harness self-test FAILED — stub drift or wrapper bug"
+  grep '^  FAIL' "$TMPDIR_FIXTURES/selftest.out" | head -10 | sed 's/^/      /'
+fi
+
+# Harness CLI contract controls (the per-script loop below relies on these
+# exit codes; lock them against harness refactors).
+GOOD_FLOW="$TMPDIR_FIXTURES/good-flow.js"
+{
+  echo '/* META-BEGIN */'
+  echo 'export const meta = { "name": "cli-control", "description": "harness CLI control fixture", "phases": ["Solo"] };'
+  echo '/* META-END */'
+  echo 'phase("Solo");'
+  echo 'const r = await agent("control prompt", { label: "ctl" });'
+  echo 'log("done:" + JSON.stringify(r));'
+} > "$GOOD_FLOW"
+if node "$HARNESS" validate "$GOOD_FLOW" >/dev/null 2>&1; then
+  pass "T2/T3.c1 harness validate exits 0 on a conforming script"
+else
+  fail "T2/T3.c1 harness validate rejected a conforming control fixture"
+fi
+
+BAD_META="$TMPDIR_FIXTURES/bad-meta.js"
+printf 'const meta = { name: "x" };\n' > "$BAD_META"
+if node "$HARNESS" validate "$BAD_META" >/dev/null 2>&1; then
+  fail "T2/T3.c2 harness validate must exit non-zero when the META markers are missing"
+else
+  pass "T2/T3.c2 harness validate reds on missing META markers"
+fi
+
+UNDECLARED_PHASE="$TMPDIR_FIXTURES/undeclared-phase.js"
+{
+  echo '/* META-BEGIN */'
+  echo 'export const meta = { "name": "cli-control-2", "description": "phase-discipline control", "phases": ["Declared"] };'
+  echo '/* META-END */'
+  echo 'phase("Undeclared");'
+} > "$UNDECLARED_PHASE"
+if node "$HARNESS" validate "$UNDECLARED_PHASE" >/dev/null 2>&1; then
+  fail "T2/T3.c3 harness validate must red on a phase() literal missing from meta.phases"
+else
+  pass "T2/T3.c3 harness validate reds on an undeclared phase() literal"
+fi
+
+# ---------------------------------------------------------------------------
+# T2 + T3 per-script (meta shape, phase discipline, dry-run under stubs).
+# ---------------------------------------------------------------------------
+echo "== T2/T3: per-script validate =="
+if [ "$SCRIPT_COUNT" -eq 0 ]; then
+  pass "T2/T3 notice: no workflow scripts on disk yet — per-script validate vacuously green"
+else
+  while IFS= read -r script; do
+    [ -n "$script" ] || continue
+    base="${script#"$REPO_ROOT"/}"
+    if node "$HARNESS" validate "$script" >"$TMPDIR_FIXTURES/validate.out" 2>&1; then
+      pass "T2/T3 $base: meta valid + dry-run clean"
+    else
+      fail "T2/T3 $base: validate failed"
+      sed 's/^/        /' "$TMPDIR_FIXTURES/validate.out" | head -10
+    fi
+  done < "$SCRIPTS_FILE"
+fi
+
+# ---------------------------------------------------------------------------
+# T4 — shared-snippet drift guard (controls always run; cross-script run
+# only when scripts exist).
+# ---------------------------------------------------------------------------
+echo "== T4: shared-snippet drift guard =="
+
+DRIFT_A="$TMPDIR_FIXTURES/drift-a.js"
+DRIFT_B="$TMPDIR_FIXTURES/drift-b.js"
+{
+  echo '// === SHARED:envelope v1 ==='
+  echo 'const WRAP = "begin";'
+  echo '// === END SHARED ==='
+} > "$DRIFT_A"
+{
+  echo '// === SHARED:envelope v1 ==='
+  echo 'const WRAP = "BEGIN";'
+  echo '// === END SHARED ==='
+} > "$DRIFT_B"
+if node "$HARNESS" shared-drift "$DRIFT_A" "$DRIFT_B" >/dev/null 2>&1; then
+  fail "T4.c1 shared-drift must red on a same-name+version block that drifted by one byte"
+else
+  pass "T4.c1 shared-drift reds on byte drift in same-name+version SHARED blocks"
+fi
+cp "$DRIFT_A" "$DRIFT_B"
+if node "$HARNESS" shared-drift "$DRIFT_A" "$DRIFT_B" >/dev/null 2>&1; then
+  pass "T4.c2 shared-drift passes byte-identical SHARED blocks"
+else
+  fail "T4.c2 shared-drift rejected byte-identical SHARED blocks"
+fi
+
+if [ "$SCRIPT_COUNT" -eq 0 ]; then
+  pass "T4 notice: no workflow scripts on disk yet — cross-script drift check vacuously green"
+else
+  # Build the argv list defensively (paths may contain spaces).
+  drift_args=()
+  while IFS= read -r script; do
+    [ -n "$script" ] && drift_args+=("$script")
+  done < "$SCRIPTS_FILE"
+  if node "$HARNESS" shared-drift "${drift_args[@]}" >"$TMPDIR_FIXTURES/drift.out" 2>&1; then
+    pass "T4 cross-script SHARED blocks are byte-identical"
+  else
+    fail "T4 SHARED block drift across workflow scripts"
+    sed 's/^/        /' "$TMPDIR_FIXTURES/drift.out" | head -10
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# §4.2 shape guard — workflow.js cannot ship without its SKILL.md carrying
+# BOTH the Workflow invocation block and the No-Workflow fallback section.
+# Vacuous-pass today (zero scripts); load-bearing from Phase 2 on.
+# ---------------------------------------------------------------------------
+echo "== §4.2: Workflow opt-in + No-Workflow fallback shape guard =="
+
+GUARDED=0
+while IFS= read -r script; do
+  [ -n "$script" ] || continue
+  case "$script" in
+    */skills/*/workflow.js) ;;   # the guard applies to top-level skill scripts
+    *) continue ;;
+  esac
+  GUARDED=$((GUARDED + 1))
+  skill_md="$(dirname "$script")/SKILL.md"
+  base="${script#"$REPO_ROOT"/}"
+  if [ ! -r "$skill_md" ]; then
+    fail "§4.2 $base: sibling SKILL.md missing — a workflow script must version with its skill"
+    continue
+  fi
+  if grep -qE 'Workflow\(' "$skill_md" && grep -qF 'workflow.js' "$skill_md"; then
+    pass "§4.2 $base: SKILL.md carries the Workflow invocation block"
+  else
+    fail "§4.2 $base: SKILL.md lacks the Workflow invocation block (Workflow( + workflow.js scriptPath)"
+  fi
+  if grep -qF '## No-Workflow fallback' "$skill_md"; then
+    pass "§4.2 $base: SKILL.md carries the '## No-Workflow fallback' section"
+  else
+    fail "§4.2 $base: SKILL.md lacks the mandatory '## No-Workflow fallback' section (DR-10)"
+  fi
+done < "$SCRIPTS_FILE"
+if [ "$GUARDED" -eq 0 ]; then
+  pass "§4.2 notice: no skills/*/workflow.js on disk yet — shape guard vacuously green"
+fi
+
+echo
+echo "== Summary =="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Phase-1 **carrier** bundle of RFC 0012 (ultracode workflow migration): ships the complete `.js` workflow-script test architecture (T1–T4) with a self-testing node harness, the `uberdev_emit_workflow_args` config→args envelope helper with contract tests, the No-Workflow fallback platform convention, the uberthink frontmatter enum-lock extension (`fable` added, **no pin**), and the pinned docs surfaces — all landing **before** any `workflow.js` ships, so the first migrated pipeline (Phase 2 `/testers`) cannot land uncovered.

Part of RFC 0012 Phase 1 (per RFC 0012 §4.1–§4.4, §9 Phase-1 row docs requirements, §5 enum extension only).

## Changes

**Test architecture (§4.4, infra-R3)**
- NEW `tests/workflow-scripts.test.sh` — suite entry:
  - **T1 lint** via the pinned stdin form `node --check --input-type=module < "$f"` over glob-discovered workflow scripts (`plugins/*/skills/*/workflow*.js` + `workflows/*.js` children). The invocation form is asserted IN the test (control fixtures + self-anchor): verified live on Node v20.19.2 that the unpinned stdin form reds on the ESM script shape while detection-default runners pass it — unpinned guards flip on runner updates.
  - Forbidden-token greps (`import`/`require`/`process.`/`fs.`/`Date.now`/`Math.random`/`new Date(`) outside `SHARED` marker blocks, word-bounded with grep controls; 512 KB size cap.
  - **Passes with ZERO workflow.js files** (empty-glob → notice), while harness self-tests + T1/T2/T4 control fixtures keep it non-vacuous (16 asserts today).
  - **§4.2 shape guard**: every on-disk `skills/*/workflow.js` must have a sibling SKILL.md matching both the Workflow invocation block and the `## No-Workflow fallback` marker (vacuous-pass today; verified live against planted good/bad fixtures).
- NEW `tests/_workflow_harness.js` — T2 META-marker pure-JSON meta validation (`{name, description, phases[]}`, every `phase()`/`opts.phase` literal ∈ `meta.phases`); T3 preprocessing (strip the meta export, wrap in an async IIFE) + `vm.runInNewContext` dry-run under faithful stubs (`agent()` canned returns keyed by label/agentType, `parallel` = thunk-throws-to-null + barrier, `pipeline` = no inter-stage barrier + item drop, phase/log recorders, budget with falsy `total` default, throwing `Date.now`/`Math.random`/argless `new Date` shadows); T4 `// === SHARED:<name> v<N> ===` byte-drift guard. **58 self-test asserts** lock every stub semantic and the preprocessing.

**Config → args plumbing (§4.3, infra-R7)**
- `plugins/uberdev/lib/config-read.sh` gains `uberdev_emit_workflow_args <pipeline> KEY=VALUE...` — jq-assembled v1 envelope `{v, run_id, now_epoch, now_iso, plugin_root, repo_root, cwd, pipeline, config{}}` printed between `WORKFLOW_ARGS_BEGIN`/`WORKFLOW_ARGS_END` markers for verbatim relay (DR-2). Values are caller-resolved via the existing `uberdev_read_*` helpers (env > uberdev.local.md > default, warn-once sentinels and audit rows untouched). Frozen-time contract (DR-7) documented in the helper; the constant-name-expansion discipline of the four legacy indirect-expansion sites is preserved — the emitter contains **zero eval** (KEY/VALUE travel via `jq --arg` only, structurally + behaviorally locked).
- NEW `tests/workflow-args.test.sh` — 37 contract asserts: marker framing, envelope keys/types, config auto-typing (int/bool/string, leading-zero strings, dotted keys), reserved overrides vs locked keys, read-helper precedence composition + emitter stderr silence, injection canary (command-substitution/backtick/quote payloads execute nothing), never-eval discipline, error paths rc=2, frozen-time docs+enforcement. `config-override.test.sh` untouched (owned by the solve-launcher PR).

**Model policy (§5 — enum extension ONLY)**
- `tests/uberthink.test.sh:80` frontmatter enum → `(opus|sonnet|haiku|fable|inherit)`. No agent pins fable (open question Q5 — registry support unverified); the per-agent all-inherit WANT_MODEL locks stay untouched.

**Docs (§9 Phase-1 row + §4.1/§4.2)**
- `references/{gemini,copilot,codex}-tools.md`: one Workflow row each — "No equivalent — use the skill's `## No-Workflow fallback` section".
- `plugins/uberdev/docs/testing.md` (pinned by docs-accuracy.test.sh:26 — all 30 anchors stay green): T1–T4 tier table + harness pointer + helper-file mentions.
- `plugins/uberdev/skills/writing-skills/SKILL.md`: workflow-script authoring conventions — META markers, script constraints, versioned SHARED blocks, thin-preflight + args-envelope pattern (scriptPath via `${CLAUDE_PLUGIN_ROOT}`, saved-name form never), mandatory `## No-Workflow fallback` section.

**CI wiring**
- Both new tests wired into the ubuntu AND windows run lists in `.github/workflows/test.yml` (node + jq ship on both GitHub images; no new skip-list entries; ci-wiring W1–W4 green).

## Tests run

- Full ubuntu run list extracted from `.github/workflows/test.yml` (61 unique entries incl. zsh fixtures) — **all green, zero failures**, including both new test files.
- `node tests/_workflow_harness.js self-test` — 58/58.
- Non-vacuous live check: planted a good fixture `skills/_tmp-probe/workflow.js` (all tiers + shape guard PASS), then a corrupted one (forbidden tokens, undeclared phase, missing fallback) → 4 FAILs, exit 1; fixture removed.
- `bash tests/workflow-args.test.sh` 37/37; `config-override.test.sh` 90/90 and `findings-to-issues.test.sh` 53/53 (config-read.sh consumers) green.
- **Windows CI fix (second commit):** the first push redded `shape-checks-windows` on exactly one assert — W4.1, because Git-for-Windows bash rewrites absolute-POSIX-looking argv values (`/pr` → `C:/Program Files/Git/pr`) at the exec boundary when invoking the native `jq.exe`, before jq sees them. The emitter's data-not-code contract held; the test process now disables the conversion via the documented controls (`MSYS_NO_PATHCONV=1` + `MSYS2_ARG_CONV_EXCL='*'`, inert on POSIX). Live Windows preflight behavior untouched (the C:/-style conversion of real host paths is desirable for node-side consumption).

## Landing notes

- **No version bump — sequential landing per RFC 0012 §9** (bumps happen at landing; the two `assert_version_bump` locks move then).
- **test.yml run-list lines are shared with the ci/bump-version PRs (disjoint regions)** — this PR appends two lines at the END of both run blocks; rebase is trivial if those land first.
- **Land before any workflow.js ships** — this is the Phase-2 gate: the §4.2 shape guard, T1–T4 tiers and authoring conventions must be on main before the first migrated pipeline PR.
- RFC anchor verified-divergence (R-16 cross-check): §4.4's T1 note says bare `node --check` reds on the ESM shape on Node v20.19.2 — live probe shows the **file form passes** on 20.19.2 (module detection backported) while the **stdin form without `--input-type=module`** is what reds there; ≥22.7 detection passes both. The design conclusion (pin the form in-test) is unchanged and implemented; the RFC's repro sentence should be corrected to name the stdin form when the RFC text lands in-repo.

