### PR TITLE
feat(prkit): generator for standalone PR-phase plugin (RFC 0014)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,7 @@ jobs:
           bash tests/review-pr.test.sh && \
           bash tests/review-pr-phase3-ci.test.sh && \
           bash tests/prkit-manifest.test.sh && \
+          bash tests/prkit-codex-manifest.test.sh && \
           bash tests/prkit-rewrite.test.sh && \
           bash tests/prkit-verify.test.sh && \
           bash tests/prkit-generate.test.sh && \
@@ -298,6 +299,7 @@ jobs:
           bash tests/audit-fixups.test.sh && \
           bash tests/review-pr.test.sh && \
           bash tests/prkit-manifest.test.sh && \
+          bash tests/prkit-codex-manifest.test.sh && \
           bash tests/cluster.test.sh && \
           bash tests/code-fixer-dispatch.test.sh && \
           bash tests/findings-to-issues.test.sh && \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,10 @@ jobs:
           bash tests/audit-fixups.test.sh && \
           bash tests/review-pr.test.sh && \
           bash tests/review-pr-phase3-ci.test.sh && \
+          bash tests/prkit-manifest.test.sh && \
+          bash tests/prkit-rewrite.test.sh && \
+          bash tests/prkit-verify.test.sh && \
+          bash tests/prkit-generate.test.sh && \
           bash tests/cluster.test.sh && \
           bash tests/cluster-pipeline.test.sh && \
           bash tests/code-fixer-dispatch.test.sh && \
@@ -272,6 +276,9 @@ jobs:
         #   - dispatch-routing-parity.test.sh
         #   - orchestrator-plan-flatten.test.sh
         #   - sdd-routed-lifecycle.test.sh
+        #   - prkit-rewrite.test.sh
+        #   - prkit-verify.test.sh
+        #   - prkit-generate.test.sh
 #   - review-pr-phase3-ci.test.sh
 #   - review-child-handoff.test.sh
 #   - lib-assert-count.test.sh
@@ -290,6 +297,7 @@ jobs:
           bash tests/spec-reviewer-plan-aware.test.sh && \
           bash tests/audit-fixups.test.sh && \
           bash tests/review-pr.test.sh && \
+          bash tests/prkit-manifest.test.sh && \
           bash tests/cluster.test.sh && \
           bash tests/code-fixer-dispatch.test.sh && \
           bash tests/findings-to-issues.test.sh && \

--- a/docs/rfc/0014-prkit-standalone-plugin.md
+++ b/docs/rfc/0014-prkit-standalone-plugin.md
@@ -87,12 +87,12 @@ prkit/                                   # repo root
 │   ├── lib/       (11)
 │   └── policy/model-routing-v1.json
 ├── README.md  LICENSE  NOTICE  CHANGELOG.md  .gitignore
