### PR TITLE
fix(ci): tolerate mutex turnover in lease observer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uberdev",
       "source": "./plugins/uberdev",
       "description": "GitHub workflow commands + full Superpowers skill suite (brainstorm with visual companion, write-plan, execute-plan, subagent-driven-dev wave-based parallel execution, finish-branch, systematic-debugging, TDD, worktrees, parallel-agents, verification, code-review pair, writing-skills, using-uberdev primer) and PR review agents. /solve and /turbo dispatch autonomous agents via a platform-aware dispatch backend (claude-bg / wezterm / background; auto-selected per OS — cross-platform on macOS, WSL2, native Windows); /issue creates well-investigated, deduped issues.",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "category": "workflow",
       "tags": [
         "github",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to UberDev are documented here.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.1] — 2026-07-11
+
+### Fixed
+
+- Hardened the live-semaphore CI observer against concurrent mutex generation removal while preserving strict direct-lease counting.
+
 ## [0.40.0] — 2026-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Personal Claude Code marketplace — opinionated GitHub-workflow slash commands.**
 
-[![Version](https://img.shields.io/badge/version-0.40.0-blue)](./CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.40.1-blue)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-8B5CF6)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Repo Agnostic](https://img.shields.io/badge/repo--agnostic-yes-success)](#configuration)

--- a/codex/uberdev-codex/.codex-plugin/plugin.json
+++ b/codex/uberdev-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev-codex",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "UberDev workflow toolkit for Codex: brainstorm/plan/execute, TDD, systematic-debugging, parallel-fanout PR review, autonomous GitHub issue triage and resolution. Skills ship here; the 42 subagents install separately via codex/install-codex.sh (Codex plugin manifest has no agents field).",
   "author": {
     "name": "TheFJK",

--- a/plugins/uberdev/.claude-plugin/plugin.json
+++ b/plugins/uberdev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uberdev",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Production-grade Claude Code plugin: parallel-fanout PR review, autonomous GitHub issue triage and resolution via a platform-aware dispatch backend (claude-bg / wezterm / background; cross-platform — macOS, WSL2, native Windows), brainstorm/plan/execute workflows with wave-based subagent dispatch.",
   "author": {
     "name": "TheFJK",

--- a/tests/goal.test.sh
+++ b/tests/goal.test.sh
@@ -422,8 +422,8 @@ assert_no_grep "$GOAL_LIB" '\bbash -c'                                   "G19.no
 assert_grep "$GOAL_CMD" '--i-know-what-im-doing'                         "G19.r12-mentioned-once"
 
 echo
-echo "== G20: version bump locked (0.40.0) =="
-assert_version_bump "$REPO_ROOT" "0.40.0"
+echo "== G20: version bump locked (0.40.1) =="
+assert_version_bump "$REPO_ROOT" "0.40.1"
 assert_no_grep "$REPO_ROOT/tests/solve-claim.test.sh"               '0\.30\.0'               "G20.solve-claim-no-old-version"
 
 assert_grep "$GOAL_SKILL" 'uberdev_dispatch_resolve_env'  "G20b.phase0-wires-resolve-env (#175 SSOT anchor)"

--- a/tests/live-semaphore.test.sh
+++ b/tests/live-semaphore.test.sh
@@ -579,7 +579,7 @@ record_max() {
   rmdir "$TMP/max.lock"
 }
 count_race_leases() {
-  local scope_root="$RACE_STATE/semaphore-v1" scope listing scope_count count=0
+  local scope_root="$RACE_STATE/semaphore-v1" scope lease count=0
   if [ ! -d "$scope_root" ]; then
     printf '0\n'
     return 0
@@ -589,13 +589,50 @@ count_race_leases() {
       continue
     fi
     [ -d "$scope" ] && [ ! -L "$scope" ] || return 1
-    listing="$(find "$scope" -mindepth 1 -maxdepth 1 -name '*.lease' -type f -print)" || return $?
-    [ -n "$listing" ] || continue
-    scope_count="$(printf '%s\n' "$listing" | awk 'END { print NR }')" || return $?
-    count=$((count + scope_count))
+    for lease in "$scope"/*.lease; do
+      if [ -L "$lease" ]; then
+        return 1
+      fi
+      if [ -f "$lease" ]; then
+        count=$((count + 1))
+      elif [ -e "$lease" ]; then
+        return 1
+      fi
+    done
   done
   printf '%s\n' "$count"
 }
+
+# Simulate GNU find observing a mutex generation after it was selected for
+# traversal but before it can be visited. Lease observation must remain valid
+# because mutex generations are unrelated to the direct *.lease population.
+OBSERVER_SCOPE="$RACE_STATE/semaphore-v1/observer.scope"
+OBSERVER_FIND_BIN="$TMP/observer-find-bin"
+mkdir -p "$OBSERVER_SCOPE/.mutex" "$OBSERVER_FIND_BIN"
+printf 'lease\n' > "$OBSERVER_SCOPE/observer.lease"
+observer_find="$OBSERVER_FIND_BIN/find"
+# These variables are expanded by the generated shim, not this test process.
+# shellcheck disable=SC2016
+printf '%s\n' '#!/bin/sh' \
+  'scope=$1' \
+  'while [ -d "$scope/.mutex" ]; do sleep 0.01; done' \
+  'printf "find: %s/.mutex: No such file or directory\\n" "$scope" >&2' \
+  'exit 1' > "$observer_find"
+chmod +x "$observer_find"
+(sleep 0.02; rm -rf "$OBSERVER_SCOPE/.mutex") &
+observer_remover=$!
+observer_count="$(PATH="$OBSERVER_FIND_BIN:$PATH" count_race_leases 2>"$TMP/observer-find.err")"
+observer_rc=$?
+wait "$observer_remover"
+if [ "$observer_rc" -eq 0 ] && [ "$observer_count" -eq 1 ] \
+   && [ ! -e "$OBSERVER_SCOPE/.mutex" ] && [ ! -s "$TMP/observer-find.err" ]; then
+  pass "lease observation ignores a concurrently removed mutex generation"
+else
+  fail "lease observation ignores a concurrently removed mutex generation" \
+    "rc=$observer_rc count=$observer_count stderr=$(cat "$TMP/observer-find.err")"
+fi
+rm -rf "$OBSERVER_SCOPE" "$OBSERVER_FIND_BIN"
+
 race_pids=""
 n=1
 while [ "$n" -le 8 ]; do

--- a/tests/live-semaphore.test.sh
+++ b/tests/live-semaphore.test.sh
@@ -603,6 +603,31 @@ count_race_leases() {
   printf '%s\n' "$count"
 }
 
+UNSAFE_COUNT_SCOPE="$RACE_STATE/semaphore-v1/unsafe-count.scope"
+mkdir -p "$UNSAFE_COUNT_SCOPE"
+printf 'unchanged\n' > "$TMP/unsafe-count-victim"
+ln -s "$TMP/unsafe-count-victim" "$UNSAFE_COUNT_SCOPE/symlink.lease"
+unsafe_count_out="$(count_race_leases 2>"$TMP/unsafe-count.err")"
+unsafe_count_rc=$?
+if [ "$unsafe_count_rc" -ne 0 ]; then
+  pass "lease observation rejects a symlink named as a lease"
+else
+  fail "lease observation rejects a symlink named as a lease" \
+    "rc=$unsafe_count_rc count=$unsafe_count_out stderr=$(cat "$TMP/unsafe-count.err")"
+fi
+rm -rf "$UNSAFE_COUNT_SCOPE"
+
+mkdir -p "$UNSAFE_COUNT_SCOPE/directory.lease"
+unsafe_count_out="$(count_race_leases 2>"$TMP/unsafe-count.err")"
+unsafe_count_rc=$?
+if [ "$unsafe_count_rc" -ne 0 ]; then
+  pass "lease observation rejects a stable non-regular lease candidate"
+else
+  fail "lease observation rejects a stable non-regular lease candidate" \
+    "rc=$unsafe_count_rc count=$unsafe_count_out stderr=$(cat "$TMP/unsafe-count.err")"
+fi
+rm -rf "$UNSAFE_COUNT_SCOPE"
+
 # Simulate GNU find observing a mutex generation after it was selected for
 # traversal but before it can be visited. Lease observation must remain valid
 # because mutex generations are unrelated to the direct *.lease population.
@@ -624,12 +649,14 @@ observer_remover=$!
 observer_count="$(PATH="$OBSERVER_FIND_BIN:$PATH" count_race_leases 2>"$TMP/observer-find.err")"
 observer_rc=$?
 wait "$observer_remover"
+observer_remover_rc=$?
 if [ "$observer_rc" -eq 0 ] && [ "$observer_count" -eq 1 ] \
-   && [ ! -e "$OBSERVER_SCOPE/.mutex" ] && [ ! -s "$TMP/observer-find.err" ]; then
+   && [ "$observer_remover_rc" -eq 0 ] && [ ! -e "$OBSERVER_SCOPE/.mutex" ] \
+   && [ ! -s "$TMP/observer-find.err" ]; then
   pass "lease observation ignores a concurrently removed mutex generation"
 else
   fail "lease observation ignores a concurrently removed mutex generation" \
-    "rc=$observer_rc count=$observer_count stderr=$(cat "$TMP/observer-find.err")"
+    "rc=$observer_rc remover_rc=$observer_remover_rc count=$observer_count stderr=$(cat "$TMP/observer-find.err")"
 fi
 rm -rf "$OBSERVER_SCOPE" "$OBSERVER_FIND_BIN"
 

--- a/tests/solve-claim.test.sh
+++ b/tests/solve-claim.test.sh
@@ -273,8 +273,8 @@ assert_grep "$SOLVE_CMD" \
   "small-team issue-claim protocol" \
   "solve.md mentions small-team claim protocol"
 
-echo "== Version bump 0.39.1 -> 0.40.0 propagated =="
-assert_version_bump "$REPO_ROOT" "0.40.0"
+echo "== Version bump 0.40.0 -> 0.40.1 propagated =="
+assert_version_bump "$REPO_ROOT" "0.40.1"
 
 echo "== #123 B1: closing-keyword regex left-anchor (rejects preclose/postfix/unresolve) =="
 # The closing-keyword regex in merge-pipeline Step 3.4 MUST require either start-of-input


### PR DESCRIPTION
## Summary

- replace the race-test helper's scope-wide find with direct lease enumeration
- add a deterministic regression for concurrent mutex generation removal
- propagate the required patch release version to 0.40.1

## Test plan

- bash tests/live-semaphore.test.sh
- bash tests/goal.test.sh
- bash tests/solve-claim.test.sh
- bash tests/bump-version.test.sh
- bash tests/child-dispatch.test.sh

Closes #332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of live semaphore monitoring during concurrent mutex-generation removal.
  * Preserved accurate direct-lease counting in race conditions.

* **Documentation**
  * Added release notes describing the live semaphore monitoring fix.

* **Chores**
  * Updated the release version to 0.40.1 across plugin manifests, the README, and version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->