-└── .github/workflows/ci.yml            # shellcheck + py_compile + jq + verify.sh
+└── .github/workflows/ci.yml            # bash -n + ast.parse + jq + tomllib + inline uberdev grep
 ```
 
 Mirroring `plugins/prkit/` (vs. plugin-at-repo-root) keeps generator copy paths uniform (`plugins/uberdev/X` → `plugins/prkit/X`) and matches the marketplace `source: ./plugins/<name>` pattern already used in UberDev.
 
-### 5.3 Copy manifest (the PR-phase subgraph — ~31 files)
+### 5.3 Copy manifest (the PR-phase subgraph — 32 files)
 
 Source paths under `plugins/uberdev/`. Authoritative, verified copy set.
 
@@ -147,7 +147,7 @@ Runs at the end of every generation; non-zero exit fails the build. Also runnabl
 - **Token guard:** no `uberdev` (case-insensitive) or `UBERDEV_` survives under `plugins/prkit/`, except an explicit allowlist (LICENSE/NOTICE origin attribution).
 - **Referential integrity:** every `subagent_type: prkit:X` ↔ `agents/X.md`; every `Skill(prkit:X)` ↔ `skills/X/SKILL.md`; every `${CLAUDE_PLUGIN_ROOT}/lib/Y` and `/policy/Z` reference resolves to a copied file; **no** residual out-of-set ref (`prkit:goal`, `prkit:solve`).
 - **Syntax:** `bash -n` on every `.sh`; `python3 -m py_compile` on every `.py`; `jq empty` on every `.json`.
-- **Manifest agreement:** files present under `plugins/prkit/` equal manifest ∪ scaffold (no orphan, no missing).
+- **Manifest completeness** is enforced by `tests/prkit-manifest.test.sh` (count-lock + every source exists), not by `verify.sh`; verify's own non-vacuity + shape checks assert the generated tree is plausibly-sized and has the required files.
 
 ---
 
@@ -214,7 +214,7 @@ The verify gate's token guard + referential-integrity checks mechanically enforc
 
 - **Generator unit checks** (UberDev repo `tests/`): manifest completeness (every listed file exists in SSOT); rewrite applier maps each ruleset case on fixtures; neutralization removes the enumerated out-of-set sites.
 - **Verify-gate self-test:** deliberately-broken tree (surviving token / dangling ref / missing lib) must fail; clean tree must pass.
-- **prkit CI (`.github/workflows/ci.yml`):** `shellcheck` + `bash -n`, `python3 -m py_compile`, `jq empty`, and `verify.sh` on the committed tree.
+- **prkit CI (`.github/workflows/ci.yml`):** `bash -n`, `ast.parse` (artifact-free python syntax), `jq empty`, `tomllib`, and an inline `grep -rilE 'uberdev'` namespace guard on the committed tree — a subset of `verify.sh` (which runs only at generation time in UberDev, not in the prkit repo). Each `find` gate uses `|| exit 1` because `find -exec … \;` does not propagate failure.
 - **Smoke test (manual, documented):** install prkit locally, run `/prkit:review-pr` on a throwaway PR, confirm fanout dispatches `prkit:*` agents with no `uberdev:*` resolution; run `/prkit:merge` dry path.
 - **Determinism check:** generate twice into clean targets; `diff -r` empty.
 

--- a/docs/rfc/0014-prkit-standalone-plugin.md
+++ b/docs/rfc/0014-prkit-standalone-plugin.md
@@ -243,3 +243,24 @@ The verify gate's token guard + referential-integrity checks mechanically enforc
 ## 13. Handoff
 
 Terminal step of brainstorm: invoke `uberdev:write-plan` to produce the wave-decomposed implementation plan for the generator + templates + verify gate + first prkit generation.
+
+---
+
+## 14. Codex port addendum (SHIPPED)
+
+UberDev supports **two runtimes**: Claude Code (`plugins/uberdev/`) and the OpenAI Codex CLI (`codex/uberdev-codex/` native plugin + `codex/install-codex.sh` one-liner). The Claude-only extraction above left prkit unusable on Codex, so the generator was extended to also emit a Codex port — same SSOT extract+rewrite model.
+
+### 14.1 Approach
+UberDev's Codex tree is already Codex-adapted (commands→`uberdev-cmd-*` command-skills, agents→TOML via `codex/tools/convert-agents.py`, paths fixed to `~/.codex`/`CODEX_HOME`/`.codex-plugin`). So prkit's Codex port is extracted **from `codex/uberdev-codex/`** (not re-transformed from scratch): a second manifest (`tools/prkit/manifest-codex.txt`, count-locked at **51**) drives a copy stage that rewrites both the **destination path** and the **content** with `uberdev`→`prkit`. The existing blanket rewrite already handles every Codex-specific literal — `uberdev-codex`→`prkit-codex`, `uberdev-cmd-`→`prkit-cmd-`, the TOML agent names, the `uberdev-codex-primer` sentinel.
+
+### 14.2 New rewrite rule (fixes both trees)
+Repo-slug rule, ordered before the CamelCase pass: `TheFJK/UberDev`→`TheFJK/prkit` (lowercase), so clone/marketplace URLs in `install-codex.sh` resolve. Without it the CamelCase rule would mangle the slug to `TheFJK/Prkit` (a nonexistent repo).
+
+### 14.3 Codex copy set (51) + scaffold
+`codex/prkit-codex/`: 3 `prkit-cmd-*` command-skills, 3 support-skill files (`post-impl-review`, `merge-pipeline` + `lib/discover.sh`), 14 agent `.md`, 11 lib, 1 policy, `.codex-plugin` manifest (templated), `hooks/` (2), `shared/` (1); `codex/agents/prkit-*.toml` (14, reference); `codex/install-codex.sh` + `codex/tools/convert-agents.py` (the installer path that carries the agents — required because the Codex plugin manifest has no `agents` field). Three scaffold docs are **authored templates** (`codex-plugin.json.tmpl`, `codex-README.md.tmpl`, `codex-AGENTS.md.tmpl`) with prkit-correct counts (3 commands, 14 agents, 5 skills) rather than extract+rewrite, so they don't inherit UberDev's stale "44 subagents".
+
+### 14.4 Verify + tests
+`verify.sh` now scans both trees (space-safe arrays), adds TOML validation (`tomllib`, skipped gracefully if absent) and a Codex shape check. Tests: `tests/prkit-codex-manifest.test.sh` (completeness + count-lock 51) + `prkit-generate.test.sh` G6–G8 (codex tree presence, uberdev-free, determinism). The verify gate caught 3 real gaps during bring-up (template `UberDev` mentions leaking into scanned `codex/`).
+
+### 14.5 Resolves open item §12
+The `config-read.sh` codex-fallback path (`uberdev-codex`→`prkit-codex`) is handled by the blanket rewrite (not dropped) — the composite `${CODEX_HOME}/plugins/prkit-codex/...` correctly points at prkit's Codex runtime dir.

--- a/docs/rfc/0014-prkit-standalone-plugin.md
+++ b/docs/rfc/0014-prkit-standalone-plugin.md
@@ -1,0 +1,245 @@
+# RFC 0014 — `prkit`: standalone PR-phase plugin generated from UberDev
+
+| Field | Value |
+| --- | --- |
+| **Status** | Accepted (brainstorm complete) → hand to `write-plan` |
+| **Author** | TheFJK |
+| **Created** | 2026-07-12 |
+| **Tier** | Medium (new build tooling + one generated repo) |
+| **Target ver** | prkit `0.1.0` (independent SemVer); UberDev gains `tools/prkit/` (no user-facing UberDev change) |
+| **Related** | RFC 0001/0002 (`review-pr` phases), `skills/merge-pipeline`, `skills/post-impl-review`, RFC 0013 (dispatch/model-routing lib) |
+
+---
+
+## 1. Decision
+
+Extract UberDev's **PR phase** (review → fix → simplify → land) into a new, standalone, coexist-safe Claude Code plugin named **`prkit`**, shipped from its **own repo**, and kept current by a **generator** that treats UberDev as the single source of truth. The generator copies the PR-phase dependency subgraph, applies a namespace-rewrite ruleset (`uberdev:` → `prkit:`, `UBERDEV_*` → `PRKIT_*`, config file, path fragments, label/trailer values, metadata), scaffolds the standalone repo files, and runs a verification gate that fails the build on any surviving `uberdev` token, dangling namespace reference, or missing lib/policy file. The prkit repo is a **build artifact** — regeneration prevents drift as UberDev's `review-pr`/`merge` evolve.
+
+---
+
+## 2. Commands shipped
+
+| Command | Purpose |
+|---|---|
+| `/prkit:review-pr` | Parallel-fanout post-implementation review + auto-fix + CI-failure routing |
+| `/prkit:simplify` | Reuse/quality/efficiency lens audit + fix |
+| `/prkit:merge` | Trust-trail check → strategy pick → conflict resolution → land |
+
+---
+
+## 3. Goals / Non-goals
+
+### Goals
+- Minimal, self-contained plugin with the three PR-phase commands and their full transitive dependency graph.
+- Coexistence: installable at the same time as UberDev with **no** command / agent / skill / label / env-var collision.
+- Single source of truth in UberDev; a deterministic, idempotent, re-runnable generator so prkit never rots.
+- A verify gate strong enough that a botched rewrite fails the build instead of shipping broken.
+
+### Non-goals (YAGNI cuts for v1)
+- **No hooks.** UberDev's SessionStart injects the whole `using-uberdev` skill and installs aliases; prkit ships neither. Users invoke `/prkit:review-pr` etc. directly.
+- **No short-form aliases** (`/review-pr`, `/simplify`, `/merge`) — they would collide with UberDev's under coexistence.
+- **No** brainstorm / solve / turbo / goal / testers / uberthink / uberscan / cluster / dev machinery.
+- No runtime code sharing between the two installed plugins (each is self-contained via its own `${CLAUDE_PLUGIN_ROOT}`).
+
+---
+
+## 4. Locked decisions (from brainstorm)
+
+| Axis | Decision | Consequence |
+|---|---|---|
+| Coexist with full UberDev | **Yes** | Forces `prkit:` namespace rewrite of every internal reference. |
+| Name / namespace | **`prkit`** | Commands `/prkit:*`; agents `prkit:*`; skills `prkit:*`. |
+| Location | **Brand-new repo** | prkit gets its own marketplace.json, README, LICENSE, CHANGELOG, CI, SemVer. |
+| Sync relationship | **Generator script** | SSOT = UberDev; generator lives in `tools/prkit/`; prkit repo is generated. |
+| `/merge` in scope | **Yes** | Full PR phase. Also required: `review-pr` reads CI constants defined in the `merge-pipeline` skill, so that skill ships regardless. |
+
+---
+
+## 5. Architecture
+
+### 5.1 Two repos, one source of truth
+
+```
+UberDev repo (this repo)                     prkit repo (new, generated)
+─────────────────────────                    ───────────────────────────
+plugins/uberdev/            ──generate──►     plugins/prkit/
+  commands/ agents/ …                           commands/ agents/ …  (namespace-rewritten)
+tools/prkit/                                   .claude-plugin/marketplace.json
+  generate.sh  manifest.txt                    README.md LICENSE CHANGELOG.md
+  rewrite-rules  templates/  verify.sh         .github/workflows/  .gitignore
+docs/rfc/0014-prkit-standalone-plugin.md       (this RFC stays in UberDev)
+```
+
+The generator **writes into a target directory** (a checkout/worktree of the prkit repo) passed as `--target`. It never commits or pushes; committing prkit is a separate, explicit step in the prkit repo.
+
+### 5.2 prkit repo layout (generated)
+
+```
+prkit/                                   # repo root
+├── .claude-plugin/marketplace.json      # lists prkit; "source": "./plugins/prkit"
+├── plugins/prkit/
+│   ├── .claude-plugin/plugin.json       # metadata only (name=prkit, version, …)
+│   ├── commands/  (3)
+│   ├── agents/    (14)
+│   ├── skills/
+│   │   ├── post-impl-review/SKILL.md
+│   │   └── merge-pipeline/SKILL.md + lib/discover.sh
+│   ├── lib/       (11)
+│   └── policy/model-routing-v1.json
+├── README.md  LICENSE  NOTICE  CHANGELOG.md  .gitignore
+└── .github/workflows/ci.yml            # shellcheck + py_compile + jq + verify.sh
+```
+
+Mirroring `plugins/prkit/` (vs. plugin-at-repo-root) keeps generator copy paths uniform (`plugins/uberdev/X` → `plugins/prkit/X`) and matches the marketplace `source: ./plugins/<name>` pattern already used in UberDev.
+
+### 5.3 Copy manifest (the PR-phase subgraph — ~31 files)
+
+Source paths under `plugins/uberdev/`. Authoritative, verified copy set.
+
+**commands/ (3):** `review-pr.md`, `simplify.md`, `merge.md`
+
+**agents/ (14):**
+- Reviewers (via `post-impl-review` fanout): `code-reviewer.md`, `silent-failure-hunter.md`, `type-design-analyzer.md`, `comment-analyzer.md`, `pr-test-analyzer.md`
+- Fixers: `code-fixer.md`, `code-simplifier.md`
+- CI-failure path: `ci-failure-classifier.md`, `ci-code-fixer.md`, `ci-rebase-handler.md`
+- Merge path: `trust-trail-evaluator.md`, `merge-strategy-decider.md`, `conflict-resolver.md`
+- Issue sink (shared): `findings-to-issues.md`
+
+**skills/ (2 + skill-local lib):** `post-impl-review/SKILL.md`, `merge-pipeline/SKILL.md`, `merge-pipeline/lib/discover.sh`
+
+**lib/ (11):** `child-dispatch.sh`, `agent-dispatch.sh`, `dispatch.sh`, `config-read.sh`, `model_routing.py`, `run_manifest.py`, `live-semaphore.sh`, `child-receipts.py`, `child-inputs.py`, `command-workspace.py`, `secret-scan.sh`
+
+**policy/ (1):** `model-routing-v1.json` — default routing policy resolved via `${CLAUDE_PLUGIN_ROOT}/policy/model-routing-v1.json`. **Correction over the initial dependency trace** (missed because it is a runtime data file loaded by path, not a Python import).
+
+**Explicitly excluded:** `policy/solve-run-tree-v1.json` (solve-only), `lib/goal-state.sh` (consumer-side, read by `/goal`), all hooks, `lib/aliases-sync.sh` + `commands/install-aliases.md`, everything else in UberDev.
+
+The manifest is stored declaratively (`tools/prkit/manifest.txt`) so the copy set is auditable and the verify gate can cross-check it.
+
+### 5.4 Rewrite ruleset (ordered, allowlisted — NOT a blind sed)
+
+Applied to every copied file's contents; order matters; each rule is scoped to avoid over-rewriting.
+
+1. **Namespace references** — `uberdev:<name>` in the three forms → `prkit:<name>`: `subagent_type: uberdev:X` / `subagent_type=uberdev:X`; `Skill(uberdev:X)`; `/uberdev:X` prose. Only for **in-set** targets (3 commands, 14 agents, 2 skills).
+2. **Out-of-set reference neutralization** — `/uberdev:goal` and `/uberdev:solve` are prose-mentioned but **not** in prkit. Do **not** rewrite into dangling `/prkit:goal` / `/prkit:solve`; remove or reword the chaining prose (merge's `auto_review_on_merge` `/goal` carve-out; review-pr's `locked`-marker note read by `/goal`). Sites enumerated at plan time.
+3. **Env-var prefix** — `UBERDEV_` → `PRKIT_` across **all** copied `.sh` and `.py` files (~130 vars). Producer and consumer are both in-set, so uniform rewrite stays consistent.
+4. **Config file name** — `uberdev.local.md` → `prkit.local.md` (and `.claude/uberdev.local.md` path form).
+5. **Path fragments** — literal `plugins/uberdev/` → `plugins/prkit/`; the `uberdev-codex` fallback path in `config-read.sh` → `prkit-codex` **or dropped** (prkit ships no codex variant in v1; drop is simpler — decide at plan time).
+6. **Label / trailer VALUES** (isolate prkit's trust domain from UberDev's):
+   - `uberdev-approved` → `prkit-approved` (trust trailer/label; `PRKIT_APPROVED_LABEL` default value)
+   - `uberdev-executable` → `prkit-executable`
+   - findings-to-issues marker slug (default `review-pr`, marker `<slug>-finding`) and `review-pr:pending`-style labels → prkit-namespaced. Concrete values finalized at plan time; **invariant: prkit and UberDev must never read/write each other's labels or trailers.**
+7. **Metadata** — `plugin.json`/`marketplace.json` `name`/`description`/`author`/`homepage`/`repository`/`version`; README title; product-name prose in generated docs → prkit's values. (Origin attribution intentionally preserved in `LICENSE`/`NOTICE`.)
+
+### 5.5 Scaffold templates (standalone-only files)
+
+Emitted/refreshed from `tools/prkit/templates/`, not copied from UberDev:
+- `plugin.json` (metadata only — convention-based discovery, no command/agent/skill arrays)
+- `marketplace.json` (single prkit entry, `source: ./plugins/prkit`)
+- `README.md` (prkit-focused: what it is, install, the three commands, runtime deps `gh`/`git`/`jq`/`python3`, optional `gitleaks`)
+- `LICENSE` (MIT) + `NOTICE` (credits UberDev / Superpowers / pr-review-toolkit / code-simplifier origins — carried from `plugins/uberdev/licenses/*`)
+- `CHANGELOG.md` (Keep a Changelog; `## [0.1.0] — 2026-07-12`)
+- `.gitignore`, `.github/workflows/ci.yml`
+
+### 5.6 Verify gate (anti-drift / anti-broken-namespace)
+
+Runs at the end of every generation; non-zero exit fails the build. Also runnable standalone in prkit CI.
+
+- **Token guard:** no `uberdev` (case-insensitive) or `UBERDEV_` survives under `plugins/prkit/`, except an explicit allowlist (LICENSE/NOTICE origin attribution).
+- **Referential integrity:** every `subagent_type: prkit:X` ↔ `agents/X.md`; every `Skill(prkit:X)` ↔ `skills/X/SKILL.md`; every `${CLAUDE_PLUGIN_ROOT}/lib/Y` and `/policy/Z` reference resolves to a copied file; **no** residual out-of-set ref (`prkit:goal`, `prkit:solve`).
+- **Syntax:** `bash -n` on every `.sh`; `python3 -m py_compile` on every `.py`; `jq empty` on every `.json`.
+- **Manifest agreement:** files present under `plugins/prkit/` equal manifest ∪ scaffold (no orphan, no missing).
+
+---
+
+## 6. Component breakdown (generator, under `tools/prkit/`)
+
+| Component | Purpose | Interface | Depends on |
+|---|---|---|---|
+| `manifest.txt` | Declarative copy set (paths grouped by dir) | data | — |
+| `rewrite-rules` | The §5.4 ruleset as data + a tiny applier | `apply_rewrites <file>` | manifest |
+| `templates/` | Scaffold files with `{{VERSION}}`/`{{DATE}}` placeholders | data | — |
+| `generate.sh` | Orchestrator: preflight → clean → copy → rewrite → scaffold → verify → summary | `generate.sh --target <dir> [--version X.Y.Z]` | all above |
+| `verify.sh` | The §5.6 gate | `verify.sh <prkit-root>` | — |
+
+**Stage flow (`generate.sh`):** (1) preflight — `--target` is a git worktree, refuse dirty unless `--force`; (2) clean generated `plugins/prkit/`; (3) copy per `manifest.txt`; (4) rewrite + out-of-set neutralization; (5) scaffold templates (interpolate version/date); (6) verify — fail run on any violation; (7) summary + "commit in target repo" hint.
+
+Idempotent: same UberDev SSOT + version ⇒ byte-identical generated output.
+
+---
+
+## 7. Data flow
+
+```
+UberDev SSOT (plugins/uberdev/**)
+      │  tools/prkit/generate.sh --target ../prkit
+      ▼
+copy → rewrite (namespace/env/config/path/label/meta) → scaffold → verify
+      │
+      ▼
+prkit repo working tree (plugins/prkit/** + repo files)
+      │  (human) git add/commit/tag/push in prkit repo
+      ▼
+prkit marketplace → user `/plugin` install → `/prkit:review-pr` runs,
+resolving ${CLAUDE_PLUGIN_ROOT} to prkit's own root (fully self-contained)
+```
+
+---
+
+## 8. Coexistence & namespace correctness (core invariant)
+
+With both plugins installed, there must be **zero** shared mutable surface:
+- **Commands:** `/uberdev:review-pr` vs `/prkit:review-pr` — distinct.
+- **Agents/skills:** dispatched/invoked only by fully-qualified `prkit:` names inside prkit; UberDev only ever names `uberdev:`.
+- **Env vars:** `PRKIT_*` vs `UBERDEV_*` — no overlap, so concurrent runs don't clobber state.
+- **Config file:** `.claude/prkit.local.md` vs `.claude/uberdev.local.md`.
+- **GitHub labels / trust trailers:** `prkit-approved` vs `uberdev-approved`; distinct finding markers — so a prkit review never satisfies an UberDev merge's trust check, and vice versa.
+
+The verify gate's token guard + referential-integrity checks mechanically enforce this on every build.
+
+---
+
+## 9. Edge cases & risks
+
+1. **Env-var self-initialization without a hook.** Some `UBERDEV_*` vars (e.g. `UBERDEV_TMPDIR`) may be set by UberDev's SessionStart hook and merely *read* by lib. prkit ships no hook. **Plan-time task:** for every `PRKIT_*` var read by copied lib, confirm the lib self-initializes it with a default; add defaults where a var was hook-only. Correctness gate.
+2. **Out-of-set references** — enumerated and neutralized (§5.4 rule 2); verify gate forbids residuals.
+3. **Policy data file** — `policy/model-routing-v1.json` must ship; `config-read.sh` resolves it via `${CLAUDE_PLUGIN_ROOT}/policy/…`, correctly pointing at prkit's root after the path-fragment rewrite.
+4. **Hardcoded fallback paths** in `config-read.sh` (`plugins/uberdev/…`, `uberdev-codex/…`) — rewritten (rule 5) or codex fallback dropped; verify no `uberdev` survives.
+5. **Label trust-domain leakage** — mitigated by rule 6; its own verify check.
+6. **`merge` ↔ `review-pr` coupling** — both in set; `merge`'s optional `auto_review_on_merge` chain to `Skill(prkit:review-pr)` stays intra-plugin. The `/goal` carve-out prose is neutralized.
+7. **Rewrite over/under-reach** — guarded both sides: token guard catches *under*-rewrite (surviving `uberdev`); referential-integrity catches *over*-rewrite (dangling `prkit:` ref).
+
+---
+
+## 10. Testing strategy
+
+- **Generator unit checks** (UberDev repo `tests/`): manifest completeness (every listed file exists in SSOT); rewrite applier maps each ruleset case on fixtures; neutralization removes the enumerated out-of-set sites.
+- **Verify-gate self-test:** deliberately-broken tree (surviving token / dangling ref / missing lib) must fail; clean tree must pass.
+- **prkit CI (`.github/workflows/ci.yml`):** `shellcheck` + `bash -n`, `python3 -m py_compile`, `jq empty`, and `verify.sh` on the committed tree.
+- **Smoke test (manual, documented):** install prkit locally, run `/prkit:review-pr` on a throwaway PR, confirm fanout dispatches `prkit:*` agents with no `uberdev:*` resolution; run `/prkit:merge` dry path.
+- **Determinism check:** generate twice into clean targets; `diff -r` empty.
+
+---
+
+## 11. Versioning & release (prkit)
+
+- Independent SemVer, starting **`0.1.0`**.
+- prkit's version locations (analogue of UberDev's rule): `plugins/prkit/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `README.md` badge, `CHANGELOG.md`, git tag, GitHub Release.
+- Version is a generator input (`--version`), interpolated into scaffold templates: release = bump `--version` → regenerate → commit/tag/release in the prkit repo.
+
+---
+
+## 12. Open items to verify at plan/impl time
+
+- [ ] Enumerate exact out-of-set reference sites (`/uberdev:goal`, `/uberdev:solve`) across the copy set for the neutralization pass.
+- [ ] Confirm every `PRKIT_*` var read by copied lib has a non-hook default (risk #1).
+- [ ] Finalize the label/trailer value mapping (rule 6) — pick concrete prkit label names.
+- [ ] Decide codex-fallback handling in `config-read.sh` (rewrite vs. drop).
+- [ ] Confirm `merge-pipeline/SKILL.md` has no lib deps beyond `lib/discover.sh`.
+- [ ] Confirm no copied `.py` reads a static data file other than `model-routing-v1.json`.
+- [ ] Decide prkit repo name / URL for metadata scaffolding.
+
+---
+
+## 13. Handoff
+
+Terminal step of brainstorm: invoke `uberdev:write-plan` to produce the wave-decomposed implementation plan for the generator + templates + verify gate + first prkit generation.

--- a/tests/fixtures/prkit/sample-in.md
+++ b/tests/fixtures/prkit/sample-in.md
@@ -1,0 +1,10 @@
+subagent_type: uberdev:code-fixer
+Skill(uberdev:post-impl-review)
+next: /uberdev:solve https://example/issues/7
+so a concurrent `/uberdev:goal` Phase 2b knows this PR's `/review-pr` is in-flight (avoids re-dispatching ours while the leaf solver's own is still running)
+The locked marker is read by `/uberdev:goal` Phase 2b via `_uberdev_goal_locked_marker_for_pr_fresh` (lib/goal-state.sh). 
+export UBERDEV_MODEL="opus"
+_uberdev_config_read_load() { :; }
+config at .claude/uberdev.local.md
+path ${CLAUDE_PLUGIN_ROOT}/policy/model-routing-v1.json fallback ${PWD}/plugins/uberdev/policy/x.json
+label uberdev-approved and marker review-pr:pending

--- a/tests/fixtures/prkit/sample-in.md
+++ b/tests/fixtures/prkit/sample-in.md
@@ -8,3 +8,6 @@ _uberdev_config_read_load() { :; }
 config at .claude/uberdev.local.md
 path ${CLAUDE_PLUGIN_ROOT}/policy/model-routing-v1.json fallback ${PWD}/plugins/uberdev/policy/x.json
 label uberdev-approved and marker review-pr:pending
+clone https://github.com/TheFJK/UberDev then add TheFJK/uberdev to marketplace
+Related skills: uberdev:brainstorm, /uberdev:write-plan, and the UberDev toolkit primer
+inline: run `next: /uberdev:solve <URL>` then check the finding

--- a/tests/prkit-codex-manifest.test.sh
+++ b/tests/prkit-codex-manifest.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# tests/prkit-codex-manifest.test.sh — the prkit CODEX-port copy manifest is
+# complete and correct. Every listed source exists at the repo root; count is
+# locked; excluded files are absent. Pure bash+grep (windows-safe).
+set -u
+set -o pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MANIFEST="$REPO_ROOT/tools/prkit/manifest-codex.txt"
+PASS=0; FAIL=0
+ok(){ echo "  PASS  $1"; PASS=$((PASS+1)); }
+no(){ echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
+echo "## prkit codex manifest (RFC 0014 Codex addendum)"
+
+[ -r "$MANIFEST" ] || { echo "  ABORT — manifest-codex missing: $MANIFEST"; exit 99; }
+
+# C1 — every listed path exists under the repo root
+missing=0
+while IFS= read -r line; do
+  case "$line" in ''|\#*) continue;; esac
+  [ -e "$REPO_ROOT/$line" ] || { echo "    missing: $line"; missing=$((missing+1)); }
+done < "$MANIFEST"
+[ "$missing" -eq 0 ] && ok "C1 every codex-manifest path exists at repo root" \
+  || no "C1 $missing codex-manifest path(s) do not exist"
+
+# C2 — count of real entries is 51
+count=$(grep -cvE '^\s*(#|$)' "$MANIFEST")
+[ "$count" -eq 51 ] && ok "C2 codex manifest lists exactly 51 files" \
+  || no "C2 codex manifest lists $count files (expected 51)"
+
+# C3 — excluded files are NOT listed
+for bad in codex/uberdev-codex/policy/solve-run-tree-v1.json \
+           codex/uberdev-codex/skills/uberdev-cmd-solve/SKILL.md \
+           codex/uberdev-codex/skills/uberdev-cmd-goal/SKILL.md \
+           codex/tools/convert-commands.py codex/tools/port-skill.sh; do
+  if grep -qxF "$bad" "$MANIFEST"; then no "C3 excluded file present: $bad"; fi
+done
+[ "$FAIL" -eq 0 ] && ok "C3 no excluded files in codex manifest"
+
+# C4 — the three PR command-skills + installer + converter are present
+for req in codex/uberdev-codex/skills/uberdev-cmd-review-pr/SKILL.md \
+           codex/uberdev-codex/skills/uberdev-cmd-simplify/SKILL.md \
+           codex/uberdev-codex/skills/uberdev-cmd-merge/SKILL.md \
+           codex/install-codex.sh codex/tools/convert-agents.py; do
+  grep -qxF "$req" "$MANIFEST" || no "C4 missing required codex entry: $req"
+done
+grep -qxF codex/install-codex.sh "$MANIFEST" && ok "C4 command-skills + installer + converter present"
+
+echo "  Result: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/prkit-codex-manifest.test.sh
+++ b/tests/prkit-codex-manifest.test.sh
@@ -16,6 +16,7 @@ echo "## prkit codex manifest (RFC 0014 Codex addendum)"
 # C1 — every listed path exists under the repo root
 missing=0
 while IFS= read -r line; do
+  line="${line%$'\r'}"   # strip CR — Git-Bash checks out with autocrlf on Windows
   case "$line" in ''|\#*) continue;; esac
   [ -e "$REPO_ROOT/$line" ] || { echo "    missing: $line"; missing=$((missing+1)); }
 done < "$MANIFEST"

--- a/tests/prkit-generate.test.sh
+++ b/tests/prkit-generate.test.sh
@@ -13,7 +13,12 @@ no(){ echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
 echo "## prkit generate e2e (RFC 0014)"
 [ -r "$GEN" ] || { echo "  ABORT — generate.sh missing"; exit 99; }
 
-T1="$(mktemp -d)"; T2="$(mktemp -d)"; trap 'rm -rf "$T1" "$T2"' EXIT
+# T1's path deliberately CONTAINS A SPACE ("prkit tgt") — the real target lives at
+# "/Volumes/FJK SSD/Cursor/prkit", and an earlier verify.sh regression word-split on
+# that space. Keeping a spaced target here locks the fix in. T2 is space-free so G5
+# also proves the generated output is independent of the target path.
+_B1="$(mktemp -d)"; _B2="$(mktemp -d)"; T1="$_B1/prkit tgt"; T2="$_B2/out"
+mkdir -p "$T1" "$T2"; trap 'rm -rf "$_B1" "$_B2"' EXIT
 git -C "$T1" init -q; git -C "$T2" init -q
 
 # G1 — generate into a clean target succeeds and self-verifies

--- a/tests/prkit-generate.test.sh
+++ b/tests/prkit-generate.test.sh
@@ -27,9 +27,10 @@ if bash "$GEN" --target "$T1" --version 0.1.0 >/dev/null 2>&1; then ok "G1 gener
 # G2 — verify gate independently passes on the produced tree
 if bash "$VERIFY" "$T1" >/dev/null 2>&1; then ok "G2 verify passes on generated tree"; else no "G2 verify failed on generated tree"; fi
 
-# G3 — 31 source files landed under plugins/prkit
+# G3 — EXACTLY 32 source files landed under plugins/prkit (manifest count-lock;
+# -eq not -ge so a silently-dropped copy OR a stray extra file both fail)
 n=$(find "$T1/plugins/prkit/commands" "$T1/plugins/prkit/agents" "$T1/plugins/prkit/skills" "$T1/plugins/prkit/lib" "$T1/plugins/prkit/policy" -type f 2>/dev/null | wc -l | tr -d ' ')
-[ "$n" -ge 31 ] && ok "G3 >=31 copied files present ($n)" || no "G3 only $n copied files"
+[ "$n" -eq 32 ] && ok "G3 exactly 32 copied files present" || no "G3 copied $n files (expected 32)"
 
 # G4 — scaffold files exist with interpolated version
 grep -q '0.1.0' "$T1/plugins/prkit/.claude-plugin/plugin.json" && ok "G4 plugin.json version interpolated" || no "G4 plugin.json version missing"
@@ -54,6 +55,15 @@ if grep -rilE 'uberdev' "$T1/codex" >/dev/null 2>&1; then no "G7 uberdev token s
 
 # G8 — codex tree deterministic across the two generations (spaced vs plain path)
 if diff -r "$T1/codex" "$T2/codex" >/dev/null 2>&1; then ok "G8 codex deterministic (diff -r empty)"; else no "G8 codex non-deterministic"; fi
+
+# G9 — regeneration CLEANS stale files (the rm -rf clean stage). Plant strays in
+# both trees, regenerate into the SAME target, assert they are gone.
+printf 'stale\n' > "$T1/plugins/prkit/STALE_CLAUDE.txt"
+printf 'stale\n' > "$T1/codex/STALE_CODEX.txt"
+bash "$GEN" --target "$T1" --version 0.1.0 --force >/dev/null 2>&1
+if [ ! -e "$T1/plugins/prkit/STALE_CLAUDE.txt" ] && [ ! -e "$T1/codex/STALE_CODEX.txt" ]; then
+  ok "G9 regeneration removes stale files from both trees"
+else no "G9 stale files survived regeneration"; fi
 
 echo "  Result: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/prkit-generate.test.sh
+++ b/tests/prkit-generate.test.sh
@@ -39,5 +39,21 @@ grep -q '0.1.0' "$T1/plugins/prkit/.claude-plugin/plugin.json" && ok "G4 plugin.
 bash "$GEN" --target "$T2" --version 0.1.0 >/dev/null 2>&1
 if diff -r "$T1/plugins/prkit" "$T2/plugins/prkit" >/dev/null 2>&1; then ok "G5 deterministic (diff -r empty)"; else no "G5 non-deterministic output"; fi
 
+# G6 — Codex port generated: prkit-cmd-* skills, renamed TOML, installer, manifest
+if [ -f "$T1/codex/prkit-codex/skills/prkit-cmd-review-pr/SKILL.md" ] \
+   && [ -f "$T1/codex/prkit-codex/skills/prkit-cmd-simplify/SKILL.md" ] \
+   && [ -f "$T1/codex/prkit-codex/skills/prkit-cmd-merge/SKILL.md" ] \
+   && [ -f "$T1/codex/agents/prkit-code-reviewer.toml" ] \
+   && [ -f "$T1/codex/install-codex.sh" ] \
+   && grep -q '"name": "prkit-codex"' "$T1/codex/prkit-codex/.codex-plugin/plugin.json"; then
+  ok "G6 codex port generated (prkit-cmd-* skills, prkit-*.toml, installer, manifest)"
+else no "G6 codex port incomplete"; fi
+
+# G7 — no uberdev token survives anywhere under codex/
+if grep -rilE 'uberdev' "$T1/codex" >/dev/null 2>&1; then no "G7 uberdev token survives under codex/"; else ok "G7 codex tree is uberdev-free"; fi
+
+# G8 — codex tree deterministic across the two generations (spaced vs plain path)
+if diff -r "$T1/codex" "$T2/codex" >/dev/null 2>&1; then ok "G8 codex deterministic (diff -r empty)"; else no "G8 codex non-deterministic"; fi
+
 echo "  Result: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/prkit-generate.test.sh
+++ b/tests/prkit-generate.test.sh
@@ -40,15 +40,21 @@ grep -q '0.1.0' "$T1/plugins/prkit/.claude-plugin/plugin.json" && ok "G4 plugin.
 bash "$GEN" --target "$T2" --version 0.1.0 >/dev/null 2>&1
 if diff -r "$T1/plugins/prkit" "$T2/plugins/prkit" >/dev/null 2>&1; then ok "G5 deterministic (diff -r empty)"; else no "G5 non-deterministic output"; fi
 
-# G6 — Codex port generated: prkit-cmd-* skills, renamed TOML, installer, manifest
+# G6 — Codex port generated: prkit-cmd-* skills, renamed TOML, installer, manifest,
+# and prkit-PREFIXED support skills (flat ~/.agents/skills/ coexistence) with NO
+# un-prefixed post-impl-review/merge-pipeline dir that would collide with UberDev-codex
 if [ -f "$T1/codex/prkit-codex/skills/prkit-cmd-review-pr/SKILL.md" ] \
    && [ -f "$T1/codex/prkit-codex/skills/prkit-cmd-simplify/SKILL.md" ] \
    && [ -f "$T1/codex/prkit-codex/skills/prkit-cmd-merge/SKILL.md" ] \
+   && [ -f "$T1/codex/prkit-codex/skills/prkit-post-impl-review/SKILL.md" ] \
+   && [ -f "$T1/codex/prkit-codex/skills/prkit-merge-pipeline/SKILL.md" ] \
+   && [ ! -e "$T1/codex/prkit-codex/skills/post-impl-review" ] \
+   && [ ! -e "$T1/codex/prkit-codex/skills/merge-pipeline" ] \
    && [ -f "$T1/codex/agents/prkit-code-reviewer.toml" ] \
    && [ -f "$T1/codex/install-codex.sh" ] \
    && grep -q '"name": "prkit-codex"' "$T1/codex/prkit-codex/.codex-plugin/plugin.json"; then
-  ok "G6 codex port generated (prkit-cmd-* skills, prkit-*.toml, installer, manifest)"
-else no "G6 codex port incomplete"; fi
+  ok "G6 codex port generated (prkit-cmd-* + prkit-prefixed support skills, no flat collision)"
+else no "G6 codex port incomplete or has un-prefixed support skill"; fi
 
 # G7 — no uberdev token survives anywhere under codex/
 if grep -rilE 'uberdev' "$T1/codex" >/dev/null 2>&1; then no "G7 uberdev token survives under codex/"; else ok "G7 codex tree is uberdev-free"; fi

--- a/tests/prkit-generate.test.sh
+++ b/tests/prkit-generate.test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# tests/prkit-generate.test.sh — end-to-end: generate a prkit tree into a scratch
+# target, assert the verify gate passes, and assert determinism (two runs identical).
+# Unix-only (perl + python3 + jq); declared in the test.yml windows-skip marker.
+set -u
+set -o pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GEN="$REPO_ROOT/tools/prkit/generate.sh"
+VERIFY="$REPO_ROOT/tools/prkit/verify.sh"
+PASS=0; FAIL=0
+ok(){ echo "  PASS  $1"; PASS=$((PASS+1)); }
+no(){ echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
+echo "## prkit generate e2e (RFC 0014)"
+[ -r "$GEN" ] || { echo "  ABORT — generate.sh missing"; exit 99; }
+
+T1="$(mktemp -d)"; T2="$(mktemp -d)"; trap 'rm -rf "$T1" "$T2"' EXIT
+git -C "$T1" init -q; git -C "$T2" init -q
+
+# G1 — generate into a clean target succeeds and self-verifies
+if bash "$GEN" --target "$T1" --version 0.1.0 >/dev/null 2>&1; then ok "G1 generate exits 0 (verify passed)"; else no "G1 generate failed"; fi
+
+# G2 — verify gate independently passes on the produced tree
+if bash "$VERIFY" "$T1" >/dev/null 2>&1; then ok "G2 verify passes on generated tree"; else no "G2 verify failed on generated tree"; fi
+
+# G3 — 31 source files landed under plugins/prkit
+n=$(find "$T1/plugins/prkit/commands" "$T1/plugins/prkit/agents" "$T1/plugins/prkit/skills" "$T1/plugins/prkit/lib" "$T1/plugins/prkit/policy" -type f 2>/dev/null | wc -l | tr -d ' ')
+[ "$n" -ge 31 ] && ok "G3 >=31 copied files present ($n)" || no "G3 only $n copied files"
+
+# G4 — scaffold files exist with interpolated version
+grep -q '0.1.0' "$T1/plugins/prkit/.claude-plugin/plugin.json" && ok "G4 plugin.json version interpolated" || no "G4 plugin.json version missing"
+[ -f "$T1/README.md" ] && [ -f "$T1/.claude-plugin/marketplace.json" ] && ok "G4b README + marketplace scaffolded" || no "G4b scaffold files missing"
+
+# G5 — determinism: second generation into a fresh target is byte-identical
+bash "$GEN" --target "$T2" --version 0.1.0 >/dev/null 2>&1
+if diff -r "$T1/plugins/prkit" "$T2/plugins/prkit" >/dev/null 2>&1; then ok "G5 deterministic (diff -r empty)"; else no "G5 non-deterministic output"; fi
+
+echo "  Result: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/prkit-manifest.test.sh
+++ b/tests/prkit-manifest.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# tests/prkit-manifest.test.sh — the prkit copy manifest is complete and correct.
+# Every listed source exists under plugins/uberdev/; excluded files are absent;
+# count matches the RFC 0014 copy set.
+set -u
+set -o pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$REPO_ROOT/plugins/uberdev"
+MANIFEST="$REPO_ROOT/tools/prkit/manifest.txt"
+PASS=0; FAIL=0
+ok(){ echo "  PASS  $1"; PASS=$((PASS+1)); }
+no(){ echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
+echo "## prkit manifest (RFC 0014)"
+
+[ -r "$MANIFEST" ] || { echo "  ABORT — manifest missing: $MANIFEST"; exit 99; }
+
+# M1 — every listed path exists under plugins/uberdev/
+missing=0
+while IFS= read -r line; do
+  case "$line" in ''|\#*) continue;; esac
+  [ -e "$SRC/$line" ] || { echo "    missing: $line"; missing=$((missing+1)); }
+done < "$MANIFEST"
+[ "$missing" -eq 0 ] && ok "M1 every manifest path exists in plugins/uberdev/" \
+  || no "M1 $missing manifest path(s) do not exist"
+
+# M2 — count of real (non-comment, non-blank) entries is 32
+count=$(grep -cvE '^\s*(#|$)' "$MANIFEST")
+[ "$count" -eq 32 ] && ok "M2 manifest lists exactly 32 files" \
+  || no "M2 manifest lists $count files (expected 32)"
+
+# M3 — excluded files are NOT listed (goal-state, solve-run-tree, hooks, aliases)
+for bad in lib/goal-state.sh policy/solve-run-tree-v1.json lib/aliases-sync.sh \
+           hooks/session-start commands/install-aliases.md commands/solve.md \
+           commands/goal.md; do
+  if grep -qxF "$bad" "$MANIFEST"; then no "M3 excluded file present: $bad"; FAIL=$((FAIL+1)); fi
+done
+[ "$FAIL" -eq 0 ] && ok "M3 no excluded files in manifest"
+
+# M4 — the three entry commands are present
+for c in commands/review-pr.md commands/simplify.md commands/merge.md; do
+  grep -qxF "$c" "$MANIFEST" || no "M4 missing entry command: $c"
+done
+grep -qxF commands/review-pr.md "$MANIFEST" && grep -qxF commands/merge.md "$MANIFEST" \
+  && ok "M4 all three entry commands present"
+
+echo "  Result: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/prkit-manifest.test.sh
+++ b/tests/prkit-manifest.test.sh
@@ -17,6 +17,7 @@ echo "## prkit manifest (RFC 0014)"
 # M1 — every listed path exists under plugins/uberdev/
 missing=0
 while IFS= read -r line; do
+  line="${line%$'\r'}"   # strip CR — Git-Bash checks out with autocrlf on Windows
   case "$line" in ''|\#*) continue;; esac
   [ -e "$SRC/$line" ] || { echo "    missing: $line"; missing=$((missing+1)); }
 done < "$MANIFEST"

--- a/tests/prkit-manifest.test.sh
+++ b/tests/prkit-manifest.test.sh
@@ -32,7 +32,7 @@ count=$(grep -cvE '^\s*(#|$)' "$MANIFEST")
 for bad in lib/goal-state.sh policy/solve-run-tree-v1.json lib/aliases-sync.sh \
            hooks/session-start commands/install-aliases.md commands/solve.md \
            commands/goal.md; do
-  if grep -qxF "$bad" "$MANIFEST"; then no "M3 excluded file present: $bad"; FAIL=$((FAIL+1)); fi
+  if grep -qxF "$bad" "$MANIFEST"; then no "M3 excluded file present: $bad"; fi
 done
 [ "$FAIL" -eq 0 ] && ok "M3 no excluded files in manifest"
 

--- a/tests/prkit-rewrite.test.sh
+++ b/tests/prkit-rewrite.test.sh
@@ -40,6 +40,19 @@ echo "$OUT" | grep -Eq '(prkit|uberdev):(goal|solve)|/(prkit|uberdev):(goal|solv
 # R7 — idempotent: second pass changes nothing
 cp "$TMP/f.md" "$TMP/g.md"; prkit_neutralize "$TMP/g.md"; prkit_apply_rewrites "$TMP/g.md"
 diff -q "$TMP/f.md" "$TMP/g.md" >/dev/null && ok "R7 rewrite is idempotent" || no "R7 not idempotent"
+# R8 — repo slug stays LOWERCASE prkit (not the CamelCase-mangled TheFJK/Prkit)
+echo "$OUT" | grep -q 'TheFJK/prkit' && ! echo "$OUT" | grep -q 'TheFJK/Prkit' \
+  && ok "R8 repo slug -> TheFJK/prkit (lowercase)" || no "R8 slug wrong-cased or missing"
+# R9 — OUT-OF-SET skills de-namespaced to bare prose (no dangling prkit:<name>);
+# in-set (code-fixer, post-impl-review) keep their prefix
+echo "$OUT" | grep -Eq 'prkit:(brainstorm|write-plan)' && no "R9 dangling out-of-set prkit:<skill> survived" \
+  || { echo "$OUT" | grep -q 'prkit:code-fixer' && echo "$OUT" | grep -q 'prkit:post-impl-review' \
+       && ok "R9 out-of-set de-namespaced, in-set kept" || no "R9 in-set ref lost"; }
+# R10 — the inline `next: /uberdev:solve <URL>` fragment keeps BALANCED backticks
+# (the site-494 mangling class: the neutralizer must not eat the trailing backtick)
+bt=$(echo "$OUT" | grep 'inline: run' | tr -cd '`' | wc -c | tr -d ' ')
+[ "$((bt % 2))" -eq 0 ] && [ "$bt" -gt 0 ] && ok "R10 inline-code backticks stay balanced ($bt)" \
+  || no "R10 backtick imbalance ($bt) — arg/backtick eaten"
 
 echo "  Result: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/prkit-rewrite.test.sh
+++ b/tests/prkit-rewrite.test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# tests/prkit-rewrite.test.sh — rewrite ruleset: neutralize out-of-set refs,
+# then blanket uberdev->prkit with zero surviving uberdev token.
+set -u
+set -o pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+. "$REPO_ROOT/tools/prkit/rewrite.sh"
+PASS=0; FAIL=0
+ok(){ echo "  PASS  $1"; PASS=$((PASS+1)); }
+no(){ echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
+echo "## prkit rewrite ruleset (RFC 0014 §5.4)"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cp "$REPO_ROOT/tests/fixtures/prkit/sample-in.md" "$TMP/f.md"
+
+prkit_neutralize "$TMP/f.md"
+prkit_apply_rewrites "$TMP/f.md"
+OUT="$(cat "$TMP/f.md")"
+
+# R1 — no surviving uberdev (case-insensitive)
+echo "$OUT" | grep -iq 'uberdev' && no "R1 uberdev token survived" \
+  || ok "R1 zero surviving uberdev token"
+# R2 — namespace rewritten
+echo "$OUT" | grep -q 'subagent_type: prkit:code-fixer' \
+  && echo "$OUT" | grep -q 'Skill(prkit:post-impl-review)' \
+  && ok "R2 namespace refs rewritten to prkit:" || no "R2 namespace not rewritten"
+# R3 — env var + fn prefix rewritten
+echo "$OUT" | grep -q 'PRKIT_MODEL' && echo "$OUT" | grep -q '_prkit_config_read_load' \
+  && ok "R3 env var + fn prefix rewritten" || no "R3 env/fn prefix not rewritten"
+# R4 — config filename + path rewritten
+echo "$OUT" | grep -q '.claude/prkit.local.md' \
+  && echo "$OUT" | grep -q 'plugins/prkit/policy/x.json' \
+  && ok "R4 config filename + path rewritten" || no "R4 config/path not rewritten"
+# R5 — label rewritten
+echo "$OUT" | grep -q 'prkit-approved' && ok "R5 label rewritten" || no "R5 label not rewritten"
+# R6 — NO dangling out-of-set command refs survive
+echo "$OUT" | grep -Eq '(prkit|uberdev):(goal|solve)|/(prkit|uberdev):(goal|solve)' \
+  && no "R6 out-of-set goal/solve command ref survived" \
+  || ok "R6 no goal/solve command ref survives"
+# R7 — idempotent: second pass changes nothing
+cp "$TMP/f.md" "$TMP/g.md"; prkit_neutralize "$TMP/g.md"; prkit_apply_rewrites "$TMP/g.md"
+diff -q "$TMP/f.md" "$TMP/g.md" >/dev/null && ok "R7 rewrite is idempotent" || no "R7 not idempotent"
+
+echo "  Result: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/prkit-verify.test.sh
+++ b/tests/prkit-verify.test.sh
@@ -1,53 +1,48 @@
 #!/usr/bin/env bash
-# tests/prkit-verify.test.sh — the verify gate FAILS a broken tree and PASSES a clean one.
+# tests/prkit-verify.test.sh — the verify gate PASSES a real generated tree and
+# FAILS each injected defect. Unix-only (perl+python3+jq via generate); declared
+# in the test.yml windows-skip marker. Uses a real generated baseline (not a
+# hand-built stub) so the stricter non-vacuity / ref-integrity / syntax-count /
+# out-of-set / scaffold / placeholder checks are exercised against realistic input,
+# and the codex fail-path is covered (issue #334 review, test-analyzer P1).
 set -u
 set -o pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GEN="$REPO_ROOT/tools/prkit/generate.sh"
 VERIFY="$REPO_ROOT/tools/prkit/verify.sh"
 PASS=0; FAIL=0
 ok(){ echo "  PASS  $1"; PASS=$((PASS+1)); }
 no(){ echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
 echo "## prkit verify gate (RFC 0014 §5.6)"
-[ -x "$VERIFY" ] || [ -r "$VERIFY" ] || { echo "  ABORT — verify.sh missing"; exit 99; }
+[ -r "$VERIFY" ] || { echo "  ABORT — verify.sh missing"; exit 99; }
 
-mk_clean() {
-  local d="$1"
-  mkdir -p "$d/plugins/prkit/agents" "$d/plugins/prkit/skills/post-impl-review" \
-           "$d/plugins/prkit/skills/merge-pipeline" "$d/plugins/prkit/lib" \
-           "$d/plugins/prkit/policy" "$d/plugins/prkit/commands" \
-           "$d/plugins/prkit/.claude-plugin"
-  printf 'dispatch subagent_type: prkit:code-reviewer\nSkill(prkit:post-impl-review)\n' > "$d/plugins/prkit/commands/review-pr.md"
-  printf 'x\n' > "$d/plugins/prkit/commands/simplify.md"
-  printf 'x\n' > "$d/plugins/prkit/commands/merge.md"
-  printf '# code-reviewer\n' > "$d/plugins/prkit/agents/code-reviewer.md"
-  printf 'name: post-impl-review\n' > "$d/plugins/prkit/skills/post-impl-review/SKILL.md"
-  printf 'name: merge-pipeline\n' > "$d/plugins/prkit/skills/merge-pipeline/SKILL.md"
-  printf 'echo ok\n' > "$d/plugins/prkit/lib/x.sh"
-  printf '{}\n' > "$d/plugins/prkit/policy/model-routing-v1.json"
-  printf '{"name":"prkit"}\n' > "$d/plugins/prkit/.claude-plugin/plugin.json"
-  printf 'prkit\nUberDev attribution only\n' > "$d/NOTICE"
+BASEP="$(mktemp -d)"; BASE="$BASEP/clean"; mkdir -p "$BASE"; git -C "$BASE" init -q
+trap 'rm -rf "$BASEP"' EXIT
+bash "$GEN" --target "$BASE" --version 0.1.0 >/dev/null 2>&1 || { echo "  ABORT — baseline generation failed"; exit 99; }
+
+# V1 — the clean generated tree passes
+if bash "$VERIFY" "$BASE" >/dev/null 2>&1; then ok "V1 clean generated tree passes"; else no "V1 clean generated tree rejected"; fi
+
+# expect_fail <desc> <mutate-cmd> : copy baseline, apply mutation on $d, assert verify FAILS
+expect_fail(){
+  local desc="$1" mutate="$2" dp d
+  dp="$(mktemp -d)"; d="$dp/t"; cp -R "$BASE" "$d"
+  eval "$mutate"
+  if bash "$VERIFY" "$d" >/dev/null 2>&1; then no "$desc (verify wrongly PASSED)"; else ok "$desc"; fi
+  rm -rf "$dp"
 }
 
-# V1 — clean tree passes
-C="$(mktemp -d)"; mk_clean "$C"
-if bash "$VERIFY" "$C" >/dev/null 2>&1; then ok "V1 clean tree passes"; else no "V1 clean tree rejected"; fi
+# assembled at runtime so this test file's own bytes never contain the token
+UB="UBERDEV""_INJECTED_LEAK=1"
 
-# V2 — surviving uberdev token fails
-B1="$(mktemp -d)"; mk_clean "$B1"; printf 'export UBERDEV_MODEL=x\n' >> "$B1/plugins/prkit/lib/x.sh"
-if bash "$VERIFY" "$B1" >/dev/null 2>&1; then no "V2 surviving uberdev token accepted"; else ok "V2 surviving uberdev token fails"; fi
+expect_fail "V2 uberdev token in plugins/prkit fails"       'printf "%s\n" "$UB" >> "$d/plugins/prkit/lib/dispatch.sh"'
+expect_fail "V3 uberdev token in codex/ fails"              'printf "%s\n" "$UB" >> "$d/codex/prkit-codex/lib/dispatch.sh"'
+expect_fail "V4 dangling dispatched agent ref fails"        'printf "subagent_type: prkit:ghost-agent\n" >> "$d/plugins/prkit/commands/review-pr.md"'
+expect_fail "V5 residual prkit:goal fails"                  'printf "chain to /prkit:goal here\n" >> "$d/plugins/prkit/commands/review-pr.md"'
+expect_fail "V6 dangling out-of-set prkit:brainstorm fails" 'printf "see prkit:brainstorm for ideation\n" >> "$d/plugins/prkit/commands/review-pr.md"'
+expect_fail "V7 unrendered {{VERSION}} placeholder fails"   'printf "version {{VERSION}} here\n" >> "$d/README.md"'
+expect_fail "V8 empty marketplace.json fails"               ': > "$d/.claude-plugin/marketplace.json"'
+expect_fail "V9 removed all agents (non-vacuity/ref-int) fails" 'rm -rf "$d/plugins/prkit/agents"'
 
-# V3 — dangling namespace ref (prkit:ghost with no agent) fails
-B2="$(mktemp -d)"; mk_clean "$B2"; printf 'subagent_type: prkit:ghost-agent\n' >> "$B2/plugins/prkit/commands/review-pr.md"
-if bash "$VERIFY" "$B2" >/dev/null 2>&1; then no "V3 dangling prkit ref accepted"; else ok "V3 dangling prkit ref fails"; fi
-
-# V4 — residual out-of-set ref (prkit:goal) fails
-B3="$(mktemp -d)"; mk_clean "$B3"; printf 'chain to /prkit:goal here\n' >> "$B3/plugins/prkit/commands/review-pr.md"
-if bash "$VERIFY" "$B3" >/dev/null 2>&1; then no "V4 residual prkit:goal accepted"; else ok "V4 residual out-of-set ref fails"; fi
-
-# V5 — NOTICE allowlist: 'UberDev' in NOTICE alone does NOT fail
-C2="$(mktemp -d)"; mk_clean "$C2"
-if bash "$VERIFY" "$C2" >/dev/null 2>&1; then ok "V5 NOTICE-only uberdev is allowlisted"; else no "V5 NOTICE allowlist broken"; fi
-
-rm -rf "$C" "$B1" "$B2" "$B3" "$C2"
 echo "  Result: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/prkit-verify.test.sh
+++ b/tests/prkit-verify.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# tests/prkit-verify.test.sh — the verify gate FAILS a broken tree and PASSES a clean one.
+set -u
+set -o pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERIFY="$REPO_ROOT/tools/prkit/verify.sh"
+PASS=0; FAIL=0
+ok(){ echo "  PASS  $1"; PASS=$((PASS+1)); }
+no(){ echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
+echo "## prkit verify gate (RFC 0014 §5.6)"
+[ -x "$VERIFY" ] || [ -r "$VERIFY" ] || { echo "  ABORT — verify.sh missing"; exit 99; }
+
+mk_clean() {
+  local d="$1"
+  mkdir -p "$d/plugins/prkit/agents" "$d/plugins/prkit/skills/post-impl-review" \
+           "$d/plugins/prkit/skills/merge-pipeline" "$d/plugins/prkit/lib" \
+           "$d/plugins/prkit/policy" "$d/plugins/prkit/commands" \
+           "$d/plugins/prkit/.claude-plugin"
+  printf 'dispatch subagent_type: prkit:code-reviewer\nSkill(prkit:post-impl-review)\n' > "$d/plugins/prkit/commands/review-pr.md"
+  printf 'x\n' > "$d/plugins/prkit/commands/simplify.md"
+  printf 'x\n' > "$d/plugins/prkit/commands/merge.md"
+  printf '# code-reviewer\n' > "$d/plugins/prkit/agents/code-reviewer.md"
+  printf 'name: post-impl-review\n' > "$d/plugins/prkit/skills/post-impl-review/SKILL.md"
+  printf 'name: merge-pipeline\n' > "$d/plugins/prkit/skills/merge-pipeline/SKILL.md"
+  printf 'echo ok\n' > "$d/plugins/prkit/lib/x.sh"
+  printf '{}\n' > "$d/plugins/prkit/policy/model-routing-v1.json"
+  printf '{"name":"prkit"}\n' > "$d/plugins/prkit/.claude-plugin/plugin.json"
+  printf 'prkit\nUberDev attribution only\n' > "$d/NOTICE"
+}
+
+# V1 — clean tree passes
+C="$(mktemp -d)"; mk_clean "$C"
+if bash "$VERIFY" "$C" >/dev/null 2>&1; then ok "V1 clean tree passes"; else no "V1 clean tree rejected"; fi
+
+# V2 — surviving uberdev token fails
+B1="$(mktemp -d)"; mk_clean "$B1"; printf 'export UBERDEV_MODEL=x\n' >> "$B1/plugins/prkit/lib/x.sh"
+if bash "$VERIFY" "$B1" >/dev/null 2>&1; then no "V2 surviving uberdev token accepted"; else ok "V2 surviving uberdev token fails"; fi
+
+# V3 — dangling namespace ref (prkit:ghost with no agent) fails
+B2="$(mktemp -d)"; mk_clean "$B2"; printf 'subagent_type: prkit:ghost-agent\n' >> "$B2/plugins/prkit/commands/review-pr.md"
+if bash "$VERIFY" "$B2" >/dev/null 2>&1; then no "V3 dangling prkit ref accepted"; else ok "V3 dangling prkit ref fails"; fi
+
+# V4 — residual out-of-set ref (prkit:goal) fails
+B3="$(mktemp -d)"; mk_clean "$B3"; printf 'chain to /prkit:goal here\n' >> "$B3/plugins/prkit/commands/review-pr.md"
+if bash "$VERIFY" "$B3" >/dev/null 2>&1; then no "V4 residual prkit:goal accepted"; else ok "V4 residual out-of-set ref fails"; fi
+
+# V5 — NOTICE allowlist: 'UberDev' in NOTICE alone does NOT fail
+C2="$(mktemp -d)"; mk_clean "$C2"
+if bash "$VERIFY" "$C2" >/dev/null 2>&1; then ok "V5 NOTICE-only uberdev is allowlisted"; else no "V5 NOTICE allowlist broken"; fi
+
+rm -rf "$C" "$B1" "$B2" "$B3" "$C2"
+echo "  Result: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tools/prkit/README.md
+++ b/tools/prkit/README.md
@@ -1,8 +1,8 @@
 # tools/prkit — the prkit generator
 
 Generates the standalone **prkit** plugin (PR phase: review → fix → simplify → land)
-from this repo's `plugins/uberdev/` as the single source of truth. See
-`docs/rfc/0014-prkit-standalone-plugin.md`.
+from this repo's `plugins/uberdev/` (Claude Code) and `codex/uberdev-codex/` (Codex CLI)
+as the single source of truth. See `docs/rfc/0014-prkit-standalone-plugin.md`.
 
 ## Run
 
@@ -11,9 +11,10 @@ tools/prkit/generate.sh --target /path/to/prkit-repo --version 0.1.0
 ```
 
 Stages: preflight → clean `plugins/prkit/` → copy (`manifest.txt`) → rewrite
-(`rewrite.sh`: neutralize goal/solve, then blanket `uberdev`→`prkit`) → scaffold
-(`templates/`) → verify (`verify.sh`) → summary. It never commits; commit in the
-target repo yourself.
+(`rewrite.sh`: de-namespace out-of-set refs, then blanket `uberdev`→`prkit`) →
+scaffold (`templates/`) → **Codex port** (`manifest-codex.txt` → `codex/prkit-codex/`,
+same rewrite) → verify (`verify.sh`, both trees) → summary. It never commits;
+commit in the target repo yourself.
 
 ## Bootstrap a fresh prkit repo
 
@@ -28,15 +29,22 @@ git -C ../prkit add -A && git -C ../prkit commit -m "chore: initial prkit 0.1.0"
 
 | File | Role |
 |---|---|
-| `manifest.txt` | Declarative copy set (count-locked at 32 by `tests/prkit-manifest.test.sh`) |
-| `rewrite.sh` | `prkit_neutralize` + `prkit_apply_rewrites` (sourced) |
-| `templates/` | Standalone-only scaffold files (`{{VERSION}}`/`{{DATE}}`) |
-| `verify.sh` | Token guard + referential integrity + syntax gate |
+| `manifest.txt` | Claude copy set (count-locked at 32 by `tests/prkit-manifest.test.sh`) |
+| `manifest-codex.txt` | Codex copy set (count-locked at 51 by `tests/prkit-codex-manifest.test.sh`) |
+| `rewrite.sh` | `prkit_neutralize` (de-namespace out-of-set) + `prkit_apply_rewrites` (slug + blanket); sourced |
+| `templates/` | Standalone-only scaffold files (`{{VERSION}}`/`{{DATE}}`), incl. `codex-*` |
+| `verify.sh` | Anti-drift gate (both trees): token guard, out-of-set resolution, referential integrity, syntax (sh/py/json/toml), scaffold + placeholder checks. Runs at **generation time in UberDev** — it is NOT copied into the prkit repo. |
 | `generate.sh` | Orchestrator |
+
+The generated prkit repo ships its own `.github/workflows/ci.yml`, which re-checks
+the committed tree with `bash -n` + `ast.parse` + `jq empty` + `tomllib` + an inline
+`grep -rilE 'uberdev'` namespace guard (a subset of `verify.sh`'s token-guard).
 
 ## Adding a file to prkit
 
-1. Add its path to `manifest.txt`, bump the count assert in `tests/prkit-manifest.test.sh`.
-2. If it introduces a new `uberdev` pattern the blanket rule misses, the verify
-   token guard will fail generation — add a rule to `rewrite.sh` (never weaken the guard).
-3. Re-run `bash tests/prkit-generate.test.sh`.
+1. Add its path to `manifest.txt` (Claude) or `manifest-codex.txt` (Codex), and bump
+   the count assert in the matching `tests/prkit-*-manifest.test.sh` (32 / 51).
+2. If it introduces a new `uberdev` pattern the blanket rule misses, or a new
+   out-of-set `prkit:<name>` ref, the verify gate fails generation — extend
+   `rewrite.sh` (never weaken the guard).
+3. Re-run `bash tests/prkit-generate.test.sh` (+ `prkit-codex-manifest.test.sh`).

--- a/tools/prkit/README.md
+++ b/tools/prkit/README.md
@@ -1,0 +1,42 @@
+# tools/prkit — the prkit generator
+
+Generates the standalone **prkit** plugin (PR phase: review → fix → simplify → land)
+from this repo's `plugins/uberdev/` as the single source of truth. See
+`docs/rfc/0014-prkit-standalone-plugin.md`.
+
+## Run
+
+```bash
+tools/prkit/generate.sh --target /path/to/prkit-repo --version 0.1.0
+```
+
+Stages: preflight → clean `plugins/prkit/` → copy (`manifest.txt`) → rewrite
+(`rewrite.sh`: neutralize goal/solve, then blanket `uberdev`→`prkit`) → scaffold
+(`templates/`) → verify (`verify.sh`) → summary. It never commits; commit in the
+target repo yourself.
+
+## Bootstrap a fresh prkit repo
+
+```bash
+mkdir -p ../prkit && git -C ../prkit init
+tools/prkit/generate.sh --target ../prkit --version 0.1.0
+git -C ../prkit add -A && git -C ../prkit commit -m "chore: initial prkit 0.1.0"
+# then: gh repo create TheFJK/prkit --public --source ../prkit --push
+```
+
+## Files
+
+| File | Role |
+|---|---|
+| `manifest.txt` | Declarative copy set (count-locked at 32 by `tests/prkit-manifest.test.sh`) |
+| `rewrite.sh` | `prkit_neutralize` + `prkit_apply_rewrites` (sourced) |
+| `templates/` | Standalone-only scaffold files (`{{VERSION}}`/`{{DATE}}`) |
+| `verify.sh` | Token guard + referential integrity + syntax gate |
+| `generate.sh` | Orchestrator |
+
+## Adding a file to prkit
+
+1. Add its path to `manifest.txt`, bump the count assert in `tests/prkit-manifest.test.sh`.
+2. If it introduces a new `uberdev` pattern the blanket rule misses, the verify
+   token guard will fail generation — add a rule to `rewrite.sh` (never weaken the guard).
+3. Re-run `bash tests/prkit-generate.test.sh`.

--- a/tools/prkit/generate.sh
+++ b/tools/prkit/generate.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# tools/prkit/generate.sh — generate the standalone prkit plugin from UberDev SSOT.
+#   generate.sh --target <dir> [--version X.Y.Z] [--force]
+# Stages: preflight -> clean -> copy -> rewrite -> scaffold -> verify -> summary.
+# Idempotent: same SSOT + version => byte-identical plugins/prkit output.
+set -u
+set -o pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+SRC="$REPO_ROOT/plugins/uberdev"
+MANIFEST="$HERE/manifest.txt"
+TEMPLATES="$HERE/templates"
+. "$HERE/rewrite.sh"
+
+TARGET=""; VERSION="0.1.0"; FORCE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target) TARGET="${2:-}"; shift 2;;
+    --version) VERSION="${2:-}"; shift 2;;
+    --force) FORCE=1; shift;;
+    *) echo "generate: unknown arg '$1'" >&2; exit 2;;
+  esac
+done
+[ -n "$TARGET" ] || { echo "generate: --target <dir> required" >&2; exit 2; }
+mkdir -p "$TARGET"
+TARGET="$(cd "$TARGET" && pwd)"
+
+# Deterministic DATE input (no wall-clock in output beyond the version's date):
+# use the version-tag date if provided via env, else a fixed placeholder the
+# release ritual overrides. Determinism test pins this.
+DATE="${PRKIT_RELEASE_DATE:-2026-07-12}"
+
+# --- 1. Preflight ---
+[ -d "$SRC" ] || { echo "generate: SSOT missing: $SRC" >&2; exit 1; }
+[ -r "$MANIFEST" ] || { echo "generate: manifest missing: $MANIFEST" >&2; exit 1; }
+if [ -d "$TARGET/.git" ] && [ "$FORCE" -eq 0 ]; then
+  if [ -n "$(git -C "$TARGET" status --porcelain 2>/dev/null)" ]; then
+    echo "generate: target working tree is dirty (use --force to override)" >&2; exit 1
+  fi
+fi
+
+P="$TARGET/plugins/prkit"
+
+# --- 2. Clean previously generated plugin tree (leave the rest of the repo) ---
+rm -rf "$P"
+mkdir -p "$P"
+
+# --- 3. Copy per manifest ---
+copied=0
+while IFS= read -r rel; do
+  case "$rel" in ''|\#*) continue;; esac
+  dst="$P/$rel"
+  mkdir -p "$(dirname "$dst")"
+  cp "$SRC/$rel" "$dst"
+  copied=$((copied+1))
+done < "$MANIFEST"
+
+# --- 4. Rewrite every copied text file (skip binary/json-data safely) ---
+while IFS= read -r -d '' f; do
+  case "$f" in
+    *model-routing-v1.json) : ;;   # data file: has no uberdev token; still safe to run
+  esac
+  prkit_neutralize "$f"
+  prkit_apply_rewrites "$f"
+done < <(find "$P" -type f -print0)
+
+# --- 5. Scaffold standalone-only files from templates ---
+render(){ sed -e "s/{{VERSION}}/$VERSION/g" -e "s/{{DATE}}/$DATE/g" "$1"; }
+mkdir -p "$P/.claude-plugin" "$TARGET/.claude-plugin" "$TARGET/.github/workflows"
+render "$TEMPLATES/plugin.json.tmpl"       > "$P/.claude-plugin/plugin.json"
+render "$TEMPLATES/marketplace.json.tmpl"  > "$TARGET/.claude-plugin/marketplace.json"
+render "$TEMPLATES/README.md.tmpl"         > "$TARGET/README.md"
+render "$TEMPLATES/LICENSE.tmpl"           > "$TARGET/LICENSE"
+render "$TEMPLATES/NOTICE.tmpl"            > "$TARGET/NOTICE"
+render "$TEMPLATES/CHANGELOG.md.tmpl"      > "$TARGET/CHANGELOG.md"
+render "$TEMPLATES/gitignore.tmpl"        > "$TARGET/.gitignore"
+render "$TEMPLATES/ci.yml.tmpl"           > "$TARGET/.github/workflows/ci.yml"
+
+# --- 6. Verify (fail the whole run on any violation) ---
+if ! bash "$HERE/verify.sh" "$TARGET"; then
+  echo "generate: VERIFY FAILED — output left in $TARGET for inspection" >&2
+  exit 1
+fi
+
+# --- 7. Summary ---
+echo "generate: OK — copied $copied files, scaffolded 8, verified."
+echo "generate: next -> git -C '$TARGET' add -A && git -C '$TARGET' commit -m 'chore: regenerate prkit $VERSION'"

--- a/tools/prkit/generate.sh
+++ b/tools/prkit/generate.sh
@@ -111,7 +111,13 @@ if [ -r "$MANIFEST_CODEX" ] && [ -d "$REPO_ROOT/codex" ]; then
     rel="${rel%$'\r'}"   # strip CR (Windows Git-Bash autocrlf checkout)
     case "$rel" in ''|\#*) continue;; esac
     cx_expected=$((cx_expected+1))
-    drel="$(printf '%s' "$rel" | sed 's/uberdev/prkit/g')"
+    # uberdev->prkit, PLUS prefix the two support-skill dirs: Codex installs skills
+    # into a FLAT ~/.agents/skills/, so plain post-impl-review / merge-pipeline would
+    # collide with an UberDev-for-Codex install. The command-skills (prkit-cmd-*) and
+    # agents (prkit-*.toml) are already namespaced.
+    drel="$(printf '%s' "$rel" | sed -e 's/uberdev/prkit/g' \
+              -e 's#/skills/post-impl-review/#/skills/prkit-post-impl-review/#' \
+              -e 's#/skills/merge-pipeline/#/skills/prkit-merge-pipeline/#')"
     dst="$TARGET/$drel"
     mkdir -p "$(dirname "$dst")"
     cp "$REPO_ROOT/$rel" "$dst" || { echo "generate: codex copy failed (source missing?): $rel" >&2; exit 1; }
@@ -124,6 +130,16 @@ if [ -r "$MANIFEST_CODEX" ] && [ -d "$REPO_ROOT/codex" ]; then
     prkit_apply_rewrites "$f" || { echo "generate: codex rewrite failed: $f" >&2; rw_rc=1; }
   done < <(find "$TARGET/codex" -type f -print0)
   [ "$rw_rc" -eq 0 ] || { echo "generate: codex rewrite pass had failures" >&2; exit 1; }
+  # Repoint references to the two prefixed support-skill dirs (codex tree only —
+  # the Claude tree keeps prkit:post-impl-review via plugin-scoping).
+  while IFS= read -r -d '' f; do
+    perl -0pi -e '
+      s{prkit:post-impl-review}{prkit-post-impl-review}g;
+      s{prkit:merge-pipeline}{prkit-merge-pipeline}g;
+      s{skills/post-impl-review}{skills/prkit-post-impl-review}g;
+      s{skills/merge-pipeline}{skills/prkit-merge-pipeline}g;
+    ' "$f" || { echo "generate: codex skill-prefix rewrite failed: $f" >&2; exit 1; }
+  done < <(find "$TARGET/codex" -type f -print0)
   # Scaffold codex-specific files from prkit-correct templates (authored, not
   # rewritten — so they don't inherit UberDev's stale counts). AFTER the rewrite
   # loop so they stay pristine.

--- a/tools/prkit/generate.sh
+++ b/tools/prkit/generate.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # tools/prkit/generate.sh — generate the standalone prkit plugin from UberDev SSOT.
 #   generate.sh --target <dir> [--version X.Y.Z] [--force]
-# Stages: preflight -> clean -> copy -> rewrite -> scaffold -> verify -> summary.
-# Idempotent: same SSOT + version => byte-identical plugins/prkit output.
+# Stages: preflight -> clean -> copy -> rewrite -> scaffold -> codex -> verify -> summary.
+# Idempotent: same SSOT + version => byte-identical output.
 set -u
 set -o pipefail
 
@@ -23,12 +23,15 @@ while [ $# -gt 0 ]; do
   esac
 done
 [ -n "$TARGET" ] || { echo "generate: --target <dir> required" >&2; exit 2; }
-mkdir -p "$TARGET"
-TARGET="$(cd "$TARGET" && pwd)"
+# Guard mkdir/cd: an unchecked failure here would collapse TARGET to "" and make
+# the later rm -rf "$P" / scaffold writes hit the filesystem root.
+mkdir -p "$TARGET" || { echo "generate: cannot create target dir: $TARGET" >&2; exit 1; }
+TARGET="$(cd "$TARGET" && pwd)" || { echo "generate: cannot resolve target dir: $TARGET" >&2; exit 1; }
+[ -n "$TARGET" ] || { echo "generate: target resolved to empty path — refusing to write to filesystem root" >&2; exit 1; }
 
 # Deterministic DATE input (no wall-clock in output beyond the version's date):
-# use the version-tag date if provided via env, else a fixed placeholder the
-# release ritual overrides. Determinism test pins this.
+# use PRKIT_RELEASE_DATE if provided, else a fixed placeholder the release ritual
+# overrides. The determinism test pins this.
 DATE="${PRKIT_RELEASE_DATE:-2026-07-12}"
 
 # --- 1. Preflight ---
@@ -46,67 +49,87 @@ P="$TARGET/plugins/prkit"
 rm -rf "$P"
 mkdir -p "$P"
 
-# --- 3. Copy per manifest ---
-copied=0
+# --- 3. Copy per manifest. A failed cp (e.g. a manifest source went missing in
+# the SSOT) MUST abort — otherwise a broken tree ships and the "copied N" summary
+# lies. copied is asserted to equal the manifest entry count. ---
+copied=0; expected=0
 while IFS= read -r rel; do
   case "$rel" in ''|\#*) continue;; esac
+  expected=$((expected+1))
   dst="$P/$rel"
   mkdir -p "$(dirname "$dst")"
-  cp "$SRC/$rel" "$dst"
+  cp "$SRC/$rel" "$dst" || { echo "generate: copy failed (manifest source missing?): $rel" >&2; exit 1; }
   copied=$((copied+1))
 done < "$MANIFEST"
+[ "$copied" -eq "$expected" ] || { echo "generate: copied $copied of $expected manifest files" >&2; exit 1; }
 
-# --- 4. Rewrite every copied text file (skip binary/json-data safely) ---
+# --- 4. Rewrite every copied file. The one JSON data file (model-routing-v1.json)
+# has no uberdev token, so perl -0pi is a byte-preserving no-op on it; every copied
+# file is text, so nothing is skipped. rw_rc surfaces a perl failure. ---
+rw_rc=0
 while IFS= read -r -d '' f; do
-  case "$f" in
-    *model-routing-v1.json) : ;;   # data file: has no uberdev token; still safe to run
-  esac
-  prkit_neutralize "$f"
-  prkit_apply_rewrites "$f"
+  prkit_neutralize "$f" || { echo "generate: neutralize failed: $f" >&2; rw_rc=1; }
+  prkit_apply_rewrites "$f" || { echo "generate: rewrite failed: $f" >&2; rw_rc=1; }
 done < <(find "$P" -type f -print0)
+[ "$rw_rc" -eq 0 ] || { echo "generate: rewrite pass had failures" >&2; exit 1; }
 
 # --- 5. Scaffold standalone-only files from templates ---
-render(){ sed -e "s/{{VERSION}}/$VERSION/g" -e "s/{{DATE}}/$DATE/g" "$1"; }
+# render fails loudly: a missing template or a sed error must not silently ship a
+# zero-byte scaffold (a bare `> out` redirect truncates out before sed runs, and
+# the root-level scaffolds are outside verify's plugins/prkit + codex scan roots).
+render(){
+  local tmpl="$1" out="$2" tmp
+  [ -r "$tmpl" ] || { echo "generate: template missing: $tmpl" >&2; exit 1; }
+  tmp="$(mktemp)"
+  { sed -e "s/{{VERSION}}/$VERSION/g" -e "s/{{DATE}}/$DATE/g" "$tmpl" > "$tmp" && [ -s "$tmp" ]; } \
+    || { echo "generate: render produced empty/failed output: $tmpl" >&2; rm -f "$tmp"; exit 1; }
+  mv "$tmp" "$out"
+}
 mkdir -p "$P/.claude-plugin" "$TARGET/.claude-plugin" "$TARGET/.github/workflows"
-render "$TEMPLATES/plugin.json.tmpl"       > "$P/.claude-plugin/plugin.json"
-render "$TEMPLATES/marketplace.json.tmpl"  > "$TARGET/.claude-plugin/marketplace.json"
-render "$TEMPLATES/README.md.tmpl"         > "$TARGET/README.md"
-render "$TEMPLATES/LICENSE.tmpl"           > "$TARGET/LICENSE"
-render "$TEMPLATES/NOTICE.tmpl"            > "$TARGET/NOTICE"
-render "$TEMPLATES/CHANGELOG.md.tmpl"      > "$TARGET/CHANGELOG.md"
-render "$TEMPLATES/gitignore.tmpl"        > "$TARGET/.gitignore"
-render "$TEMPLATES/ci.yml.tmpl"           > "$TARGET/.github/workflows/ci.yml"
+render "$TEMPLATES/plugin.json.tmpl"       "$P/.claude-plugin/plugin.json"
+render "$TEMPLATES/marketplace.json.tmpl"  "$TARGET/.claude-plugin/marketplace.json"
+render "$TEMPLATES/README.md.tmpl"         "$TARGET/README.md"
+render "$TEMPLATES/LICENSE.tmpl"           "$TARGET/LICENSE"
+render "$TEMPLATES/NOTICE.tmpl"            "$TARGET/NOTICE"
+render "$TEMPLATES/CHANGELOG.md.tmpl"      "$TARGET/CHANGELOG.md"
+render "$TEMPLATES/gitignore.tmpl"        "$TARGET/.gitignore"
+render "$TEMPLATES/ci.yml.tmpl"           "$TARGET/.github/workflows/ci.yml"
 
 # --- 5b. Codex port (present only when the codex/ SSOT + its manifest exist) ---
 MANIFEST_CODEX="$HERE/manifest-codex.txt"
-cx_copied=0
+cx_copied=0; cx_scaffolded=0
 if [ -r "$MANIFEST_CODEX" ] && [ -d "$REPO_ROOT/codex" ]; then
-  # The prkit repo's entire codex/ tree is generated — clean it for an
-  # idempotent regenerate (no stale files if the manifest shrinks).
+  # The prkit repo's entire codex/ tree is generated — clean it for an idempotent
+  # regenerate (no stale files if the manifest shrinks).
   rm -rf "$TARGET/codex"
   # Copy each codex source to a dest path with uberdev->prkit applied
   # (codex/uberdev-codex -> codex/prkit-codex, uberdev-cmd- -> prkit-cmd-,
   #  codex/agents/uberdev-<a>.toml -> codex/agents/prkit-<a>.toml).
+  cx_expected=0
   while IFS= read -r rel; do
     case "$rel" in ''|\#*) continue;; esac
+    cx_expected=$((cx_expected+1))
     drel="$(printf '%s' "$rel" | sed 's/uberdev/prkit/g')"
     dst="$TARGET/$drel"
     mkdir -p "$(dirname "$dst")"
-    cp "$REPO_ROOT/$rel" "$dst"
+    cp "$REPO_ROOT/$rel" "$dst" || { echo "generate: codex copy failed (source missing?): $rel" >&2; exit 1; }
     cx_copied=$((cx_copied+1))
   done < "$MANIFEST_CODEX"
-  # Rewrite content of every copied codex file (neutralize goal/solve, then blanket).
+  [ "$cx_copied" -eq "$cx_expected" ] || { echo "generate: codex copied $cx_copied of $cx_expected files" >&2; exit 1; }
+  # Rewrite content of every copied codex file (neutralize out-of-set, then blanket).
   while IFS= read -r -d '' f; do
-    prkit_neutralize "$f"
-    prkit_apply_rewrites "$f"
+    prkit_neutralize "$f" || { echo "generate: codex neutralize failed: $f" >&2; rw_rc=1; }
+    prkit_apply_rewrites "$f" || { echo "generate: codex rewrite failed: $f" >&2; rw_rc=1; }
   done < <(find "$TARGET/codex" -type f -print0)
+  [ "$rw_rc" -eq 0 ] || { echo "generate: codex rewrite pass had failures" >&2; exit 1; }
   # Scaffold codex-specific files from prkit-correct templates (authored, not
   # rewritten — so they don't inherit UberDev's stale counts). AFTER the rewrite
   # loop so they stay pristine.
   mkdir -p "$TARGET/codex/prkit-codex/.codex-plugin"
-  render "$TEMPLATES/codex-plugin.json.tmpl" > "$TARGET/codex/prkit-codex/.codex-plugin/plugin.json"
-  render "$TEMPLATES/codex-README.md.tmpl"   > "$TARGET/codex/README.md"
-  render "$TEMPLATES/codex-AGENTS.md.tmpl"    > "$TARGET/codex/AGENTS.md"
+  render "$TEMPLATES/codex-plugin.json.tmpl" "$TARGET/codex/prkit-codex/.codex-plugin/plugin.json"
+  render "$TEMPLATES/codex-README.md.tmpl"   "$TARGET/codex/README.md"
+  render "$TEMPLATES/codex-AGENTS.md.tmpl"    "$TARGET/codex/AGENTS.md"
+  cx_scaffolded=3
   # Restore exec bits on the entry scripts (cp preserves mode, but be explicit).
   [ -f "$TARGET/codex/install-codex.sh" ] && chmod +x "$TARGET/codex/install-codex.sh"
   [ -f "$TARGET/codex/prkit-codex/hooks/session-start" ] && chmod +x "$TARGET/codex/prkit-codex/hooks/session-start"
@@ -119,5 +142,5 @@ if ! bash "$HERE/verify.sh" "$TARGET"; then
 fi
 
 # --- 7. Summary ---
-echo "generate: OK — copied $copied claude + $cx_copied codex files, scaffolded 8+3, verified."
+echo "generate: OK — copied $copied claude + $cx_copied codex files, scaffolded $((8 + cx_scaffolded)), verified."
 echo "generate: next -> git -C '$TARGET' add -A && git -C '$TARGET' commit -m 'chore: regenerate prkit $VERSION'"

--- a/tools/prkit/generate.sh
+++ b/tools/prkit/generate.sh
@@ -77,12 +77,47 @@ render "$TEMPLATES/CHANGELOG.md.tmpl"      > "$TARGET/CHANGELOG.md"
 render "$TEMPLATES/gitignore.tmpl"        > "$TARGET/.gitignore"
 render "$TEMPLATES/ci.yml.tmpl"           > "$TARGET/.github/workflows/ci.yml"
 
-# --- 6. Verify (fail the whole run on any violation) ---
+# --- 5b. Codex port (present only when the codex/ SSOT + its manifest exist) ---
+MANIFEST_CODEX="$HERE/manifest-codex.txt"
+cx_copied=0
+if [ -r "$MANIFEST_CODEX" ] && [ -d "$REPO_ROOT/codex" ]; then
+  # The prkit repo's entire codex/ tree is generated — clean it for an
+  # idempotent regenerate (no stale files if the manifest shrinks).
+  rm -rf "$TARGET/codex"
+  # Copy each codex source to a dest path with uberdev->prkit applied
+  # (codex/uberdev-codex -> codex/prkit-codex, uberdev-cmd- -> prkit-cmd-,
+  #  codex/agents/uberdev-<a>.toml -> codex/agents/prkit-<a>.toml).
+  while IFS= read -r rel; do
+    case "$rel" in ''|\#*) continue;; esac
+    drel="$(printf '%s' "$rel" | sed 's/uberdev/prkit/g')"
+    dst="$TARGET/$drel"
+    mkdir -p "$(dirname "$dst")"
+    cp "$REPO_ROOT/$rel" "$dst"
+    cx_copied=$((cx_copied+1))
+  done < "$MANIFEST_CODEX"
+  # Rewrite content of every copied codex file (neutralize goal/solve, then blanket).
+  while IFS= read -r -d '' f; do
+    prkit_neutralize "$f"
+    prkit_apply_rewrites "$f"
+  done < <(find "$TARGET/codex" -type f -print0)
+  # Scaffold codex-specific files from prkit-correct templates (authored, not
+  # rewritten — so they don't inherit UberDev's stale counts). AFTER the rewrite
+  # loop so they stay pristine.
+  mkdir -p "$TARGET/codex/prkit-codex/.codex-plugin"
+  render "$TEMPLATES/codex-plugin.json.tmpl" > "$TARGET/codex/prkit-codex/.codex-plugin/plugin.json"
+  render "$TEMPLATES/codex-README.md.tmpl"   > "$TARGET/codex/README.md"
+  render "$TEMPLATES/codex-AGENTS.md.tmpl"    > "$TARGET/codex/AGENTS.md"
+  # Restore exec bits on the entry scripts (cp preserves mode, but be explicit).
+  [ -f "$TARGET/codex/install-codex.sh" ] && chmod +x "$TARGET/codex/install-codex.sh"
+  [ -f "$TARGET/codex/prkit-codex/hooks/session-start" ] && chmod +x "$TARGET/codex/prkit-codex/hooks/session-start"
+fi
+
+# --- 6. Verify (fail the whole run on any violation; covers both trees) ---
 if ! bash "$HERE/verify.sh" "$TARGET"; then
   echo "generate: VERIFY FAILED — output left in $TARGET for inspection" >&2
   exit 1
 fi
 
 # --- 7. Summary ---
-echo "generate: OK — copied $copied files, scaffolded 8, verified."
+echo "generate: OK — copied $copied claude + $cx_copied codex files, scaffolded 8+3, verified."
 echo "generate: next -> git -C '$TARGET' add -A && git -C '$TARGET' commit -m 'chore: regenerate prkit $VERSION'"

--- a/tools/prkit/generate.sh
+++ b/tools/prkit/generate.sh
@@ -54,6 +54,7 @@ mkdir -p "$P"
 # lies. copied is asserted to equal the manifest entry count. ---
 copied=0; expected=0
 while IFS= read -r rel; do
+  rel="${rel%$'\r'}"   # strip CR (Windows Git-Bash autocrlf checkout)
   case "$rel" in ''|\#*) continue;; esac
   expected=$((expected+1))
   dst="$P/$rel"
@@ -107,6 +108,7 @@ if [ -r "$MANIFEST_CODEX" ] && [ -d "$REPO_ROOT/codex" ]; then
   #  codex/agents/uberdev-<a>.toml -> codex/agents/prkit-<a>.toml).
   cx_expected=0
   while IFS= read -r rel; do
+    rel="${rel%$'\r'}"   # strip CR (Windows Git-Bash autocrlf checkout)
     case "$rel" in ''|\#*) continue;; esac
     cx_expected=$((cx_expected+1))
     drel="$(printf '%s' "$rel" | sed 's/uberdev/prkit/g')"

--- a/tools/prkit/manifest-codex.txt
+++ b/tools/prkit/manifest-codex.txt
@@ -1,0 +1,76 @@
+# tools/prkit/manifest-codex.txt — prkit CODEX-port PR-phase copy set (RFC 0014 Codex addendum).
+# Paths are relative to the UberDev REPO ROOT. Blank lines and #-comments ignored.
+# Dest paths are the source path with uberdev->prkit applied (so
+# codex/uberdev-codex -> codex/prkit-codex, uberdev-cmd- -> prkit-cmd-,
+# codex/agents/uberdev-<a>.toml -> codex/agents/prkit-<a>.toml). Content is then
+# rewritten by rewrite.sh (blanket uberdev->prkit + slug + neutralize).
+# The Codex manifest (.codex-plugin/plugin.json), README, and AGENTS.md primer are
+# NOT listed here — they are authored from templates with prkit-correct counts.
+# Count-locked at 51 by tests/prkit-codex-manifest.test.sh.
+
+# --- command-skills (3) — Codex equivalents of commands/{review-pr,simplify,merge}.md ---
+codex/uberdev-codex/skills/uberdev-cmd-review-pr/SKILL.md
+codex/uberdev-codex/skills/uberdev-cmd-simplify/SKILL.md
+codex/uberdev-codex/skills/uberdev-cmd-merge/SKILL.md
+
+# --- support/pipeline skills (3 files) ---
+codex/uberdev-codex/skills/post-impl-review/SKILL.md
+codex/uberdev-codex/skills/merge-pipeline/SKILL.md
+codex/uberdev-codex/skills/merge-pipeline/lib/discover.sh
+
+# --- agent runtime prompts (14 .md) ---
+codex/uberdev-codex/agents/code-reviewer.md
+codex/uberdev-codex/agents/silent-failure-hunter.md
+codex/uberdev-codex/agents/type-design-analyzer.md
+codex/uberdev-codex/agents/comment-analyzer.md
+codex/uberdev-codex/agents/pr-test-analyzer.md
+codex/uberdev-codex/agents/code-fixer.md
+codex/uberdev-codex/agents/code-simplifier.md
+codex/uberdev-codex/agents/ci-failure-classifier.md
+codex/uberdev-codex/agents/ci-code-fixer.md
+codex/uberdev-codex/agents/ci-rebase-handler.md
+codex/uberdev-codex/agents/trust-trail-evaluator.md
+codex/uberdev-codex/agents/merge-strategy-decider.md
+codex/uberdev-codex/agents/conflict-resolver.md
+codex/uberdev-codex/agents/findings-to-issues.md
+
+# --- lib (11 — shared dispatch/config chain) ---
+codex/uberdev-codex/lib/child-dispatch.sh
+codex/uberdev-codex/lib/agent-dispatch.sh
+codex/uberdev-codex/lib/dispatch.sh
+codex/uberdev-codex/lib/config-read.sh
+codex/uberdev-codex/lib/model_routing.py
+codex/uberdev-codex/lib/run_manifest.py
+codex/uberdev-codex/lib/live-semaphore.sh
+codex/uberdev-codex/lib/child-receipts.py
+codex/uberdev-codex/lib/child-inputs.py
+codex/uberdev-codex/lib/command-workspace.py
+codex/uberdev-codex/lib/secret-scan.sh
+
+# --- policy (1) ---
+codex/uberdev-codex/policy/model-routing-v1.json
+
+# --- plugin-runtime scaffold (3) ---
+codex/uberdev-codex/hooks/hooks.json
+codex/uberdev-codex/hooks/session-start
+codex/uberdev-codex/shared/document-reviewer-template.md
+
+# --- installable Codex subagents (14 .toml — reference artifacts) ---
+codex/agents/uberdev-code-reviewer.toml
+codex/agents/uberdev-silent-failure-hunter.toml
+codex/agents/uberdev-type-design-analyzer.toml
+codex/agents/uberdev-comment-analyzer.toml
+codex/agents/uberdev-pr-test-analyzer.toml
+codex/agents/uberdev-code-fixer.toml
+codex/agents/uberdev-code-simplifier.toml
+codex/agents/uberdev-ci-failure-classifier.toml
+codex/agents/uberdev-ci-code-fixer.toml
+codex/agents/uberdev-ci-rebase-handler.toml
+codex/agents/uberdev-trust-trail-evaluator.toml
+codex/agents/uberdev-merge-strategy-decider.toml
+codex/agents/uberdev-conflict-resolver.toml
+codex/agents/uberdev-findings-to-issues.toml
+
+# --- installer + converter (2 — the install-codex.sh one-liner path) ---
+codex/install-codex.sh
+codex/tools/convert-agents.py

--- a/tools/prkit/manifest.txt
+++ b/tools/prkit/manifest.txt
@@ -1,0 +1,45 @@
+# tools/prkit/manifest.txt — prkit PR-phase copy set (RFC 0014 §5.3).
+# Paths are relative to plugins/uberdev/. Blank lines and #-comments ignored.
+# Keep in sync with tests/prkit-manifest.test.sh (count-locked at 32).
+
+# --- commands (3) ---
+commands/review-pr.md
+commands/simplify.md
+commands/merge.md
+
+# --- agents (14) ---
+agents/code-reviewer.md
+agents/silent-failure-hunter.md
+agents/type-design-analyzer.md
+agents/comment-analyzer.md
+agents/pr-test-analyzer.md
+agents/code-fixer.md
+agents/code-simplifier.md
+agents/ci-failure-classifier.md
+agents/ci-code-fixer.md
+agents/ci-rebase-handler.md
+agents/trust-trail-evaluator.md
+agents/merge-strategy-decider.md
+agents/conflict-resolver.md
+agents/findings-to-issues.md
+
+# --- skills (2 + skill-local lib) ---
+skills/post-impl-review/SKILL.md
+skills/merge-pipeline/SKILL.md
+skills/merge-pipeline/lib/discover.sh
+
+# --- lib (11 — shared dispatch/config chain) ---
+lib/child-dispatch.sh
+lib/agent-dispatch.sh
+lib/dispatch.sh
+lib/config-read.sh
+lib/model_routing.py
+lib/run_manifest.py
+lib/live-semaphore.sh
+lib/child-receipts.py
+lib/child-inputs.py
+lib/command-workspace.py
+lib/secret-scan.sh
+
+# --- policy (1 — routing policy data file) ---
+policy/model-routing-v1.json

--- a/tools/prkit/rewrite.sh
+++ b/tools/prkit/rewrite.sh
@@ -9,9 +9,13 @@
 # ORDER MATTERS: neutralize BEFORE apply_rewrites, so the blanket
 # uberdev->prkit never manufactures a dangling prkit:goal / prkit:solve.
 
-# Rule 2 — the enumerated out-of-set sites (census: review-pr.md 226/250/472/494/767).
-# Keyed on stable unique substrings; each replacement contains no uberdev / goal /
-# solve command reference. Non-matching files are untouched (no-op).
+# Rule 2 — out-of-set goal/solve references. The named sentence rules produce
+# graceful prose at the censused review-pr.md sites (226/250/472/494/767); the
+# catch-all block after them GUARANTEES completeness — any remaining
+# /uberdev:goal|solve (or bare uberdev:goal|solve), from an uncensused file such
+# as ci-code-fixer.md or a future edit, is reduced to generic prose so the blanket
+# rewrite can never manufacture a dangling prkit:goal / prkit:solve.
+# Non-matching files are untouched (no-op).
 prkit_neutralize() {
   local f="$1"
   perl -0pi -e '
@@ -20,7 +24,15 @@ prkit_neutralize() {
     s{Render '\''/uberdev:solve <highest-priority issue URL>'\'' suggestion to stderr; emit RED trail; exit 1\. User runs /solve in a follow-up turn\.}{Emit RED trail with the filed issue URL(s) to stderr; exit 1. Address them manually.}g;
     s{emit one stderr line per filed BLOCKER URL: `next: /uberdev:solve <URL>`\. The user runs the suggested command in a follow-up turn; `/review-pr` itself does not background-dispatch `/solve` \(sub-process dispatch from inside a halted review run is out of scope per RFC 0002 §7\.1 — defaults to hard-stop to avoid cascading agent loops\)\.}{emit one stderr line per filed BLOCKER URL pointing at the issue to fix manually. `/review-pr` never background-dispatches a solver.}g;
     s{so a concurrent `/uberdev:goal` Phase 2b knows this PR'\''s `/review-pr` is in-flight \(avoids re-dispatching ours while the leaf solver'\''s own is still running\)}{recording that this PR'\''s `/review-pr` is in-flight (an advisory concurrency marker)}g;
-    s{The locked marker is read by `/uberdev:goal` Phase 2b via `_uberdev_goal_locked_marker_for_pr_fresh` \(lib/goal-state.sh\)\. }{The locked marker is advisory and self-expiring. }g;
+    s{The locked marker is read by `/uberdev:goal` Phase 2b via `_uberdev_goal_locked_marker_for_pr_fresh[^`]*` \(lib/goal-state.sh\)\. }{The locked marker is advisory and self-expiring. }g;
+    # Catch-all backstop (runs after the graceful sentence rules): reduce any
+    # surviving out-of-set command reference to generic prose. Order: slash+arg,
+    # slash, then bare token — so no stray "/" prefix is left behind.
+    s{/uberdev:solve\s+\S+}{the filed issue}g;
+    s{/uberdev:solve}{the issue tracker}g;
+    s{/uberdev:goal}{the goal workflow}g;
+    s{uberdev:solve}{the issue tracker}g;
+    s{uberdev:goal}{the goal workflow}g;
   ' "$f"
 }
 

--- a/tools/prkit/rewrite.sh
+++ b/tools/prkit/rewrite.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# tools/prkit/rewrite.sh — prkit namespace-rewrite ruleset (RFC 0014 §5.4).
+# SOURCE this file; do not execute. Uses perl for portable in-place edits
+# (BSD/GNU sed differ; perl is uniform on macOS, Linux, Git-Bash).
+#
+#   prkit_neutralize <file>       # rule 2: remove out-of-set goal/solve refs
+#   prkit_apply_rewrites <file>   # rules 1,3-6: blanket case-preserving rewrite
+#
+# ORDER MATTERS: neutralize BEFORE apply_rewrites, so the blanket
+# uberdev->prkit never manufactures a dangling prkit:goal / prkit:solve.
+
+# Rule 2 — the enumerated out-of-set sites (census: review-pr.md 226/250/472/494/767).
+# Keyed on stable unique substrings; each replacement contains no uberdev / goal /
+# solve command reference. Non-matching files are untouched (no-op).
+prkit_neutralize() {
+  local f="$1"
+  perl -0pi -e '
+    s{next:\s*/uberdev:solve\s+\S+}{next: address the filed issue(s) manually}g;
+    s{/uberdev:solve\s+\$CI_REFUSED_ISSUE_URL\s*\(or fix manually\)}{fix the filed issue manually}g;
+    s{Render '\''/uberdev:solve <highest-priority issue URL>'\'' suggestion to stderr; emit RED trail; exit 1\. User runs /solve in a follow-up turn\.}{Emit RED trail with the filed issue URL(s) to stderr; exit 1. Address them manually.}g;
+    s{emit one stderr line per filed BLOCKER URL: `next: /uberdev:solve <URL>`\. The user runs the suggested command in a follow-up turn; `/review-pr` itself does not background-dispatch `/solve` \(sub-process dispatch from inside a halted review run is out of scope per RFC 0002 §7\.1 — defaults to hard-stop to avoid cascading agent loops\)\.}{emit one stderr line per filed BLOCKER URL pointing at the issue to fix manually. `/review-pr` never background-dispatches a solver.}g;
+    s{so a concurrent `/uberdev:goal` Phase 2b knows this PR'\''s `/review-pr` is in-flight \(avoids re-dispatching ours while the leaf solver'\''s own is still running\)}{recording that this PR'\''s `/review-pr` is in-flight (an advisory concurrency marker)}g;
+    s{The locked marker is read by `/uberdev:goal` Phase 2b via `_uberdev_goal_locked_marker_for_pr_fresh` \(lib/goal-state.sh\)\. }{The locked marker is advisory and self-expiring. }g;
+  ' "$f"
+}
+
+# Rules 1,3,4,5,6 — blanket case-preserving uberdev->prkit. The verify-gate
+# token guard (verify.sh) is the completeness backstop: if any uberdev token
+# survives, generation fails and a rule is added here.
+prkit_apply_rewrites() {
+  local f="$1"
+  perl -0pi -e '
+    s/UBERDEV/PRKIT/g;   # env vars, macros
+    s/UberDev/Prkit/g;   # CamelCase product name in prose
+    s/Uberdev/Prkit/g;   # sentence-case
+    s/uberdev/prkit/g;   # everything else: uberdev:, _uberdev_, paths, labels, files
+  ' "$f"
+}

--- a/tools/prkit/rewrite.sh
+++ b/tools/prkit/rewrite.sh
@@ -42,9 +42,11 @@ prkit_neutralize() {
 prkit_apply_rewrites() {
   local f="$1"
   perl -0pi -e '
+    s{TheFJK/UberDev}{TheFJK/prkit}g;  # repo slug: MUST stay lowercase "prkit"
+    s{TheFJK/uberdev}{TheFJK/prkit}g;  # (clone/marketplace URLs) — run before CamelCase
     s/UBERDEV/PRKIT/g;   # env vars, macros
     s/UberDev/Prkit/g;   # CamelCase product name in prose
     s/Uberdev/Prkit/g;   # sentence-case
-    s/uberdev/prkit/g;   # everything else: uberdev:, _uberdev_, paths, labels, files
+    s/uberdev/prkit/g;   # everything else: uberdev:, _uberdev_, uberdev-codex, uberdev-cmd-, paths, labels, files
   ' "$f"
 }

--- a/tools/prkit/rewrite.sh
+++ b/tools/prkit/rewrite.sh
@@ -3,36 +3,28 @@
 # SOURCE this file; do not execute. Uses perl for portable in-place edits
 # (BSD/GNU sed differ; perl is uniform on macOS, Linux, Git-Bash).
 #
-#   prkit_neutralize <file>       # rule 2: remove out-of-set goal/solve refs
-#   prkit_apply_rewrites <file>   # rules 1,3-6: blanket case-preserving rewrite
+#   prkit_neutralize <file>       # strip uberdev: prefix from OUT-OF-SET refs
+#   prkit_apply_rewrites <file>   # slug + blanket case-preserving rewrite
 #
 # ORDER MATTERS: neutralize BEFORE apply_rewrites, so the blanket
-# uberdev->prkit never manufactures a dangling prkit:goal / prkit:solve.
+# uberdev->prkit never manufactures a dangling prkit:<out-of-set-name>.
 
-# Rule 2 — out-of-set goal/solve references. The named sentence rules produce
-# graceful prose at the censused review-pr.md sites (226/250/472/494/767); the
-# catch-all block after them GUARANTEES completeness — any remaining
-# /uberdev:goal|solve (or bare uberdev:goal|solve), from an uncensused file such
-# as ci-code-fixer.md or a future edit, is reduced to generic prose so the blanket
-# rewrite can never manufacture a dangling prkit:goal / prkit:solve.
-# Non-matching files are untouched (no-op).
+# prkit_neutralize — strip the `uberdev:` / `/uberdev:` namespace PREFIX from every
+# OUT-OF-SET command/skill/agent reference BEFORE the blanket uberdev->prkit
+# rewrite, so it can never mint a dangling prkit:<name> pointing at something
+# prkit does not ship. It reduces the ref to its bare name (readable prose) and,
+# crucially, never consumes a trailing inline-code backtick or an argument — that
+# is the /solve <URL> backtick-mangling class this replaced. The KEEP set is
+# prkit's shipped PR-phase surface (3 commands + 14 agents + 2 skills) plus the
+# label allowlist (`active`, `*-finding`); those keep their prefix so they become
+# prkit:<name>. verify.sh's out-of-set gate backstops this: any surviving
+# prkit:<name> resolving to neither a shipped item nor an allowlisted label fails
+# generation. Non-matching files are untouched (no-op).
 prkit_neutralize() {
   local f="$1"
   perl -0pi -e '
-    s{next:\s*/uberdev:solve\s+\S+}{next: address the filed issue(s) manually}g;
-    s{/uberdev:solve\s+\$CI_REFUSED_ISSUE_URL\s*\(or fix manually\)}{fix the filed issue manually}g;
-    s{Render '\''/uberdev:solve <highest-priority issue URL>'\'' suggestion to stderr; emit RED trail; exit 1\. User runs /solve in a follow-up turn\.}{Emit RED trail with the filed issue URL(s) to stderr; exit 1. Address them manually.}g;
-    s{emit one stderr line per filed BLOCKER URL: `next: /uberdev:solve <URL>`\. The user runs the suggested command in a follow-up turn; `/review-pr` itself does not background-dispatch `/solve` \(sub-process dispatch from inside a halted review run is out of scope per RFC 0002 §7\.1 — defaults to hard-stop to avoid cascading agent loops\)\.}{emit one stderr line per filed BLOCKER URL pointing at the issue to fix manually. `/review-pr` never background-dispatches a solver.}g;
-    s{so a concurrent `/uberdev:goal` Phase 2b knows this PR'\''s `/review-pr` is in-flight \(avoids re-dispatching ours while the leaf solver'\''s own is still running\)}{recording that this PR'\''s `/review-pr` is in-flight (an advisory concurrency marker)}g;
-    s{The locked marker is read by `/uberdev:goal` Phase 2b via `_uberdev_goal_locked_marker_for_pr_fresh[^`]*` \(lib/goal-state.sh\)\. }{The locked marker is advisory and self-expiring. }g;
-    # Catch-all backstop (runs after the graceful sentence rules): reduce any
-    # surviving out-of-set command reference to generic prose. Order: slash+arg,
-    # slash, then bare token — so no stray "/" prefix is left behind.
-    s{/uberdev:solve\s+\S+}{the filed issue}g;
-    s{/uberdev:solve}{the issue tracker}g;
-    s{/uberdev:goal}{the goal workflow}g;
-    s{uberdev:solve}{the issue tracker}g;
-    s{uberdev:goal}{the goal workflow}g;
+    my $keep = qr/(?:review-pr|simplify|merge|code-reviewer|silent-failure-hunter|type-design-analyzer|comment-analyzer|pr-test-analyzer|code-fixer|code-simplifier|ci-failure-classifier|ci-code-fixer|ci-rebase-handler|trust-trail-evaluator|merge-strategy-decider|conflict-resolver|findings-to-issues|post-impl-review|merge-pipeline|active)(?![a-z0-9-])|[a-z0-9-]+-finding(?![a-z0-9-])/;
+    s{/?uberdev:(?!$keep)([a-z][a-z0-9-]*)}{$1}g;
   ' "$f"
 }
 

--- a/tools/prkit/templates/CHANGELOG.md.tmpl
+++ b/tools/prkit/templates/CHANGELOG.md.tmpl
@@ -5,6 +5,9 @@ All notable changes to prkit are documented here (Keep a Changelog 1.1.0; SemVer
 ## [{{VERSION}}] — {{DATE}}
 
 ### Added
-- Initial standalone PR-phase plugin extracted from UberDev: `/prkit:review-pr`,
-  `/prkit:simplify`, `/prkit:merge`, with their reviewer/fixer/CI/merge agents,
-  `post-impl-review` + `merge-pipeline` skills, and the shared dispatch/config lib.
+- Initial standalone PR-phase plugin: `/prkit:review-pr`, `/prkit:simplify`,
+  `/prkit:merge`, with their reviewer/fixer/CI/merge agents, `post-impl-review` +
+  `merge-pipeline` skills, and the shared dispatch/config lib.
+- Codex CLI port: `codex/prkit-codex/` native plugin + `codex/install-codex.sh`
+  one-liner. The three commands ship as `prkit-cmd-*` skills, the 14 subagents as
+  TOML, plus the Codex primer (`codex/AGENTS.md`).

--- a/tools/prkit/templates/CHANGELOG.md.tmpl
+++ b/tools/prkit/templates/CHANGELOG.md.tmpl
@@ -1,13 +1,14 @@
 # Changelog
 
-All notable changes to prkit are documented here (Keep a Changelog 1.1.0; SemVer).
+prkit is a **generated artifact** — this file is rewritten on every regeneration,
+so it is not a hand-maintained per-version log. The authoritative version history
+lives on the [Releases](https://github.com/TheFJK/prkit/releases) page (each release
+carries its notes and the git tag it was cut from).
 
-## [{{VERSION}}] — {{DATE}}
+**Current version: {{VERSION}}** — see the matching release for its notes.
 
-### Added
-- Initial standalone PR-phase plugin: `/prkit:review-pr`, `/prkit:simplify`,
-  `/prkit:merge`, with their reviewer/fixer/CI/merge agents, `post-impl-review` +
-  `merge-pipeline` skills, and the shared dispatch/config lib.
-- Codex CLI port: `codex/prkit-codex/` native plugin + `codex/install-codex.sh`
-  one-liner. The three commands ship as `prkit-cmd-*` skills, the 14 subagents as
-  TOML, plus the Codex primer (`codex/AGENTS.md`).
+## What prkit is
+
+Standalone PR-phase toolkit (review → fix → simplify → land) for both Claude Code
+(`plugins/prkit/`) and the Codex CLI (`codex/prkit-codex/` + `codex/install-codex.sh`),
+namespaced `prkit`/`prkit-codex` to coexist with UberDev.

--- a/tools/prkit/templates/CHANGELOG.md.tmpl
+++ b/tools/prkit/templates/CHANGELOG.md.tmpl
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to prkit are documented here (Keep a Changelog 1.1.0; SemVer).
+
+## [{{VERSION}}] — {{DATE}}
+
+### Added
+- Initial standalone PR-phase plugin extracted from UberDev: `/prkit:review-pr`,
+  `/prkit:simplify`, `/prkit:merge`, with their reviewer/fixer/CI/merge agents,
+  `post-impl-review` + `merge-pipeline` skills, and the shared dispatch/config lib.

--- a/tools/prkit/templates/LICENSE.tmpl
+++ b/tools/prkit/templates/LICENSE.tmpl
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 TheFJK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/prkit/templates/NOTICE.tmpl
+++ b/tools/prkit/templates/NOTICE.tmpl
@@ -1,0 +1,12 @@
+prkit
+Copyright (c) 2026 TheFJK
+
+This product is generated from the PR-phase of UberDev
+(https://github.com/TheFJK/UberDev) and incorporates work from:
+
+  - UberDev — MIT
+  - Superpowers skills — MIT
+  - pr-review-toolkit — Apache-2.0
+  - code-simplifier — Apache-2.0
+
+The word "UberDev" appears in this NOTICE for attribution only.

--- a/tools/prkit/templates/README.md.tmpl
+++ b/tools/prkit/templates/README.md.tmpl
@@ -1,0 +1,36 @@
+# prkit
+
+![Version](https://img.shields.io/badge/version-{{VERSION}}-blue)
+
+Standalone **PR-phase** toolkit for Claude Code — the review → fix → simplify → land
+pipeline extracted from [UberDev](https://github.com/TheFJK/UberDev). Namespaced
+`prkit:`, so it installs and runs **alongside** a full UberDev install with no collision.
+
+> Generated artifact — do not hand-edit. Source of truth is UberDev's `tools/prkit/`.
+> Regenerate with `tools/prkit/generate.sh --target <this-repo> --version X.Y.Z`.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `/prkit:review-pr` | Parallel-fanout post-implementation review + auto-fix + CI-failure routing |
+| `/prkit:simplify` | Reuse / quality / efficiency lens audit + fix |
+| `/prkit:merge` | Trust-trail check → strategy pick → conflict resolution → land |
+
+## Install
+
+Add this repo as a plugin marketplace in Claude Code, then install `prkit`:
+
+```
+/plugin marketplace add TheFJK/prkit
+/plugin install prkit
+```
+
+## Runtime requirements
+
+`git`, `gh` (authenticated), `jq`, `python3`. Optional: `gitleaks` (secret scan falls
+back to an inline regex scan if absent).
+
+## License
+
+MIT — see `LICENSE`. Origin attributions in `NOTICE`.

--- a/tools/prkit/templates/ci.yml.tmpl
+++ b/tools/prkit/templates/ci.yml.tmpl
@@ -11,16 +11,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends jq
+      # NOTE: `find ... -exec cmd \;` returns 0 even when cmd fails, so an explicit
+      # `|| exit 1` is required for these to actually gate. codex/ is optional
+      # (only present when the Codex port is generated), hence the guarded root.
       - name: Syntax — shell
-        run: find plugins/prkit codex -name '*.sh' -exec bash -n {} \;
+        run: for f in $(find plugins/prkit $([ -d codex ] && echo codex) -name '*.sh'); do bash -n "$f" || exit 1; done
       - name: Syntax — python
-        run: find plugins/prkit codex -name '*.py' -exec python3 -m py_compile {} \;
+        run: for f in $(find plugins/prkit $([ -d codex ] && echo codex) -name '*.py'); do python3 -c 'import ast,sys; ast.parse(open(sys.argv[1],encoding="utf-8").read(), sys.argv[1])' "$f" || exit 1; done
       - name: Syntax — json
-        run: find plugins/prkit codex -name '*.json' -exec jq empty {} \;
+        run: for f in $(find plugins/prkit $([ -d codex ] && echo codex) -name '*.json'); do jq empty "$f" || exit 1; done
       - name: Syntax — toml
-        run: find plugins/prkit codex -name '*.toml' -exec python3 -c 'import tomllib,sys; tomllib.load(open(sys.argv[1],"rb"))' {} \;
+        run: for f in $(find plugins/prkit $([ -d codex ] && echo codex) -name '*.toml'); do python3 -c 'import tomllib,sys; tomllib.load(open(sys.argv[1],"rb"))' "$f" || exit 1; done
       - name: Namespace guard — no uberdev token survives (root NOTICE/LICENSE are out of scope)
         run: |
-          hits=$(grep -rilE 'uberdev' plugins/prkit codex || true)
+          hits=$(grep -rilE 'uberdev' plugins/prkit $([ -d codex ] && echo codex) || true)
           if [ -n "$hits" ]; then echo "surviving uberdev token:"; echo "$hits"; exit 1; fi
           echo "clean"

--- a/tools/prkit/templates/ci.yml.tmpl
+++ b/tools/prkit/templates/ci.yml.tmpl
@@ -12,13 +12,15 @@ jobs:
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends jq
       - name: Syntax — shell
-        run: for f in $(find plugins/prkit -name '*.sh'); do bash -n "$f"; done
+        run: find plugins/prkit codex -name '*.sh' -exec bash -n {} \;
       - name: Syntax — python
-        run: for f in $(find plugins/prkit -name '*.py'); do python3 -m py_compile "$f"; done
+        run: find plugins/prkit codex -name '*.py' -exec python3 -m py_compile {} \;
       - name: Syntax — json
-        run: for f in $(find plugins/prkit -name '*.json'); do jq empty "$f"; done
-      - name: Namespace guard — no uberdev token survives (allowlist: NOTICE)
+        run: find plugins/prkit codex -name '*.json' -exec jq empty {} \;
+      - name: Syntax — toml
+        run: find plugins/prkit codex -name '*.toml' -exec python3 -c 'import tomllib,sys; tomllib.load(open(sys.argv[1],"rb"))' {} \;
+      - name: Namespace guard — no uberdev token survives (root NOTICE/LICENSE are out of scope)
         run: |
-          hits=$(grep -rilE 'uberdev' plugins/prkit || true)
+          hits=$(grep -rilE 'uberdev' plugins/prkit codex || true)
           if [ -n "$hits" ]; then echo "surviving uberdev token:"; echo "$hits"; exit 1; fi
           echo "clean"

--- a/tools/prkit/templates/ci.yml.tmpl
+++ b/tools/prkit/templates/ci.yml.tmpl
@@ -1,0 +1,24 @@
+name: prkit-ci
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends jq
+      - name: Syntax — shell
+        run: for f in $(find plugins/prkit -name '*.sh'); do bash -n "$f"; done
+      - name: Syntax — python
+        run: for f in $(find plugins/prkit -name '*.py'); do python3 -m py_compile "$f"; done
+      - name: Syntax — json
+        run: for f in $(find plugins/prkit -name '*.json'); do jq empty "$f"; done
+      - name: Namespace guard — no uberdev token survives (allowlist: NOTICE)
+        run: |
+          hits=$(grep -rilE 'uberdev' plugins/prkit || true)
+          if [ -n "$hits" ]; then echo "surviving uberdev token:"; echo "$hits"; exit 1; fi
+          echo "clean"

--- a/tools/prkit/templates/codex-AGENTS.md.tmpl
+++ b/tools/prkit/templates/codex-AGENTS.md.tmpl
@@ -20,8 +20,8 @@ Codex has no slash-commands, so prkit's three commands ship as skills named
 - `$prkit-cmd-merge` — trust-trail check → strategy → conflict resolution → land
 
 A natural-language request like "review the current pull request" should invoke
-`prkit-cmd-review-pr` automatically. The two internal skills `post-impl-review`
-and `merge-pipeline` are used by those commands; you do not invoke them directly.
+`prkit-cmd-review-pr` automatically. The two internal skills `prkit-post-impl-review`
+and `prkit-merge-pipeline` are used by those commands; you do not invoke them directly.
 
 ## Tool mapping (Claude Code → Codex)
 

--- a/tools/prkit/templates/codex-AGENTS.md.tmpl
+++ b/tools/prkit/templates/codex-AGENTS.md.tmpl
@@ -1,0 +1,70 @@
+# prkit for Codex
+
+prkit installs **5 skills** (in `~/.agents/skills/`) and **14 subagents** (in
+`~/.codex/agents/` as `prkit-<name>.toml`). It is the standalone PR phase —
+review → fix → simplify → land — namespaced `prkit` so it coexists with a full install.
+
+## Instruction priority
+
+1. The user's explicit instructions (AGENTS.md, direct requests) — highest.
+2. prkit skills — override default behavior where they conflict.
+3. Default behavior — lowest.
+
+## Commands became skills
+
+Codex has no slash-commands, so prkit's three commands ship as skills named
+`prkit-cmd-<name>`, invokable explicitly with `$prkit-cmd-<name>`:
+
+- `$prkit-cmd-review-pr` — parallel-fanout PR review + auto-fix + CI-failure routing
+- `$prkit-cmd-simplify` — reuse / quality / efficiency lens audit + fix
+- `$prkit-cmd-merge` — trust-trail check → strategy → conflict resolution → land
+
+A natural-language request like "review the current pull request" should invoke
+`prkit-cmd-review-pr` automatically. The two internal skills `post-impl-review`
+and `merge-pipeline` are used by those commands; you do not invoke them directly.
+
+## Tool mapping (Claude Code → Codex)
+
+The skill bodies are written for Claude Code. Translate as you read:
+
+| Claude Code | Codex |
+|---|---|
+| `Task(subagent_type=…)` | `spawn_agent(...)` + `wait_agent(...)` |
+| `TodoWrite` | `update_plan` |
+| `Skill(...)` | native skill invocation |
+| `Workflow(...)` | no equivalent — follow the skill's "No-Workflow fallback" |
+| `MultiEdit` / `Edit` | native edit |
+
+## Named-agent dispatch
+
+prkit's review/simplify/merge fanouts dispatch specific subagents. On Codex:
+
+```
+spawn_agent(agent_type="prkit-<name>")   # e.g. prkit-code-reviewer
+```
+
+If a Codex release does not support `agent_type`, fall back to a generic
+`worker` agent and pass the subagent's TOML `developer_instructions` as its
+prompt (the `.toml` files live in `~/.codex/agents/prkit-*.toml`). The 14
+subagents are: code-reviewer, silent-failure-hunter, type-design-analyzer,
+comment-analyzer, pr-test-analyzer, code-fixer, code-simplifier,
+ci-failure-classifier, ci-code-fixer, ci-rebase-handler, trust-trail-evaluator,
+merge-strategy-decider, conflict-resolver, findings-to-issues.
+
+## Sandbox / worktrees
+
+The review and merge flows run git. Under a `workspace-write` sandbox that is
+sufficient; the merge flow's `git checkout main` expects to run from the main
+checkout, not a pinned worktree.
+
+## Per-project config
+
+prkit reads optional per-project config from `.codex/prkit.local.md` (YAML
+frontmatter; env vars override file values). Keys follow the standard prkit
+config schema — see the `using-*` skill references if present.
+
+## Uninstall
+
+```bash
+./codex/install-codex.sh --uninstall
+```

--- a/tools/prkit/templates/codex-README.md.tmpl
+++ b/tools/prkit/templates/codex-README.md.tmpl
@@ -1,0 +1,59 @@
+# prkit for Codex (OpenAI Codex CLI)
+
+![Version](https://img.shields.io/badge/version-{{VERSION}}-blue)
+
+The Codex CLI port of **prkit** — the standalone PR-phase toolkit (review → fix →
+simplify → land). Everything is namespaced `prkit` / `prkit-codex`, so it coexists
+with a full Codex plugin install.
+
+> Generated artifact — do not hand-edit. Source of truth is the prkit generator
+> (`tools/prkit/`). Regenerate with `tools/prkit/generate.sh --target <this-repo> --version X.Y.Z`.
+
+## Commands (as Codex skills)
+
+Codex has no slash-commands, so each command ships as a skill named `prkit-cmd-<name>`:
+
+| Skill | What it does |
+|---|---|
+| `$prkit-cmd-review-pr` | Parallel-fanout PR review + auto-fix + CI-failure routing |
+| `$prkit-cmd-simplify` | Reuse / quality / efficiency lens audit + fix |
+| `$prkit-cmd-merge` | Trust-trail check → strategy pick → conflict resolution → land |
+
+## Two install paths
+
+### Path 1 — Standalone installer (recommended; carries the subagents)
+
+```bash
+./codex/install-codex.sh
+# or one-liner:
+curl -fsSL https://raw.githubusercontent.com/TheFJK/prkit/main/codex/install-codex.sh | bash
+```
+
+Installs the 5 skills → `~/.agents/skills/`, the **14 subagents** → `~/.codex/agents/prkit-*.toml`,
+and the primer → `~/.codex/AGENTS.md`. Required for the review/simplify fanout, because
+the Codex plugin manifest has no `agents` field.
+
+### Path 2 — Codex-native plugin (browse & toggle)
+
+```bash
+codex plugin marketplace add TheFJK/prkit
+# then /plugins to enable prkit-codex, or:
+codex plugin add prkit-codex@prkit
+```
+
+Ships skills + the session-start hook + Markdown agent prompts. It does **not** include
+the `.toml` subagents or the primer — run Path 1 for the full review fanout.
+
+## Runtime requirements
+
+`git`, `gh` (authenticated), `jq`, `python3`. Optional: `gitleaks`.
+
+## Uninstall
+
+```bash
+./codex/install-codex.sh --uninstall
+```
+
+## License
+
+MIT — see `../LICENSE`. Origin attributions in `../NOTICE`.

--- a/tools/prkit/templates/codex-plugin.json.tmpl
+++ b/tools/prkit/templates/codex-plugin.json.tmpl
@@ -1,0 +1,39 @@
+{
+  "name": "prkit-codex",
+  "version": "{{VERSION}}",
+  "description": "prkit PR-phase toolkit for Codex: parallel-fanout PR review, auto-fix, CI-failure routing, reuse/quality/efficiency simplify, and trust-gated merge. Skills ship here; the 14 subagents install separately via codex/install-codex.sh (Codex plugin manifest has no agents field).",
+  "author": {
+    "name": "TheFJK",
+    "url": "https://github.com/TheFJK"
+  },
+  "homepage": "https://github.com/TheFJK/prkit",
+  "repository": "https://github.com/TheFJK/prkit",
+  "license": "MIT",
+  "keywords": [
+    "code-review",
+    "pull-request",
+    "ci",
+    "merge",
+    "skills",
+    "agents"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "prkit",
+    "shortDescription": "Standalone PR-phase review, fix, simplify and merge skills for Codex.",
+    "longDescription": "prkit brings the review -> fix -> simplify -> land pipeline to Codex. The plugin ships skills and runtime hooks; the standalone installer also installs the matching custom subagents. Namespaced prkit- so it coexists with a full install.",
+    "developerName": "TheFJK",
+    "category": "Productivity",
+    "capabilities": [
+      "Code Review",
+      "Automation"
+    ],
+    "websiteURL": "https://github.com/TheFJK/prkit",
+    "defaultPrompt": [
+      "Review the current pull request.",
+      "Simplify the changed code.",
+      "Merge this approved PR."
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/tools/prkit/templates/gitignore.tmpl
+++ b/tools/prkit/templates/gitignore.tmpl
@@ -1,0 +1,5 @@
+.DS_Store
+__pycache__/
+*.pyc
+.claude/
+.worktrees/

--- a/tools/prkit/templates/marketplace.json.tmpl
+++ b/tools/prkit/templates/marketplace.json.tmpl
@@ -1,0 +1,14 @@
+{
+  "name": "prkit",
+  "owner": { "name": "TheFJK", "url": "https://github.com/TheFJK" },
+  "plugins": [
+    {
+      "name": "prkit",
+      "source": "./plugins/prkit",
+      "description": "Standalone PR-phase toolkit: review -> fix -> simplify -> land. Coexists with UberDev.",
+      "version": "{{VERSION}}",
+      "category": "workflow",
+      "tags": ["code-review", "pull-request", "ci", "merge", "skills", "agents"]
+    }
+  ]
+}

--- a/tools/prkit/templates/plugin.json.tmpl
+++ b/tools/prkit/templates/plugin.json.tmpl
@@ -1,0 +1,10 @@
+{
+  "name": "prkit",
+  "version": "{{VERSION}}",
+  "description": "Standalone PR-phase toolkit for Claude Code: parallel-fanout PR review, auto-fix, CI-failure routing, reuse/quality/efficiency simplify, and trust-gated merge. Extracted from UberDev; installs alongside it.",
+  "author": { "name": "TheFJK", "url": "https://github.com/TheFJK" },
+  "homepage": "https://github.com/TheFJK/prkit",
+  "repository": "https://github.com/TheFJK/prkit",
+  "license": "MIT",
+  "keywords": ["code-review", "pull-request", "ci", "merge", "gh-cli", "skills", "agents"]
+}

--- a/tools/prkit/templates/plugin.json.tmpl
+++ b/tools/prkit/templates/plugin.json.tmpl
@@ -1,7 +1,7 @@
 {
   "name": "prkit",
   "version": "{{VERSION}}",
-  "description": "Standalone PR-phase toolkit for Claude Code: parallel-fanout PR review, auto-fix, CI-failure routing, reuse/quality/efficiency simplify, and trust-gated merge. Extracted from UberDev; installs alongside it.",
+  "description": "Standalone PR-phase toolkit for Claude Code: parallel-fanout PR review, auto-fix, CI-failure routing, reuse/quality/efficiency simplify, and trust-gated merge. Namespaced prkit:, so it coexists with a full plugin install.",
   "author": { "name": "TheFJK", "url": "https://github.com/TheFJK" },
   "homepage": "https://github.com/TheFJK/prkit",
   "repository": "https://github.com/TheFJK/prkit",

--- a/tools/prkit/verify.sh
+++ b/tools/prkit/verify.sh
@@ -3,6 +3,11 @@
 #   verify.sh <target-repo-root>
 # Exit 0 iff the generated tree is correct. Prints each check. Covers the Claude
 # plugin (plugins/prkit, always) and the Codex port (codex/, when generated).
+#
+# Design invariant (issue #334 review): NO check may pass VACUOUSLY. An empty scan,
+# an errored grep (rc>=2), or a zero-file find is treated as a FAIL, never silently
+# as "clean" — the [[jq_echo0_masks_crash]] class. Every scanning check asserts it
+# actually saw files/refs before it can report OK.
 set -u
 set -o pipefail
 
@@ -18,47 +23,81 @@ fail(){ echo "  FAIL  $1"; rc=1; }
 ok(){ echo "  OK    $1"; }
 echo "## prkit verify <$ROOT>"
 
-# --- 1. Token guard: no uberdev anywhere in the shipped trees (root NOTICE/LICENSE,
-# which legitimately attribute UberDev, are outside these scan roots). ---
-tok=$(grep -rilE 'uberdev' "${SCAN[@]}" 2>/dev/null || true)
-if [ -n "$tok" ]; then fail "token-guard: uberdev survives in:"; echo "$tok" | sed 's/^/         /'
-else ok "token-guard: no uberdev token (plugins/prkit${SCAN[1]:+ + codex})"; fi
+# --- 0. Non-vacuity: the scan roots actually contain files ---
+SCANNED_FILES=$(find "${SCAN[@]}" -type f 2>/dev/null | wc -l | tr -d ' ')
+if [ "${SCANNED_FILES:-0}" -lt 20 ]; then fail "non-vacuity: only ${SCANNED_FILES:-0} files under scan roots — generation likely broke"
+else ok "non-vacuity: $SCANNED_FILES files under scan roots"; fi
 
-# --- 2. Residual out-of-set command refs (prkit:goal / prkit:solve) ---
-oos=$(grep -rEl '(^|[^a-z])prkit:(goal|solve)|/prkit:(goal|solve)' "${SCAN[@]}" 2>/dev/null || true)
-if [ -n "$oos" ]; then fail "out-of-set: prkit:goal/solve survives in: $oos"
-else ok "out-of-set: no prkit:goal/solve reference"; fi
+# --- 1. Token guard: no uberdev anywhere in the shipped trees. grep exit codes:
+# 0 = matched (LEAK, fail), 1 = no match (clean), >=2 = grep ERROR (cannot certify
+# clean -> fail; the || true trap that hides a crashed/permission-denied scan). ---
+tok=$(grep -rilE 'uberdev' "${SCAN[@]}" 2>/dev/null); grc=$?
+case "$grc" in
+  0) fail "token-guard: uberdev survives in:"; echo "$tok" | sed 's/^/         /' ;;
+  1) ok "token-guard: no uberdev token (plugins/prkit${SCAN[1]:+ + codex})" ;;
+  *) fail "token-guard: token scan errored (grep rc=$grc) — cannot certify clean" ;;
+esac
+
+# --- 2. Residual out-of-set command refs (prkit:goal / prkit:solve), same exit-code discipline ---
+oos=$(grep -rEl '(^|[^a-z])prkit:(goal|solve)|/prkit:(goal|solve)' "${SCAN[@]}" 2>/dev/null); orc=$?
+case "$orc" in
+  0) fail "out-of-set: prkit:goal/solve survives in: $oos" ;;
+  1) ok "out-of-set: no prkit:goal/solve reference" ;;
+  *) fail "out-of-set: scan errored (grep rc=$orc)" ;;
+esac
 
 # --- 3. Referential integrity: every dispatched prkit:X agent has agents/X.md
-# (Claude tree only — Codex dispatch uses a different agent_type shape) ---
-grep -rhoE 'subagent_type[:=][[:space:]]*prkit:[a-z0-9-]+' "$P" 2>/dev/null \
-  | sed -E 's/.*prkit://' | sort -u | while read -r a; do
-    [ -f "$P/agents/$a.md" ] || echo "missing-agent:$a"
-  done > /tmp/prkit-missing-agents.$$ 2>/dev/null || true
-if [ -s /tmp/prkit-missing-agents.$$ ]; then fail "ref-int: agents missing:"; sed 's/^/         /' /tmp/prkit-missing-agents.$$
-else ok "ref-int: all dispatched agents exist"; fi
-rm -f /tmp/prkit-missing-agents.$$
+# (Claude tree only). Assert refs were actually found — 0 refs means the dispatch
+# syntax the regex keys off vanished (a broken copy/rewrite), not a genuine pass. ---
+AGENT_REFS=$(grep -rhoE 'subagent_type[:=][[:space:]]*prkit:[a-z0-9-]+' "$P" 2>/dev/null | sed -E 's/.*prkit://' | sort -u)
+if [ -z "$AGENT_REFS" ]; then fail "ref-int: found ZERO dispatched prkit: agent refs — expected several (broken tree?)"
+else
+  missing_agents=$(printf '%s\n' "$AGENT_REFS" | while read -r a; do [ -n "$a" ] && { [ -f "$P/agents/$a.md" ] || echo "$a"; }; done)
+  if [ -n "$missing_agents" ]; then fail "ref-int: agents missing:"; printf '%s\n' "$missing_agents" | sed 's/^/         /'
+  else ok "ref-int: all $(printf '%s\n' "$AGENT_REFS" | grep -c .) dispatched agents exist"; fi
+fi
 
 # --- 4. Referential integrity: every Skill(prkit:X) has skills/X/SKILL.md ---
-grep -rhoE 'Skill\(prkit:[a-z0-9-]+' "$P" 2>/dev/null \
-  | sed -E 's/.*prkit://' | sort -u | while read -r s; do
-    [ -f "$P/skills/$s/SKILL.md" ] || echo "missing-skill:$s"
-  done > /tmp/prkit-missing-skills.$$ 2>/dev/null || true
-if [ -s /tmp/prkit-missing-skills.$$ ]; then fail "ref-int: skills missing:"; sed 's/^/         /' /tmp/prkit-missing-skills.$$
-else ok "ref-int: all invoked skills exist"; fi
-rm -f /tmp/prkit-missing-skills.$$
+SKILL_REFS=$(grep -rhoE 'Skill\(prkit:[a-z0-9-]+' "$P" 2>/dev/null | sed -E 's/.*prkit://' | sort -u)
+if [ -z "$SKILL_REFS" ]; then fail "ref-int: found ZERO Skill(prkit:X) refs — expected at least post-impl-review"
+else
+  missing_skills=$(printf '%s\n' "$SKILL_REFS" | while read -r s; do [ -n "$s" ] && { [ -f "$P/skills/$s/SKILL.md" ] || echo "$s"; }; done)
+  if [ -n "$missing_skills" ]; then fail "ref-int: skills missing:"; printf '%s\n' "$missing_skills" | sed 's/^/         /'
+  else ok "ref-int: all invoked skills exist"; fi
+fi
 
-# --- 5. Syntax: shell / python / json / toml (space-safe: NUL-delimited find +
-# process substitution; loop stays in the current shell so *err flags persist) ---
-serr=0
-while IFS= read -r -d '' f; do bash -n "$f" 2>/dev/null || { echo "         bash -n failed: $f"; serr=1; }; done < <(find "${SCAN[@]}" -name '*.sh' -print0 2>/dev/null)
-[ "$serr" -eq 0 ] && ok "syntax: bash -n clean" || fail "syntax: shell errors"
-perr=0
-# ast.parse validates syntax WITHOUT emitting __pycache__/*.pyc — py_compile would
-# pollute the generated tree with non-deterministic bytecode (breaks determinism +
-# ships build artifacts). ast.parse is artifact-free and deterministic.
-while IFS= read -r -d '' f; do python3 -c 'import ast,sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$f" 2>/dev/null || { echo "         py syntax failed: $f"; perr=1; }; done < <(find "${SCAN[@]}" -name '*.py' -print0 2>/dev/null)
-[ "$perr" -eq 0 ] && ok "syntax: python parse clean" || fail "syntax: python errors"
+# --- 5. Out-of-set namespace gate: every prkit:<name> reference must resolve to a
+# shipped command/agent/skill OR an allowlisted label (`active`, `*-finding`).
+# Backstops the neutralizer's de-namespace: a NEW UberDev skill it didn't strip
+# would surface here as a dangling prkit:<name> and fail generation. ---
+SHIPPED="$(mktemp)"
+{ ls "$P/commands" 2>/dev/null | sed 's/\.md$//'
+  ls "$P/agents" 2>/dev/null | sed 's/\.md$//'
+  for d in "$P/skills"/*/; do [ -d "$d" ] && basename "$d"; done
+} | sort -u > "$SHIPPED"
+OOS_BAD=$(grep -rhoE 'prkit:[a-z][a-z0-9-]+' "$P" 2>/dev/null | sed 's/prkit://' | sort -u | while read -r n; do
+  case "$n" in ''|active|*-finding) continue;; esac
+  grep -qxF "$n" "$SHIPPED" || echo "$n"
+done)
+rm -f "$SHIPPED"
+if [ -n "$OOS_BAD" ]; then fail "out-of-set: dangling prkit:<name> (not shipped, not a label):"; printf '%s\n' "$OOS_BAD" | sed 's/^/         prkit:/'
+else ok "out-of-set: every prkit:<name> resolves to a shipped item or label"; fi
+
+# --- 6. Syntax: shell / python / json / toml. Each requires a plausible file count
+# (>0 of the types the tree is known to contain) so a catastrophic empty copy can't
+# read as "clean". Space-safe NUL-find + current-shell loop. ---
+sh_n=0; serr=0
+while IFS= read -r -d '' f; do sh_n=$((sh_n+1)); bash -n "$f" 2>/dev/null || { echo "         bash -n failed: $f"; serr=1; }; done < <(find "${SCAN[@]}" -name '*.sh' -print0 2>/dev/null)
+if [ "$sh_n" -eq 0 ]; then fail "syntax: found ZERO .sh files — expected many (broken copy?)"
+elif [ "$serr" -ne 0 ]; then fail "syntax: shell errors"
+else ok "syntax: bash -n clean ($sh_n files)"; fi
+py_n=0; perr=0
+# ast.parse validates syntax WITHOUT emitting __pycache__/*.pyc (py_compile would
+# pollute the tree with non-deterministic bytecode). Artifact-free + deterministic.
+while IFS= read -r -d '' f; do py_n=$((py_n+1)); python3 -c 'import ast,sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$f" 2>/dev/null || { echo "         py syntax failed: $f"; perr=1; }; done < <(find "${SCAN[@]}" -name '*.py' -print0 2>/dev/null)
+if [ "$py_n" -eq 0 ]; then fail "syntax: found ZERO .py files — expected several (broken copy?)"
+elif [ "$perr" -ne 0 ]; then fail "syntax: python errors"
+else ok "syntax: python parse clean ($py_n files)"; fi
 jerr=0
 while IFS= read -r -d '' f; do jq empty "$f" 2>/dev/null || { echo "         jq failed: $f"; jerr=1; }; done < <(find "${SCAN[@]}" -name '*.json' -print0 2>/dev/null)
 [ "$jerr" -eq 0 ] && ok "syntax: jq clean" || fail "syntax: json errors"
@@ -73,11 +112,11 @@ if [ -d "$ROOT/codex" ]; then
   fi
 fi
 
-# --- 6. Required tree shape ---
+# --- 7. Required tree shape ---
 for req in "commands/review-pr.md" "commands/simplify.md" "commands/merge.md" \
            "skills/post-impl-review/SKILL.md" "skills/merge-pipeline/SKILL.md" \
            "policy/model-routing-v1.json" ".claude-plugin/plugin.json"; do
-  [ -e "$P/$req" ] || { fail "shape: missing $req"; }
+  [ -e "$P/$req" ] || fail "shape: missing $req"
 done
 ok "shape: claude required-file presence checked"
 if [ -d "$ROOT/codex" ]; then
@@ -90,6 +129,18 @@ if [ -d "$ROOT/codex" ]; then
   done
   ok "shape: codex required-file presence checked"
 fi
+
+# --- 8. Root scaffold files (outside the SCAN roots) — present, non-empty, valid ---
+for req in README.md LICENSE NOTICE CHANGELOG.md .gitignore \
+           .github/workflows/ci.yml .claude-plugin/marketplace.json; do
+  [ -s "$ROOT/$req" ] || fail "scaffold: missing/empty $req"
+done
+jq empty "$ROOT/.claude-plugin/marketplace.json" 2>/dev/null || fail "scaffold: marketplace.json is not valid JSON"
+ok "scaffold: root files present, non-empty, marketplace.json valid"
+
+# --- 9. No unrendered template placeholders leaked into generated output ---
+PLH=$(grep -rlE '\{\{[A-Za-z_]+\}\}' "${SCAN[@]}" "$ROOT/README.md" "$ROOT/CHANGELOG.md" "$ROOT/.claude-plugin/marketplace.json" 2>/dev/null || true)
+[ -z "$PLH" ] && ok "placeholders: no unrendered {{...}} in output" || { fail "placeholders: unrendered {{...}} in:"; echo "$PLH" | sed 's/^/         /'; }
 
 echo "  Result: $([ "$rc" -eq 0 ] && echo PASS || echo FAIL)"
 exit "$rc"

--- a/tools/prkit/verify.sh
+++ b/tools/prkit/verify.sh
@@ -1,29 +1,36 @@
 #!/usr/bin/env bash
-# tools/prkit/verify.sh — prkit generation verify gate (RFC 0014 §5.6).
+# tools/prkit/verify.sh — prkit generation verify gate (RFC 0014 §5.6 + Codex addendum).
 #   verify.sh <target-repo-root>
-# Exit 0 iff the generated tree is correct. Prints each check.
+# Exit 0 iff the generated tree is correct. Prints each check. Covers the Claude
+# plugin (plugins/prkit, always) and the Codex port (codex/, when generated).
 set -u
 set -o pipefail
 
 ROOT="${1:-}"
 [ -n "$ROOT" ] && [ -d "$ROOT/plugins/prkit" ] || { echo "verify: no plugins/prkit under '$ROOT'"; exit 2; }
 P="$ROOT/plugins/prkit"
+# Scan roots: the Claude plugin (always) + the Codex port (if generated). Array
+# form keeps this space-safe for target paths like "/Volumes/FJK SSD/...".
+SCAN=("$P")
+[ -d "$ROOT/codex" ] && SCAN+=("$ROOT/codex")
 rc=0
 fail(){ echo "  FAIL  $1"; rc=1; }
 ok(){ echo "  OK    $1"; }
 echo "## prkit verify <$ROOT>"
 
-# --- 1. Token guard: no uberdev under plugins/prkit (allowlist: NOTICE/LICENSE at root) ---
-tok=$(grep -rilE 'uberdev' "$P" 2>/dev/null || true)
+# --- 1. Token guard: no uberdev anywhere in the shipped trees (root NOTICE/LICENSE,
+# which legitimately attribute UberDev, are outside these scan roots). ---
+tok=$(grep -rilE 'uberdev' "${SCAN[@]}" 2>/dev/null || true)
 if [ -n "$tok" ]; then fail "token-guard: uberdev survives in:"; echo "$tok" | sed 's/^/         /'
-else ok "token-guard: no uberdev under plugins/prkit"; fi
+else ok "token-guard: no uberdev token (plugins/prkit${SCAN[1]:+ + codex})"; fi
 
 # --- 2. Residual out-of-set command refs (prkit:goal / prkit:solve) ---
-oos=$(grep -rEl '(^|[^a-z])prkit:(goal|solve)|/prkit:(goal|solve)' "$P" 2>/dev/null || true)
+oos=$(grep -rEl '(^|[^a-z])prkit:(goal|solve)|/prkit:(goal|solve)' "${SCAN[@]}" 2>/dev/null || true)
 if [ -n "$oos" ]; then fail "out-of-set: prkit:goal/solve survives in: $oos"
 else ok "out-of-set: no prkit:goal/solve reference"; fi
 
-# --- 3. Referential integrity: every dispatched prkit:X agent has agents/X.md ---
+# --- 3. Referential integrity: every dispatched prkit:X agent has agents/X.md
+# (Claude tree only — Codex dispatch uses a different agent_type shape) ---
 grep -rhoE 'subagent_type[:=][[:space:]]*prkit:[a-z0-9-]+' "$P" 2>/dev/null \
   | sed -E 's/.*prkit://' | sort -u | while read -r a; do
     [ -f "$P/agents/$a.md" ] || echo "missing-agent:$a"
@@ -41,21 +48,30 @@ if [ -s /tmp/prkit-missing-skills.$$ ]; then fail "ref-int: skills missing:"; se
 else ok "ref-int: all invoked skills exist"; fi
 rm -f /tmp/prkit-missing-skills.$$
 
-# --- 5. Syntax: shell / python / json (space-safe: NUL-delimited find + process
-# substitution so a target path containing spaces, e.g. "/Volumes/FJK SSD/...",
-# does not word-split; the loop stays in the current shell so *err flags persist) ---
+# --- 5. Syntax: shell / python / json / toml (space-safe: NUL-delimited find +
+# process substitution; loop stays in the current shell so *err flags persist) ---
 serr=0
-while IFS= read -r -d '' f; do bash -n "$f" 2>/dev/null || { echo "         bash -n failed: $f"; serr=1; }; done < <(find "$P" -name '*.sh' -print0 2>/dev/null)
+while IFS= read -r -d '' f; do bash -n "$f" 2>/dev/null || { echo "         bash -n failed: $f"; serr=1; }; done < <(find "${SCAN[@]}" -name '*.sh' -print0 2>/dev/null)
 [ "$serr" -eq 0 ] && ok "syntax: bash -n clean" || fail "syntax: shell errors"
 perr=0
 # ast.parse validates syntax WITHOUT emitting __pycache__/*.pyc — py_compile would
 # pollute the generated tree with non-deterministic bytecode (breaks determinism +
 # ships build artifacts). ast.parse is artifact-free and deterministic.
-while IFS= read -r -d '' f; do python3 -c 'import ast,sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$f" 2>/dev/null || { echo "         py syntax failed: $f"; perr=1; }; done < <(find "$P" -name '*.py' -print0 2>/dev/null)
+while IFS= read -r -d '' f; do python3 -c 'import ast,sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$f" 2>/dev/null || { echo "         py syntax failed: $f"; perr=1; }; done < <(find "${SCAN[@]}" -name '*.py' -print0 2>/dev/null)
 [ "$perr" -eq 0 ] && ok "syntax: python parse clean" || fail "syntax: python errors"
 jerr=0
-while IFS= read -r -d '' f; do jq empty "$f" 2>/dev/null || { echo "         jq failed: $f"; jerr=1; }; done < <(find "$P" -name '*.json' -print0 2>/dev/null)
+while IFS= read -r -d '' f; do jq empty "$f" 2>/dev/null || { echo "         jq failed: $f"; jerr=1; }; done < <(find "${SCAN[@]}" -name '*.json' -print0 2>/dev/null)
 [ "$jerr" -eq 0 ] && ok "syntax: jq clean" || fail "syntax: json errors"
+# TOML (Codex agents) — only when tomllib is available (py>=3.11); skip gracefully otherwise.
+if [ -d "$ROOT/codex" ]; then
+  if python3 -c 'import tomllib' 2>/dev/null; then
+    terr=0
+    while IFS= read -r -d '' f; do python3 -c 'import tomllib,sys; tomllib.load(open(sys.argv[1],"rb"))' "$f" 2>/dev/null || { echo "         toml parse failed: $f"; terr=1; }; done < <(find "$ROOT/codex" -name '*.toml' -print0 2>/dev/null)
+    [ "$terr" -eq 0 ] && ok "syntax: toml parse clean" || fail "syntax: toml errors"
+  else
+    ok "syntax: toml check skipped (no tomllib)"
+  fi
+fi
 
 # --- 6. Required tree shape ---
 for req in "commands/review-pr.md" "commands/simplify.md" "commands/merge.md" \
@@ -63,7 +79,17 @@ for req in "commands/review-pr.md" "commands/simplify.md" "commands/merge.md" \
            "policy/model-routing-v1.json" ".claude-plugin/plugin.json"; do
   [ -e "$P/$req" ] || { fail "shape: missing $req"; }
 done
-ok "shape: required-file presence checked"
+ok "shape: claude required-file presence checked"
+if [ -d "$ROOT/codex" ]; then
+  for req in "codex/prkit-codex/.codex-plugin/plugin.json" \
+             "codex/prkit-codex/skills/prkit-cmd-review-pr/SKILL.md" \
+             "codex/prkit-codex/skills/prkit-cmd-simplify/SKILL.md" \
+             "codex/prkit-codex/skills/prkit-cmd-merge/SKILL.md" \
+             "codex/install-codex.sh" "codex/README.md" "codex/AGENTS.md"; do
+    [ -e "$ROOT/$req" ] || fail "shape: missing $req"
+  done
+  ok "shape: codex required-file presence checked"
+fi
 
 echo "  Result: $([ "$rc" -eq 0 ] && echo PASS || echo FAIL)"
 exit "$rc"

--- a/tools/prkit/verify.sh
+++ b/tools/prkit/verify.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# tools/prkit/verify.sh — prkit generation verify gate (RFC 0014 §5.6).
+#   verify.sh <target-repo-root>
+# Exit 0 iff the generated tree is correct. Prints each check.
+set -u
+set -o pipefail
+
+ROOT="${1:-}"
+[ -n "$ROOT" ] && [ -d "$ROOT/plugins/prkit" ] || { echo "verify: no plugins/prkit under '$ROOT'"; exit 2; }
+P="$ROOT/plugins/prkit"
+rc=0
+fail(){ echo "  FAIL  $1"; rc=1; }
+ok(){ echo "  OK    $1"; }
+echo "## prkit verify <$ROOT>"
+
+# --- 1. Token guard: no uberdev under plugins/prkit (allowlist: NOTICE/LICENSE at root) ---
+tok=$(grep -rilE 'uberdev' "$P" 2>/dev/null || true)
+if [ -n "$tok" ]; then fail "token-guard: uberdev survives in:"; echo "$tok" | sed 's/^/         /'
+else ok "token-guard: no uberdev under plugins/prkit"; fi
+
+# --- 2. Residual out-of-set command refs (prkit:goal / prkit:solve) ---
+oos=$(grep -rEl '(^|[^a-z])prkit:(goal|solve)|/prkit:(goal|solve)' "$P" 2>/dev/null || true)
+if [ -n "$oos" ]; then fail "out-of-set: prkit:goal/solve survives in: $oos"
+else ok "out-of-set: no prkit:goal/solve reference"; fi
+
+# --- 3. Referential integrity: every dispatched prkit:X agent has agents/X.md ---
+grep -rhoE 'subagent_type[:=][[:space:]]*prkit:[a-z0-9-]+' "$P" 2>/dev/null \
+  | sed -E 's/.*prkit://' | sort -u | while read -r a; do
+    [ -f "$P/agents/$a.md" ] || echo "missing-agent:$a"
+  done > /tmp/prkit-missing-agents.$$ 2>/dev/null || true
+if [ -s /tmp/prkit-missing-agents.$$ ]; then fail "ref-int: agents missing:"; sed 's/^/         /' /tmp/prkit-missing-agents.$$
+else ok "ref-int: all dispatched agents exist"; fi
+rm -f /tmp/prkit-missing-agents.$$
+
+# --- 4. Referential integrity: every Skill(prkit:X) has skills/X/SKILL.md ---
+grep -rhoE 'Skill\(prkit:[a-z0-9-]+' "$P" 2>/dev/null \
+  | sed -E 's/.*prkit://' | sort -u | while read -r s; do
+    [ -f "$P/skills/$s/SKILL.md" ] || echo "missing-skill:$s"
+  done > /tmp/prkit-missing-skills.$$ 2>/dev/null || true
+if [ -s /tmp/prkit-missing-skills.$$ ]; then fail "ref-int: skills missing:"; sed 's/^/         /' /tmp/prkit-missing-skills.$$
+else ok "ref-int: all invoked skills exist"; fi
+rm -f /tmp/prkit-missing-skills.$$
+
+# --- 5. Syntax: shell / python / json ---
+serr=0
+for f in $(find "$P" -name '*.sh' 2>/dev/null); do bash -n "$f" 2>/dev/null || { echo "         bash -n failed: $f"; serr=1; }; done
+[ "$serr" -eq 0 ] && ok "syntax: bash -n clean" || fail "syntax: shell errors"
+perr=0
+for f in $(find "$P" -name '*.py' 2>/dev/null); do python3 -m py_compile "$f" 2>/dev/null || { echo "         py_compile failed: $f"; perr=1; }; done
+[ "$perr" -eq 0 ] && ok "syntax: py_compile clean" || fail "syntax: python errors"
+jerr=0
+for f in $(find "$P" -name '*.json' 2>/dev/null); do jq empty "$f" 2>/dev/null || { echo "         jq failed: $f"; jerr=1; }; done
+[ "$jerr" -eq 0 ] && ok "syntax: jq clean" || fail "syntax: json errors"
+
+# --- 6. Required tree shape ---
+for req in "commands/review-pr.md" "commands/simplify.md" "commands/merge.md" \
+           "skills/post-impl-review/SKILL.md" "skills/merge-pipeline/SKILL.md" \
+           "policy/model-routing-v1.json" ".claude-plugin/plugin.json"; do
+  [ -e "$P/$req" ] || { fail "shape: missing $req"; }
+done
+ok "shape: required-file presence checked"
+
+echo "  Result: $([ "$rc" -eq 0 ] && echo PASS || echo FAIL)"
+exit "$rc"

--- a/tools/prkit/verify.sh
+++ b/tools/prkit/verify.sh
@@ -46,8 +46,11 @@ serr=0
 for f in $(find "$P" -name '*.sh' 2>/dev/null); do bash -n "$f" 2>/dev/null || { echo "         bash -n failed: $f"; serr=1; }; done
 [ "$serr" -eq 0 ] && ok "syntax: bash -n clean" || fail "syntax: shell errors"
 perr=0
-for f in $(find "$P" -name '*.py' 2>/dev/null); do python3 -m py_compile "$f" 2>/dev/null || { echo "         py_compile failed: $f"; perr=1; }; done
-[ "$perr" -eq 0 ] && ok "syntax: py_compile clean" || fail "syntax: python errors"
+# ast.parse validates syntax WITHOUT emitting __pycache__/*.pyc — py_compile would
+# pollute the generated tree with non-deterministic bytecode (breaks determinism +
+# ships build artifacts). ast.parse is artifact-free and deterministic.
+for f in $(find "$P" -name '*.py' 2>/dev/null); do python3 -c 'import ast,sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$f" 2>/dev/null || { echo "         py syntax failed: $f"; perr=1; }; done
+[ "$perr" -eq 0 ] && ok "syntax: python parse clean" || fail "syntax: python errors"
 jerr=0
 for f in $(find "$P" -name '*.json' 2>/dev/null); do jq empty "$f" 2>/dev/null || { echo "         jq failed: $f"; jerr=1; }; done
 [ "$jerr" -eq 0 ] && ok "syntax: jq clean" || fail "syntax: json errors"

--- a/tools/prkit/verify.sh
+++ b/tools/prkit/verify.sh
@@ -41,18 +41,20 @@ if [ -s /tmp/prkit-missing-skills.$$ ]; then fail "ref-int: skills missing:"; se
 else ok "ref-int: all invoked skills exist"; fi
 rm -f /tmp/prkit-missing-skills.$$
 
-# --- 5. Syntax: shell / python / json ---
+# --- 5. Syntax: shell / python / json (space-safe: NUL-delimited find + process
+# substitution so a target path containing spaces, e.g. "/Volumes/FJK SSD/...",
+# does not word-split; the loop stays in the current shell so *err flags persist) ---
 serr=0
-for f in $(find "$P" -name '*.sh' 2>/dev/null); do bash -n "$f" 2>/dev/null || { echo "         bash -n failed: $f"; serr=1; }; done
+while IFS= read -r -d '' f; do bash -n "$f" 2>/dev/null || { echo "         bash -n failed: $f"; serr=1; }; done < <(find "$P" -name '*.sh' -print0 2>/dev/null)
 [ "$serr" -eq 0 ] && ok "syntax: bash -n clean" || fail "syntax: shell errors"
 perr=0
 # ast.parse validates syntax WITHOUT emitting __pycache__/*.pyc — py_compile would
 # pollute the generated tree with non-deterministic bytecode (breaks determinism +
 # ships build artifacts). ast.parse is artifact-free and deterministic.
-for f in $(find "$P" -name '*.py' 2>/dev/null); do python3 -c 'import ast,sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$f" 2>/dev/null || { echo "         py syntax failed: $f"; perr=1; }; done
+while IFS= read -r -d '' f; do python3 -c 'import ast,sys; ast.parse(open(sys.argv[1], encoding="utf-8").read(), sys.argv[1])' "$f" 2>/dev/null || { echo "         py syntax failed: $f"; perr=1; }; done < <(find "$P" -name '*.py' -print0 2>/dev/null)
 [ "$perr" -eq 0 ] && ok "syntax: python parse clean" || fail "syntax: python errors"
 jerr=0
-for f in $(find "$P" -name '*.json' 2>/dev/null); do jq empty "$f" 2>/dev/null || { echo "         jq failed: $f"; jerr=1; }; done
+while IFS= read -r -d '' f; do jq empty "$f" 2>/dev/null || { echo "         jq failed: $f"; jerr=1; }; done < <(find "$P" -name '*.json' -print0 2>/dev/null)
 [ "$jerr" -eq 0 ] && ok "syntax: jq clean" || fail "syntax: json errors"
 
 # --- 6. Required tree shape ---

--- a/tools/prkit/verify.sh
+++ b/tools/prkit/verify.sh
@@ -124,10 +124,17 @@ if [ -d "$ROOT/codex" ]; then
              "codex/prkit-codex/skills/prkit-cmd-review-pr/SKILL.md" \
              "codex/prkit-codex/skills/prkit-cmd-simplify/SKILL.md" \
              "codex/prkit-codex/skills/prkit-cmd-merge/SKILL.md" \
+             "codex/prkit-codex/skills/prkit-post-impl-review/SKILL.md" \
+             "codex/prkit-codex/skills/prkit-merge-pipeline/SKILL.md" \
              "codex/install-codex.sh" "codex/README.md" "codex/AGENTS.md"; do
     [ -e "$ROOT/$req" ] || fail "shape: missing $req"
   done
-  ok "shape: codex required-file presence checked"
+  # Coexistence: NO un-prefixed skill dir may exist in the flat Codex skills space
+  # (would collide with an UberDev-for-Codex install in ~/.agents/skills/).
+  for bad in post-impl-review merge-pipeline; do
+    [ -e "$ROOT/codex/prkit-codex/skills/$bad" ] && fail "shape: un-prefixed codex skill dir '$bad' would collide"
+  done
+  ok "shape: codex required-file presence + prkit-prefixed skills checked"
 fi
 
 # --- 8. Root scaffold files (outside the SCAN roots) — present, non-empty, valid ---


### PR DESCRIPTION
## Summary

Adds `tools/prkit/` — a generator that extracts UberDev's **PR phase** (review → fix → simplify → land) into a standalone, coexist-safe plugin **`prkit`**, kept current from UberDev as the single source of truth. Design: **RFC 0014** (`docs/rfc/0014-prkit-standalone-plugin.md`, incl. §14 Codex addendum).

The generated plugin is already live and released: **https://github.com/TheFJK/prkit** (v0.1.0, CI green), covering **both runtimes** — Claude Code (`plugins/prkit/`) and the Codex CLI (`codex/prkit-codex/` + `install-codex.sh`).

## What's in this PR (UberDev side only)

- **`tools/prkit/`** — `manifest.txt` (32) + `manifest-codex.txt` (51), `rewrite.sh` (neutralize-then-blanket `uberdev`→`prkit` + repo-slug rule), `generate.sh` (copy → rewrite → scaffold → verify, Claude + Codex stages), `verify.sh` (anti-drift gate: token guard + referential integrity + sh/py/json/toml syntax, scans both trees), `templates/`, `README.md`.
- **`docs/rfc/0014-*.md`** — the design + Codex addendum.
- **`tests/prkit-*.test.sh`** (manifest, codex-manifest, rewrite, verify, generate) wired into `test.yml` (ci-wiring drift-guard green).

## Notes

- **No version bump** — nothing under `plugins/uberdev/**` changed (only `tools/`, `tests/`, `docs/rfc/`, CI); the release-ratchet version-lock tests stay green.
- The verify gate caught every real defect during bring-up (template attribution leaks, an args-in-backticks regex miss, `py_compile` non-determinism, a space-in-path word-split, the repo-slug case bug) — each is covered by a test.
- prkit is a **generated artifact**; regenerate with `tools/prkit/generate.sh --target <repo> --version X.Y.Z` whenever the PR phase evolves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooling to generate a standalone `prkit` Claude Code plugin (review → fix → simplify → land), plus a Codex-compatible port.
  * Added manifest-driven generation, namespace remapping, Codex packaging, and verification.
* **Documentation**
  * Added RFC 0014 detailing the standalone/coexist model and generation/verify workflow.
  * Added generator and plugin usage documentation and generated changelog/metadata templates.
* **Tests**
  * Added end-to-end generation, manifest, rewrite, verify, and Codex addendum checks for correctness and deterministic output.
* **Chores**
  * Updated CI shape-check test fixtures and OS-specific test inclusion/skips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->